### PR TITLE
docs: update opus references to claude-opus-4-6

### DIFF
--- a/context/CONTEXT_POISONING.md
+++ b/context/CONTEXT_POISONING.md
@@ -118,7 +118,7 @@ The --model flag is required. Command fails without it.
 amplifier provider use anthropic
 
 # docs/USER_GUIDE.md
-amplifier provider use anthropic --model claude-opus-4
+amplifier provider use anthropic --model claude-opus-4-6
 
 # POISON: Which example is correct?
 ```

--- a/providers/anthropic-opus.yaml
+++ b/providers/anthropic-opus.yaml
@@ -7,6 +7,6 @@ providers:
   - module: provider-anthropic
     source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
     config:
-      default_model: claude-opus-4-5
+      default_model: claude-opus-4-6
       debug: true
       raw_debug: true

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -64,7 +64,9 @@ class TestBundleValidator:
 
     def test_validate_module_entry_invalid_config(self) -> None:
         """Module entry with non-dict config is invalid."""
-        bundle = Bundle(name="test", providers=[{"module": "provider-test", "config": "string"}])
+        bundle = Bundle(
+            name="test", providers=[{"module": "provider-test", "config": "string"}]
+        )
         validator = BundleValidator()
         result = validator.validate(bundle)
         assert result.valid is False
@@ -138,7 +140,9 @@ class TestCompletenessValidation:
         # Provider-only bundle - this is valid as a bundle but incomplete for mounting
         provider_bundle = Bundle(
             name="anthropic-opus",
-            providers=[{"module": "provider-anthropic", "config": {"model": "claude-opus-4"}}],
+            providers=[
+                {"module": "provider-anthropic", "config": {"model": "claude-opus-4-6"}}
+            ],
         )
         validator = BundleValidator()
 


### PR DESCRIPTION
Update all opus model references across docs, examples, configs, and tests to use `claude-opus-4-6` (the current release that supports 1M context and adaptive thinking).

Replaces stale references to `claude-opus-4`, `claude-opus-4-1`, and `claude-opus-4-5`.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)