### PR TITLE
fix: Add consolidation API to InstallStateManager

### DIFF
--- a/amplifier_foundation/modules/install_state.py
+++ b/amplifier_foundation/modules/install_state.py
@@ -3,18 +3,103 @@
 Tracks fingerprints of installed modules to skip redundant `uv pip install` calls.
 When a module's pyproject.toml/requirements.txt hasn't changed, we can skip
 the install step entirely, significantly speeding up startup.
+
+Self-healing: Also verifies that declared dependencies are actually installed.
+This catches stale state after `uv tool install --force` wipes the venv.
 """
 
 from __future__ import annotations
 
 import hashlib
+import importlib.metadata
 import json
 import logging
+import re
 import sys
 import tempfile
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_dependencies_from_pyproject(pyproject_path: Path) -> list[str]:
+    """Extract dependency names from a pyproject.toml file.
+
+    Args:
+        pyproject_path: Path to pyproject.toml file.
+
+    Returns:
+        List of dependency package names (without version specifiers).
+    """
+    if not pyproject_path.exists():
+        return []
+
+    try:
+        # Use tomllib (Python 3.11+) or tomli as fallback
+        try:
+            import tomllib
+        except ImportError:
+            try:
+                import tomli as tomllib  # type: ignore[import-not-found]
+            except ImportError:
+                # No TOML parser available - skip dependency check
+                logger.debug("No TOML parser available, skipping dependency extraction")
+                return []
+
+        with open(pyproject_path, "rb") as f:
+            config = tomllib.load(f)
+    except Exception as e:
+        logger.debug(f"Failed to parse {pyproject_path}: {e}")
+        return []
+
+    deps = []
+
+    # Get dependencies from [project.dependencies]
+    project_deps = config.get("project", {}).get("dependencies", [])
+    for dep in project_deps:
+        # Parse dependency string like "aiohttp>=3.8", "requests[security]", or "zope.interface>=5.0"
+        # Extract the full package name including dots (for namespace packages)
+        # Stops at: whitespace, extras [...], version specifiers [<>=!~], markers [;], URL [@]
+        match = re.match(r"^([a-zA-Z0-9._-]+?)(?:\s|\[|[<>=!~;@]|$)", dep)
+        if match:
+            deps.append(match.group(1))
+
+    return deps
+
+
+def _check_dependency_installed(dep_name: str) -> bool:
+    """Check if a dependency is installed in the current environment.
+
+    Uses importlib.metadata to check by distribution name, which correctly
+    handles packages where the import name differs from the package name
+    (e.g., Pillow -> PIL, beautifulsoup4 -> bs4, scikit-learn -> sklearn).
+
+    Args:
+        dep_name: Package/distribution name (e.g., "aiohttp", "Pillow").
+
+    Returns:
+        True if the package is installed, False otherwise.
+    """
+    # Normalize for comparison: PEP 503 says package names are case-insensitive
+    # and treats hyphens/underscores as equivalent
+    normalized = dep_name.lower().replace("-", "_").replace(".", "_")
+
+    try:
+        # Try exact name first
+        importlib.metadata.distribution(dep_name)
+        return True
+    except importlib.metadata.PackageNotFoundError:
+        pass
+
+    # Try normalized variations (handles case differences and hyphen/underscore)
+    for variation in [normalized, normalized.replace("_", "-")]:
+        try:
+            importlib.metadata.distribution(variation)
+            return True
+        except importlib.metadata.PackageNotFoundError:
+            continue
+
+    return False
 
 
 class InstallStateManager:
@@ -105,11 +190,17 @@ class InstallStateManager:
     def is_installed(self, module_path: Path) -> bool:
         """Check if module is already installed with matching fingerprint.
 
+        Also verifies that declared dependencies are actually present in the
+        Python environment. This catches stale install state after operations
+        like `uv tool install --force` that wipe the venv but don't clear
+        the install-state.json file.
+
         Args:
             module_path: Path to the module directory.
 
         Returns:
