### PR TITLE
feat: add delegate tool with two-parameter context inheritance

### DIFF
--- a/behaviors/agents.yaml
+++ b/behaviors/agents.yaml
@@ -2,19 +2,19 @@ bundle:
   name: behavior-agents
   version: 2.0.0
   description: |
-    Agent orchestration capability - delegate tool and delegation patterns.
-    Provides the infrastructure for agent delegation without specifying
-    which agents to include. Agent selection is owned by root bundles
-    and other behaviors that compose this one.
+    Agent orchestration capability with enhanced delegate tool.
     
     Features:
     - Two-parameter context inheritance (depth + scope)
     - Short session ID resolution (6+ chars)
     - Fixed tool inheritance (agent declarations honored)
     - Multi-agent collaboration patterns
+    
+    Note: This behavior uses the NEW delegate tool. For legacy task tool,
+    use the 'tasks' behavior instead.
 
 tools:
-  # New delegate tool - recommended for new development
+  # New delegate tool with enhanced features
   - module: tool-delegate
     source: ./modules/tool-delegate
     config:
@@ -32,13 +32,6 @@ tools:
         exclude_tools: [delegate]  # Spawned agents can't further delegate by default
         exclude_hooks: []
         timeout: 300
-
-  # Legacy task tool - maintained for backwards compatibility
-  # Consider migrating to delegate tool for new features
-  - module: tool-task
-    source: git+https://github.com/microsoft/amplifier-module-tool-task@main
-    config:
-      exclude_tools: [tool-task, delegate]  # Prevent both tools from spawning
 
 context:
   include:

--- a/behaviors/agents.yaml
+++ b/behaviors/agents.yaml
@@ -1,17 +1,44 @@
 bundle:
   name: behavior-agents
-  version: 1.0.0
+  version: 2.0.0
   description: |
-    Agent orchestration capability - task tool and delegation patterns.
+    Agent orchestration capability - delegate tool and delegation patterns.
     Provides the infrastructure for agent delegation without specifying
     which agents to include. Agent selection is owned by root bundles
     and other behaviors that compose this one.
+    
+    Features:
+    - Two-parameter context inheritance (depth + scope)
+    - Short session ID resolution (6+ chars)
+    - Fixed tool inheritance (agent declarations honored)
+    - Multi-agent collaboration patterns
 
 tools:
+  # New delegate tool - recommended for new development
+  - module: tool-delegate
+    source: ./modules/tool-delegate
+    config:
+      features:
+        self_delegation:
+          enabled: true
+        session_resume:
+          enabled: true
+        context_inheritance:
+          enabled: true
+          max_turns: 10
+        provider_selection:
+          enabled: true
+      settings:
+        exclude_tools: [delegate]  # Spawned agents can't further delegate by default
+        exclude_hooks: []
+        timeout: 300
+
+  # Legacy task tool - maintained for backwards compatibility
+  # Consider migrating to delegate tool for new features
   - module: tool-task
     source: git+https://github.com/microsoft/amplifier-module-tool-task@main
     config:
-      exclude_tools: [tool-task]
+      exclude_tools: [tool-task, delegate]  # Prevent both tools from spawning
 
 context:
   include:

--- a/behaviors/tasks.yaml
+++ b/behaviors/tasks.yaml
@@ -1,0 +1,19 @@
+bundle:
+  name: behavior-tasks
+  version: 1.0.0
+  description: |
+    Legacy task tool behavior for backwards compatibility.
+    For new development, consider using the 'agents' behavior with the
+    enhanced delegate tool (two-parameter context, short session IDs, etc.)
+
+tools:
+  # Legacy task tool - maintained for backwards compatibility
+  - module: tool-task
+    source: git+https://github.com/microsoft/amplifier-module-tool-task@main
+    config:
+      exclude_tools: [tool-task]
+
+context:
+  include:
+    - foundation:context/agents/delegation-instructions.md
+    - foundation:context/agents/multi-agent-patterns.md

--- a/bundle.md
+++ b/bundle.md
@@ -16,7 +16,7 @@ includes:
   - bundle: foundation:behaviors/redaction
   - bundle: foundation:behaviors/todo-reminder
   - bundle: foundation:behaviors/streaming-ui
-  - bundle: foundation:behaviors/agents
+  - bundle: foundation:behaviors/tasks  # Legacy task tool behavior (for new delegate tool, use exp-foundation)
   # External bundles
   - bundle: git+https://github.com/microsoft/amplifier-bundle-recipes@main#subdirectory=behaviors/recipes.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-design-intelligence@main#subdirectory=behaviors/design-intelligence.yaml

--- a/context/agents/delegation-instructions.md
+++ b/context/agents/delegation-instructions.md
@@ -4,6 +4,48 @@ This context provides agent orchestration capabilities. It is loaded via the `fo
 
 ---
 
+## The Delegation Imperative
+
+**Delegation is not optional - it is the PRIMARY operating mode.**
+
+Every tool call you make consumes tokens from YOUR context window. Long-running sessions degrade as context fills. The solution: **delegate aggressively**.
+
+### Token Conservation Through Delegation
+
+| Approach | Token Cost | Session Longevity |
+|----------|------------|-------------------|
+| Direct work (20 file reads) | ~20,000 tokens in YOUR context | Session degrades quickly |
+| Delegated work (same 20 reads) | ~500 tokens (summary only) | Session stays fresh |
+
+**The math is clear:** Delegation preserves your context for high-value orchestration while agents handle token-heavy exploration.
+
+### The Rule: Delegate First, Always
+
+Before attempting ANY of the following yourself, you MUST delegate:
+
+| Task Type | Delegate To | Why |
+|-----------|-------------|-----|
+| File exploration (>2 files) | `foundation:explorer` | Context sink |
+| Code understanding | `lsp-python:python-code-intel` | Specialized tools |
+| Architecture/design | `foundation:zen-architect` | Philosophy context |
+| Implementation | `foundation:modular-builder` | Implementation patterns |
+| Debugging | `foundation:bug-hunter` | Hypothesis methodology |
+| Git operations | `foundation:git-ops` | Safety protocols |
+| Session analysis | `foundation:session-analyst` | Handles 100k+ token lines |
+
+### Signs You're Violating This
+
+- "Let me just check this file quickly..." → STOP. Delegate.
+- "I think I know the answer..." → STOP. Consult an expert agent first.
+- "This seems straightforward..." → It's not. Delegate.
+- Reading more than 2 files without delegation → STOP. Delegate.
+- Making architectural decisions without zen-architect → Invalid.
+
+**Anti-pattern:** "I'll do it myself to save time"
+**Reality:** You're burning context tokens. Delegation IS faster for session longevity.
+
+---
+
 ## Why Delegation Matters
 
 Agents are **context sinks** that provide critical benefits:
@@ -18,6 +60,12 @@ Agents are **context sinks** that provide critical benefits:
 - Delegated approach: 20 file reads in AGENT context, 500 token summary returned to you
 
 **Rule**: If a task will consume significant context, requires exploration, or matches an agent's domain, DELEGATE.
+
+### Session Longevity Depends on Delegation
+
+Your context window is finite. Every direct tool call, every file read, every search result consumes tokens that NEVER come back. Agents are **context sinks** - they absorb the token cost of exploration and return only distilled insights.
+
+**Think of it this way:** You are the orchestrator. Orchestrators don't read every file - they dispatch specialists and synthesize results. The more you delegate, the longer your session can run effectively.
 
 ---
 

--- a/context/agents/delegation-instructions.md
+++ b/context/agents/delegation-instructions.md
@@ -4,48 +4,6 @@ This context provides agent orchestration capabilities. It is loaded via the `fo
 
 ---
 
