### PR TITLE
docs: add tool result visibility guidance to delegation instructions

### DIFF
--- a/context/agents/delegation-instructions.md
+++ b/context/agents/delegation-instructions.md
@@ -110,6 +110,17 @@ When you encounter these situations, delegate IMMEDIATELY without hesitation:
 3. **Zero partial knowledge** - If capability isn't composed, zero context about it
 4. **Summarize, don't relay** - Agents return insights, not raw data
 
+### Relaying Results to the User
+
+The user does not see full tool results — they see only a brief, truncated preview. Intermediate text you write before tool calls may also not be prominently visible. Therefore:
+
+- **Always relay key findings** in your final response text
+- **Never assume** the user has seen tool output or intermediate narration
+- **When agents return results**, summarize the important parts in your own words as part of your response to the user
+- **Err on the side of over-communicating** — repeating a finding is better than the user missing it entirely
+
+This is not about verbosity. It's about ensuring the user receives the information they need without having to ask you to repeat yourself.
+
 ---
 
 ## Why Delegation Matters


### PR DESCRIPTION
## Summary

- Adds a "Relaying Results to the User" section to `context/agents/delegation-instructions.md`
- Teaches the assistant that users **do not see full tool results** — only a brief, truncated preview — and that intermediate narration may not be prominently visible
- Establishes four behavioral guidelines: always relay key findings, never assume visibility, summarize agent results, and err on the side of over-communicating

## Problem

When an assistant delegates work to sub-agents or invokes tools, it often assumes the user can see the full output. In practice, the user sees only a short preview of tool results. This creates an **information gap** where important findings are technically "returned" but never surfaced to the user, forcing them to ask the assistant to repeat itself.

## Fix

A behavioral guardrail added directly to the delegation instructions — the shared context that governs how the assistant delegates and reports. The new section is placed immediately after the "Context Sink Pattern" guidance, reinforcing that delegation results must be **relayed**, not just received.

This is part of the broader **Tool Result Visibility** feature, which addresses the information gap across multiple layers of the Amplifier stack.

## Test plan

- [x] Diff review: change is a clean 11-line addition with no unrelated modifications
- [x] Section placement is correct (after Context Sink Pattern, before "Why Delegation Matters")
- [ ] Verify guidance is picked up by assistants in practice

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)