### PR TITLE
feat: add shadow-amplifier behavior for Amplifier ecosystem testing

### DIFF
--- a/agents/amplifier-smoke-test.md
+++ b/agents/amplifier-smoke-test.md
@@ -1,0 +1,242 @@
+---
+meta:
+  name: amplifier-smoke-test
+  description: |
+    Amplifier-specialized smoke test for shadow environments.
+    Extends the generic shadow-smoke-test with Amplifier ecosystem knowledge.
+
+    Knows about:
+    - amplifier_core imports (Session, Coordinator, etc.)
+    - Provider installation and configuration
+    - Bundle loading and agent availability
+    - Amplifier CLI commands and workflows
+
+    Use AFTER shadow-operator creates an environment to validate Amplifier changes.
+    For non-Amplifier projects, use the generic shadow-smoke-test instead.
+
+    Returns objective VERDICT: PASS/FAIL with evidence.
+
+    <example>
+    Context: After shadow-operator creates environment for testing amplifier-core changes
+    user: 'Validate that the shadow environment is using my local amplifier-core'
+    assistant: 'I'll use amplifier-smoke-test to verify your Amplifier changes with ecosystem-specific validation.'
+    </example>
+
+    <example>
+    Context: Verifying multi-repo Amplifier changes work together
+    user: 'Confirm my changes to core and foundation work together'
+    assistant: 'I'll use amplifier-smoke-test to validate both local sources and test their Amplifier integration.'
+    </example>
+---
+
+# Amplifier Smoke Test Agent
+
+You are an independent validation agent for Amplifier shadow environments. Your job is to objectively verify that local Amplifier changes work correctly in the shadow.
+
+**Key principle:** You run SEPARATELY from shadow-operator to provide unbiased verification. Don't trust claims - verify with evidence.
+
+---
+
+## Your Mission
+
+Given a shadow environment ID and information about what's being tested, you:
+
+1. **Verify local sources are being used** (not just configured)
+2. **Test Amplifier-specific functionality** (imports, CLI, basic operations)
+3. **Produce objective VERDICT** with evidence
+
+---
+
+## Validation Rubric (100 points)
+
+### 1. Source Verification (25 points)
+
+| Check | Points | How to Verify |
+|-------|--------|---------------|
+| Snapshot commits exist | 5 | `shadow status` shows `snapshot_commits` |
+| Git URL rewriting configured | 5 | Check `git config --global --get-regexp "url.*insteadOf"` |
+| Installed package uses snapshot | 10 | Compare installed commit to snapshot_commits |
+| Unregistered repos NOT redirected | 5 | Test repo not in local_sources reaches real GitHub |
+
+### 2. Installation Health (20 points)
+
+| Check | Points | How to Verify |
+|-------|--------|---------------|
+| Package installs without errors | 8 | `uv pip install` exits code 0 |
+| Package imports successfully | 6 | `python -c 'import amplifier_core'` works |
+| CLI tools respond | 6 | `amplifier --version` returns output |
+
+### 3. Code Execution (30 points)
+
+| Check | Points | How to Verify |
+|-------|--------|---------------|
+| Touched modules load | 10 | Import specific changed modules |
+| Basic functionality works | 10 | Create Session, Coordinator instances |
+| Integration test passes | 10 | `amplifier run 'test' --max-turns 1` |
+
+### 4. Isolation Integrity (15 points)
+
+| Check | Points | How to Verify |
+|-------|--------|---------------|
+| Container hostname differs | 5 | `hostname` is container ID |
+| Host home not accessible | 5 | `~/.amplifier` is empty/missing |
+| Only expected env vars present | 5 | Compare `env` to env_vars_passed |
+
+### 5. No Regressions (10 points)
+
+| Check | Points | How to Verify |
+|-------|--------|---------------|
+| Basic imports work | 5 | Standard amplifier_core imports |
+| Smoke test passes | 5 | Simple operation completes |
+
+---
+
+## Amplifier-Specific Tests
+
+### Testing amplifier-core Changes
+
+```bash
+# Verify import
+shadow exec <id> "python -c 'from amplifier_core import Session, Coordinator; print(\"OK\")'"
+
+# Test Session creation
+shadow exec <id> "python -c '
+from amplifier_core import Session
+s = Session()
+print(f\"Session ID: {s.id}\")
+'"
+
+# Test Coordinator creation
+shadow exec <id> "python -c '
+from amplifier_core import Coordinator
+c = Coordinator({})
+print(f\"Coordinator: {type(c).__name__}\")
+'"
+```
+
+### Testing amplifier-foundation Changes
+
+```bash
+# Verify bundle loading
+shadow exec <id> "python -c '
+from amplifier_foundation import load_bundle
+print(\"Bundle loading available\")
+'"
+```
+
+### Testing amplifier-app-cli Changes
+
+```bash
+# Verify CLI responds
+shadow exec <id> "amplifier --version"
+
+# Test basic run (requires provider)
+shadow exec <id> "amplifier run 'Say hello' --max-turns 1"
+```
+
+### Testing Module Changes
+
+```bash
+# For a module like tool-filesystem
+shadow exec <id> "python -c '
+from amplifier_module_tool_filesystem import mount
+print(\"Module loads correctly\")
+'"
+```
+
+---
+
+## Verdict Decision
+
+```
+IF Total >= 75:
+    IF any critical failure (score 0 in Source Verification or Code Execution):
+        VERDICT: FAIL (critical path broken despite high score)
+    ELSE:
+        VERDICT: PASS
+ELSE:
+    VERDICT: FAIL
+```
+
+### Critical Failures (automatic FAIL)
+
+- Source Verification score is 0 (local sources not being used)
+- Code Execution score is 0 (changed code completely broken)
+- Installation Health score is 0 (nothing installs)
+
+---
+
+## Output Format
+
+```
++================================================================+
+|  AMPLIFIER SHADOW SMOKE TEST                                    |
+|  Shadow ID: {shadow_id}                                         |
+|  Local Sources: {repos}                                         |
+|  Tested: {timestamp}                                            |
++================================================================+
+
+## Source Verification ({score}/25)
+- [✓|✗] Snapshot commits exist: {evidence}
+- [✓|✗] Git URL rewriting configured: {evidence}
+- [✓|✗] Installed package uses snapshot: {evidence}
+- [✓|✗] Unregistered repos NOT redirected: {evidence}
+
+## Installation Health ({score}/20)
+- [✓|✗] Package installs without errors: {evidence}
+- [✓|✗] Package imports successfully: {evidence}
+- [✓|✗] CLI tools respond: {evidence}
+
+## Code Execution ({score}/30)
+- [✓|✗] Touched modules load: {evidence}
+- [✓|✗] Basic functionality works: {evidence}
+- [✓|✗] Integration test passes: {evidence}
+
+## Isolation Integrity ({score}/15)
+- [✓|✗] Container hostname differs: {evidence}
+- [✓|✗] Host home not accessible: {evidence}
+- [✓|✗] Only expected env vars present: {evidence}
+
+## No Regressions ({score}/10)
+- [✓|✗] Basic imports work: {evidence}
+- [✓|✗] Smoke test passes: {evidence}
+
+===================================================================
+Total Score: {total}/100
+Pass Threshold: 75
+
+{summary}
+
+VERDICT: {PASS|FAIL}
+===================================================================
+```
+
+---
+
+## Common Amplifier Failure Patterns
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| `amplifier` command not found | CLI not installed as tool | Use `uv tool install git+https://github.com/microsoft/amplifier` |
+| `No providers mounted` | Settings.yaml missing | Create `~/.amplifier/settings.yaml` with provider config |
+| Import fails for `amplifier_core` | Package not installed | Install with `uv pip install git+https://github.com/microsoft/amplifier-core` |
+| Commit mismatch | Local repo has uncommitted changes | This is expected - snapshot includes working tree changes |
+| Provider module not found | Provider not installed | Run `amplifier provider install <name> -q` |
+
+---
+
+## Process Safety
+
+**NEVER run these commands:**
+- `pkill -f amplifier` - kills parent session
+- `pkill amplifier` - kills parent session
+- `killall amplifier` - kills parent session
+
+If tests hang, report timeout and let user handle cleanup.
+
+---
+
+## Reference
+
+For generic shadow environment documentation: @shadow:context/shadow-instructions.md
+For Amplifier-specific test patterns: @foundation:context/amplifier-shadow-tests.md

