### PR TITLE
fix: Add explicit UTF-8 encoding to file reads on Windows

### DIFF
--- a/amplifier_foundation/bundle.py
+++ b/amplifier_foundation/bundle.py
@@ -593,7 +593,7 @@ class PreparedBundle:
             # Load and append all context files (re-read each call)
             for context_name, context_path in captured_bundle.context.items():
                 if context_path.exists():
-                    content = context_path.read_text()
+                    content = context_path.read_text(encoding="utf-8")
                     instruction_parts.append(f"# Context: {context_name}\n\n{content}")
 
             combined_instruction = "\n\n---\n\n".join(instruction_parts)

--- a/amplifier_foundation/sources/git.py
+++ b/amplifier_foundation/sources/git.py
@@ -93,7 +93,7 @@ class GitSourceHandler:
         meta_path = cache_path / CACHE_METADATA_FILE
         if meta_path.exists():
             try:
-                return json.loads(meta_path.read_text())
+                return json.loads(meta_path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 pass
         return {}


### PR DESCRIPTION
## Summary

Fixes  on Windows systems with non-UTF-8 default encodings (cp949/Korean, cp1252, etc.) when reading UTF-8 context files and metadata.

## Changes

- **amplifier_foundation/bundle.py:596** - Add `encoding="utf-8"` to `context_path.read_text()`
  - This is the exact location from issue #147 where Korean Windows users hit `UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2`
- **amplifier_foundation/sources/git.py:96** - Add `encoding="utf-8"` to `meta_path.read_text()`
  - Preemptively fixes the same pattern in git source metadata loading

## Root Cause

Windows uses system-default encoding (cp1252, cp949, etc.) instead of UTF-8. When `read_text()` is called without an explicit encoding parameter, it uses `locale.getpreferredencoding()`, which causes decode errors on UTF-8 content for international users (Korean, Japanese, etc.).

## Test Plan

- [x] Code review to verify explicit encoding is added
- [x] Follows same pattern as microsoft/amplifier-app-cli#36
- [ ] Would benefit from testing on Windows with non-UTF-8 locale (Korean/cp949)

## Related

- Fixes #147
- Follows pattern from microsoft/amplifier-app-cli#36

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>