### PR TITLE
fix: guard Bundle against None collection fields in __post_init__

### DIFF
--- a/amplifier_foundation/bundle.py
+++ b/amplifier_foundation/bundle.py
@@ -80,6 +80,21 @@ class Bundle:
         default_factory=dict
     )  # Context refs needing namespace resolution
 
+    def __post_init__(self) -> None:
+        """Ensure collection fields are never None.
+
+        Protects against callers passing None explicitly (e.g., via
+        dataclasses.replace or direct construction) which bypasses
+        default_factory. Without this guard, 'x in self.context' raises
+        TypeError: argument of type 'NoneType' is not iterable.
+        """
+        if self.context is None:
+            self.context = {}
+        if self.source_base_paths is None:
+            self.source_base_paths = {}
+        if self._pending_context is None:
+            self._pending_context = {}
+
     def compose(self, *others: Bundle) -> Bundle:
         """Compose this bundle with others (later overrides earlier).
 


### PR DESCRIPTION
## Summary

- **`Bundle.resolve_context_path()` crashes with `TypeError`** when `self.context` is `None` because `default_factory` is bypassed by explicit `None` values (e.g., when YAML fields are present but empty).
- Added a `__post_init__` method that **normalizes `None` to `{}`** for `context`, `source_base_paths`, and `_pending_context` fields.
- This fixes `@mention` resolution crashes in the CLI when bundles have unset collection fields.

## Details

`dataclasses.field(default_factory=dict)` only applies when the field is *omitted* — if YAML deserialization explicitly passes `None`, the factory is bypassed and the field stays `None`. Downstream code (e.g., `resolve_context_path`, iteration over `source_base_paths`) then fails with `TypeError: argument of type 'NoneType' is not iterable` or similar.

The `__post_init__` guard is the minimal, idiomatic fix: it runs after `__init__` and normalizes the three dict/list fields to safe defaults.

## Companion PR

This fix works together with a companion fix in **amplifier-module-context-simple** (guard against `None` metadata in message dicts). Both are needed to fully resolve `@mention` crashes end-to-end.

## Test plan

- [x] Shadow-tested both fixes together in an isolated environment
- [x] Smoke test passed **100/100**
- [x] Verified `@mention` resolution works correctly after fix
- [x] Verified bundles with explicit `None` collection fields no longer crash

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)