-## The Delegation Imperative
-
-**Delegation is not optional - it is the PRIMARY operating mode.**
-
-Every tool call you make consumes tokens from YOUR context window. Long-running sessions degrade as context fills. The solution: **delegate aggressively**.
-
-### Token Conservation Through Delegation
-
-| Approach | Token Cost | Session Longevity |
-|----------|------------|-------------------|
-| Direct work (20 file reads) | ~20,000 tokens in YOUR context | Session degrades quickly |
-| Delegated work (same 20 reads) | ~500 tokens (summary only) | Session stays fresh |
-
-**The math is clear:** Delegation preserves your context for high-value orchestration while agents handle token-heavy exploration.
-
-### The Rule: Delegate First, Always
-
-Before attempting ANY of the following yourself, you MUST delegate:
-
-| Task Type | Delegate To | Why |
-|-----------|-------------|-----|
-| File exploration (>2 files) | `foundation:explorer` | Context sink |
-| Code understanding | `lsp-python:python-code-intel` | Specialized tools |
-| Architecture/design | `foundation:zen-architect` | Philosophy context |
-| Implementation | `foundation:modular-builder` | Implementation patterns |
-| Debugging | `foundation:bug-hunter` | Hypothesis methodology |
-| Git operations | `foundation:git-ops` | Safety protocols |
-| Session analysis | `foundation:session-analyst` | Handles 100k+ token lines |
-
-### Signs You're Violating This
-
-- "Let me just check this file quickly..." → STOP. Delegate.
-- "I think I know the answer..." → STOP. Consult an expert agent first.
-- "This seems straightforward..." → It's not. Delegate.
-- Reading more than 2 files without delegation → STOP. Delegate.
-- Making architectural decisions without zen-architect → Invalid.
-
-**Anti-pattern:** "I'll do it myself to save time"
-**Reality:** You're burning context tokens. Delegation IS faster for session longevity.
-
----
-
 ## Why Delegation Matters
 
 Agents are **context sinks** that provide critical benefits:
@@ -60,12 +18,6 @@ Agents are **context sinks** that provide critical benefits:
 - Delegated approach: 20 file reads in AGENT context, 500 token summary returned to you
 
 **Rule**: If a task will consume significant context, requires exploration, or matches an agent's domain, DELEGATE.
-
-### Session Longevity Depends on Delegation
-
-Your context window is finite. Every direct tool call, every file read, every search result consumes tokens that NEVER come back. Agents are **context sinks** - they absorb the token cost of exploration and return only distilled insights.
-
-**Think of it this way:** You are the orchestrator. Orchestrators don't read every file - they dispatch specialists and synthesize results. The more you delegate, the longer your session can run effectively.
 
 ---
 

--- a/context/agents/delegation-instructions.md
+++ b/context/agents/delegation-instructions.md
@@ -46,9 +46,51 @@ Before attempting ANY of the following yourself, you MUST delegate:
 
 ---
 