--- a/behaviors/shadow-amplifier.yaml
+++ b/behaviors/shadow-amplifier.yaml
@@ -1,0 +1,41 @@
+# Shadow Amplifier Behavior
+# Amplifier-specific overlay for shadow environments
+# INCLUDES the generic shadow bundle, so users only need to include this one behavior
+bundle:
+  name: behavior-shadow-amplifier
+  version: 1.0.0
+  description: |
+    Amplifier ecosystem-specific shadow environment support.
+    Includes the generic shadow bundle plus Amplifier-specific:
+    - shadow-smoke-test agent for Amplifier validation
+    - Amplifier testing patterns and examples
+    - Pre-configured workflows for testing amplifier-core, amplifier-foundation, etc.
+
+# Include the generic shadow bundle - this brings in shadow-operator and base shadow tool
+includes:
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-shadow@main
+
+# Amplifier-specific agents
+agents:
+  amplifier-smoke-test:
+    description: |
+      Amplifier-specialized smoke test for shadow environments.
+      Extends the generic shadow-smoke-test with Amplifier ecosystem knowledge:
+      - Knows about amplifier_core, Session, Coordinator imports
+      - Understands provider installation and configuration
+      - Tests bundle loading and agent availability
+      - Validates amplifier-specific CLI commands
+      
+      Use AFTER shadow-operator creates an environment to validate Amplifier changes.
+      For non-Amplifier projects, use the generic shadow-smoke-test instead.
+      
+      Returns objective VERDICT: PASS/FAIL with evidence.
+    instructions: foundation:agents/amplifier-smoke-test.md
+    tools:
+      - module: tool-shadow
+        source: git+https://github.com/microsoft/amplifier-bundle-shadow@main#subdirectory=modules/tool-shadow
+
+# Amplifier-specific context
+context:
+  include:
+    - foundation:context/amplifier-shadow-tests.md

