### PR TITLE
feat: Add analysis paralysis prevention for implementation agents

### DIFF
--- a/agents/modular-builder.md
+++ b/agents/modular-builder.md
@@ -16,6 +16,58 @@ tools:
 
 You are the primary implementation agent, building code from specifications created by the zen-architect. You follow the "bricks and studs" philosophy to create self-contained, regeneratable modules with clear contracts.
 
+## CRITICAL: Anti-Paralysis Rules
+
+**You are an IMPLEMENTATION agent, not a research agent.** Your job is to BUILD, not to endlessly analyze.
+
+### The 3-Read Rule
+
+**If you read the same file 3 times, STOP READING and START IMPLEMENTING.**
+
+You have enough information. Analysis paralysis is your enemy. Implement with what you know and iterate.
+
+### The 20-Read Checkpoint
+
+**After 20 file reads without a write_file or edit_file, you MUST:**
+
+1. STOP all research immediately
+2. Write at least ONE file (even a skeleton/stub)
+3. Only then continue with targeted reads
+
+If you find yourself thinking "I need to understand X better before I can implement", you are in paralysis. Implement what you know, then learn from the gaps.
+
+### Phase Gates
+
+| Phase | Duration | Activities | Exit Criteria |
+|-------|----------|------------|---------------|
+| **Research** | First 10 reads max | Understand interfaces, find examples | Have enough to start |
+| **Implementation** | Unlimited | Write code, run tests, iterate | Feature complete |
+| **Refinement** | As needed | Polish, optimize, document | Meets spec |
+
+**Once you exit Research phase, you may NOT return to pure research.** Any further reads must be targeted to solve a specific implementation problem.
+
+### Forbidden Patterns
+
+- Reading the same file repeatedly "to make sure"
+- Searching for "how others did it" after already seeing examples
+- Waiting for "complete understanding" before starting
+- Re-analyzing code you've already read
+
+### Implementation-First Mindset
+
+```
+WRONG: "Let me read more files to understand the full picture..."
+RIGHT: "I have enough context. Let me write a skeleton and see what breaks."
+
+WRONG: "I should check how this is used elsewhere before implementing..."
+RIGHT: "I'll implement to the spec and fix integration issues as I find them."
+
+WRONG: "Let me search for similar patterns in the codebase..."
+RIGHT: "I'll write my implementation and refactor if I discover better patterns."
+```
+
+**Remember**: Working code that needs iteration is infinitely more valuable than perfect understanding with zero output.
+
 ## LSP-Enhanced Implementation
 
 You have access to **LSP (Language Server Protocol)** for semantic code intelligence. Use it to understand existing code before modifying:

--- a/behaviors/progress-monitor.yaml
+++ b/behaviors/progress-monitor.yaml
@@ -1,0 +1,20 @@
+# Progress Monitor Behavior
+#
+# Detects analysis paralysis patterns and injects corrective prompts.
+# Include this behavior in bundles where agents may get stuck in research loops.
+#
+# Usage:
+#   includes:
+#     - bundle: foundation:behaviors/progress-monitor
+#
+# This is particularly useful for implementation agents like modular-builder
+# that might over-research before implementing.
+
+hooks:
+  - module: hooks-progress-monitor
+    source: foundation:modules/hooks-progress-monitor
+    config:
+      enabled: true
+      read_threshold: 30      # Warn after 30 reads with 0 writes
+      same_file_threshold: 3  # Warn after reading same file 3 times
+      warning_interval: 15    # Re-warn every 15 additional reads

