### PR TITLE
feat: add amplifier-dev bundle for ecosystem development

### DIFF
--- a/agents/ecosystem-expert.md
+++ b/agents/ecosystem-expert.md
@@ -1,0 +1,101 @@
+---
+meta:
+  name: ecosystem-expert
+  description: "Amplifier ecosystem development specialist. Delegate for: multi-repo coordination, testing local changes, cross-repo workflows, working memory patterns. Example: 'How do I test changes across core and foundation?'"
+---
+
+# Amplifier Ecosystem Development Expert
+
+You are the specialist for **developing ON the Amplifier ecosystem itself** - not just using Amplifier, but contributing to its repos.
+
+## Your Knowledge
+
+@foundation:context/amplifier-dev/ecosystem-map.md
+@foundation:context/amplifier-dev/dev-workflows.md
+@foundation:context/amplifier-dev/testing-patterns.md
+
+## Your Role
+
+1. **Guide multi-repo development** - Help coordinate changes across amplifier-core, amplifier-foundation, modules, and bundles
+2. **Recommend testing patterns** - Local override → Shadow environment → Push & CI
+3. **Working memory guidance** - Help use SCRATCH.md effectively for long sessions
+4. **Cross-repo debugging** - Help trace issues across repo boundaries
+
+## Delegation Pattern
+
+You complement other experts - delegate when appropriate:
+
+| Question Type | Delegate To |
+|---------------|-------------|
+| "Which repo owns X?" | `amplifier:amplifier-expert` |
+| "What's the kernel contract for Y?" | `core:core-expert` |
+| "How do bundles compose?" | `foundation:foundation-expert` |
+| "Create a shadow environment" | `shadow:shadow-operator` |
+
+**You handle**: "How do I work on X effectively?" - the practical workflow questions.
+
+## Key Patterns You Teach
+
+### The Testing Ladder
+
+```
+4. Push & CI          (confidence: ████░)
+3. Shadow Environment (confidence: ███░░)  ← OS-isolated with local snapshots
+2. Local Override     (confidence: ██░░░)  ← settings.yaml source override
+1. Unit Tests         (confidence: █░░░░)  ← Module-level pytest
+```
+
+### Cross-Repo Change Workflow
+
+1. Create workspace: `amplifier-dev ~/work/my-feature`
+2. Identify affected repos (you help with this)
+3. Make changes in dependency order (core → foundation → modules → bundles)
+4. Test at each level
+5. Push in dependency order
+6. Destroy workspace when done
+
+### Working Memory (SCRATCH.md)
+
+For long sessions, maintain SCRATCH.md with:
+- Current focus (one sentence)
+- Key decisions made
+- Blockers/questions
+- Next actions
+
+Prune aggressively - if it doesn't inform the NEXT action, remove it.
+
+## Common Scenarios
+
+### "I need to change something in amplifier-core"
+
+1. Understand the change scope (kernel contract? module protocol? internal?)
+2. If contract change: identify all affected modules
+3. Recommend shadow testing before push
+4. Guide push order: core first, then dependent modules
+
+### "My change touches multiple repos"
+
+1. Map the dependency chain
+2. Create a workspace with all affected repos
+3. Make changes in dependency order
+4. Test incrementally (don't batch all changes)
+5. Push in dependency order
+
+### "How do I test this safely?"
+
+1. For module changes: unit tests + local override usually sufficient
+2. For core changes: shadow environment recommended
+3. For breaking changes: shadow environment required
+4. Guide through shadow tool usage or delegate to shadow-operator
+
+## Tools Available
+
+You have access to all foundation tools. For shadow environments, either:
+- Use the `shadow` tool directly if available
+- Delegate to `shadow:shadow-operator` for guidance
+
+## Philosophy Alignment
+
+- **Ruthless simplicity**: Recommend the simplest testing approach that provides confidence
+- **Bricks & studs**: Each repo is a brick - changes should maintain clean interfaces
+- **Mechanism not policy**: Guide workflows, don't enforce them

--- a/behaviors/amplifier-dev.yaml
+++ b/behaviors/amplifier-dev.yaml
@@ -1,0 +1,14 @@
+bundle:
+  name: behavior-amplifier-dev
+  version: 1.0.0
+  description: Amplifier ecosystem development behavior - multi-repo workflows, testing patterns, and ecosystem expertise
+
+agents:
+  include:
+    - foundation:ecosystem-expert
+
+context:
+  include:
+    - foundation:context/amplifier-dev/ecosystem-map.md
+    - foundation:context/amplifier-dev/dev-workflows.md
+    - foundation:context/amplifier-dev/testing-patterns.md

--- a/bundles/amplifier-dev.yaml
+++ b/bundles/amplifier-dev.yaml
@@ -1,0 +1,12 @@
+bundle:
+  name: amplifier-dev
+  version: 1.0.0
+  description: Bundle for developing ON the Amplifier ecosystem - multi-repo coordination, testing patterns, shadow integration
+
+includes:
+  # Base foundation capabilities
+  - bundle: foundation
+  # Shadow environment for isolated testing
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-shadow@main
+  # Amplifier dev behavior (agents + context)
+  - bundle: foundation:behaviors/amplifier-dev

--- a/context/amplifier-dev/dev-workflows.md
+++ b/context/amplifier-dev/dev-workflows.md
@@ -1,0 +1,223 @@
+# Amplifier Development Workflows
+
+## Workspace Lifecycle
+
+### Create → Work → Destroy Pattern
+
+```bash
+# 1. Create ephemeral workspace
+amplifier-dev ~/work/feature-name
+
+# 2. Work in the workspace (changes go to submodule repos)
+cd ~/work/feature-name
+# ... make changes, commit to submodules, push ...
+
+# 3. Destroy workspace when done
+amplifier-dev -d ~/work/feature-name
+```
+
+**Key insight**: The workspace itself is disposable. Your work persists because you push submodule changes to their repos.
+
+### Working Memory with SCRATCH.md
+
+For long sessions, maintain a `SCRATCH.md` file at workspace root:
+
+```markdown
+# Current Focus
+[One sentence: what are we doing RIGHT NOW]
+
+# Key Decisions
+- Decision: [what] → Reason: [why]
+
+# Blockers / Questions
+- [ ] Thing to resolve
+
+# Next Actions
+1. Immediate next step
+2. After that
+```
+
+**Pruning rule**: If it doesn't inform the NEXT action, remove it.
+
+## Cross-Repo Development Flow
+
+### Standard Flow
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ 1. Create workspace with affected repos                 │
+├─────────────────────────────────────────────────────────┤
+│ 2. Make changes in dependency order:                    │
+│    core → foundation → modules → bundles → apps         │
+├─────────────────────────────────────────────────────────┤
+│ 3. Test at each level (unit → local override → shadow)  │
+├─────────────────────────────────────────────────────────┤
+│ 4. Push in dependency order                             │
+├─────────────────────────────────────────────────────────┤
+│ 5. Destroy workspace                                    │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Dependency Order
+
+Always make changes and push in this order:
+
+1. **amplifier-core** (if kernel changes needed)
+2. **amplifier-foundation** (if foundation changes needed)
+3. **amplifier-module-*** (affected modules)
+4. **amplifier-bundle-*** (affected bundles)
+5. **amplifier-app-*** (affected apps)
+6. **amplifier** (docs, MODULES.md updates)
+
+## Common Workflows
+
+### Adding a Feature to a Module
+
+```bash
+# 1. Create minimal workspace
+amplifier-dev ~/work/module-feature
+cd ~/work/module-feature
+
+# 2. Add the module repo
+git submodule add https://github.com/microsoft/amplifier-module-xyz.git
+
+# 3. Make changes
+cd amplifier-module-xyz
+git checkout -b feat/my-feature
+# ... edit, test ...
+
+# 4. Test locally
+pytest tests/
+
+# 5. Push
+git push origin feat/my-feature
+# Create PR
+
+# 6. Cleanup
+cd ~/work
+amplifier-dev -d ~/work/module-feature
+```
+
+### Changing Core + Dependent Module
+
+```bash
+# 1. Workspace with both repos
+amplifier-dev ~/work/core-change
+
+# 2. Make core changes first
+cd amplifier-core
+git checkout -b feat/new-capability
+# ... make changes ...
+pytest tests/
+
+# 3. Update module to use new capability
+cd ../amplifier-module-xyz
+git checkout -b feat/use-new-capability
+# ... make changes ...
+pytest tests/
+
+# 4. Shadow test (critical for core changes)
+# Use shadow tool to test module works with local core changes
+
+# 5. Push core first
+cd ../amplifier-core
+git push origin feat/new-capability
+# Wait for CI, merge
+
+# 6. Then push module
+cd ../amplifier-module-xyz
+git push origin feat/use-new-capability
+```
+
+### Adding a New Bundle
+
+```bash
+# 1. Create the bundle repo on GitHub first
+# microsoft/amplifier-bundle-newbundle
+
+# 2. Clone and structure
+git clone https://github.com/microsoft/amplifier-bundle-newbundle.git
+cd amplifier-bundle-newbundle
+
+# 3. Create bundle structure
+mkdir -p behaviors agents context docs
+
+# 4. Create bundle.md (see BUNDLE_GUIDE.md for details)
+cat > bundle.md << 'EOF'
+---
+bundle:
+  name: newbundle
+  version: 1.0.0
+  description: Description of what this bundle provides
+
+includes:
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main
+  - bundle: newbundle:behaviors/main
+---
+
+# New Bundle
+
+@newbundle:context/instructions.md
+
+---
+
+@foundation:context/shared/common-system-base.md
+EOF
+
+# 5. Add to MODULES.md
+# Edit amplifier/docs/MODULES.md to include new bundle
+```
+
+## Git Workflow
+
+### Commit Message Format
+
+```
+type: short description
+
+Longer explanation if needed.
+
+🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
+```
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+
+### Branch Naming
+
+- `feat/description` - New features
+- `fix/description` - Bug fixes
+- `docs/description` - Documentation
+- `refactor/description` - Code restructuring
+
+### PR Process
+
+1. Push branch to origin
+2. Create PR with clear description
+3. Link related PRs if cross-repo change
+4. Wait for CI
+5. Request review if needed
+6. Squash merge
+
+## Debugging Cross-Repo Issues
+
+### Issue in Module Using Core
+
+1. Identify which core API the module calls
+2. Check if core API contract changed
+3. Test with pinned core version to isolate
+4. Use shadow environment to test fix
+
+### Issue in Bundle Composition
+
+1. Validate bundle YAML syntax
+2. Check include paths resolve correctly
+3. Test with `amplifier bundle validate`
+4. Load bundle and check agent availability
+
+### Issue in App
+
+1. Check if foundation or core changed
+2. Test with pinned dependencies
+3. Use local source overrides to test fixes

--- a/context/amplifier-dev/ecosystem-map.md
+++ b/context/amplifier-dev/ecosystem-map.md
@@ -1,0 +1,118 @@
+# Amplifier Ecosystem Map
+
+## Dependency Hierarchy
+
+```
+                      amplifier (entry point, docs, governance)
+                           │
+                           ▼
+                     amplifier-app-cli (reference CLI app)
+                      │           │
+          ┌──────────┘           └──────────┐
+          ▼                                  ▼
+    amplifier-foundation              amplifier-core
+    (bundle primitives,               (kernel, contracts,
+     shared utilities)                 session lifecycle)
+          │                                  │
+          │                                  ▼
+          │                           [ALL MODULES]
+          │                                ▲
+          └────────────────────────────────┘
+                (modules import core, never foundation)
+```
+
+## Repository Roles
+
+| Repository | Role | Changes Here Affect |
+|------------|------|---------------------|
+| **amplifier** | Entry point, docs, governance | User onboarding, ecosystem rules |
+| **amplifier-core** | Kernel, contracts, protocols | ALL modules and apps |
+| **amplifier-foundation** | Bundle primitives, utilities | Apps using foundation |
+| **amplifier-app-cli** | Reference CLI implementation | End users |
+| **amplifier-bundle-*** | Capability bundles | Users of that bundle |
+| **amplifier-module-*** | Runtime modules | Sessions using that module |
+
+## Change Impact Matrix
+
+| If You Change... | Test By... | Push Order |
+|------------------|------------|------------|
+| amplifier-core contracts | Shadow env with ALL dependent modules | Core first, then modules |
+| amplifier-core internals | Unit tests + shadow with sample modules | Core only |
+| amplifier-foundation | Direct tests + app integration | Foundation first |
+| A module | Module unit tests | Module only (isolated) |
+| A bundle | Load bundle, verify composition | Bundle only |
+| amplifier-app-cli | Integration tests | After dependencies |
+
+## Architectural Boundaries
+
+### The Kernel Boundary
+```
+┌─────────────────────────────────────────┐
+│           Applications                   │
+│  (amplifier-app-cli, custom apps)       │
+├─────────────────────────────────────────┤
+│           Libraries                      │
+│  (amplifier-foundation)                 │
+├─────────────────────────────────────────┤
+│           Kernel                         │  ← Stability boundary
+│  (amplifier-core)                       │
+├─────────────────────────────────────────┤
+│           Modules                        │
+│  (providers, tools, hooks, etc.)        │
+└─────────────────────────────────────────┘
+```
+
+**Key rule**: Modules depend ONLY on amplifier-core, never on foundation or apps.
+
+### Bundle vs Module
+
+| Aspect | Bundle | Module |
+|--------|--------|--------|
+| Contains | YAML config, context, agent definitions | Python code |
+| Depends on | Other bundles | Only amplifier-core |
+| Changes require | No code changes to Amplifier | Module protocol compliance |
+| Testing | Load and verify composition | Unit tests + integration |
+
+## Multi-Repo Workspace Pattern
+
+When working across repos, use `amplifier-dev` to create ephemeral workspaces:
+
+```bash
+# Create workspace with all core repos as submodules
+amplifier-dev ~/work/my-feature
+
+# Structure created:
+~/work/my-feature/
+├── AGENTS.md           # Workspace context
+├── amplifier/          # submodule
+├── amplifier-core/     # submodule
+├── amplifier-foundation/  # submodule
+└── [other repos as needed]
+```
+
+## Common Cross-Repo Scenarios
+
+### Adding a New Module Protocol
+
+1. Define contract in `amplifier-core/docs/contracts/`
+2. Update kernel to support new protocol
+3. Create reference implementation as a module
+4. Document in `amplifier/docs/MODULES.md`
+
+### Adding a New Bundle
+
+1. Create repo `amplifier-bundle-<name>`
+2. Define bundle.md with composition
+3. Add to `amplifier/docs/MODULES.md`
+4. (Optional) Add behavior to foundation for reuse
+
+### Changing a Kernel Contract
+
+**High-impact change** - requires careful coordination:
+
+1. Design change, document in spec
+2. Implement in core with backward compatibility if possible
+3. Test ALL affected modules in shadow environment
+4. Update modules to use new contract
+5. Push core, then modules
+6. Deprecation period if breaking

--- a/context/amplifier-dev/testing-patterns.md
+++ b/context/amplifier-dev/testing-patterns.md
@@ -1,0 +1,218 @@
+# Amplifier Testing Patterns
+
+## The Testing Ladder
+
+Each level provides more confidence but requires more setup:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ 4. Push & CI              (confidence: ████░)           │
+│    Full CI pipeline, all tests, real dependencies       │
+├─────────────────────────────────────────────────────────┤
+│ 3. Shadow Environment     (confidence: ███░░)           │
+│    OS-isolated sandbox with local source snapshots      │
+│    Tests: Does my change work with other local changes? │
+├─────────────────────────────────────────────────────────┤
+│ 2. Local Source Override  (confidence: ██░░░)           │
+│    settings.yaml points to local checkout               │
+│    Tests: Does Amplifier load my local module?          │
+├─────────────────────────────────────────────────────────┤
+│ 1. Unit Tests             (confidence: █░░░░)           │
+│    pytest in the module/repo                            │
+│    Tests: Does my code work in isolation?               │
+└─────────────────────────────────────────────────────────┘
+```
+
+## When to Use Each Level
+
+| Change Type | Minimum Testing Level |
+|-------------|----------------------|
+| Module internal change | 1. Unit tests |
+| Module API change | 2. Local override |
+| Core internal change | 2. Local override + sample modules |
+| Core contract change | 3. Shadow environment |
+| Multi-repo coordinated change | 3. Shadow environment |
+| Breaking change | 3. Shadow + careful push order |
+
+## Level 1: Unit Tests
+
+Standard pytest in the repo:
+
+```bash
+cd amplifier-module-xyz
+pytest tests/ -v
+
+# With coverage
+pytest tests/ --cov=amplifier_module_xyz
+```
+
+**When sufficient**: Internal changes that don't affect the public API.
+
+## Level 2: Local Source Override
+
+Use `.amplifier/settings.yaml` to point to local checkouts:
+
+```yaml
+# .amplifier/settings.yaml
+sources:
+  # Override a module to use local version
+  amplifier-module-xyz:
+    type: local
+    path: /home/user/repos/amplifier-module-xyz
+    
+  # Override core (rarely needed)
+  amplifier-core:
+    type: local
+    path: /home/user/repos/amplifier-core
+```
+
+Then run Amplifier normally - it will use your local sources.
+
+**When sufficient**: Testing that Amplifier correctly loads and uses your changes.
+
+## Level 3: Shadow Environment
+
+For testing changes that span multiple repos or need isolation:
+
+```bash
+# Create shadow environment with local sources
+amplifier shadow create \
+  --local-source amplifier-core:/path/to/amplifier-core \
+  --local-source amplifier-foundation:/path/to/amplifier-foundation
+
+# Run Amplifier in the shadow
+amplifier shadow run interactive
+
+# Clean up
+amplifier shadow destroy
+```
+
+### What Shadow Provides
+
+1. **OS-level isolation** - Sandboxed filesystem (bubblewrap on Linux, sandbox-exec on macOS)
+2. **Local source snapshots** - Your uncommitted changes captured as bare git repos
+3. **Git URL rewriting** - `git clone https://github.com/microsoft/amplifier-core` fetches from local snapshot
+4. **Full network access** - Can still reach PyPI, other dependencies
+
+### When to Use Shadow
+
+- Testing core changes with module compatibility
+- Testing multi-repo changes together
+- Verifying `uv tool install` works with your changes
+- Destructive tests that shouldn't affect real environment
+
+### Shadow Workflow
+
+```bash
+# 1. Make changes in your local repos (don't need to commit)
+
+# 2. Create shadow with those changes
+amplifier shadow create \
+  --local-source amplifier-core:~/repos/amplifier-core \
+  --local-source amplifier-module-xyz:~/repos/amplifier-module-xyz
+
+# 3. Test in shadow
+amplifier shadow run interactive
+# or
+amplifier shadow run -- pytest tests/
+
+# 4. If tests pass, commit and push your changes
+
+# 5. Destroy shadow
+amplifier shadow destroy
+```
+
+## Level 4: Push & CI
+
+Full CI validation on GitHub:
+
+1. Push branch
+2. CI runs all tests
+3. Integration tests with real dependencies
+4. Cross-repo CI if configured
+
+**When required**: Before merging any PR.
+
+## Testing Specific Scenarios
+
+### Testing a New Module
+
+```bash
+# 1. Unit tests
+cd amplifier-module-new
+pytest tests/
+
+# 2. Local override test
+# In a test project:
+cat > .amplifier/settings.yaml << EOF
+sources:
+  amplifier-module-new:
+    type: local
+    path: /path/to/amplifier-module-new
+EOF
+amplifier interactive
+# Verify module loads and works
+
+# 3. Push and verify CI
+```
+
+### Testing Core Contract Change
+
+```bash
+# 1. Unit tests in core
+cd amplifier-core
+pytest tests/
+
+# 2. Shadow test with dependent modules
+amplifier shadow create \
+  --local-source amplifier-core:. \
+  --local-source amplifier-module-affected1:/path/to/module1 \
+  --local-source amplifier-module-affected2:/path/to/module2
+
+amplifier shadow run -- pytest  # Run all module tests in shadow
+
+# 3. If passing, push core first
+git push origin feat/contract-change
+# Wait for merge
+
+# 4. Then update and push modules
+```
+
+### Testing Bundle Composition
+
+```bash
+# 1. Validate YAML
+amplifier bundle validate path/to/bundle.md
+
+# 2. Load and check
+amplifier bundle use path/to/bundle.md
+amplifier interactive
+# Verify agents available, context loaded
+
+# 3. Test specific agents
+> List available agents
+> Use the new-agent to do X
+```
+
+## Debugging Test Failures
+
+### Module Won't Load
+
+1. Check module exports in `__init__.py`
+2. Verify protocol compliance (Tool, Provider, etc.)
+3. Check for missing dependencies
+4. Use `amplifier --verbose` to see load errors
+
+### Shadow Environment Issues
+
+1. Verify local paths are correct
+2. Check that repos have content (not empty)
+3. On Linux, verify bubblewrap is installed: `which bwrap`
+4. On macOS, sandbox-exec should be available by default
+
+### Integration Test Failures
+
+1. Check if dependency versions changed
+2. Verify all local changes are captured in shadow
+3. Test each repo individually first
+4. Check push order - did you push dependencies first?


### PR DESCRIPTION
## Summary

Adds the **amplifier-dev** bundle - a specialized configuration for developing ON the Amplifier ecosystem itself.

## What's Included

### New Agent: `ecosystem-expert`
- Multi-repo coordination guidance
- Testing ladder recommendations (unit → local override → shadow → CI)
- Cross-repo workflow patterns
- Working memory (SCRATCH.md) guidance

### Context Files
- `ecosystem-map.md` - How repos relate, dependency hierarchy, change impact matrix
- `dev-workflows.md` - Workspace lifecycle, cross-repo development flow, git workflow
- `testing-patterns.md` - The testing ladder, when to use each level, debugging patterns

### Bundle Configuration
- `bundles/amplifier-dev.yaml` - Standalone bundle that includes foundation + shadow + dev behavior
- `behaviors/amplifier-dev.yaml` - Reusable behavior for mixing into other bundles

## Usage

```bash
# Use directly
amplifier run --bundle amplifier-dev --mode chat

# Or via amplifier-cli-tools (after companion PR merged)
amplifier-dev ~/work/my-feature
```

## Integration

This bundle is designed to work with:
- **amplifier-bundle-shadow** - For isolated testing of local changes
- **amplifier-cli-tools** - For workspace lifecycle management

## Related PRs

- amplifier-cli-tools: bkrabach/amplifier-cli-tools (feat/bundle-support branch)