--- a/bundles/amplifier-dev.yaml
+++ b/bundles/amplifier-dev.yaml
@@ -1,13 +1,15 @@
 bundle:
   name: amplifier-dev
-  version: 1.1.0
+  version: 1.2.0
   description: Bundle for developing ON the Amplifier ecosystem - multi-repo coordination, testing patterns, shadow environments
 
 includes:
-  # Base foundation capabilities (includes python-dev, shadow, recipes, etc.)
+  # Base foundation capabilities
   - bundle: foundation
   # Amplifier dev behavior (agents + context)
   - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/amplifier-dev.yaml
+  # Shadow environments with Amplifier-specific helpers (includes generic shadow bundle)
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/shadow-amplifier.yaml
 
 # Development-specific session settings
 session:

--- a/context/amplifier-shadow-tests.md
+++ b/context/amplifier-shadow-tests.md
@@ -1,0 +1,282 @@
+# Amplifier Shadow Testing Patterns
+
+This document provides Amplifier-specific patterns for testing local changes in shadow environments.
+
+## Common Amplifier Testing Scenarios
+
+### Testing amplifier-core Changes
+
+```python
+# Create shadow with local amplifier-core
+shadow.create(local_sources=["~/repos/amplifier-core:microsoft/amplifier-core"])
+
+# Install amplifier - it will use YOUR local amplifier-core as a dependency
+shadow.exec(shadow_id, "uv tool install git+https://github.com/microsoft/amplifier")
+
+# Verify local code is installed (check commit in output)
+# Look for: amplifier-core @ git+...@<your-snapshot-commit>
+
+# Install providers
+shadow.exec(shadow_id, "amplifier provider install -q")
+
+# Test functionality
+shadow.exec(shadow_id, 'amplifier run "Hello, confirm you are working" --max-turns 1')
+```
+
+### Testing amplifier-foundation Changes
+
+```python
+# Create shadow with local foundation
+shadow.create(local_sources=["~/repos/amplifier-foundation:microsoft/amplifier-foundation"])
+
+# Install amplifier 
+shadow.exec(shadow_id, "uv tool install git+https://github.com/microsoft/amplifier")
+
+# Verify bundle loading works with your changes
+shadow.exec(shadow_id, "python -c 'from amplifier_foundation import load_bundle; print(\"OK\")'")
+```
+
+### Testing amplifier-app-cli Changes
+
+```python
+# Create shadow with local CLI
+shadow.create(local_sources=["~/repos/amplifier-app-cli:microsoft/amplifier-app-cli"])
+
+# Install amplifier (uses your local CLI)
+shadow.exec(shadow_id, "uv tool install git+https://github.com/microsoft/amplifier")
+
+# Test CLI changes
+shadow.exec(shadow_id, "amplifier --version")
+shadow.exec(shadow_id, "amplifier --help")
+```
+
+### Testing Multi-Repo Changes
+
+When testing changes that span multiple Amplifier repos:
+
+```python
+# Create shadow with ALL affected repos
+shadow.create(local_sources=[
+    "~/repos/amplifier-core:microsoft/amplifier-core",
+    "~/repos/amplifier-foundation:microsoft/amplifier-foundation",
+    "~/repos/amplifier-app-cli:microsoft/amplifier-app-cli"
+])
+
+# Install - all dependencies use local snapshots
+shadow.exec(shadow_id, "uv tool install git+https://github.com/microsoft/amplifier")
+
+# Verify each repo's changes are included (check commits in install output)
+```
+
+### Testing Module Changes
+
+For testing changes to specific modules (providers, tools, hooks):
+
+```python
+# Create shadow with local module
+shadow.create(local_sources=["~/repos/amplifier-module-tool-xyz:microsoft/amplifier-module-tool-xyz"])
+
+# Option 1: Install via bundle that uses the module
+shadow.exec(shadow_id, "uv tool install git+https://github.com/microsoft/amplifier")
+
+# Option 2: Install module directly for testing
+shadow.exec(shadow_id, "uv pip install git+https://github.com/microsoft/amplifier-module-tool-xyz")
+
+# Test module loads
+shadow.exec(shadow_id, "python -c 'from amplifier_module_tool_xyz import mount; print(\"OK\")'")
+```
+
+### Testing Bundle Changes
+
+For testing changes to bundles:
+
+```python
+# Create shadow with local bundle
+shadow.create(local_sources=["~/repos/amplifier-bundle-xyz:microsoft/amplifier-bundle-xyz"])
+
+# Install amplifier
+shadow.exec(shadow_id, "uv tool install git+https://github.com/microsoft/amplifier")
+
+# Add and use the bundle
+shadow.exec(shadow_id, "amplifier bundle add git+https://github.com/microsoft/amplifier-bundle-xyz")
+shadow.exec(shadow_id, "amplifier bundle use xyz")
+
+# Test the bundle
+shadow.exec(shadow_id, "amplifier run 'test the bundle'")
+```
+
+---
+
+## Provider Setup in Shadow
+
+Shadow environments need provider configuration to run Amplifier:
+
+### Quick Setup (Manual settings.yaml)
+
+```python
+# Create settings with provider
+shadow.exec(shadow_id, '''mkdir -p ~/.amplifier && cat > ~/.amplifier/settings.yaml << 'EOF'
+providers:
+  - module: provider-anthropic
+    config:
+      priority: 1
+      model: claude-sonnet-4-5-20250514
+EOF''')
+
+# Install provider module
+shadow.exec(shadow_id, "amplifier provider install anthropic -q")
+```
+
+### Using Environment Variables
+
+Shadow automatically passes common API keys:
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+- `AZURE_OPENAI_ENDPOINT`
+- `GOOGLE_API_KEY`
+
+Verify they're present:
+```python
+shadow.exec(shadow_id, "env | grep -E '(ANTHROPIC|OPENAI|AZURE|GOOGLE)_'")
+```
+
+---
+
+## Verification Patterns
+
+### Verify Local Code Is Being Used
+
+```python
+# Get snapshot commits from creation
+result = shadow.create(local_sources=["~/repos/amplifier-core:microsoft/amplifier-core"])
+expected_commit = result["snapshot_commits"]["microsoft/amplifier-core"]
+
+# After installation, check what was installed
+install_output = shadow.exec(shadow_id, "uv tool install git+https://github.com/microsoft/amplifier")
+
+# Look for: amplifier-core @ git+https://...@{expected_commit}
+# If commit matches, local code is being used!
+```
+
+### Verify Specific Code Changes
+
+```python
+# If you changed a specific function, test it directly
+shadow.exec(shadow_id, """python -c '
+from amplifier_core.session import Session
+# Test your specific change
+s = Session()
+result = s.your_new_method()
+print(f"New method works: {result}")
+'""")
+```
+
+### Verify Import Paths
+
+```python
+# Check where modules are loaded from
+shadow.exec(shadow_id, """python -c '
+import amplifier_core
+print(f"amplifier_core loaded from: {amplifier_core.__file__}")
+'""")
+```
+
+---
+
+## Troubleshooting Amplifier in Shadow
+
+### "amplifier: command not found"
+
+The CLI isn't installed as a tool:
+```python
+shadow.exec(shadow_id, "uv tool install git+https://github.com/microsoft/amplifier")
+```
+
+### "No providers mounted"
+
+Create settings.yaml:
+```python
+shadow.exec(shadow_id, '''mkdir -p ~/.amplifier && cat > ~/.amplifier/settings.yaml << 'EOF'
+providers:
+  - module: provider-anthropic
+    config:
+      priority: 1
+EOF''')
+shadow.exec(shadow_id, "amplifier provider install anthropic -q")
+```
+
+### Import Errors for amplifier_core
+
+Package not installed:
+```python
+shadow.exec(shadow_id, "uv pip install git+https://github.com/microsoft/amplifier-core")
+```
+
+### Commit Mismatch
+
+If installed commit differs from snapshot commit, this may be expected:
+- Uncommitted changes in your working directory get snapshotted as a new commit
+- The snapshot commit will differ from HEAD
+
+Check your working directory status:
+```bash
+cd ~/repos/amplifier-core
+git status  # Shows if you have uncommitted changes
+```
+
+### Provider Module Not Found
+
+Install the specific provider:
+```python
+shadow.exec(shadow_id, "amplifier provider install anthropic -q")
+# Or for other providers:
+shadow.exec(shadow_id, "amplifier provider install openai -q")
+```
+
+---
+
+## Integration Test Pattern
+
+Full integration test for Amplifier changes:
+
+```python
+# 1. Create shadow with all local changes
+shadow.create(
+    local_sources=[
+        "~/repos/amplifier-core:microsoft/amplifier-core",
+        "~/repos/amplifier-foundation:microsoft/amplifier-foundation"
+    ],
+    name="integration-test"
+)
+
+# 2. Install Amplifier
+shadow.exec(shadow_id, "uv tool install git+https://github.com/microsoft/amplifier")
+
+# 3. Configure provider
+shadow.exec(shadow_id, '''mkdir -p ~/.amplifier && cat > ~/.amplifier/settings.yaml << 'EOF'
+providers:
+  - module: provider-anthropic
+    config:
+      priority: 1
+EOF''')
+shadow.exec(shadow_id, "amplifier provider install anthropic -q")
+
+# 4. Run integration test
+result = shadow.exec(shadow_id, 'amplifier run "Say hello and confirm you are working" --max-turns 1')
+
+# 5. Check result
+if result["exit_code"] == 0 and "hello" in result["stdout"].lower():
+    print("Integration test PASSED")
+else:
+    print(f"Integration test FAILED: {result['stderr']}")
+
+# 6. Cleanup
+shadow.destroy(shadow_id)
+```
+
+---
+
+## Reference
+
+For generic shadow documentation: @shadow:context/shadow-instructions.md
+For smoke test rubric: See `shadow-smoke-test` agent instructions


### PR DESCRIPTION
Add Amplifier-specific shadow environment support that composes with the generic shadow bundle (mechanism vs policy separation):

## New files
- **behaviors/shadow-amplifier.yaml** - includes generic shadow bundle + adds:
  - amplifier-smoke-test agent for Amplifier validation
  - Amplifier-specific context and test patterns
- **agents/amplifier-smoke-test.md** - Amplifier-specialized validation agent
- **context/amplifier-shadow-tests.md** - Amplifier testing patterns

## Updated
- **bundles/amplifier-dev.yaml** - includes shadow-amplifier (v1.2.0)

## Architecture
`shadow-amplifier.yaml` INCLUDES the generic shadow bundle, so users of amplifier-dev get both via a single include. This follows the lsp-python pattern: generic mechanism + ecosystem-specific overlay.

## Agent naming
- `shadow-operator` - from shadow bundle (create/manage)
- `shadow-smoke-test` - from shadow bundle (generic validation)
- `amplifier-smoke-test` - from this behavior (Amplifier-specialized)