--- a/modules/hooks-progress-monitor/README.md
+++ b/modules/hooks-progress-monitor/README.md
@@ -1,0 +1,53 @@
+# Progress Monitor Hook
+
+Detects analysis paralysis patterns and injects corrective prompts to keep agents productive.
+
+## Problem It Solves
+
+Agents can get stuck in "analysis paralysis" - endlessly reading files and searching without ever writing code. This hook monitors the read/write ratio and injects warnings when patterns suggest the agent is stuck.
+
+## Detection Patterns
+
+| Pattern | Threshold | Action |
+|---------|-----------|--------|
+| High read/write ratio | 30 reads with 0 writes | Inject warning to start implementing |
+| Repeated file reads | Same file read 3 times | Remind agent they have enough info |
+| Continued paralysis | Every 15 additional reads | Escalating warnings |
+
+## Configuration
+
+```yaml
+hooks:
+  - module: hooks-progress-monitor
+    source: foundation:modules/hooks-progress-monitor
+    config:
+      enabled: true           # Enable/disable (default: true)
+      read_threshold: 30      # Reads before first warning (default: 30)
+      same_file_threshold: 3  # Same-file reads before warning (default: 3)
+      warning_interval: 15    # Reads between repeated warnings (default: 15)
+```
+
+## Warning Escalation
+
+The hook escalates urgency with repeated warnings:
+
+1. **First warning** (at read_threshold): "Note: Consider starting implementation..."
+2. **Second warning** (+warning_interval reads): "Warning: You should start implementing NOW..."
+3. **Third+ warning** (+warning_interval reads): "CRITICAL: STOP READING. Write code IMMEDIATELY..."
+
+## Reset Behavior
+
+Warnings reset when the agent writes a file (write_file or edit_file). This indicates progress is being made.
+
+## Tracked Operations
+
+**Read operations** (increment counter):
+- `read_file`
+- `grep`
+- `glob`
+- `web_fetch`
+- `web_search`
+
+**Write operations** (reset warning state):
+- `write_file`
+- `edit_file`

