### PR TITLE
fix: sanitize agent names in delegate tool session ID construction

### DIFF
--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -36,11 +36,11 @@ __amplifier_module_type__ = "tool"
 
 import asyncio
 import logging
-import uuid
 from typing import Any
 
 from amplifier_core import ModuleCoordinator, ToolResult
 from amplifier_foundation import ProviderPreference
+from amplifier_foundation.tracing import generate_sub_session_id
 
 logger = logging.getLogger(__name__)
 
@@ -771,9 +771,11 @@ Agent usage notes:
         # Get parent session ID
         parent_session_id = self.coordinator.session_id
 
-        # Generate hierarchical sub-session ID
-        child_span = uuid.uuid4().hex[:16]
-        sub_session_id = f"{parent_session_id}-{child_span}_{agent_name}"
+        # Generate hierarchical sub-session ID (sanitized for filesystem safety)
+        sub_session_id = generate_sub_session_id(
+            agent_name=agent_name,
+            parent_session_id=parent_session_id,
+        )
 
         try:
             # Get spawn capability


### PR DESCRIPTION
## Summary

- **Bug:** Delegating to namespaced agents (e.g., `containers:agents/container-operator`) immediately crashes with `ValueError: Invalid session_id` because `/` and `:` in agent names are embedded verbatim into the session ID
- **Root cause:** The delegate tool constructs session IDs inline without sanitization (line 776), bypassing the existing `generate_sub_session_id()` utility in `amplifier_foundation.tracing` that already handles this
- **Fix:** Replace inline ID generation with `generate_sub_session_id()`, which sanitizes special characters (`:` → `-`, `/` → `-`) and follows W3C Trace Context principles

## Details

The delegate tool was constructing session IDs like this:

```python
child_span = uuid.uuid4().hex[:16]
sub_session_id = f"{parent_session_id}-{child_span}_{agent_name}"
```

For `agent_name = "containers:agents/container-operator"`, this produces:
```
5ca563ef-...-139e4d5e2de94206_containers:agents/container-operator
```

The `/` triggers `SessionStore`'s path-traversal protection (`session_store.py` line 118), and the session is never created.

Meanwhile, `amplifier_foundation.tracing.generate_sub_session_id()` already exists with proper sanitization and has 10 passing tests — including `test_colon_in_agent_name_sanitized`. This fix simply wires up the existing utility.

## Changes

Single file: `modules/tool-delegate/amplifier_module_tool_delegate/__init__.py`

1. Added import: `from amplifier_foundation.tracing import generate_sub_session_id`
2. Replaced inline ID construction with `generate_sub_session_id(agent_name=..., parent_session_id=...)`
3. Removed unused `import uuid`

## Test plan

- [x] All 10 `test_tracing.py` tests pass (including `test_colon_in_agent_name_sanitized`)
- [x] `ruff`, `pyright` checks pass clean
- [x] 2 pre-existing failures in `test_delegate_surface_status.py` confirmed unrelated (reference non-existent `_spawn_new_session` method — fail identically on `main`)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)