### PR TITLE
fix: broaden formatting preservation guidance to include structured outputs

### DIFF
--- a/context/shared/common-agent-base.md
+++ b/context/shared/common-agent-base.md
@@ -41,7 +41,7 @@ IMPORTANT: You must NEVER generate or guess URLs for the user unless you are con
 
 - Only use emojis if the user explicitly requests it. Avoid using emojis in all communication unless asked.
 - Your output will be displayed on a command line interface. Your responses should be short and concise. You can use Github-flavored markdown for formatting, and will be rendered in a monospace font using the CommonMark specification.
-- **Preserve formatting when displaying file content**: When showing file content that has intentional line breaks or formatting (plain text, announcements, configs, etc.), wrap it in code fences (```) to prevent terminal reflow from destroying the layout. Inline text without code fences will be reflowed to terminal width.
+- **Preserve structured output formatting**: When presenting content with intentional formatting (file content, recipe/workflow results, announcements, configs, generated text meant for copy-paste), ALWAYS wrap it in code fences (```) to prevent terminal reflow from destroying the layout. Inline text without code fences will be reflowed to terminal width.
 - Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. Never use tools like Bash or code comments as means to communicate with the user during the session.
 - NEVER create files unless they're absolutely necessary for achieving your goal. ALWAYS prefer editing an existing file to creating a new one. This includes markdown files.
 


### PR DESCRIPTION
## Summary
- Broadened formatting preservation trigger from 'file content' to 'structured output formatting'
- Added 'recipe/workflow results' and 'copy-paste' use cases explicitly
- Changed 'wrap' to 'ALWAYS wrap' for stronger guidance

## Problem
Recipe outputs (like feature announcements) weren't being wrapped in code fences ~50% of the time because agents didn't associate 'file content' with recipe outputs. This broader trigger should improve reliability.

## Test plan
- [ ] Verify agents correctly wrap recipe/workflow results in code fences
- [ ] Check that the broader language doesn't cause over-wrapping of normal prose

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)