### PR TITLE
fix: correct event registration for session naming hook

### DIFF
--- a/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
+++ b/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
@@ -457,10 +457,10 @@ async def mount(
 
     hook = SessionNamingHook(coordinator, hook_config)
 
-    # Register for prompt completion events (fires after each turn)
+    # Register for orchestrator completion events (fires after each turn)
     # Use low priority (high number) so we run after other hooks
     coordinator.hooks.register(
-        "prompt:complete",
+        "orchestrator:complete",
         hook.on_orchestrator_complete,
         priority=100,
         name="session-naming",


### PR DESCRIPTION
## Summary

The session-naming hook was registering for `prompt:complete` but the orchestrator emits `orchestrator:complete`. These are different events, so the hook was never triggered and sessions were never auto-named.

Changed the event registration from `prompt:complete` to `orchestrator:complete` to match what the loop-streaming orchestrator actually emits.

## Test plan

- [x] Verified the orchestrator emits `orchestrator:complete` events
- [x] Confirmed session naming hook now triggers correctly
- [x] Sessions are auto-named after conversation completes

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>