### PR TITLE
fix: use full git URLs for behavior includes in amplifier-dev bundle

### DIFF
--- a/bundles/amplifier-dev.yaml
+++ b/bundles/amplifier-dev.yaml
@@ -14,9 +14,9 @@ includes:
   # Base foundation (has delegate tool)
   - bundle: foundation
   # Amplifier dev behavior (agents + context)
-  - bundle: foundation:behaviors/amplifier-dev
-  # Shadow environments with Amplifier-specific helpers
-  - bundle: foundation:behaviors/shadow-amplifier
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/amplifier-dev.yaml
+  # Shadow environments with Amplifier-specific helpers (includes generic shadow bundle)
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/shadow-amplifier.yaml
 
 # Development-specific session settings
 session:


### PR DESCRIPTION
## Summary

- **P0 regression fix** - amplifier-dev bundle broken after promotion
- Namespace references (`foundation:behaviors/...`) don't resolve when the bundle is loaded via git subdirectory URL
- Reverted behavior includes to explicit git URLs that work in all contexts

## Root Cause

When the amplifier-dev bundle is loaded from:
```
git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=bundles/amplifier-dev.yaml
```

References like `foundation:behaviors/amplifier-dev` fail to resolve because the namespace resolution doesn't have the right context.

## Changes

```yaml
# Before (broken)
- bundle: foundation:behaviors/amplifier-dev
- bundle: foundation:behaviors/shadow-amplifier

# After (working)
- bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/amplifier-dev.yaml
- bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/shadow-amplifier.yaml
```

## Impact

Without this fix, amplifier-dev bundle doesn't properly include foundation's capabilities, resulting in missing delegate tool.

## Test plan

- [x] Verified the fix resolves correctly when loading amplifier-dev bundle

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)