### PR TITLE
docs: prevent silent failures in bundle authoring with syntax anti-patterns

### DIFF
--- a/docs/URI_FORMATS.md
+++ b/docs/URI_FORMATS.md
@@ -40,6 +40,53 @@ parsed = parse_uri("git+https://github.com/org/repo@main#subdirectory=bundles/de
 # parsed.subpath = "bundles/dev"
 ```
 
+## Namespace Resolution with Subdirectories
+
+When loading a bundle via `#subdirectory=`, understand how the namespace and paths are determined:
+
+### Namespace Comes from bundle.name
+
+The namespace is **always** the `bundle.name` field from YAML frontmatter, NOT from the git URL:
+
+```
+# Repository structure:
+amplifier-expert-cookbook/          # Git repo root
+└── cli-tool-builder/               # Subdirectory containing bundle
+    ├── bundle.md                   # Has: bundle.name: cli-tool-builder
+    └── context/
+        └── instructions.md
+```
+
+When loaded via:
+```
+git+https://github.com/org/amplifier-expert-cookbook@main#subdirectory=cli-tool-builder
+```
+
+| Question | Answer |
+|----------|--------|
+| **Namespace is:** | `cli-tool-builder` (from `bundle.name`) |
+| **Namespace is NOT:** | `amplifier-expert-cookbook` (the repo name) |
+
+### Path Resolution
+
+Paths are relative to the **bundle root** (the subdirectory), not the git repository root:
+
+```yaml
+# ❌ WRONG: Including subdirectory in path
+context:
+  include:
+    - cli-tool-builder:cli-tool-builder/context/instructions.md  # Duplicates path!
+
+# ✅ CORRECT: Path relative to bundle root
+context:
+  include:
+    - cli-tool-builder:context/instructions.md
+```
+
+**Rule:** If you loaded via `#subdirectory=X`, you're already "inside" X. Don't repeat it in paths.
+
+---
+
 ## Reading the Source
 
 For complete URI parsing logic:


### PR DESCRIPTION
## Summary

- Added **Syntax Anti-Patterns** section to BUNDLE_GUIDE.md documenting common mistakes that cause silent failures
- Added **Syntax Quick Reference** table showing markdown vs YAML syntax differences
- Added **Namespace Resolution with Subdirectories** section to URI_FORMATS.md explaining path resolution

## Why this matters

All of these mistakes cause **silent failures** - content just doesn't load with no error message:

| Anti-Pattern | What Happens |
|--------------|--------------|
| Using `@` prefix in YAML `context.include` | Creates namespace `"@foundation"` which doesn't exist |
| Using repository name as namespace | References wrong bundle (e.g., `amplifier-foundation` vs `foundation`) |
| Including subdirectory in paths | Path doesn't exist relative to bundle root |
| Using `context.include` in markdown | YAML syntax in markdown is ignored |

These patterns were identified from real-world bundle authoring errors. The code has no validation to catch these errors, so documentation is the primary defense.

## Files Changed

- `docs/BUNDLE_GUIDE.md` - ~110 lines added (anti-patterns + quick reference)
- `docs/URI_FORMATS.md` - ~45 lines added (subdirectory namespace resolution)

## Test plan

- [x] Verified examples are accurate against codebase behavior
- [x] Confirmed via LSP analysis that these patterns cause silent failures
- [x] Documentation renders correctly in markdown preview

---

cc @robotdad for awareness

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>