### PR TITLE
docs: fix install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Foundation provides:
 ## Quick Start
 
 ```bash
-pip install amplifier-foundation
+pip install git+https://github.com/microsoft/amplifier-foundation
 ```
 
 ### Load, Compose, and Execute


### PR DESCRIPTION
## Summary

- Fixed incorrect install command in README.md line 14
- Changed `pip install amplifier-foundation` to `pip install git+https://github.com/microsoft/amplifier-foundation`
- The package is not published on PyPI, only available via git install

## Test plan

- [x] Verified the new install command works correctly
- [ ] Review that documentation renders correctly

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>