### PR TITLE
fix: use git URL for tool-delegate module source

### DIFF
--- a/behaviors/agents.yaml
+++ b/behaviors/agents.yaml
@@ -16,7 +16,7 @@ bundle:
 tools:
   # New delegate tool with enhanced features
   - module: tool-delegate
-    source: foundation:modules/tool-delegate
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/tool-delegate
     config:
       features:
         self_delegation:


### PR DESCRIPTION
## Summary
- **P0 regression fix** from PR #50
- Namespace references (`foundation:modules/tool-delegate`) don't work for module sources - only git URLs are supported
- Changed to full git URL: `git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/tool-delegate`

## Root Cause
Error seen: `Failed to activate tool-delegate: No handler for URI: foundation:modules/tool-delegate`

## Test plan
- [x] Verified git URL format matches working module references
- [ ] Confirm tool-delegate activation succeeds with this fix

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)