### PR TITLE
refactor(behaviors): remove behavior-level context.include (context sink pattern)

### DIFF
--- a/behaviors/shadow-amplifier.yaml
+++ b/behaviors/shadow-amplifier.yaml
@@ -16,12 +16,8 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-bundle-shadow@main
 
 # Amplifier-specific agents
+# Context is loaded via @mentions in the agent files (context sink pattern)
 agents:
   include:
     # Agent file contains full description and tool configuration
     - foundation:amplifier-smoke-test
-
-# Amplifier-specific context
-context:
-  include:
-    - foundation:context/amplifier-shadow-tests.md


### PR DESCRIPTION
## Summary
- Remove `context.include` from `shadow-amplifier.yaml` behavior
- Context files should only be loaded via @mentions in agent files (context sink pattern)
- The `amplifier-smoke-test` agent already has the @mention to load the context

## Why
This prevents unintended token inflation when behaviors are composed. Behaviors shouldn't carry context—agents should (they're the context sinks).

## Test plan
- [x] Verified agent file already has @mention to context file
- [ ] Run bundle validation recipe to confirm token counts

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)