### PR TITLE
feat: add hook-shell module to foundation bundle

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -38,6 +38,7 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-bundle-python-dev@main
   - bundle: git+https://github.com/microsoft/amplifier-bundle-shadow@main
   - bundle: git+https://github.com/microsoft/amplifier-module-tool-skills@main#subdirectory=behaviors/skills.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-module-hook-shell@main#subdirectory=behaviors/hook-shell.yaml
 
 
 session:


### PR DESCRIPTION
## Summary

Adds shell hooks support to the foundation bundle via behavior bundle reference.

## Changes

- Added `hook-shell-behavior` to includes in bundle.md

## What This Enables

Shell-based hooks for Amplifier lifecycle events:
- `tool:pre` / `tool:post` - Before/after tool execution
- `prompt:submit` - When user submits a prompt
- `session:start` / `session:end` - Session lifecycle
- `skill:loaded` / `skill:unloaded` - Skill lifecycle (integrates with tool-skills)
- And more (see [hook-shell README](https://github.com/microsoft/amplifier-module-hook-shell))

## Integration with tool-skills

When a skill is loaded with hooks configuration, hook-shell automatically activates those hooks:

```yaml
# In a skill's SKILL.md frontmatter
hooks:
  - event: user-prompt-submit
    command: ./validate.sh
```

This enables skills to bring their own hooks that are active only while the skill is loaded.

## Testing

- Validated bundle syntax via shadow environment
- hook-shell module tests pass (43 tests in tool-skills, hook-shell unit tests)

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>