### PR TITLE
fix: use namespace reference for tool-delegate source path (P0)

### DIFF
--- a/behaviors/agents.yaml
+++ b/behaviors/agents.yaml
@@ -16,7 +16,7 @@ bundle:
 tools:
   # New delegate tool with enhanced features
   - module: tool-delegate
-    source: ../modules/tool-delegate
+    source: foundation:modules/tool-delegate
     config:
       features:
         self_delegation:


### PR DESCRIPTION
## Summary
- **P0 REGRESSION FIX** - Delegate tool broken after `amplifier reset`
- Changed `source: ../modules/tool-delegate` to `source: foundation:modules/tool-delegate`
- Namespace reference resolves correctly for both local and remote bundle loading

## Root Cause
The relative path `../modules/tool-delegate` works when loaded from a local file path but **FAILS** when loaded via git URL (which is what happens after `amplifier reset`).

## Impact
Without this fix, all users on foundation v2.0.0 or amplifier-dev v2.0.0 will **NOT** have the delegate tool available after a reset.

## Test plan
- [x] Verified the change in agents.yaml
- [ ] Test `amplifier reset` with foundation bundle
- [ ] Verify delegate tool loads correctly

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)