### PR TITLE
docs: Add 'Before Building New Functionality' guidance to AWARENESS_INDEX

### DIFF
--- a/context/shared/AWARENESS_INDEX.md
+++ b/context/shared/AWARENESS_INDEX.md
@@ -105,8 +105,20 @@ Some domains have anti-patterns that cause significant rework. **Load required r
 | Bundle/module packaging | `foundation:docs/BUNDLE_GUIDE.md` |
 | Hook implementation | `core:docs/HOOKS_API.md` |
 | Embedding Amplifier in apps | `foundation:docs/APPLICATION_INTEGRATION_GUIDE.md` |
+| **New module/tool/capability** | **Consult `amplifier:amplifier-expert`** |
 
 **Pattern**: When you detect work in a listed domain, load the doc FIRST—don't wait until you hit problems.
+
+### Before Building New Functionality
+
+**CRITICAL**: Before implementing new tools, modules, bundles, or capabilities:
+
+1. **Consult `amplifier:amplifier-expert`** - Authoritative ecosystem consultant with access to MODULES.md
+2. **Check if it exists** - Similar functionality may already exist under a different name
+3. **Consider extending** - Can you contribute to an existing module instead of creating a new one?
+4. **Only then build new** - If no existing solution covers your use case
+
+This ensures the ecosystem grows through reuse and contribution, not duplication.
 
 ---
 


### PR DESCRIPTION
## Summary

Add "check before building" guidance to AWARENESS_INDEX.md to prevent module duplication.

**Tracking issue:** https://github.com/microsoft-amplifier/amplifier-support/issues/43

## Changes

| File | Change |
|------|--------|
| `context/shared/AWARENESS_INDEX.md` | Add domain prerequisite and "Before Building New Functionality" section |

## What This Adds

### Domain Prerequisite Table Entry

```markdown
| **New module/tool/capability** | **Consult `amplifier:module-catalog-expert`** |
```

### "Before Building New Functionality" Section

4-step process:
1. Consult `amplifier:module-catalog-expert` - Focused expert with complete ecosystem catalog
2. Check if it exists - Similar functionality may exist under different name
3. Consider extending - Contribute to existing module instead of creating new
4. Only then build new - If no existing solution covers use case

## Architecture

```
Every Session (minimal cost, ~30 tokens)
┌─────────────────────────────────────────────────┐
│ AWARENESS_INDEX.md                              │
│ "New module → Consult module-catalog-expert"    │
└──────────────────────┬──────────────────────────┘
                       │ triggers delegation
                       ▼
Only When Checking Catalog (~4,600 tokens)
┌─────────────────────────────────────────────────┐
│ amplifier:module-catalog-expert (from PR #211)  │
└─────────────────────────────────────────────────┘
```

## Related

- Companion PR: https://github.com/microsoft/amplifier/pull/211 (creates the `module-catalog-expert` agent)
- Issue: https://github.com/microsoft-amplifier/amplifier-support/issues/43