### PR TITLE
feat: add custom orchestrator example for model routing

### DIFF
--- a/examples/21_custom_orchestrator_routing.py
+++ b/examples/21_custom_orchestrator_routing.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Example 21: Custom Orchestrator (Model Routing)
+===============================================
+
+AUDIENCE: Teams wanting cost/latency control without changing core modules
+VALUE: Shows how to build and use a custom orchestrator module that routes
+       between GPT-5 Mini and GPT-5 Codex based on the prompt.
+
+What this demonstrates:
+  - Packaging an orchestrator module (mount() + Orchestrator protocol)
+  - Swapping the session orchestrator via bundle composition
+  - Capturing routing decisions (model + latency) via hooks
+
+Run me:
+  export OPENAI_API_KEY="sk-..."
+  uv run python examples/21_custom_orchestrator_routing.py [--verbose]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import argparse
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+from typing import Literal
+
+from amplifier_core import HookResult
+from amplifier_foundation import Bundle, load_bundle
+
+
+@dataclass
+class Task:
+    """Simple task envelope for demonstration."""
+
+    id: str
+    prompt: str
+    kind: Literal["code", "analysis", "general"] = "general"
+    importance: Literal["low", "medium", "high"] = "medium"
+    prefer_mini_first: bool = True
+
+
+class RoutingObserver:
+    """Hook to capture routing decisions emitted by the custom orchestrator."""
+
+    def __init__(self):
+        self.decisions: list[dict[str, object]] = []
+
+    async def on_orchestrator_turn_complete(self, event: str, data: dict) -> HookResult:
+        # Keep a simple history of turn decisions
+        self.decisions.append(data or {})
+        return HookResult(action="continue")
+
+
+async def main():
+    """Demonstrate routing via the custom orchestrator module."""
+    parser = argparse.ArgumentParser(description="Custom orchestrator routing demo")
+    parser.add_argument("--verbose", action="store_true", help="Show all router logs and enable raw_debug")
+    args = parser.parse_args()
+
+    if not os.getenv("OPENAI_API_KEY"):
+        print("❌ Set OPENAI_API_KEY before running this example.")
+        print("   export OPENAI_API_KEY='your-key'")
+        return
+
+    # Logging: by default only show the router selection line.
+    # With --verbose, show all logs (including escalation) and enable raw_debug.
+    if not logging.getLogger().handlers:
+        if args.verbose:
+            logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+        else:
+            logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+            router_logger = logging.getLogger("amplifier_module_router_orchestrator")
+            router_logger.setLevel(logging.INFO)
+            router_logger.propagate = False
+            handler = logging.StreamHandler()
+            handler.setLevel(logging.INFO)
+            handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+            router_logger.addHandler(handler)
+
+    repo_root = Path(__file__).parent.parent
+
+    # Base + provider bundles (all standard amplifier-foundation)
+    foundation = await load_bundle(str(repo_root / "bundles" / "minimal.yaml"))
+    openai_provider = await load_bundle(str(repo_root / "providers" / "openai-gpt.yaml"))
+
+    # Overlay: use our local orchestrator module for model routing
+    router_overlay = Bundle(
+        name="router-overlay",
+        description="Example-only custom orchestrator module (routing mini vs codex)",
+        session={
+            "orchestrator": {
+                "module": "router-orchestrator",
+                "source": str(repo_root / "examples" / "modules" / "router-orchestrator"),
+                "config": {
+                    "mini_model": "gpt-5-mini",
+                    "codex_model": "gpt-5.1-codex",
+                    "prefer_mini_first": True,
+                    "raw_debug": args.verbose,  # set via --verbose to see all router logs
+                },
+            }
+        },
+    )
+
+    # Compose and prepare
+    composed = foundation.compose(openai_provider, router_overlay)
+    prepared = await composed.prepare()
+    print("\n🔧 Mounted orchestrator:", prepared.mount_plan["session"]["orchestrator"])
+
+    # Demo tasks
+    tasks = [
+        Task(
+            id="summary",
+            prompt="Give me a 3-bullet summary of the latest Python logging best practices.",
+            kind="analysis",
+            importance="low",
+            prefer_mini_first=True,
+        ),
+        Task(
+            id="codegen",
+            prompt="Write a Python function that parses a CSV of users into Pydantic models with validation.",
+            kind="code",
+            importance="high",
+            prefer_mini_first=False,
+        ),
+        Task(
+            id="refactor",
+            prompt="Refactor this snippet for clarity and add type hints:\n```python\n"
+            "def load_cfg(p):\n    import json\n    return json.loads(open(p).read())\n```",
+            kind="code",
+            importance="medium",
+            prefer_mini_first=True,
+        ),
+    ]
+
+    # Single session to accumulate context across tasks
+    session = await prepared.create_session()
+    observer = RoutingObserver()
+    session.coordinator.hooks.register(
+        "orchestrator:turn_complete", observer.on_orchestrator_turn_complete, name="routing-observer"
+    )
+
+    async with session:
+        for idx, task in enumerate(tasks, 1):
+            print(f"\n🧭 Task {idx} '{task.id}'")
+            response = await session.execute(task.prompt)
+
+            decision = observer.decisions[-1] if observer.decisions else {}
+            model = decision.get("model", "unknown")
+            latency = decision.get("latency_s", 0.0)
+
+            preview = response[:400].replace("\n\n", "\n")
+            print(f"   Model: {model}")
+            print(f"   Latency: {latency:.2f}s")
+            print(f"   Preview:\n{preview}\n{'-'*60}")
+
+        # Ask the session to summarize what it just did
+        print("\n🧭 Asking the session to summarize its work so far...")
+        summary_prompt = "Summarize the tasks you just completed in this session."
+        summary = await session.execute(summary_prompt)
+        print(f"\n📝 Session summary:\n{summary}\n{'='*60}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/modules/router-orchestrator/amplifier_module_router_orchestrator/__init__.py
+++ b/examples/modules/router-orchestrator/amplifier_module_router_orchestrator/__init__.py
@@ -1,0 +1,155 @@
+"""Example routing orchestrator module (demo-only).
+
+This lives under examples/ to clearly distinguish sample code from the core
+amplifier-foundation runtime. It implements the Orchestrator protocol and
+routes between mini vs codex models with a simple heuristic and fallback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from amplifier_core.interfaces import Orchestrator
+from amplifier_core.message_models import ChatRequest, Message, TextBlock
+
+logger = logging.getLogger(__name__)
+
+
+class RoutingOrchestrator:
+    """Minimal orchestrator that routes to mini vs codex and records latency."""
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        cfg = config or {}
+        self.mini_model = cfg.get("mini_model", "gpt-5-mini")
+        self.codex_model = cfg.get("codex_model", "gpt-5.1-codex")
+        self.prefer_mini_first = cfg.get("prefer_mini_first", True)
+        self.raw_debug = cfg.get("raw_debug", False)
+
+    def _is_code_prompt(self, prompt: str) -> bool:
+        """Detect code-heavy prompts via simple keyword heuristics."""
+        keywords = (
+            "function",
+            "class",
+            "refactor",
+            "bug",
+            "stack trace",
+            "traceback",
+            "compile",
+            "exception",
+            "unit test",
+            "pytest",
+            "api",
+            "sdk",
+            "script",
+        )
+        return any(kw in prompt.lower() for kw in keywords)
+
+    def _choose_model(self, prompt: str) -> str:
+        """Select model based on prompt characteristics."""
+        if self._is_code_prompt(prompt):
+            return self.codex_model
+        if self.prefer_mini_first and len(prompt) < 600:
+            return self.mini_model
+        return self.codex_model
+
+    def _provider_choice(self, providers: dict[str, Any]) -> Any:
+        """Pick a provider (first available)."""
+        if not providers:
+            raise RuntimeError("No providers available for routing orchestrator")
+        if "openai" in providers:
+            return providers["openai"]
+        return next(iter(providers.values()))
+
+    def _response_text(self, response: Any) -> str:
+        """Extract user-facing text from ChatResponse."""
+        if response is None:
+            return ""
+        if hasattr(response, "text") and response.text:
+            return str(response.text)
+        if hasattr(response, "content") and response.content:
+            texts = []
+            for block in response.content:
+                if isinstance(block, TextBlock):
+                    texts.append(block.text)
+                elif hasattr(block, "text"):
+                    texts.append(str(block.text))
+            if texts:
+                return "\n\n".join(texts)
+        return str(response)
+
+    async def execute(  # type: ignore[override]
+        self,
+        prompt: str,
+        context,
+        providers,
+        tools,
+        hooks,
+        coordinator=None,  # Accept coordinator for compatibility with AmplifierSession
+    ) -> str:
+        """Run one turn: choose model, call provider, fallback if needed, record latency."""
+        await context.add_message({"role": "user", "content": prompt})
+
+        if await context.should_compact():
+            await context.compact()
+
+        raw_messages = await context.get_messages()
+        messages = []
+        for msg in raw_messages:
+            if isinstance(msg, Message):
+                messages.append(msg)
+            elif isinstance(msg, dict):
+                try:
+                    messages.append(Message(**msg))
+                except Exception as e:
+                    logger.debug(f"Skipping message that failed to parse: {e}")
+
+        target_model = self._choose_model(prompt)
+        provider = self._provider_choice(providers)
+        logger.info(f"[router-orchestrator] model={target_model} provider={getattr(provider, 'name', 'unknown')}")
+
+        request = ChatRequest(messages=messages)
+        start = time.perf_counter()
+        response = await provider.complete(request, model=target_model)
+        latency = time.perf_counter() - start
+
+        reply_text = self._response_text(response)
+        used_model = target_model
+
+        if (
+            target_model == self.mini_model
+            and self._is_code_prompt(prompt)
+            and ("```" not in reply_text and "def " not in reply_text and "class " not in reply_text)
+        ):
+            if self.raw_debug:
+                logger.info("[router-orchestrator] escalating to codex due to missing code in mini response")
+            else:
+                logger.debug("[router-orchestrator] escalating to codex due to missing code in mini response")
+            start = time.perf_counter()
+            response = await provider.complete(request, model=self.codex_model)
+            latency = time.perf_counter() - start
+            reply_text = self._response_text(response)
+            used_model = self.codex_model
+
+        await context.add_message({"role": "assistant", "content": reply_text})
+
+        if hooks:
+            await hooks.emit(
+                "orchestrator:turn_complete",
+                {"model": used_model, "latency_s": latency, "prompt_chars": len(prompt), "response_chars": len(reply_text)},
+            )
+
+        return reply_text
+
+
+async def mount(coordinator, config: dict[str, Any] | None = None):
+    """Module entrypoint: mounts the example orchestrator."""
+    orchestrator = RoutingOrchestrator(config=config)
+    await coordinator.mount("orchestrator", orchestrator)
+
+    async def cleanup():
+        logger.debug("router-orchestrator cleanup")
+
+    return cleanup

--- a/providers/openai-gpt-mini.yaml
+++ b/providers/openai-gpt-mini.yaml
@@ -1,0 +1,13 @@
+bundle:
+  name: provider-openai-gpt-mini
+  version: 1.0.0
+  description: OpenAI GPT Mini provider (cost-efficient, fast)
+
+providers:
+  - module: provider-openai
+    source: git+https://github.com/microsoft/amplifier-module-provider-openai@main
+    config:
+      # Adjust to the exact mini model id available in your account (example value shown)
+      default_model: gpt-5-mini
+      debug: true
+      raw_debug: true


### PR DESCRIPTION
## Summary

  - Added a demo-only router orchestrator module under examples/modules/router-orchestrator that routes between GPT-5
    Mini and GPT-5 Codex with latency and optional fallback.
  - Updated examples/21_custom_orchestrator_routing.py to mount the custom orchestrator via bundle composition, use a
    single session, capture routing decisions, and optionally summarize work.
  - Improved logging ergonomics: default shows only router model/provider selection; --verbose enables full router
    logs and raw_debug.

  ## Testing

  - uv run python examples/21_custom_orchestrator_routing.py
  - uv run python examples/21_custom_orchestrator_routing.py --verbose