-            True if module is installed and fingerprint matches.
+            True if module is installed, fingerprint matches, AND all
+            dependencies are actually present.
         """
         path_key = str(module_path.resolve())
         entry = self._state["modules"].get(path_key)
@@ -125,6 +216,25 @@ class InstallStateManager:
                 f"Fingerprint mismatch for {module_path.name}: "
                 f"{stored_fingerprint} -> {current_fingerprint}"
             )
+            return False
+
+        # Self-healing: Verify dependencies are actually installed
+        # This catches stale state after venv wipe (e.g., uv tool install --force)
+        pyproject_path = module_path / "pyproject.toml"
+        deps = _extract_dependencies_from_pyproject(pyproject_path)
+
+        missing_deps = []
+        for dep in deps:
+            if not _check_dependency_installed(dep):
+                missing_deps.append(dep)
+
+        if missing_deps:
+            logger.info(
+                f"Module {module_path.name} has missing dependencies: {missing_deps}. "
+                f"Will reinstall."
+            )
+            # Invalidate this entry so save() will persist the change
+            self.invalidate(module_path)
             return False
 
         return True
@@ -191,3 +301,77 @@ class InstallStateManager:
                 del self._state["modules"][path_key]
                 self._dirty = True
                 logger.debug(f"Invalidated install state for {module_path.name}")
+
+    def clear(self) -> None:
+        """Clear all module install state.
+
+        This is a convenience method equivalent to `invalidate(None)`.
+        Use after operations that may have invalidated the Python environment,
+        such as `amplifier reset --remove cache`.
+
+        Changes are not persisted until `save()` is called.
+        """
+        self.invalidate(None)
+
+    def invalidate_modules_with_missing_deps(self) -> tuple[int, int]:
+        """Surgically invalidate only modules whose dependencies are missing.
+
+        Checks each tracked module's declared dependencies against what's
+        actually installed in the Python environment. Only invalidates entries
+        for modules that have missing dependencies.
+
+        This is useful after operations like `uv tool install --force` that
+        recreate the Python environment but don't clear install-state.json.
+        Modules with all dependencies still satisfied won't be reinstalled.
+
+        Returns:
+            Tuple of (modules_checked, modules_invalidated).
+
+        Note:
+            Changes are persisted immediately (calls save() internally).
+        """
+        modules = self._state.get("modules", {})
+        if not modules:
+            logger.debug("No modules in install state to check")
+            return (0, 0)
+
+        modules_checked = 0
+        modules_to_invalidate = []
+
+        for module_path_str in list(modules.keys()):
+            module_path = Path(module_path_str)
+
+            # Module directory no longer exists - mark for invalidation
+            if not module_path.exists():
+                modules_to_invalidate.append(module_path_str)
+                continue
+
+            pyproject_path = module_path / "pyproject.toml"
+            deps = _extract_dependencies_from_pyproject(pyproject_path)
+            modules_checked += 1
+
+            # Check if all dependencies are installed
+            missing_deps = []
+            for dep in deps:
+                if not _check_dependency_installed(dep):
+                    missing_deps.append(dep)
+
+            if missing_deps:
+                logger.debug(
+                    f"Module {module_path.name} has missing deps: {missing_deps}"
+                )
+                modules_to_invalidate.append(module_path_str)
+
+        # Remove invalidated entries
+        for path_str in modules_to_invalidate:
+            del self._state["modules"][path_str]
+            module_name = Path(path_str).name
+            logger.info(
+                f"Invalidated install state for {module_name} (missing dependencies)"
+            )
+
+        if modules_to_invalidate:
+            self._dirty = True
+            self.save()
+
+        return (modules_checked, len(modules_to_invalidate))

--- a/tests/test_install_state.py
+++ b/tests/test_install_state.py
@@ -1,0 +1,532 @@
+"""Tests for InstallStateManager and related functions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+
+from amplifier_foundation.modules.install_state import (
+    InstallStateManager,
+    _check_dependency_installed,
+    _extract_dependencies_from_pyproject,
+)
+
+
+class TestExtractDependenciesFromPyproject:
+    """Tests for _extract_dependencies_from_pyproject helper function."""
+
+    def test_nonexistent_file_returns_empty(self, tmp_path: Path) -> None:
+        """Returns empty list when pyproject.toml doesn't exist."""
+        result = _extract_dependencies_from_pyproject(tmp_path / "pyproject.toml")
+        assert result == []
+
+    def test_extracts_simple_dependencies(self, tmp_path: Path) -> None:
+        """Extracts simple dependency names without version specifiers."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+dependencies = [
+    "aiohttp",
+    "requests",
+]
+""")
+        result = _extract_dependencies_from_pyproject(pyproject)
+        assert result == ["aiohttp", "requests"]
+
+    def test_extracts_dependencies_with_version_specifiers(
+        self, tmp_path: Path
+    ) -> None:
+        """Extracts dependency names, stripping version specifiers."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+dependencies = [
+    "aiohttp>=3.8",
+    "requests>=2.28,<3.0",
+    "pydantic~=2.0",
+]
+""")
+        result = _extract_dependencies_from_pyproject(pyproject)
+        assert result == ["aiohttp", "requests", "pydantic"]
+
+    def test_extracts_dependencies_with_extras(self, tmp_path: Path) -> None:
+        """Extracts dependency names, stripping extras."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+dependencies = [
+    "requests[security]",
+    "httpx[http2]>=0.24",
+]
+""")
+        result = _extract_dependencies_from_pyproject(pyproject)
+        assert result == ["requests", "httpx"]
+
+    def test_extracts_namespace_packages(self, tmp_path: Path) -> None:
+        """Extracts namespace package names with dots."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+dependencies = [
+    "zope.interface>=5.0",
+    "ruamel.yaml",
+]
+""")
+        result = _extract_dependencies_from_pyproject(pyproject)
+        assert result == ["zope.interface", "ruamel.yaml"]
+
+    def test_empty_dependencies_returns_empty(self, tmp_path: Path) -> None:
+        """Returns empty list when no dependencies declared."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+name = "test-package"
+""")
+        result = _extract_dependencies_from_pyproject(pyproject)
+        assert result == []
+
+    def test_invalid_toml_returns_empty(self, tmp_path: Path) -> None:
+        """Returns empty list when TOML is invalid."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("this is not valid toml {{{{")
+        result = _extract_dependencies_from_pyproject(pyproject)
+        assert result == []
+
+
+class TestCheckDependencyInstalled:
+    """Tests for _check_dependency_installed helper function."""
+
+    def test_installed_package_returns_true(self) -> None:
+        """Returns True for packages that are installed."""
+        # pytest is definitely installed since we're running tests
+        assert _check_dependency_installed("pytest") is True
+
+    def test_uninstalled_package_returns_false(self) -> None:
+        """Returns False for packages that are not installed."""
+        assert _check_dependency_installed("definitely-not-a-real-package-xyz") is False
+
+    def test_case_insensitive_matching(self) -> None:
+        """Package names are matched case-insensitively."""
+        # PyTest vs pytest
+        assert _check_dependency_installed("PyTest") is True
+
+    def test_hyphen_underscore_normalization(self) -> None:
+        """Hyphens and underscores are treated as equivalent."""
+        # Test with a package we know is installed
+        # amplifier-core uses hyphens but installs as amplifier_core
+        with patch("importlib.metadata.distribution") as mock_dist:
+            # First call with exact name fails, second with normalized succeeds
+            mock_dist.side_effect = [
+                __import__("importlib.metadata").metadata.PackageNotFoundError(),
+                None,  # Success on normalized name
+            ]
+            result = _check_dependency_installed("some-package")
+            assert result is True
+
+
+class TestInstallStateManager:
+    """Tests for InstallStateManager class."""
+
+    def test_creates_fresh_state_when_no_file(self, tmp_path: Path) -> None:
+        """Creates fresh state when install-state.json doesn't exist."""
+        mgr = InstallStateManager(tmp_path)
+        assert mgr._state["version"] == 1
+        assert mgr._state["modules"] == {}
+
+    def test_loads_existing_state(self, tmp_path: Path) -> None:
+        """Loads existing state from disk."""
+        import sys
+
+        state_file = tmp_path / "install-state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "python": sys.executable,
+                    "modules": {"/some/path": {"pyproject_hash": "sha256:abc123"}},
+                }
+            )
+        )
+        mgr = InstallStateManager(tmp_path)
+        assert "/some/path" in mgr._state["modules"]
+
+    def test_creates_fresh_state_on_version_mismatch(self, tmp_path: Path) -> None:
+        """Creates fresh state when version doesn't match."""
+        state_file = tmp_path / "install-state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "version": 999,  # Wrong version
+                    "python": "/usr/bin/python",
+                    "modules": {"/some/path": {"pyproject_hash": "sha256:abc123"}},
+                }
+            )
+        )
+        mgr = InstallStateManager(tmp_path)
+        assert mgr._state["modules"] == {}
+
+    def test_creates_fresh_state_on_python_change(self, tmp_path: Path) -> None:
+        """Creates fresh state when Python executable changed."""
+        state_file = tmp_path / "install-state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "python": "/different/python",  # Different Python
+                    "modules": {"/some/path": {"pyproject_hash": "sha256:abc123"}},
+                }
+            )
+        )
+        mgr = InstallStateManager(tmp_path)
+        assert mgr._state["modules"] == {}
+
+    def test_creates_fresh_state_on_invalid_json(self, tmp_path: Path) -> None:
+        """Creates fresh state when JSON is invalid."""
+        state_file = tmp_path / "install-state.json"
+        state_file.write_text("not valid json {{{")
+        mgr = InstallStateManager(tmp_path)
+        assert mgr._state["modules"] == {}
+
+
+class TestInstallStateManagerIsInstalled:
+    """Tests for InstallStateManager.is_installed method."""
+
+    def test_returns_false_when_not_tracked(self, tmp_path: Path) -> None:
+        """Returns False when module is not in state."""
+        mgr = InstallStateManager(tmp_path)
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+        assert mgr.is_installed(module_path) is False
+
+    def test_returns_true_when_fingerprint_matches(self, tmp_path: Path) -> None:
+        """Returns True when fingerprint matches and no deps to check."""
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+        # No pyproject.toml means no deps to check
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module_path)
+
+        assert mgr.is_installed(module_path) is True
+
+    def test_returns_false_when_fingerprint_changes(self, tmp_path: Path) -> None:
+        """Returns False when pyproject.toml content changed."""
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+
+        pyproject = module_path / "pyproject.toml"
+        pyproject.write_text("[project]\nname = 'test'\n")
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module_path)
+
+        # Change the pyproject.toml
+        pyproject.write_text("[project]\nname = 'test'\nversion = '2.0'\n")
+
+        assert mgr.is_installed(module_path) is False
+
+    def test_returns_false_when_dependency_missing(self, tmp_path: Path) -> None:
+        """Returns False when a declared dependency is not installed."""
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+
+        pyproject = module_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+name = "test"
+dependencies = ["definitely-not-installed-package-xyz"]
+""")
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module_path)
+
+        # Should return False because dependency is missing
+        assert mgr.is_installed(module_path) is False
+
+    def test_returns_true_when_all_dependencies_present(self, tmp_path: Path) -> None:
+        """Returns True when all declared dependencies are installed."""
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+
+        pyproject = module_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+name = "test"
+dependencies = ["pytest"]
+""")
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module_path)
+
+        # Should return True because pytest is installed
+        assert mgr.is_installed(module_path) is True
+
+    def test_invalidates_entry_when_dependency_missing(self, tmp_path: Path) -> None:
+        """Invalidates the state entry when dependency is missing."""
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+
+        pyproject = module_path / "pyproject.toml"
+        pyproject.write_text("""
+[project]
+name = "test"
+dependencies = ["definitely-not-installed-xyz"]
+""")
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module_path)
+        path_key = str(module_path.resolve())
+
+        # Verify it's tracked
+        assert path_key in mgr._state["modules"]
+
+        # Check is_installed (should return False and invalidate)
+        assert mgr.is_installed(module_path) is False
+
+        # Verify it was invalidated
+        assert path_key not in mgr._state["modules"]
+
+
+class TestInstallStateManagerMarkInstalled:
+    """Tests for InstallStateManager.mark_installed method."""
+
+    def test_marks_module_as_installed(self, tmp_path: Path) -> None:
+        """Records module as installed with fingerprint."""
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module_path)
+
+        path_key = str(module_path.resolve())
+        assert path_key in mgr._state["modules"]
+        assert "pyproject_hash" in mgr._state["modules"][path_key]
+
+    def test_computes_fingerprint_from_pyproject(self, tmp_path: Path) -> None:
+        """Computes fingerprint from pyproject.toml content."""
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+        (module_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module_path)
+
+        path_key = str(module_path.resolve())
+        assert mgr._state["modules"][path_key]["pyproject_hash"].startswith("sha256:")
+
+
+class TestInstallStateManagerSave:
+    """Tests for InstallStateManager.save method."""
+
+    def test_saves_state_to_disk(self, tmp_path: Path) -> None:
+        """Persists state to disk."""
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module_path)
+        mgr.save()
+
+        state_file = tmp_path / "install-state.json"
+        assert state_file.exists()
+
+        data = json.loads(state_file.read_text())
+        assert str(module_path.resolve()) in data["modules"]
+
+    def test_no_op_when_not_dirty(self, tmp_path: Path) -> None:
+        """Does nothing when state hasn't changed."""
+        state_file = tmp_path / "install-state.json"
+
+        mgr = InstallStateManager(tmp_path)
+        mgr._dirty = False
+        mgr.save()
+
+        # File might exist from init, but check it wasn't modified
+        # by verifying a second save also does nothing
+        if state_file.exists():
+            mtime = state_file.stat().st_mtime
+            mgr.save()
+            assert state_file.stat().st_mtime == mtime
+
+
+class TestInstallStateManagerInvalidate:
+    """Tests for InstallStateManager.invalidate method."""
+
+    def test_invalidates_specific_module(self, tmp_path: Path) -> None:
+        """Removes state for a specific module."""
+        module1 = tmp_path / "module1"
+        module1.mkdir()
+        module2 = tmp_path / "module2"
+        module2.mkdir()
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module1)
+        mgr.mark_installed(module2)
+
+        mgr.invalidate(module1)
+
+        assert str(module1.resolve()) not in mgr._state["modules"]
+        assert str(module2.resolve()) in mgr._state["modules"]
+
+    def test_invalidates_all_modules_when_none(self, tmp_path: Path) -> None:
+        """Removes state for all modules when path is None."""
+        module1 = tmp_path / "module1"
+        module1.mkdir()
+        module2 = tmp_path / "module2"
+        module2.mkdir()
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module1)
+        mgr.mark_installed(module2)
+
+        mgr.invalidate(None)
+
+        assert mgr._state["modules"] == {}
+
+
+class TestInstallStateManagerClear:
+    """Tests for InstallStateManager.clear method."""
+
+    def test_clears_all_modules(self, tmp_path: Path) -> None:
+        """Clears all module state."""
+        module1 = tmp_path / "module1"
+        module1.mkdir()
+        module2 = tmp_path / "module2"
+        module2.mkdir()
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module1)
+        mgr.mark_installed(module2)
+
+        mgr.clear()
+
+        assert mgr._state["modules"] == {}
+        assert mgr._dirty is True
+
+
+class TestInstallStateManagerInvalidateModulesWithMissingDeps:
+    """Tests for InstallStateManager.invalidate_modules_with_missing_deps method."""
+
+    def test_returns_zero_when_no_modules(self, tmp_path: Path) -> None:
+        """Returns (0, 0) when no modules tracked."""
+        mgr = InstallStateManager(tmp_path)
+        checked, invalidated = mgr.invalidate_modules_with_missing_deps()
+        assert checked == 0
+        assert invalidated == 0
+
+    def test_invalidates_module_with_missing_dep(self, tmp_path: Path) -> None:
+        """Invalidates module when dependency is missing."""
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+        (module_path / "pyproject.toml").write_text("""
+[project]
+name = "test"
+dependencies = ["definitely-not-installed-xyz"]
+""")
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module_path)
+        mgr.save()
+
+        checked, invalidated = mgr.invalidate_modules_with_missing_deps()
+
+        assert checked == 1
+        assert invalidated == 1
+        assert str(module_path.resolve()) not in mgr._state["modules"]
+
+    def test_keeps_module_with_all_deps_present(self, tmp_path: Path) -> None:
+        """Keeps module when all dependencies are present."""
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+        (module_path / "pyproject.toml").write_text("""
+[project]
+name = "test"
+dependencies = ["pytest"]
+""")
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module_path)
+        mgr.save()
+
+        checked, invalidated = mgr.invalidate_modules_with_missing_deps()
+
+        assert checked == 1
+        assert invalidated == 0
+        assert str(module_path.resolve()) in mgr._state["modules"]
+
+    def test_invalidates_module_with_nonexistent_path(self, tmp_path: Path) -> None:
+        """Invalidates module when its directory no longer exists."""
+        import sys
+
+        # Directly inject a state entry for a non-existent path
+        mgr = InstallStateManager(tmp_path)
+        mgr._state["modules"]["/nonexistent/path"] = {"pyproject_hash": "sha256:abc"}
+        mgr._dirty = True
+        mgr.save()
+
+        # Reload and check
+        mgr2 = InstallStateManager(tmp_path)
+        # Fix the python path to match current
+        mgr2._state["python"] = sys.executable
+        checked, invalidated = mgr2.invalidate_modules_with_missing_deps()
+
+        assert invalidated == 1
+        assert "/nonexistent/path" not in mgr2._state["modules"]
+
+    def test_persists_changes_immediately(self, tmp_path: Path) -> None:
+        """Saves changes to disk immediately after invalidation."""
+        module_path = tmp_path / "some-module"
+        module_path.mkdir()
+        (module_path / "pyproject.toml").write_text("""
+[project]
+name = "test"
+dependencies = ["not-installed-xyz"]
+""")
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(module_path)
+        mgr.save()
+
+        mgr.invalidate_modules_with_missing_deps()
+
+        # Reload from disk and verify change was persisted
+        mgr2 = InstallStateManager(tmp_path)
+        assert str(module_path.resolve()) not in mgr2._state["modules"]
+
+    def test_handles_mixed_modules(self, tmp_path: Path) -> None:
+        """Correctly handles mix of valid and invalid modules."""
+        # Module with missing dep
+        bad_module = tmp_path / "bad-module"
+        bad_module.mkdir()
+        (bad_module / "pyproject.toml").write_text("""
+[project]
+dependencies = ["not-installed-xyz"]
+""")
+
+        # Module with present dep
+        good_module = tmp_path / "good-module"
+        good_module.mkdir()
+        (good_module / "pyproject.toml").write_text("""
+[project]
+dependencies = ["pytest"]
+""")
+
+        # Module with no deps
+        nodeps_module = tmp_path / "nodeps-module"
+        nodeps_module.mkdir()
+
+        mgr = InstallStateManager(tmp_path)
+        mgr.mark_installed(bad_module)
+        mgr.mark_installed(good_module)
+        mgr.mark_installed(nodeps_module)
+        mgr.save()
+
+        checked, invalidated = mgr.invalidate_modules_with_missing_deps()
+
+        assert checked == 3
+        assert invalidated == 1
+        assert str(bad_module.resolve()) not in mgr._state["modules"]
+        assert str(good_module.resolve()) in mgr._state["modules"]
+        assert str(nodeps_module.resolve()) in mgr._state["modules"]


