### PR TITLE
feat: include MCP tool module by default

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -24,6 +24,7 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-bundle-shadow@main
   - bundle: git+https://github.com/microsoft/amplifier-module-tool-skills@main#subdirectory=behaviors/skills.yaml
   - bundle: git+https://github.com/microsoft/amplifier-module-hook-shell@main#subdirectory=behaviors/hook-shell.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-module-tool-mcp@main#subdirectory=behaviors/mcp.yaml
 
 
 session:


### PR DESCRIPTION
## Summary
- Add amplifier-module-tool-mcp to the foundation bundle's includes list
- Makes MCP capabilities available by default in the foundation bundle
- Users just need to add an mcp.json to configure servers when they want to use it

## Why
The tool-mcp module is now "always-on friendly":
- Silent when unconfigured (no errors or warnings)
- No hook overhead when not in use
- Safe to include by default

This gives users MCP capabilities out-of-the-box without any setup cost.

## Test plan
- [x] Verified tool-mcp module loads without errors when no mcp.json present
- [x] Confirmed MCP tools work correctly when configured

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)