### PR TITLE
feat: include apply-patch behavior for V4A file editing

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -33,6 +33,7 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-module-tool-skills@main#subdirectory=behaviors/skills.yaml
   - bundle: git+https://github.com/microsoft/amplifier-module-hook-shell@main#subdirectory=behaviors/hook-shell.yaml
   - bundle: git+https://github.com/microsoft/amplifier-module-tool-mcp@main#subdirectory=behaviors/mcp.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-filesystem@main#subdirectory=behaviors/apply-patch.yaml
 
 
 session:


### PR DESCRIPTION
Adds the apply-patch behavior from `amplifier-bundle-filesystem` to the foundation bundle. This makes the `apply_patch` tool available in all sessions, providing V4A diff-based file editing. The tool has two engines: "native" (default, integrates with OpenAI's Responses API built-in apply_patch) and "function" (standard tool, works with any provider). Companion repo: https://github.com/microsoft/amplifier-bundle-filesystem