### PR TITLE
Add tool-skills module to foundation bundle

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -18,6 +18,7 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-bundle-recipes@main#subdirectory=behaviors/recipes.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-design-intelligence@main#subdirectory=behaviors/design-intelligence.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-lsp-python@main#subdirectory=behaviors/python-lsp.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-module-tool-skills@main#subdirectory=behaviors/skills.yaml
 
 session:
   orchestrator:


### PR DESCRIPTION
## Summary

- Adds tool-skills capability to foundation bundle via behavior inclusion pattern
- Users automatically get load_skill tool and visibility hook for progressive disclosure
- Tool-skills remains a standalone module at microsoft/amplifier-module-tool-skills
- Single line change to bundle.md including the external behavior

## Benefits

- Skills are shown to agents through progressive disclosure (visibility hook)
- Users can load specialized skills on-demand via load_skill tool
- Maintains modular architecture with external module composition
- Foundation users get skills support by default

## Test plan

- ✓ Verified single line addition to bundle.md
- ✓ Committed and pushed to fork
- Needs testing: Skills module loads correctly in foundation bundle
- Needs testing: load_skill tool available to agents
- Needs testing: Visibility hook shows skills appropriately

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>