+## The Context Sink Pattern
+
+**Agents are context sinks** - they absorb the token cost of exploration and return only distilled insights.
+
+### How It Works
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Root Session (YOUR context)                                │
+│  - Orchestration decisions                                  │
+│  - User interaction                                         │
+│  - ~500 token summaries from agents                         │
+└────────────────────────┬────────────────────────────────────┘
+                         │ delegate()
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Agent Session (AGENT's context)                            │
+│  - Heavy @-mentioned documentation                          │
+│  - 20+ file reads (~20k tokens)                             │
+│  - Specialized tools and analysis                           │
+│  - Returns: concise summary to parent                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Why This Matters
+
+| Without Context Sink | With Context Sink |
+|---------------------|-------------------|
+| 20 file reads = 20k tokens in YOUR context | 20 file reads in AGENT context |
+| Session fills quickly | Session stays lean |
+| Can't run long tasks | Can orchestrate for hours |
+| Loses history to compaction | Preserves important history |
+
+### Applying the Pattern
+
+1. **Expert agents carry heavy docs** - @-mentioned documentation loads in THEIR context
+2. **Root sessions get thin pointers** - "This capability exists, delegate to X"
+3. **Zero partial knowledge** - If capability isn't composed, zero context about it
+4. **Summarize, don't relay** - Agents return insights, not raw data
+
+---
+
 ## Why Delegation Matters
 
-Agents are **context sinks** that provide critical benefits:
+Agents as **context sinks** provide critical benefits:
 
 1. **Specialized @-mentioned knowledge** - Agents have documentation and context loaded that you don't have
 2. **Token efficiency** - Their work consumes THEIR context, not the main session's

--- a/context/agents/delegation-instructions.md
+++ b/context/agents/delegation-instructions.md
@@ -89,76 +89,91 @@ Agent domain claims are authoritative. The agent descriptions contain expertise 
 
 ---
 
-## Task Tool Usage
+## Delegate Tool Usage
 
-- When doing file search, prefer to use the task tool in order to reduce context usage.
-- You should proactively use the task tool with specialized agents when the task at hand matches the agent's description.
-- If the user specifies that they want you to run tools "in parallel", you MUST send a single message with multiple tool use content blocks.
-- **Git operations**: ALWAYS delegate git operations to `foundation:git-ops` including:
-  - Commits and PRs (creates quality messages with context, has safety protocols)
-  - Multi-repo sync operations (fetch, pull, status checks)
-  - Branch management and conflict resolution
-  
-  When delegating, pass context: what was accomplished, files changed, and intent.
+The `delegate` tool spawns specialized agents for autonomous task handling.
 
-- VERY IMPORTANT: When exploring local files (codebase, etc.) to gather context or to answer a question that is not a needle query for a specific file/class/function, it is CRITICAL that you use the task tool with agent=foundation:explorer instead of running search commands directly.
+### Basic Delegation
 
----
-
-## Context Management for Agent Delegation
-
-### Default: Clean Context (Preferred)
-
-By default, agents start with clean context (no main conversation history).
-This provides:
-- Focused, unbiased execution
-- Token efficiency (agent work doesn't consume main session tokens)
-- Fresh context space for agent
-- Parallel execution capability
-
-**Use clean context for:**
-- Independent tasks
-- Initial delegations
-- Parallel agent execution
-- Tasks with explicit specifications
-
-### Context Inheritance: When to Use
-
-Override default with `inherit_context` when agent needs recent discussion context:
-
-**Good for:**
-- Follow-up questions building on recent work ("analyze the design we just discussed")
-- Iterative refinement with user feedback from conversation
-- Meta-analysis tasks (analyzing the conversation itself)
-
-**Avoid for:**
-- Initial calls (no prior context needed)
-- Independent tasks (specification is sufficient)
-- Parallel execution (agents should be independent)
-
-**Usage:**
 ```python
-task(agent="foundation:zen-architect",
-     instruction="Analyze failure modes in the design we discussed",
-     inherit_context="recent",
-     inherit_context_turns=3)
+delegate(agent="foundation:explorer", instruction="Survey the authentication module")
 ```
 
-**Prefer `recent` (3-5 turns) over `all`** - keeps tokens reasonable.
+### Special Agent Values
+
+- `agent="self"` - Spawn yourself as a sub-agent (maximum token conservation)
+- `agent="namespace:path/to/bundle"` - Delegate to any bundle directly
+
+### Context Control (Two Independent Parameters)
+
+The delegate tool provides fine-grained control over context inheritance:
+
+**Parameter 1: `context_depth`** - HOW MUCH context to inherit
+
+| Value | Behavior |
+|-------|----------|
+| `"none"` | Clean slate - agent starts fresh (use for independent tasks) |
+| `"recent"` | Last N turns (default, controlled by `context_turns`) |
+| `"all"` | Full conversation history |
+
+**Parameter 2: `context_scope`** - WHICH content to include
+
+| Value | What's Included |
+|-------|-----------------|
+| `"conversation"` | User/assistant text only (default, safest) |
+| `"agents"` | + results from delegate tool calls (for multi-agent collaboration) |
+| `"full"` | + ALL tool results (complete context mirror) |
+
+### Context Usage Examples
+
+```python
+# Default: Recent conversation text (most common)
+delegate(agent="foundation:explorer", instruction="...")
+
+# Independent task - fresh perspective
+delegate(agent="foundation:zen-architect", instruction="Review design",
+         context_depth="none")
+
+# Multi-agent collaboration - agent B sees agent A's output
+delegate(agent="foundation:architect", instruction="Design based on findings",
+         context_scope="agents")
+
+# Self-delegation with full context (recommended for "self")
+delegate(agent="self", instruction="Continue this analysis",
+         context_depth="all", context_scope="full")
+
+# Debugging - bug-hunter needs to see everything
+delegate(agent="foundation:bug-hunter", instruction="Why did this fail?",
+         context_depth="all", context_scope="full")
+```
+
+### Git Operations
+
+**ALWAYS delegate git operations to `foundation:git-ops`** including:
+- Commits and PRs (creates quality messages with context, has safety protocols)
+- Multi-repo sync operations (fetch, pull, status checks)
+- Branch management and conflict resolution
+
+When delegating, pass context: what was accomplished, files changed, and intent.
 
 ---
 
-## Follow-up Sessions
+## Session Resumption
 
-You can resume agent sessions to continue work or ask follow-up questions:
+Delegate returns a `short_id` (6-8 characters) for easy session resume:
 
+```python
+# Initial delegation
+result = delegate(agent="foundation:explorer", instruction="Survey codebase")
+# result.short_id = "a3f2b8"
+
+# Resume with short ID
+delegate(session_id="a3f2b8", instruction="Now also check the tests")
 ```
-[task session_id="previous-session-id" instruction="Now also check for edge cases"]
-```
 
-Use follow-ups when:
+Use session resumption when:
 - Initial findings need deeper investigation
-- You want the same agent to continue with accumulated context
+- You want the agent to continue with accumulated context
 - Breaking a large task into progressive refinements
 
 ---
@@ -167,10 +182,11 @@ Use follow-ups when:
 
 For large codebases or complex investigations, dispatch MULTIPLE instances of the same agent with different scopes:
 
-```
-[task agent=foundation:explorer instruction="Survey the auth/ directory"]
-[task agent=foundation:explorer instruction="Survey the api/ directory"]  
-[task agent=foundation:explorer instruction="Survey the models/ directory"]
+```python
+# Parallel dispatch - independent surveys
+delegate(agent="foundation:explorer", instruction="Survey auth/", context_depth="none")
+delegate(agent="foundation:explorer", instruction="Survey api/", context_depth="none")
+delegate(agent="foundation:explorer", instruction="Survey models/", context_depth="none")
 ```
 
 **When to scale:**

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,47 +1,149 @@
 # Experimental Bundles
 
-This directory contains experimental bundle configurations for testing new ideas and patterns before potentially promoting them to the main foundation bundle.
+This directory contains **experimental** bundles for testing new features before wider rollout.
 
-## Available Experiments
+## Philosophy
 
-### `delegation-only/`
+### Why Experimental Bundles?
 
-**Status**: Active Experiment
+New features need real-world validation before becoming defaults. Experimental bundles provide:
 
-A bundle that has **NO direct tool access** - the coordinator must delegate ALL work to specialized agents. This tests:
+1. **Safe opt-in testing** - Users explicitly choose to test new features
+2. **Feedback collection** - Early adopters help refine implementations
+3. **Gradual rollout** - Features mature in experiments before promotion
+4. **Easy rollback** - Standard bundles remain stable
 
-1. **Context offloading** - Agents handle heavy exploration, return summaries
-2. **Reduced context bloat** - Main conversation stays clean and focused
-3. **Effective delegation patterns** - How to communicate with stateless agents
+### The Experiment Lifecycle
 
-**To use:**
-```bash
-amplifier bundle use foundation:experiments/delegation-only
+```
+1. EXPERIMENT     → Feature implemented in exp-* bundle
+2. VALIDATION     → Early adopters test and provide feedback
+3. REFINEMENT     → Issues fixed, patterns refined
+4. PROMOTION      → Feature moves to standard bundle
+5. DEPRECATION    → Experimental bundle marked for removal
 ```
 
-**Key insight**: Agents cannot see the main conversation history, and the coordinator cannot see agent internal work. This means:
-- Provide COMPLETE context in every delegation
-- Specify EXACTLY what information to return
-- Assume agents know NOTHING about prior work
+### Naming Convention
 
-## Adding New Experiments
+All experimental bundles use the `exp-` prefix:
 
-1. Create a new directory under `experiments/`
-2. Add a `bundle.md` with the bundle definition
-3. Add any custom agents in an `agents/` subdirectory
-4. Update this README with the experiment description
-5. Document the hypothesis and what you're testing
+| Bundle | Description |
+|--------|-------------|
+| `exp-foundation` | Foundation bundle with experimental features |
+| `exp-amplifier-dev` | Amplifier development bundle with experimental features |
 
-## Promotion Path
+---
 
-Experiments that prove successful may be:
-- Merged into the main `foundation` bundle as options
-- Extracted to their own standalone bundle
-- Used to inform changes to existing patterns
+## Current Experiments
 
-## Guidelines
+### exp-foundation
 
-- Keep experiments focused on a single idea/hypothesis
-- Document what you're testing and why
-- Include instructions for others to try it
-- Note any limitations or known issues
+**Testing:** New `delegate` tool with enhanced agent orchestration
+
+**Key Features:**
+- Two-parameter context inheritance (`context_depth` + `context_scope`)
+- Short session ID resolution (6+ character prefixes)
+- Fixed tool inheritance (explicit declarations always honored)
+- Feature Registry for dynamic description composition
+
+**How to Use:**
+```bash
+amplifier bundle add foundation:experiments/exp-foundation --name exp-foundation
+amplifier bundle use exp-foundation
+```
+
+### exp-amplifier-dev
+
+**Testing:** Amplifier ecosystem development with new delegate tool
+
+**Includes:**
+- All exp-foundation features
+- Amplifier dev behavior (multi-repo workflows)
+- Shadow environment helpers
+
+**How to Use:**
+```bash
+amplifier bundle add foundation:experiments/exp-amplifier-dev --name exp-amplifier-dev
+amplifier bundle use exp-amplifier-dev
+```
+
+---
+
+## Providing Feedback
+
+When testing experimental bundles, please report:
+
+1. **What worked well** - Features that improved your workflow
+2. **What didn't work** - Bugs, unexpected behavior, regressions
+3. **What's missing** - Features that would help but aren't implemented
+4. **Suggestions** - Ideas for improvement
+
+Open issues in the amplifier-foundation repository with the `[experiment]` tag.
+
+---
+
+## Comparison: Standard vs Experimental
+
+| Aspect | Standard (foundation) | Experimental (exp-foundation) |
+|--------|----------------------|-------------------------------|
+| Delegation tool | `task` (legacy) | `delegate` (new) |
+| Context params | `inherit_context` | `context_depth` + `context_scope` |
+| Session resume | Full UUID required | Short 6+ char prefix |
+| Tool inheritance | Bug: exclusions override | Fixed: declarations honored |
+| Stability | Production-ready | Testing/validation |
+
+---
+
+## Creating New Experiments
+
+When adding a new experimental bundle:
+
+1. **Name it `exp-<name>`** - Follow the naming convention
+2. **Document the experiment** - What's being tested and why
+3. **Set version to 0.x.x** - Signal experimental status
+4. **Include feedback instructions** - How to report issues
+5. **Update this README** - Add to "Current Experiments" section
+
+### Template
+
+```yaml
+---
+bundle:
+  name: exp-<name>
+  version: 0.1.0
+  description: |
+    EXPERIMENTAL bundle for testing <feature>.
+    
+    To use: amplifier bundle add foundation:experiments/exp-<name>
+---
+
+# Experimental <Name> Bundle
+
+## What's Being Tested
+<description>
+
+## Feedback
+Please report issues with [experiment] tag.
+```
+
+---
+
+## Graduation Criteria
+
+An experiment is ready for promotion when:
+
+- [ ] Core functionality works reliably
+- [ ] No critical bugs outstanding
+- [ ] Positive feedback from early adopters
+- [ ] Documentation is complete
+- [ ] Performance is acceptable
+- [ ] Backwards compatibility addressed (migration path if breaking)
+
+---
+
+## Current Status
+
+| Experiment | Status | Target Promotion |
+|------------|--------|------------------|
+| exp-foundation | Active testing | TBD |
+| exp-amplifier-dev | Active testing | TBD |

--- a/experiments/exp-amplifier-dev.md
+++ b/experiments/exp-amplifier-dev.md
@@ -1,0 +1,78 @@
+---
+bundle:
+  name: exp-amplifier-dev
+  version: 0.1.0
+  description: |
+    EXPERIMENTAL amplifier-dev bundle with NEW delegate tool.
+    
+    Bundle for developing ON the Amplifier ecosystem with enhanced agent delegation:
+    - Multi-repo coordination
+    - Testing patterns  
+    - Shadow environments
+    - NEW delegate tool with two-param context
+    
+    To use this bundle:
+      amplifier bundle add foundation:experiments/exp-amplifier-dev --name exp-amplifier-dev
+      amplifier bundle use exp-amplifier-dev
+
+includes:
+  # Base experimental foundation (has new delegate tool)
+  - bundle: foundation:experiments/exp-foundation
+  # Amplifier dev behavior (agents + context)
+  - bundle: foundation:behaviors/amplifier-dev
+  # Shadow environments with Amplifier-specific helpers
+  - bundle: foundation:behaviors/shadow-amplifier
+
+# Development-specific session settings
+session:
+  raw_debug: true  # Enable raw debug events (debug: true inherited from exp-foundation)
+---
+
+# Experimental Amplifier Development Bundle
+
+This is an **EXPERIMENTAL** bundle for Amplifier ecosystem development, using the new delegate tool.
+
+## What's Included
+
+| Component | Source |
+|-----------|--------|
+| Base capabilities | `exp-foundation` (with new delegate tool) |
+| Amplifier dev behavior | Multi-repo workflows, testing patterns |
+| Shadow environments | Amplifier-specific shadow helpers |
+
+## New Delegate Tool Features
+
+This bundle inherits the new delegate tool from exp-foundation:
+
+### Two-Parameter Context Control
+
+```python
+# Clean slate - agent starts fresh
+delegate(agent="foundation:explorer", context_depth="none", ...)
+
+# Multi-agent collaboration - see other agent results
+delegate(agent="foundation:architect", context_scope="agents", ...)
+
+# Self-delegation with full context
+delegate(agent="self", context_depth="all", context_scope="full", ...)
+```
+
+### Short Session IDs
+
+```python
+result = delegate(agent="foundation:explorer", instruction="Survey codebase")
+# result.short_id = "a3f2b8"
+
+# Resume with short prefix
+delegate(session_id="a3f2b8", instruction="Now check the tests")
+```
+
+## Use Cases
+
+- Multi-repo development with coordinated changes
+- Shadow testing of local Amplifier ecosystem changes
+- Ecosystem-wide analysis and refactoring
+
+## Feedback
+
+Please report issues and feedback to help refine the delegate tool before wider rollout.

--- a/experiments/exp-foundation.md
+++ b/experiments/exp-foundation.md
@@ -1,0 +1,123 @@
+---
+bundle:
+  name: exp-foundation
+  version: 0.1.0
+  description: |
+    EXPERIMENTAL foundation bundle with NEW delegate tool.
+    
+    This bundle uses the enhanced agent delegation system with:
+    - Two-parameter context inheritance (context_depth + context_scope)
+    - Short session ID resolution (6+ character prefixes)
+    - Fixed tool inheritance (explicit declarations always honored)
+    
+    USE FOR: Testing and validating the new delegate tool before wider rollout.
+    
+    To use this bundle:
+      amplifier bundle add foundation:experiments/exp-foundation --name exp-foundation
+      amplifier bundle use exp-foundation
+
+includes:
+  # Ecosystem expert behaviors (provides @amplifier: and @core: namespaces)
+  - bundle: git+https://github.com/microsoft/amplifier@main#subdirectory=behaviors/amplifier-expert.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-core@main#subdirectory=behaviors/core-expert.yaml
+  # Foundation expert behavior
+  - bundle: foundation:behaviors/foundation-expert
+  # Foundation behaviors
+  - bundle: foundation:behaviors/sessions
+  - bundle: foundation:behaviors/status-context
+  - bundle: foundation:behaviors/redaction
+  - bundle: foundation:behaviors/todo-reminder
+  - bundle: foundation:behaviors/streaming-ui
+  # NEW: agents behavior with delegate tool (instead of tasks behavior)
+  - bundle: foundation:behaviors/agents
+  # External bundles
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-recipes@main#subdirectory=behaviors/recipes.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-design-intelligence@main#subdirectory=behaviors/design-intelligence.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-python-dev@main
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-shadow@main
+  - bundle: git+https://github.com/microsoft/amplifier-module-tool-skills@main#subdirectory=behaviors/skills.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-module-hook-shell@main#subdirectory=behaviors/hook-shell.yaml
+
+
+session:
+  debug: true
+  orchestrator:
+    module: loop-streaming
+    source: git+https://github.com/microsoft/amplifier-module-loop-streaming@main
+    config:
+      extended_thinking: true
+  context:
+    module: context-simple
+    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
+    config:
+      max_tokens: 300000
+      compact_threshold: 0.8
+      auto_compact: true
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+  - module: tool-web
+    source: git+https://github.com/microsoft/amplifier-module-tool-web@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+  # NOTE: delegate tool comes from agents behavior, task tool is NOT included
+
+agents:
+  include:
+    # Note: amplifier-expert, core-expert, and foundation-expert come via included behaviors above
+    - foundation:bug-hunter
+    - foundation:explorer
+    - foundation:file-ops
+    - foundation:git-ops
+    - foundation:integration-specialist
+    - foundation:modular-builder
+    - foundation:post-task-cleanup
+    - foundation:security-guardian
+    - foundation:test-coverage
+    - foundation:web-research
+    - foundation:zen-architect
+---
+
+# Experimental Foundation Bundle
+
+This is an **EXPERIMENTAL** bundle for testing the new delegate tool.
+
+## What's Different
+
+| Feature | Standard Foundation | exp-foundation |
+|---------|--------------------|--------------------|
+| Delegation tool | `task` (legacy) | `delegate` (new) |
+| Context params | `inherit_context` | `context_depth` + `context_scope` |
+| Session resume | Full UUID only | Short ID (6+ chars) |
+| Tool inheritance | Bug: exclusions override declarations | Fixed: declarations honored |
+
+## New Delegate Tool Features
+
+### Two-Parameter Context
+
+```python
+# HOW MUCH context to inherit
+context_depth: "none" | "recent" | "all"
+
+# WHICH content to include
+context_scope: "conversation" | "agents" | "full"
+```
+
+### Short Session IDs
+
+```python
+result = delegate(agent="foundation:explorer", instruction="...")
+# result.short_id = "a3f2b8"
+
+# Resume with short ID
+delegate(session_id="a3f2b8", instruction="Continue...")
+```
+
+## Feedback
+
+Please report issues and feedback to help refine the delegate tool before wider rollout.
+
+@foundation:context/shared/common-system-base.md

--- a/modules/tool-delegate/README.md
+++ b/modules/tool-delegate/README.md
@@ -1,0 +1,73 @@
+# tool-delegate
+
+Delegate tasks to specialized agents with enhanced context control.
+
+## Purpose
+
+The `delegate` tool enables AI agents to spawn sub-sessions for complex subtasks. It provides fine-grained control over context inheritance and supports seamless session resumption.
+
+## Key Features
+
+### Two-Parameter Context System
+
+Control context inheritance with two orthogonal parameters:
+
+- **`context_depth`** - HOW MUCH context to pass:
+  - `none` - Clean slate, no parent context
+  - `recent` - Last N turns (configurable via `context_turns`)
+  - `all` - Full conversation history
+
+- **`context_scope`** - WHICH content to include:
+  - `conversation` - Only user/assistant text (strips all tool content)
+  - `agents` - Includes delegate/task tool results
+  - `full` - Includes ALL tool results
+
+### Short Session ID Resolution
+
+Resume sessions using just the first 6+ characters of a session ID:
+
+```
+session_id: "a3f2b1"  # Resolves to full session ID
+```
+
+### Tool Inheritance Fix
+
+Agent's explicit tool declarations are always honored, even when parent excludes them. Exclusions apply only to inheritance, not explicit declarations.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `agent` | string | required | Agent to delegate to (e.g., 'foundation:explorer', 'self') |
+| `instruction` | string | required | Clear instruction for the agent |
+| `session_id` | string | - | Resume existing session (supports 6+ char prefixes) |
+| `context_depth` | enum | "recent" | How much context: none, recent, all |
+| `context_turns` | integer | 5 | Number of turns when context_depth is 'recent' |
+| `context_scope` | enum | "conversation" | Which content: conversation, agents, full |
+| `provider_preferences` | array | - | Ordered provider/model preferences |
+
+## Configuration
+
+```yaml
+modules:
+  tool-delegate:
+    features:
+      self_delegation:
+        enabled: true
+      session_resume:
+        enabled: true
+      context_inheritance:
+        enabled: true
+        max_turns: 10
+      provider_selection:
+        enabled: true
+    settings:
+      exclude_tools:
+        - delegate  # Default: spawned agents can't further delegate
+      exclude_hooks: []
+      timeout: 300
+```
+
+## Note
+
+This module is recommended over `tool-task` for new development due to its enhanced context control and bug fixes.

--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -1,0 +1,971 @@
+"""
+Agent delegation tool module.
+
+Enables AI agents to spawn sub-sessions for complex subtasks via capability-based architecture.
+This module implements the Delegate tool with enhanced context control and session management.
+
+Key Design Points:
+- Two-parameter context system: depth (how much) and scope (which content)
+- Short session ID resolution (minimum 6 characters)
+- Fixed tool inheritance: agent's explicit declarations always honored
+- Dynamic description with agent list
+- Configurable features via structured config
+
+Config Options:
+- features.self_delegation.enabled: Allow agent="self" (default: True)
+- features.session_resume.enabled: Allow session resumption (default: True)
+- features.context_inheritance.enabled: Allow context passing (default: True)
+- features.context_inheritance.max_turns: Maximum turns for "recent" mode (default: 10)
+- features.provider_selection.enabled: Allow provider preferences (default: True)
+- settings.exclude_tools: Tools spawned agents should NOT inherit (default: ["delegate"])
+- settings.exclude_hooks: Hooks spawned agents should NOT inherit (default: [])
+- settings.timeout: Maximum execution time in seconds (default: 300)
+
+Tool Parameters:
+- agent: Agent to delegate to (e.g., 'foundation:explorer', 'self')
+- instruction: Clear instruction for the agent
+- session_id: Resume existing session (supports 6+ char prefixes)
+- context_depth: "none" | "recent" | "all" - HOW MUCH context (default: "recent")
+- context_turns: Number of turns for "recent" mode (default: 5)
+- context_scope: "conversation" | "agents" | "full" - WHICH content (default: "conversation")
+- provider_preferences: Ordered list of provider/model preferences
+"""
+
+# Amplifier module metadata
+__amplifier_module_type__ = "tool"
+
+import logging
+import uuid
+from typing import Any
+
+from amplifier_core import ModuleCoordinator, ToolResult
+from amplifier_foundation import ProviderPreference
+
+logger = logging.getLogger(__name__)
+
+
+async def mount(coordinator: ModuleCoordinator, config: dict[str, Any] | None = None):
+    """Mount the agent delegation tool.
+
+    Args:
+        coordinator: The module coordinator
+        config: Optional configuration with features and settings
+
+    Returns:
+        None - No cleanup needed for this module
+    """
+    config = config or {}
+
+    # Declare observable lifecycle events for this module
+    obs_events = coordinator.get_capability("observability.events") or []
+    obs_events.extend(
+        [
+            "delegate:agent_spawned",  # When agent sub-session spawned
+            "delegate:agent_resumed",  # When agent sub-session resumed
+            "delegate:agent_completed",  # When agent sub-session completed
+            "delegate:error",  # When delegation fails
+        ]
+    )
+    coordinator.register_capability("observability.events", obs_events)
+
+    tool = DelegateTool(coordinator, config)
+    await coordinator.mount("tools", tool, name=tool.name)
+    logger.info("Mounted DelegateTool with observable events")
+    return  # No cleanup needed
+
+
+class DelegateTool:
+    """Delegate tasks to specialized agents via sub-sessions.
+
+    This tool provides fine-grained control over context inheritance
+    and supports seamless session resumption with short ID prefixes.
+
+    Key improvements over task tool:
+    - Two-parameter context: depth (how much) and scope (which content)
+    - Short session ID resolution (6+ characters)
+    - Fixed tool inheritance: agent declarations always honored
+    """
+
+    name = "delegate"
+
+    def __init__(self, coordinator: ModuleCoordinator, config: dict[str, Any]):
+        """Initialize the delegate tool.
+
+        Args:
+            coordinator: Module coordinator for accessing capabilities
+            config: Configuration with features and settings sections
+        """
+        self.coordinator = coordinator
+        self.config = config
+
+        # Parse structured config
+        features = config.get("features", {})
+        settings = config.get("settings", {})
+
+        # Feature flags
+        self.self_delegation_enabled = features.get("self_delegation", {}).get(
+            "enabled", True
+        )
+        self.session_resume_enabled = features.get("session_resume", {}).get(
+            "enabled", True
+        )
+        self.context_inheritance_enabled = features.get("context_inheritance", {}).get(
+            "enabled", True
+        )
+        self.max_context_turns = features.get("context_inheritance", {}).get(
+            "max_turns", 10
+        )
+        self.provider_selection_enabled = features.get("provider_selection", {}).get(
+            "enabled", True
+        )
+
+        # Settings
+        self.exclude_tools: list[str] = settings.get("exclude_tools", ["delegate"])
+        self.exclude_hooks: list[str] = settings.get("exclude_hooks", [])
+        self.timeout: int = settings.get("timeout", 300)
+
+    @property
+    def description(self) -> str:
+        """Generate dynamic description with available agents.
+
+        Queries the agent registry to provide an up-to-date list
+        of available agents in the tool description.
+        """
+        agents_list = self._get_agent_list()
+
+        base_description = """Spawn a specialized agent to handle complex, multi-step tasks autonomously.
+
+Agent delegation conserves your context window. Work done by agents uses THEIR context, returning only
+the summary to you. Prefer agent delegation for:
+- Tasks requiring multiple file reads or searches
+- Self-contained work with clear success criteria
+- Tasks matching an agent's specialty
+
+Special agent values:
+- agent="self": Spawn yourself as a sub-agent (maximum token conservation)
+- agent="namespace:path/to/bundle": Delegate to any bundle directly as an agent
+
+Context control (two independent parameters):
+- context_depth: HOW MUCH context - "none" (clean slate), "recent" (last N turns), "all" (full history)
+- context_scope: WHICH content - "conversation" (text only), "agents" (+ agent results), "full" (+ all tools)
+
+Agent usage notes:
+- Launch multiple agents concurrently when tasks are independent
+- When an agent completes, it returns a single message back to you
+- Each agent invocation is stateless - provide complete context in your instruction
+- Use session_id to resume an existing agent session (supports 6+ char prefixes)"""
+
+        if agents_list:
+            agent_desc = "\n".join(
+                f"  - {a['name']}: {a.get('description', 'No description')}"
+                for a in agents_list
+            )
+            return f"{base_description}\n\nAvailable agents:\n{agent_desc}"
+
+        return f'{base_description}\n\nNo agents currently registered. Use agent="self" or a bundle path.'
+
+    @property
+    def input_schema(self) -> dict:
+        """Input schema for agent delegation.
+
+        Supports both spawn (agent + instruction) and resume (session_id + instruction).
+
+        Returns:
+            JSON schema for the tool input with structured parameters
+        """
+        return {
+            "type": "object",
+            "properties": {
+                "agent": {
+                    "type": "string",
+                    "description": "Agent to delegate to (e.g., 'foundation:explorer', 'self', or bundle path)",
+                },
+                "instruction": {
+                    "type": "string",
+                    "description": "Clear instruction for the agent",
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": "Resume existing agent session (supports short 6+ char prefixes)",
+                },
+                "context_depth": {
+                    "type": "string",
+                    "enum": ["none", "recent", "all"],
+                    "description": "HOW MUCH context: 'none' (clean slate), 'recent' (last N turns), 'all' (full history)",
+                },
+                "context_turns": {
+                    "type": "integer",
+                    "description": "Number of turns when context_depth is 'recent' (default: 5)",
+                },
+                "context_scope": {
+                    "type": "string",
+                    "enum": ["conversation", "agents", "full"],
+                    "description": "WHICH content: 'conversation' (user/assistant text), 'agents' (+ delegate results), 'full' (+ all tool results)",
+                },
+                "provider_preferences": {
+                    "type": "array",
+                    "description": "Ordered list of provider/model preferences with glob pattern support",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "provider": {
+                                "type": "string",
+                                "description": "Provider name (e.g., 'anthropic', 'openai')",
+                            },
+                            "model": {
+                                "type": "string",
+                                "description": "Model name or glob pattern (e.g., 'claude-haiku-*')",
+                            },
+                        },
+                        "required": ["provider", "model"],
+                    },
+                },
+            },
+            "required": ["instruction"],
+        }
+
+    def _get_agent_list(self) -> list[dict[str, Any]]:
+        """Get list of available agents from mount plan.
+
+        Returns:
+            List of agent definitions with name and description
+        """
+        agents = self.coordinator.config.get("agents", {})
+        sorted_agents = sorted(agents.items(), key=lambda item: item[0])
+        return [
+            {"name": name, "description": cfg.get("description", "No description")}
+            for name, cfg in sorted_agents
+        ]
+
+    async def _resolve_short_session_id(self, prefix: str) -> str:
+        """Resolve short prefix to full session ID.
+
+        Args:
+            prefix: Session ID prefix (minimum 6 characters)
+
+        Returns:
+            Full session ID
+
+        Raises:
+            ValueError: If prefix is too short, no matches, or ambiguous
+        """
+        # Already full UUID format (36 chars with dashes, or longer with suffix)
+        if len(prefix) >= 36:
+            return prefix
+
+        if len(prefix) < 6:
+            raise ValueError("Session ID prefix must be at least 6 characters")
+
+        # Use session.list capability to find matches
+        list_fn = self.coordinator.get_capability("session.list")
+        if list_fn is None:
+            # If no list capability, assume prefix is valid and let resume fail
+            logger.warning("session.list capability not available, using prefix as-is")
+            return prefix
+
+        try:
+            sessions = await list_fn()
+            matches = [
+                s["session_id"]
+                for s in sessions
+                if s.get("session_id", "").startswith(prefix)
+            ]
+
+            if len(matches) == 0:
+                raise ValueError(f"No session found matching prefix '{prefix}'")
+            elif len(matches) > 1:
+                raise ValueError(
+                    f"Ambiguous prefix '{prefix}' matches {len(matches)} sessions: "
+                    f"{[m[:12] + '...' for m in matches[:3]]}"
+                )
+            else:
+                return matches[0]
+
+        except Exception as e:
+            if "No session found" in str(e) or "Ambiguous prefix" in str(e):
+                raise
+            # If list fails for other reasons, try with prefix as-is
+            logger.warning(f"session.list failed ({e}), using prefix as-is")
+            return prefix
+
+    async def _get_parent_messages(self) -> list[dict[str, Any]] | None:
+        """Get all messages from parent session.
+
+        Returns:
+            List of messages or None if not available
+        """
+        parent_context = self.coordinator.get("context")
+        if not parent_context or not hasattr(parent_context, "get_messages"):
+            logger.debug("No parent context available for inheritance")
+            return None
+
+        try:
+            messages = await parent_context.get_messages()
+            return messages if messages else None
+        except Exception as e:
+            logger.warning(f"Failed to get parent messages: {e}")
+            return None
+
+    def _extract_recent_turns(
+        self, messages: list[dict[str, Any]], n_turns: int
+    ) -> list[dict[str, Any]]:
+        """Extract the last N user->assistant turns from messages.
+
+        A "turn" starts with a user message and includes all subsequent messages
+        until the next user message.
+
+        Args:
+            messages: Full message history
+            n_turns: Number of recent turns to extract
+
+        Returns:
+            Messages from the last N turns
+        """
+        if not messages or n_turns <= 0:
+            return []
+
+        # Find indices where user messages start (turn boundaries)
+        turn_starts = [i for i, m in enumerate(messages) if m.get("role") == "user"]
+
+        if not turn_starts:
+            return messages  # No user messages, return all
+
+        if len(turn_starts) <= n_turns:
+            return messages  # Fewer turns than requested, return all
+
+        # Get messages from the nth-to-last turn onwards
+        start_index = turn_starts[-n_turns]
+        return messages[start_index:]
+
+    def _sanitize_content(self, content: Any) -> str:
+        """Extract text content from message content field.
+
+        Handles both string and list formats (Anthropic/Amplifier).
+
+        Args:
+            content: Message content (string or list of content blocks)
+
+        Returns:
+            Extracted text content as string
+        """
+        if isinstance(content, str):
+            return content
+
+        if isinstance(content, list):
+            text_parts = []
+            # Types to explicitly filter out
+            filtered_types = {
+                "tool_use",
+                "tool_call",
+                "tool_result",
+                "thinking",
+                "redacted_thinking",
+            }
+
+            for block in content:
+                if isinstance(block, dict):
+                    block_type = block.get("type", "")
+                    if block_type == "text":
+                        text = block.get("text", "")
+                        if text:
+                            text_parts.append(text)
+                    elif block_type not in filtered_types:
+                        logger.debug(f"Unknown content block type '{block_type}'")
+                elif isinstance(block, str):
+                    text_parts.append(block)
+
+            if text_parts:
+                return "\n".join(text_parts)
+
+        return ""
+
+    def _sanitize_conversation_only(
+        self, messages: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Sanitize messages to include only user/assistant conversation text.
+
+        Strips ALL tool content - only human-readable conversation remains.
+
+        Args:
+            messages: Raw messages from parent
+
+        Returns:
+            Sanitized messages with only conversation content
+        """
+        sanitized = []
+        for msg in messages:
+            role = msg.get("role")
+
+            # Skip tool messages entirely
+            if role == "tool":
+                continue
+            if msg.get("tool_call_id"):
+                continue
+
+            # Only user and assistant
+            if role in ("user", "assistant"):
+                # Skip assistant messages that only contain tool calls
+                if (
+                    role == "assistant"
+                    and msg.get("tool_calls")
+                    and not msg.get("content")
+                ):
+                    continue
+
+                content = msg.get("content", "")
+                sanitized_content = self._sanitize_content(content)
+
+                if sanitized_content:
+                    sanitized.append({"role": role, "content": sanitized_content})
+
+        return sanitized
+
+    def _sanitize_with_agent_results(
+        self, messages: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Sanitize messages to include conversation plus delegate/task tool results.
+
+        Includes results from agent delegation tools but not other tools.
+
+        Args:
+            messages: Raw messages from parent
+
+        Returns:
+            Sanitized messages with conversation and agent results
+        """
+        sanitized = []
+        agent_tools = {"delegate", "task"}
+
+        for msg in messages:
+            role = msg.get("role")
+
+            # Include tool results only from agent tools
+            if role == "tool":
+                tool_name = msg.get("name", "")
+                if tool_name in agent_tools:
+                    content = msg.get("content", "")
+                    if content:
+                        # Format as assistant message with agent context
+                        sanitized.append(
+                            {
+                                "role": "assistant",
+                                "content": f"[Agent Result from {tool_name}]: {content}",
+                            }
+                        )
+                continue
+
+            if msg.get("tool_call_id"):
+                # Check if this is a result from an agent tool
+                # Tool call ID doesn't tell us the tool name, so skip
+                continue
+
+            # User and assistant messages
+            if role in ("user", "assistant"):
+                if (
+                    role == "assistant"
+                    and msg.get("tool_calls")
+                    and not msg.get("content")
+                ):
+                    continue
+
+                content = msg.get("content", "")
+                sanitized_content = self._sanitize_content(content)
+
+                if sanitized_content:
+                    sanitized.append({"role": role, "content": sanitized_content})
+
+        return sanitized
+
+    def _sanitize_all_content(
+        self, messages: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Sanitize messages to include all content including tool results.
+
+        Preserves tool results but strips internal metadata.
+
+        Args:
+            messages: Raw messages from parent
+
+        Returns:
+            Sanitized messages with all content
+        """
+        sanitized = []
+
+        for msg in messages:
+            role = msg.get("role")
+
+            # Include all tool results
+            if role == "tool":
+                tool_name = msg.get("name", "unknown")
+                content = msg.get("content", "")
+                if content:
+                    # Truncate very long tool results
+                    if len(content) > 4000:
+                        content = content[:4000] + "... [truncated]"
+                    sanitized.append(
+                        {
+                            "role": "assistant",
+                            "content": f"[Tool Result from {tool_name}]: {content}",
+                        }
+                    )
+                continue
+
+            if msg.get("tool_call_id"):
+                continue
+
+            # User and assistant messages
+            if role in ("user", "assistant"):
+                if (
+                    role == "assistant"
+                    and msg.get("tool_calls")
+                    and not msg.get("content")
+                ):
+                    continue
+
+                content = msg.get("content", "")
+                sanitized_content = self._sanitize_content(content)
+
+                if sanitized_content:
+                    sanitized.append({"role": role, "content": sanitized_content})
+
+        return sanitized
+
+    async def _build_inherited_context(
+        self, depth: str, turns: int, scope: str
+    ) -> list[dict[str, Any]] | None:
+        """Build context based on depth (how much) and scope (which content).
+
+        Args:
+            depth: "none", "recent", or "all"
+            turns: Number of turns for "recent" mode
+            scope: "conversation", "agents", or "full"
+
+        Returns:
+            List of sanitized messages or None
+        """
+        if depth == "none":
+            return None
+
+        messages = await self._get_parent_messages()
+        if not messages:
+            return None
+
+        # Step 1: Filter by DEPTH
+        if depth == "recent":
+            messages = self._extract_recent_turns(messages, turns)
+        # else: "all" - keep all messages
+
+        # Step 2: Filter by SCOPE
+        if scope == "conversation":
+            return self._sanitize_conversation_only(messages)
+        elif scope == "agents":
+            return self._sanitize_with_agent_results(messages)
+        else:  # "full"
+            return self._sanitize_all_content(messages)
+
+    def _format_parent_context_for_instruction(
+        self, messages: list[dict[str, Any]]
+    ) -> str:
+        """Format parent messages as text to prepend to the instruction.
+
+        Args:
+            messages: List of sanitized messages from parent session
+
+        Returns:
+            Formatted text block with parent conversation context
+        """
+        if not messages:
+            return ""
+
+        lines = ["[PARENT CONVERSATION CONTEXT]"]
+        lines.append(
+            "The following is recent conversation history from the parent session:"
+        )
+        lines.append("")
+
+        for msg in messages:
+            role = msg.get("role", "unknown")
+            content = msg.get("content", "")
+
+            role_label = role.upper()
+            if role == "user":
+                role_label = "USER"
+            elif role == "assistant":
+                role_label = "ASSISTANT"
+
+            # Truncate very long messages
+            max_content_len = 2000
+            if len(content) > max_content_len:
+                content = content[:max_content_len] + "... [truncated]"
+
+            lines.append(f"{role_label}: {content}")
+            lines.append("")
+
+        lines.append("[END PARENT CONTEXT]")
+        return "\n".join(lines)
+
+    def _merge_tools(
+        self,
+        parent_tools: list[dict[str, Any]],
+        agent_tools: list[dict[str, Any]],
+        exclude: list[str],
+    ) -> list[dict[str, Any]]:
+        """Merge tools with correct inheritance semantics.
+
+        Exclusions apply to INHERITANCE only.
+        Explicit declarations from agent are ALWAYS honored.
+
+        Args:
+            parent_tools: Tools from parent session
+            agent_tools: Tools explicitly declared by agent config
+            exclude: Tools to exclude from inheritance
+
+        Returns:
+            Merged tool list
+        """
+        # Start with inherited, apply exclusions
+        inherited = [t for t in parent_tools if t.get("module") not in exclude]
+
+        # Agent's explicit declarations ALWAYS added (even if excluded from inheritance)
+        inherited_modules = {t.get("module") for t in inherited}
+        for tool in agent_tools:
+            if tool.get("module") not in inherited_modules:
+                inherited.append(tool)
+
+        return inherited
+
+    async def execute(self, input: dict) -> ToolResult:
+        """Execute agent delegation with structured parameters.
+
+        Routes to spawn (new agent session) or resume (existing agent session)
+        based on input parameters.
+
+        Args:
+            input: Dict with 'instruction' (required) and either:
+                   - 'agent' (for spawn) or
+                   - 'session_id' (for resume)
+
+        Returns:
+            ToolResult with success status and output or error
+        """
+        # Extract parameters
+        agent_name = input.get("agent", "").strip()
+        instruction = input.get("instruction", "").strip()
+        session_id = input.get("session_id", "").strip()
+
+        # Context parameters (two-parameter system)
+        context_depth = input.get("context_depth", "recent")
+        context_turns = input.get("context_turns", 5)
+        context_scope = input.get("context_scope", "conversation")
+
+        # Validate context_turns against max
+        if context_turns > self.max_context_turns:
+            context_turns = self.max_context_turns
+
+        # Provider preferences
+        raw_provider_prefs = input.get("provider_preferences", [])
+        provider_preferences = None
+        if raw_provider_prefs and self.provider_selection_enabled:
+            provider_preferences = [
+                ProviderPreference.from_dict(p) for p in raw_provider_prefs
+            ]
+
+        # Validate instruction (always required)
+        if not instruction:
+            return ToolResult(
+                success=False, error={"message": "Instruction cannot be empty"}
+            )
+
+        # Get hooks for event emission
+        hooks = self.coordinator.get("hooks")
+
+        # Route based on session_id presence
+        if session_id:
+            if not self.session_resume_enabled:
+                return ToolResult(
+                    success=False,
+                    error={"message": "Session resumption is disabled"},
+                )
+            return await self._resume_existing_session(session_id, instruction, hooks)
+
+        # SPAWN MODE: Create new agent session (requires agent)
+        if not agent_name:
+            return ToolResult(
+                success=False,
+                error={
+                    "message": "Agent name required for new delegation (or provide session_id to resume)"
+                },
+            )
+
+        # Check agent exists in registry (with special handling for "self" and bundle paths)
+        agents = self.coordinator.config.get("agents", {})
+
+        # Handle special "self" value
+        if agent_name == "self":
+            if not self.self_delegation_enabled:
+                return ToolResult(
+                    success=False,
+                    error={"message": "Self-delegation is disabled"},
+                )
+            # Self-delegation uses parent's bundle - spawn capability handles it
+            pass
+        elif ":" in agent_name:
+            # Bundle path format (e.g., "foundation:agents/explorer")
+            # Skip registry validation - spawn capability handles bundle resolution
+            pass
+        elif agent_name not in agents:
+            return ToolResult(
+                success=False,
+                error={
+                    "message": f"Agent '{agent_name}' not found. Available: {list(agents.keys())}"
+                },
+            )
+
+        # Get parent session ID
+        parent_session_id = self.coordinator.session_id
+
+        # Generate hierarchical sub-session ID
+        child_span = uuid.uuid4().hex[:16]
+        sub_session_id = f"{parent_session_id}-{child_span}_{agent_name}"
+
+        try:
+            # Get spawn capability
+            spawn_fn = self.coordinator.get_capability("session.spawn")
+            if spawn_fn is None:
+                return ToolResult(
+                    success=False,
+                    error={
+                        "message": "Session spawning not available. App layer must register 'session.spawn' capability."
+                    },
+                )
+
+            # Get parent session
+            parent_session = self.coordinator.session
+
+            # Emit delegate:agent_spawned event
+            if hooks:
+                await hooks.emit(
+                    "delegate:agent_spawned",
+                    {
+                        "agent": agent_name,
+                        "sub_session_id": sub_session_id,
+                        "parent_session_id": parent_session_id,
+                        "context_depth": context_depth,
+                        "context_scope": context_scope,
+                    },
+                )
+
+            # Build tool inheritance policy
+            tool_inheritance = {}
+            if self.exclude_tools:
+                tool_inheritance["exclude_tools"] = self.exclude_tools
+
+            # Build hook inheritance policy
+            hook_inheritance = {}
+            if self.exclude_hooks:
+                hook_inheritance["exclude_hooks"] = self.exclude_hooks
+
+            # Build inherited context using two-parameter system
+            parent_messages = None
+            if self.context_inheritance_enabled and context_depth != "none":
+                parent_messages = await self._build_inherited_context(
+                    context_depth, context_turns, context_scope
+                )
+
+            # Format parent context into instruction
+            effective_instruction = instruction
+            if parent_messages:
+                logger.debug(
+                    f"Built {len(parent_messages)} context messages (depth={context_depth}, scope={context_scope})"
+                )
+                context_text = self._format_parent_context_for_instruction(
+                    parent_messages
+                )
+                effective_instruction = f"{context_text}\n\n[YOUR TASK]\n{instruction}"
+
+            # Extract orchestrator config from parent session for inheritance
+            orchestrator_config = None
+            parent_config = parent_session.config or {}
+            session_config = parent_config.get("session", {})
+            orch_section = session_config.get("orchestrator", {})
+            if orch_config := orch_section.get("config"):
+                orchestrator_config = orch_config
+                logger.debug(f"Inheriting orchestrator config: {orchestrator_config}")
+
+            # Spawn agent sub-session
+            result = await spawn_fn(
+                agent_name=agent_name,
+                instruction=effective_instruction,
+                parent_session=parent_session,
+                agent_configs=agents,
+                sub_session_id=sub_session_id,
+                tool_inheritance=tool_inheritance,
+                hook_inheritance=hook_inheritance,
+                orchestrator_config=orchestrator_config,
+                provider_preferences=provider_preferences,
+            )
+
+            # Emit delegate:agent_completed event
+            if hooks:
+                await hooks.emit(
+                    "delegate:agent_completed",
+                    {
+                        "agent": agent_name,
+                        "sub_session_id": sub_session_id,
+                        "parent_session_id": parent_session_id,
+                        "success": True,
+                    },
+                )
+
+            # Return output with session_id for multi-turn capability
+            session_id_result = result["session_id"]
+            return ToolResult(
+                success=True,
+                output={
+                    "response": result["output"],
+                    "session_id": session_id_result,
+                    "short_id": session_id_result[:8],
+                    "agent": agent_name,
+                    "turn_count": result.get("turn_count", 1),
+                },
+            )
+
+        except Exception as e:
+            # Emit delegate:error event
+            if hooks:
+                await hooks.emit(
+                    "delegate:error",
+                    {
+                        "agent": agent_name,
+                        "sub_session_id": sub_session_id,
+                        "parent_session_id": parent_session_id,
+                        "error": str(e),
+                    },
+                )
+
+            return ToolResult(
+                success=False, error={"message": f"Agent delegation failed: {str(e)}"}
+            )
+
+    async def _resume_existing_session(
+        self, session_id: str, instruction: str, hooks
+    ) -> ToolResult:
+        """Resume existing agent session.
+
+        Args:
+            session_id: Agent session ID (or short prefix) to resume
+            instruction: Follow-up instruction
+            hooks: Hook coordinator for event emission
+
+        Returns:
+            ToolResult with success status and output or error
+        """
+        parent_session_id = self.coordinator.session_id
+
+        try:
+            # Resolve short session ID to full ID
+            full_session_id = await self._resolve_short_session_id(session_id)
+
+            # Emit delegate:agent_resumed event
+            if hooks:
+                await hooks.emit(
+                    "delegate:agent_resumed",
+                    {
+                        "session_id": full_session_id,
+                        "parent_session_id": parent_session_id,
+                        "original_prefix": session_id
+                        if session_id != full_session_id
+                        else None,
+                    },
+                )
+
+            # Get resume capability
+            resume_fn = self.coordinator.get_capability("session.resume")
+            if resume_fn is None:
+                return ToolResult(
+                    success=False,
+                    error={
+                        "message": "Session resumption not available. App layer must register 'session.resume' capability."
+                    },
+                )
+
+            # Resume agent session
+            result = await resume_fn(
+                sub_session_id=full_session_id,
+                instruction=instruction,
+            )
+
+            # Emit delegate:agent_completed event
+            if hooks:
+                await hooks.emit(
+                    "delegate:agent_completed",
+                    {
+                        "sub_session_id": full_session_id,
+                        "parent_session_id": parent_session_id,
+                        "success": True,
+                    },
+                )
+
+            # Extract agent name from session ID if possible
+            agent_name = "unknown"
+            if "_" in full_session_id:
+                agent_name = full_session_id.split("_")[-1]
+
+            # Return output with session info
+            session_id_result = result["session_id"]
+            return ToolResult(
+                success=True,
+                output={
+                    "response": result["output"],
+                    "session_id": session_id_result,
+                    "short_id": session_id_result[:8],
+                    "agent": agent_name,
+                    "turn_count": result.get("turn_count", 1),
+                },
+            )
+
+        except ValueError as e:
+            # Session ID resolution error
+            if hooks:
+                await hooks.emit(
+                    "delegate:error",
+                    {
+                        "session_id": session_id,
+                        "parent_session_id": parent_session_id,
+                        "error": str(e),
+                    },
+                )
+            return ToolResult(success=False, error={"message": str(e)})
+
+        except FileNotFoundError as e:
+            # Session not found
+            if hooks:
+                await hooks.emit(
+                    "delegate:error",
+                    {
+                        "session_id": session_id,
+                        "parent_session_id": parent_session_id,
+                        "error": f"Session not found: {str(e)}",
+                    },
+                )
+            return ToolResult(
+                success=False,
+                error={
+                    "message": f"Agent session '{session_id}' not found. May have expired or never existed."
+                },
+            )
+
+        except Exception as e:
+            # Other errors
+            if hooks:
+                await hooks.emit(
+                    "delegate:error",
+                    {
+                        "session_id": session_id,
+                        "parent_session_id": parent_session_id,
+                        "error": str(e),
+                    },
+                )
+            return ToolResult(
+                success=False, error={"message": f"Agent resume failed: {str(e)}"}
+            )

--- a/modules/tool-delegate/pyproject.toml
+++ b/modules/tool-delegate/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "amplifier-module-tool-delegate"
+version = "0.1.0"
+description = "Delegate tasks to specialized agents with enhanced context control"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Microsoft", email = "amplifier@microsoft.com" }]
+dependencies = ["amplifier-core>=0.1.0"]
+
+[project.entry-points."amplifier.modules"]
+tool-delegate = "amplifier_module_tool_delegate:mount"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["amplifier_module_tool_delegate"]


### PR DESCRIPTION
## Summary

New `delegate` tool for enhanced agent orchestration, available via experimental bundles for opt-in testing.

## Key Features

- **Two-parameter context inheritance**: `context_depth` (how much) + `context_scope` (which content)
- **Short session ID resolution**: Resume sessions with 6+ character prefixes
- **Tool inheritance bug fix**: Explicit tool declarations honored despite exclusions
- **Feature Registry**: Dynamic description composition based on enabled features
- **Observable events**: `delegate:agent_spawned`, `delegate:agent_completed`, etc.

## Files Changed

### New Module
- `modules/tool-delegate/` - Complete delegate tool implementation (1000+ lines)

### Behavior Separation
- `behaviors/tasks.yaml` - Legacy task tool (standard bundle uses this)
- `behaviors/agents.yaml` - New delegate tool only

### Experimental Bundles
- `experiments/exp-foundation.md` - Foundation + delegate tool
- `experiments/exp-amplifier-dev.md` - Amplifier-dev + delegate tool
- `experiments/README.md` - Experimentation philosophy

### Updated Files
- `bundle.md` - Uses tasks behavior (stable for all users)
- `context/agents/delegation-instructions.md` - Context Sink pattern docs
- `context/agents/multi-agent-patterns.md` - Updated examples

## Testing

- Shadow structural validation: PASS
- Smoke test exp-foundation: 100/100
- Smoke test exp-amplifier-dev: 100/100

## Rollout Strategy

```
Standard users (foundation bundle)
└── Uses legacy task tool via tasks.yaml
└── No changes, fully stable

Early adopters (exp-foundation, exp-amplifier-dev)
└── Uses new delegate tool via agents.yaml
└── Opt-in testing for validation
```

## Usage

```bash
# Opt-in to experimental delegate tool
amplifier bundle add foundation:experiments/exp-foundation --name exp-foundation
amplifier bundle use exp-foundation
```

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)