### PR DESCRIPTION
## Summary

Adds consolidation API to `InstallStateManager` for proper dependency verification and state management, enabling users stuck in stale install state to auto-recover.

- Fixes microsoft/amplifier#194
- Part of microsoft/amplifier#193

## Problem

After operations like `uv tool install --force` or `amplifier update`, the Python venv is recreated but `install-state.json` persists. This causes:

```
Failed to load module 'tool-web': Module 'tool-web' failed validation: 
FAILED: 0/1 checks passed (1 errors, 0 warnings). 
Errors: module_importable: Failed to import module: No module named 'aiohttp'
```

Users had no automatic recovery path and had to manually delete `~/.amplifier/install-state.json`.

## Solution

Three new capabilities added to `InstallStateManager`:

| Method | Purpose |
|--------|---------|
| `invalidate_modules_with_missing_deps()` | Surgical invalidation - removes only modules with missing deps |
| `clear()` | Full state reset for complete reinstall scenarios |
| `is_installed()` (enhanced) | Proactive verification - checks deps are actually present |

## Evidence of Improvement

### Before (stale state causes crash)

```bash
# User updates amplifier (venv recreated, install-state.json preserved)
$ amplifier update

# Next session fails - aiohttp missing but state claims tool-web installed
$ amplifier run "fetch https://example.com"
Failed to load module 'tool-web': No module named 'aiohttp'
ModuleValidationError: Module 'tool-web' failed validation
```

