### PR TITLE
fix: correct namespace resolution for subdirectory bundles

### DIFF
--- a/amplifier_foundation/registry.py
+++ b/amplifier_foundation/registry.py
@@ -381,10 +381,10 @@ class BundleRegistry:
 
                 # Also register subdirectory bundle's own name if different
                 if bundle.name and bundle.name != root_bundle.name:
-                    bundle.source_base_paths[bundle.name] = resolved.source_root
+                    bundle.source_base_paths[bundle.name] = local_path
                     logger.debug(
                         f"Sub-bundle also registered own namespace "
-                        f"@{bundle.name}: -> {resolved.source_root}"
+                        f"@{bundle.name}: -> {local_path}"
                     )
 
             # Determine if this is a root bundle or sub-bundle

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -292,7 +292,8 @@ class TestSubdirectoryBundleLoading:
 
             # The bundle should have source_base_paths set up
             assert bundle.name == "recipes"
-            assert bundle.source_base_paths.get("recipes") == base.resolve()
+            # Subdirectory bundle's own namespace should point to its actual location
+            assert bundle.source_base_paths.get("recipes") == (base / "behaviors" / "recipes").resolve()
 
     @pytest.mark.asyncio
     async def test_root_bundle_no_extra_source_base_paths(self) -> None:


### PR DESCRIPTION
## Summary

- Fix `@bundle:path` mention resolution for subdirectory bundles (e.g., `git+https://...#subdirectory=my-bundle`)
- Update test assertion that was inadvertently testing the buggy behavior

## Problem

When loading bundles from subdirectories, the `@bundle:path` mention syntax was failing to resolve files correctly.

**Root cause:** In `registry.py` line 384, `source_base_paths[bundle.name]` was being set to `resolved.source_root` (the git repo root) instead of `local_path` (the actual subdirectory where the bundle lives).

**Example:**
- Bundle `cli-tool-builder` located at `repo_root/cli-tool-builder/`
- User tries: `@cli-tool-builder:recipes/cli-tool-development.yaml`
- **Expected:** `repo_root/cli-tool-builder/recipes/cli-tool-development.yaml`
- **Actual (before fix):** `repo_root/recipes/cli-tool-development.yaml` (file not found!)

## Fix

Changed `resolved.source_root` to `local_path` so subdirectory bundles correctly map their own namespace to their actual location.

## Test plan

- [x] Updated test assertion to expect correct subdirectory path
- [x] All 34 tests pass in registry and bundle test files
- [x] Verified fix resolves the original issue with subdirectory bundle file resolution

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>