### PR TITLE
fix: skip uv pip install for non-installable pyproject.toml files

### DIFF
--- a/amplifier_foundation/modules/activator.py
+++ b/amplifier_foundation/modules/activator.py
@@ -167,6 +167,21 @@ class ModuleActivator:
             )
             return
 
+        # Check if pyproject.toml actually defines an installable package.
+        # Bundles may have a root pyproject.toml with only [tool.*] sections
+        # for ruff/pyright/pytest configuration — these are NOT installable.
+        import tomllib
+
+        with open(pyproject, "rb") as f:
+            pyproject_data = tomllib.load(f)
+
+        if "project" not in pyproject_data and "build-system" not in pyproject_data:
+            logger.debug(
+                f"pyproject.toml at {bundle_path} has no [project] or [build-system], "
+                "skipping bundle package install (tool-config only)"
+            )
+            return
+
         logger.debug(f"Installing bundle package from {bundle_path}")
         await self._install_dependencies(bundle_path)
 


### PR DESCRIPTION
## Summary

- `activate_bundle_package` only checked if `pyproject.toml` existed at the bundle root, then blindly ran `uv pip install -e`. Bundles like `amplifier-bundle-containers` have a root `pyproject.toml` with only `[tool.*]` sections (ruff/pyright/pytest config) — not an installable package. Setuptools auto-discovery found the bundle's content directories (`images/`, `agents/`, `context/`, `modules/`, `behaviors/`) and refused to build with "Multiple top-level packages discovered in a flat-layout".
- The fix parses the `pyproject.toml` with `tomllib` (stdlib since Python 3.11) and skips installation if there's no `[project]` or `[build-system]` section. This preserves behavior for bundles where the root IS an installable package (like `amplifier-bundle-shadow`).

## Test plan

- [x] Verified bundles with installable `pyproject.toml` (containing `[project]`) still get installed
- [x] Verified bundles with config-only `pyproject.toml` (only `[tool.*]`) are skipped gracefully

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)