### PR TITLE
fix: resolve relative module paths at parse time

### DIFF
--- a/amplifier_foundation/bundle.py
+++ b/amplifier_foundation/bundle.py
@@ -688,6 +688,22 @@ def _validate_module_list(
                 f"Correct format: {field_name}: [{{module: 'module-id', source: 'git+https://...'}}]"
             )
 
+    # Resolve relative source paths to absolute (before composition can change base_path)
+    # This fixes issue #190: relative paths must be resolved at parse time
+    if base_path:
+        resolved_items = []
+        for item in items:
+            source = item.get("source", "")
+            if isinstance(source, str) and (
+                source.startswith("./") or source.startswith("../")
+            ):
+                # Resolve relative path against bundle's base_path
+                resolved_source = str((base_path / source).resolve())
+                # Copy dict to avoid mutating original
+                item = {**item, "source": resolved_source}
+            resolved_items.append(item)
+        return resolved_items
+
     return items
 
 


### PR DESCRIPTION
## Summary

Fixes microsoft/amplifier#190

Relative module paths in behaviors (`source: ./modules/...`) lost their bundle context during composition because `base_path` gets overwritten by the last bundle.

## Root Cause

1. In `compose()` (lines 191-195), `base_path` is overwritten by the last bundle
2. In `prepare()` (line 276), ALL modules use the single `base_path`

When Bundle A (with `source: ./modules/tool-foo`) is composed with Bundle B (composed last), Bundle A's relative path incorrectly resolved from Bundle B's directory.

## Solution

Resolve relative paths (`./` and `../`) to absolute at **parse time** in `_validate_module_list()`, BEFORE composition can overwrite `base_path`.

This ensures relative paths are resolved relative to their **original bundle**, matching the documented behavior in BUNDLE_GUIDE.md.

## Changes

- `amplifier_foundation/bundle.py`: Added ~16 lines to `_validate_module_list()` to resolve relative source paths at parse time

## Testing

Verified with comprehensive shadow environment test:

```
Bundle A base_path: /tmp/bundle-a
Bundle B base_path: /tmp/bundle-b
Bundle A tool-a source BEFORE compose: /tmp/bundle-a/modules/tool-a

After composition:
Composed bundle base_path: /tmp/bundle-b
tool-a source: /tmp/bundle-a/modules/tool-a  ✅ Still points to bundle-a!

✅ ALL TESTS PASSED: Issue #190 is fixed!
```

## Checklist

- [x] Fix resolves the reported issue
- [x] Relative paths resolved at parse time (before composition)
- [x] URL sources (git+https://) pass through unchanged
- [x] Absolute paths pass through unchanged
- [x] Original input data not mutated
- [x] Shadow environment test passes

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)