--- a/modules/hooks-progress-monitor/amplifier_module_hooks_progress_monitor/__init__.py
+++ b/modules/hooks-progress-monitor/amplifier_module_hooks_progress_monitor/__init__.py
@@ -1,0 +1,239 @@
+"""Progress Monitor Hooks Module
+
+Detects analysis paralysis patterns and injects corrective prompts.
+
+Monitors the ratio of read operations (read_file, grep, glob, web_fetch, web_search)
+to write operations (write_file, edit_file) and injects warnings when agents appear
+stuck in endless research loops.
+
+Detection Patterns:
+- High read/write ratio: Many reads with zero writes suggests analysis paralysis
+- Repeated file reads: Reading the same file multiple times indicates uncertainty
+- Endless web research: Excessive web searches without implementation
+
+Thresholds (configurable):
+- read_threshold: Trigger warning after N reads with 0 writes (default: 30)
+- same_file_threshold: Warn after reading same file N times (default: 3)
+- warning_interval: Re-warn every N additional reads (default: 15)
+"""
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+from amplifier_core import HookResult
+
+
+# Read operation tools
+READ_TOOLS = frozenset(
+    {
+        "read_file",
+        "grep",
+        "glob",
+        "web_fetch",
+        "web_search",
+    }
+)
+
+# Write operation tools
+WRITE_TOOLS = frozenset(
+    {
+        "write_file",
+        "edit_file",
+    }
+)
+
+
+@dataclass
+class ProgressMonitorConfig:
+    """Configuration for progress monitoring."""
+
+    read_threshold: int = 30  # Warn after this many reads with 0 writes
+    same_file_threshold: int = 3  # Warn after reading same file this many times
+    warning_interval: int = 15  # Re-warn every N additional reads
+    enabled: bool = True
+
+
+@dataclass
+class ProgressState:
+    """Tracks read/write progress within a session."""
+
+    read_count: int = 0
+    write_count: int = 0
+    file_read_counts: dict[str, int] = field(default_factory=dict)
+    last_warning_at: int = 0  # Read count when last warning was issued
+    warnings_issued: int = 0
+
+
+class ProgressMonitorHooks:
+    """Hook handlers for detecting analysis paralysis."""
+
+    def __init__(self, config: ProgressMonitorConfig):
+        self.config = config
+        # Track state per session (keyed by session_id)
+        self._states: dict[str, ProgressState] = {}
+
+    def _get_state(self, session_id: str) -> ProgressState:
+        """Get or create state for a session."""
+        if session_id not in self._states:
+            self._states[session_id] = ProgressState()
+        return self._states[session_id]
+
+    async def handle_tool_post(self, _event: str, data: dict[str, Any]) -> HookResult:
+        """Track tool usage and detect paralysis patterns."""
+        if not self.config.enabled:
+            return HookResult(action="continue")
+
+        tool_name = data.get("tool_name", "")
+        session_id = data.get("session_id", "default")
+        state = self._get_state(session_id)
+
+        # Track write operations
+        if tool_name in WRITE_TOOLS:
+            state.write_count += 1
+            # Reset warning state on writes - agent is making progress
+            state.last_warning_at = 0
+            state.warnings_issued = 0
+            return HookResult(action="continue")
+
+        # Track read operations
+        if tool_name in READ_TOOLS:
+            state.read_count += 1
+
+            # Track specific file reads
+            if tool_name == "read_file":
+                tool_input = data.get("tool_input", {})
+                if isinstance(tool_input, dict):
+                    file_path = tool_input.get("file_path", "")
+                    if file_path:
+                        state.file_read_counts[file_path] = (
+                            state.file_read_counts.get(file_path, 0) + 1
+                        )
+
+                        # Check for repeated file reads
+                        if (
+                            state.file_read_counts[file_path]
+                            == self.config.same_file_threshold
+                        ):
+                            return self._inject_same_file_warning(file_path, state)
+
+            # Check for high read count with no writes
+            if (
+                state.write_count == 0
+                and state.read_count >= self.config.read_threshold
+            ):
+                reads_since_warning = state.read_count - state.last_warning_at
+
+                # Issue warning at threshold and then at intervals
+                if (
+                    state.last_warning_at == 0
+                    or reads_since_warning >= self.config.warning_interval
+                ):
+                    return self._inject_paralysis_warning(state)
+
+        return HookResult(action="continue")
+
+    def _inject_paralysis_warning(self, state: ProgressState) -> HookResult:
+        """Inject a warning about potential analysis paralysis."""
+        state.last_warning_at = state.read_count
+        state.warnings_issued += 1
+
+        # Escalate urgency with repeated warnings
+        if state.warnings_issued == 1:
+            urgency = "Note"
+            instruction = "Consider starting implementation with what you know."
+        elif state.warnings_issued == 2:
+            urgency = "Warning"
+            instruction = "You should start implementing NOW. Write a file, even if it's just a skeleton."
+        else:
+            urgency = "CRITICAL"
+            instruction = (
+                "STOP READING. Write code IMMEDIATELY. You have enough information."
+            )
+
+        warning = f"""<system-reminder source="hooks-progress-monitor">
+**{urgency}: Potential Analysis Paralysis Detected**
+
+You have performed {state.read_count} read operations with 0 write operations.
+
+{instruction}
+
+Remember:
+- Working code that needs iteration > perfect understanding with zero output
+- If you've read a file 3+ times, you have enough information
+- Implementation reveals gaps faster than research
+
+This is warning #{state.warnings_issued}. Please make progress.
+</system-reminder>"""
+
+        return HookResult(
+            action="inject_context",
+            context_injection=warning,
+            context_injection_role="user",
+            ephemeral=True,
+            append_to_last_tool_result=True,
+        )
+
+    def _inject_same_file_warning(
+        self, file_path: str, state: ProgressState
+    ) -> HookResult:
+        """Inject a warning about reading the same file repeatedly."""
+        # Extract just the filename for readability
+        filename = file_path.split("/")[-1] if "/" in file_path else file_path
+
+        warning = f"""<system-reminder source="hooks-progress-monitor">
+**Note: Repeated File Read Detected**
+
+You have read `{filename}` {self.config.same_file_threshold} times.
+
+If you're re-reading to "make sure" or "understand better", STOP.
+You have the information you need. Start implementing.
+
+The 3-Read Rule: After reading a file 3 times, you must implement, not read again.
+</system-reminder>"""
+
+        return HookResult(
+            action="inject_context",
+            context_injection=warning,
+            context_injection_role="user",
+            ephemeral=True,
+            append_to_last_tool_result=True,
+        )
+
+
+async def mount(
+    coordinator: Any, config: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Mount the progress monitor hooks module.
+
+    Config options:
+        enabled: bool (default: True) - Enable/disable monitoring
+        read_threshold: int (default: 30) - Reads before first warning
+        same_file_threshold: int (default: 3) - Same-file reads before warning
+        warning_interval: int (default: 15) - Reads between repeated warnings
+    """
+    config = config or {}
+
+    monitor_config = ProgressMonitorConfig(
+        enabled=config.get("enabled", True),
+        read_threshold=config.get("read_threshold", 30),
+        same_file_threshold=config.get("same_file_threshold", 3),
+        warning_interval=config.get("warning_interval", 15),
+    )
+
+    hooks = ProgressMonitorHooks(monitor_config)
+
+    # Register hook - runs after tool execution to track operations
+    coordinator.hooks.register("tool:post", hooks.handle_tool_post, priority=50)
+
+    return {
+        "name": "hooks-progress-monitor",
+        "version": "0.1.0",
+        "description": "Detects analysis paralysis and injects corrective prompts",
+        "config": {
+            "enabled": monitor_config.enabled,
+            "read_threshold": monitor_config.read_threshold,
+            "same_file_threshold": monitor_config.same_file_threshold,
+            "warning_interval": monitor_config.warning_interval,
+        },
+    }

--- a/modules/hooks-progress-monitor/pyproject.toml
+++ b/modules/hooks-progress-monitor/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "amplifier-module-hooks-progress-monitor"
+version = "0.1.0"
+description = "Progress monitoring hook that detects analysis paralysis patterns"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = ["amplifier-core>=1.0.0"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary

Adds two layers of defense against analysis paralysis in implementation agents, addressing sessions where agents ran 7+ hours making 570+ tool calls with zero file writes.

## Problem

Session analysis revealed that sub-agent sessions (like modular-builder) were getting stuck in endless research loops:
- Reading the same files repeatedly
- Doing web searches without implementing
- Never writing any code despite hours of "research"

This pattern wastes resources and produces no output.

## Solution

### 1. Soft Layer: Agent Instructions (modular-builder.md)

Added a **"CRITICAL: Anti-Paralysis Rules"** section with:

| Rule | Description |
|------|-------------|
| **3-Read Rule** | If you read the same file 3 times, STOP and implement |
| **20-Read Checkpoint** | After 20 reads without a write, must write something |
| **Phase Gates** | Research limited to first 10 reads, then implementation only |
| **Forbidden Patterns** | Explicit patterns to avoid (repeated reads, endless searching) |
| **Implementation-First Mindset** | Examples of wrong vs right thinking |

### 2. Hard Layer: Runtime Hook (hooks-progress-monitor)

New hook module that monitors tool usage and injects corrective prompts:

**Detection:**
- Tracks read operations: `read_file`, `grep`, `glob`, `web_fetch`, `web_search`
- Tracks write operations: `write_file`, `edit_file`
- Monitors read/write ratio and repeated file reads

**Warnings (escalating):**
1. First warning at 30 reads with 0 writes: "Note: Consider starting implementation..."
2. Second warning: "Warning: You should start implementing NOW..."
3. Third+ warning: "CRITICAL: STOP READING. Write code IMMEDIATELY..."

**Reset:** Warnings reset when agent writes a file (progress detected)

### 3. Behavior File (progress-monitor.yaml)

Easy inclusion in bundles:
```yaml
includes:
  - bundle: foundation:behaviors/progress-monitor
```

## Files Changed

| File | Change |
|------|--------|
| `agents/modular-builder.md` | Added anti-paralysis rules section |
| `behaviors/progress-monitor.yaml` | New behavior for hook inclusion |
| `modules/hooks-progress-monitor/` | New hook module |

## Why Two Layers?

1. **Soft layer (instructions)** guides agents toward implementation-first behavior proactively
2. **Hard layer (hook)** provides a safety net that detects paralysis at runtime, even if the agent ignores instructions

## Testing Considerations

- Hook tracks state per-session, so multi-session scenarios work correctly
- Warnings are ephemeral (not persisted in context)
- Reset on writes prevents false positives when agent is making progress

## Configuration

The hook is configurable via behavior:
```yaml
config:
  enabled: true
  read_threshold: 30      # Reads before first warning
  same_file_threshold: 3  # Same-file reads before warning  
  warning_interval: 15    # Reads between repeated warnings
```