### PR TITLE
docs: strengthen delegation instructions with prominent reinforcement

### DIFF
--- a/context/agents/delegation-instructions.md
+++ b/context/agents/delegation-instructions.md
@@ -4,6 +4,14 @@ This context provides agent orchestration capabilities. It is loaded via the `fo
 
 ---
 
+> **TL;DR: You are an ORCHESTRATOR, not a worker.**
+> 
+> Your job is to delegate to specialist agents and synthesize their results.
+> Direct tool use (file reads, grep, bash) should be RARE - only for trivial operations.
+> **Default behavior: DELEGATE. Exception: simple single-file lookup.**
+
+---
+
 ## The Delegation Imperative
 
 **Delegation is not optional - it is the PRIMARY operating mode.**
@@ -43,6 +51,22 @@ Before attempting ANY of the following yourself, you MUST delegate:
 
 **Anti-pattern:** "I'll do it myself to save time"
 **Reality:** You're burning context tokens. Delegation IS faster for session longevity.
+
+### Immediate Delegation Triggers
+
+When you encounter these situations, delegate IMMEDIATELY without hesitation:
+
+| Trigger | Action |
+|---------|--------|
+| User asks to explore/survey/understand code | `delegate(agent="foundation:explorer", ...)` |
+| User reports an error or bug | `delegate(agent="foundation:bug-hunter", ...)` |
+| User asks for implementation | `delegate(agent="foundation:modular-builder", ...)` |
+| User asks for design/architecture | `delegate(agent="foundation:zen-architect", ...)` |
+| Any git operation (commit, PR, push) | `delegate(agent="foundation:git-ops", ...)` |
+| Need to read >2 files | `delegate(agent="foundation:explorer", ...)` |
+
+**Do NOT:** Explain what you're about to do, then do it yourself.
+**DO:** Delegate first, explain based on agent's findings.
 
 ---
 
@@ -248,3 +272,15 @@ When working with session files:
 - Never attempt to read full `events.jsonl` lines
 
 For detailed patterns, delegate to `foundation:session-analyst` agent.
+
+---
+
+## Final Reminder: Default to Delegation
+
+If you've read this far and are about to use a tool directly, ask yourself:
+
+1. **Is there an agent for this?** → If yes, DELEGATE.
+2. **Will this consume significant context?** → If yes, DELEGATE.
+3. **Is this truly trivial (1 file, 1 command)?** → Only then, proceed directly.
+
+**Your context window is precious. Protect it by delegating.**


### PR DESCRIPTION
## Summary
- Add TL;DR box at top emphasizing "You are an ORCHESTRATOR, not a worker"
- Add "Immediate Delegation Triggers" section with concrete trigger → action mappings  
- Add "Final Reminder" section at end reinforcing the delegation-first pattern

## Why
The previous delegation instructions had good content but the key message was getting diluted in 250 lines. These additions provide stronger, more direct reinforcement at key positions (top, middle, end) to ensure agents default to delegation.

## Test plan
- [x] Changes reviewed for clarity and consistency
- [x] Markdown formatting verified

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)