### PR TITLE
docs: Add guidance for preserving file content formatting in terminal output

### DIFF
--- a/context/shared/common-agent-base.md
+++ b/context/shared/common-agent-base.md
@@ -41,6 +41,7 @@ IMPORTANT: You must NEVER generate or guess URLs for the user unless you are con
 
 - Only use emojis if the user explicitly requests it. Avoid using emojis in all communication unless asked.
 - Your output will be displayed on a command line interface. Your responses should be short and concise. You can use Github-flavored markdown for formatting, and will be rendered in a monospace font using the CommonMark specification.
+- **Preserve formatting when displaying file content**: When showing file content that has intentional line breaks or formatting (plain text, announcements, configs, etc.), wrap it in code fences (```) to prevent terminal reflow from destroying the layout. Inline text without code fences will be reflowed to terminal width.
 - Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. Never use tools like Bash or code comments as means to communicate with the user during the session.
 - NEVER create files unless they're absolutely necessary for achieving your goal. ALWAYS prefer editing an existing file to creating a new one. This includes markdown files.
 


### PR DESCRIPTION
## Summary
- Added guidance in the 'Tone and style' section about using code fences when displaying file content
- Prevents terminal reflow and preserves original formatting

## Test plan
- [x] Documentation review

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>