### After (auto-healing on startup)

```bash
# Same scenario - but now is_installed() detects missing deps
$ amplifier run "fetch https://example.com"
INFO: Module tool-web has missing dependencies: ['aiohttp']. Will reinstall.
# ... aiohttp automatically reinstalled ...
🔧 Using tool: web_fetch
   url: https://example.com
✅ Tool result: web_fetch
   content: Example Domain...
```

### Shadow Test Results

| Test | Result |
|------|--------|
| Uninstall aiohttp → run amplifier | ✅ Auto-healed, web_fetch worked |
| `invalidate_modules_with_missing_deps()` API | ✅ 27 checked, 1 invalidated (surgical) |
| Modules with all deps present | ✅ Not reinstalled (fast startup preserved) |

### Unit Test Coverage

```
35 new tests added covering:
- _extract_dependencies_from_pyproject() - 7 tests
- _check_dependency_installed() - 4 tests  
- InstallStateManager core - 5 tests
- is_installed() with dep verification - 6 tests
- mark_installed(), save(), invalidate() - 6 tests
- clear(), invalidate_modules_with_missing_deps() - 7 tests

Total: 290 passed (255 existing + 35 new)
```

## API for app-cli Integration

This enables follow-up work in microsoft/amplifier#195 to replace direct JSON manipulation:

```python
# In update_executor.py (after self-update)
from amplifier_foundation.modules.install_state import InstallStateManager
mgr = InstallStateManager(cache_dir)
checked, invalidated = mgr.invalidate_modules_with_missing_deps()

# In reset.py (when clearing cache)
mgr = InstallStateManager(cache_dir)
mgr.clear()
mgr.save()
```

## Files Changed

- `amplifier_foundation/modules/install_state.py` - New API methods + dependency verification
- `tests/test_install_state.py` - Comprehensive test coverage (new file)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)