### PR TITLE
docs: add interface boundary examples to implementation philosophy

### DIFF
--- a/context/IMPLEMENTATION_PHILOSOPHY.md
+++ b/context/IMPLEMENTATION_PHILOSOPHY.md
@@ -295,6 +295,25 @@ class EnhancedMcpClient:
         # [50+ more lines of complex state tracking and retry logic]
 ```
 
+### Bad Example: Bypassing Public Interfaces
+
+```python
+# Fragile: reaching into internal state instead of using public API
+def get_activator(resolver):
+    bundle_resolver = getattr(resolver, "_bundle", resolver)
+    activator = getattr(bundle_resolver, "_activator", None)
+    return activator
+    # Breaks when implementation changes; extend the interface instead
+```
+
+### Good Example: Using Public Interfaces
+
+```python
+# If you need access to something, extend the public interface
+def get_activator(resolver):
+    return resolver.get_activator()
+```
+
 ## Remember
 
 - It's easier to add complexity later than to remove it


### PR DESCRIPTION
## Summary

Adds good/bad examples to IMPLEMENTATION_PHILOSOPHY.md showing why bypassing public interfaces creates fragile code.

## Motivation

This PR was motivated by [microsoft/amplifier-app-cli#70](https://github.com/microsoft/amplifier-app-cli/pull/70) which demonstrates a "fix" that reaches into private internal state instead of using public APIs:

```python
# The anti-pattern
bundle_resolver = getattr(resolver, "_bundle", resolver)
activator = getattr(bundle_resolver, "_activator", None)
```

## What's Added

Two new practical examples in the "Practical Examples" section:

- **Bad Example: Bypassing Public Interfaces** - shows the anti-pattern of unwrapping internal state
- **Good Example: Respecting Interface Boundaries** - shows the correct approach

Plus the key rule: *If you can't do something through the public interface, the fix is to extend the interface—not bypass it.*

## Why IMPLEMENTATION_PHILOSOPHY.md

This is development-time guidance that belongs where developers look when making implementation decisions. The "Practical Examples" section already establishes the pattern of showing good vs bad approaches with code.

## Related

- Companion PR: microsoft/amplifier-bundle-python-dev#5 (Python-specific details)
- Motivating issue: microsoft/amplifier-app-cli#70

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>