### PR TITLE
fix: use git URL for hooks-progress-monitor source

### DIFF
--- a/behaviors/progress-monitor.yaml
+++ b/behaviors/progress-monitor.yaml
@@ -12,7 +12,7 @@ bundle:
 
 hooks:
   - module: hooks-progress-monitor
-    source: foundation:modules/hooks-progress-monitor
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/hooks-progress-monitor
     config:
       enabled: true
       read_threshold: 30      # Warn after 30 reads with 0 writes


### PR DESCRIPTION
## Summary
- Fixed `behaviors/progress-monitor.yaml` to use full git URL instead of namespace reference
- Changed from `foundation:modules/hooks-progress-monitor` to `git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/hooks-progress-monitor`
- Preemptive fix - this behavior isn't currently included in any bundles, but would break if used directly

## Test plan
- [x] Verified the new URL format matches other module references
- [x] Syntax check passed

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)