### PR TITLE
fix: use correct config key for model override in provider_preferences

### DIFF
--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -379,7 +379,7 @@ def _apply_single_override(
         if i == target_idx:
             # Promote to priority 0 (highest)
             p_copy["config"]["priority"] = 0
-            p_copy["config"]["model"] = model
+            p_copy["config"]["default_model"] = model
             logger.info(
                 "Provider preference applied: %s (priority=0, model=%s)",
                 p_copy.get("module"),

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -105,7 +105,7 @@ class TestApplyProviderPreferences:
 
         # Anthropic should be promoted to priority 0
         assert result["providers"][0]["config"]["priority"] == 0
-        assert result["providers"][0]["config"]["model"] == "claude-haiku-3"
+        assert result["providers"][0]["config"]["default_model"] == "claude-haiku-3"
         # OpenAI should be unchanged
         assert result["providers"][1]["config"]["priority"] == 20
 
@@ -124,7 +124,7 @@ class TestApplyProviderPreferences:
 
         # OpenAI should be promoted since anthropic isn't available
         assert result["providers"][0]["config"]["priority"] == 0
-        assert result["providers"][0]["config"]["model"] == "gpt-4o-mini"
+        assert result["providers"][0]["config"]["default_model"] == "gpt-4o-mini"
 
     def test_no_preferences_match(self) -> None:
         """Test that mount plan is unchanged when no preferences match."""
@@ -141,7 +141,7 @@ class TestApplyProviderPreferences:
 
         # Should be unchanged
         assert result["providers"][0]["config"]["priority"] == 10
-        assert "model" not in result["providers"][0]["config"]
+        assert "default_model" not in result["providers"][0]["config"]
 
     def test_flexible_provider_matching_short_name(self) -> None:
         """Test that short provider names match full module names."""
@@ -155,7 +155,7 @@ class TestApplyProviderPreferences:
         result = apply_provider_preferences(mount_plan, prefs)
 
         assert result["providers"][0]["config"]["priority"] == 0
-        assert result["providers"][0]["config"]["model"] == "claude-haiku-3"
+        assert result["providers"][0]["config"]["default_model"] == "claude-haiku-3"
 
     def test_flexible_provider_matching_full_name(self) -> None:
         """Test that full module names also work."""
@@ -187,11 +187,11 @@ class TestApplyProviderPreferences:
 
         # Original should be unchanged
         assert mount_plan["providers"][0]["config"]["priority"] == original_priority
-        assert "model" not in mount_plan["providers"][0]["config"]
+        assert "default_model" not in mount_plan["providers"][0]["config"]
 
         # Result should have new values
         assert result["providers"][0]["config"]["priority"] == 0
-        assert result["providers"][0]["config"]["model"] == "claude-haiku-3"
+        assert result["providers"][0]["config"]["default_model"] == "claude-haiku-3"
 
 
 class TestResolveModelPattern:
@@ -295,7 +295,7 @@ class TestApplyProviderPreferencesWithResolution:
         )
 
         # Should resolve pattern to latest model
-        assert result["providers"][0]["config"]["model"] == "claude-3-haiku-20240307"
+        assert result["providers"][0]["config"]["default_model"] == "claude-3-haiku-20240307"
 
     @pytest.mark.asyncio
     async def test_exact_model_not_resolved(self) -> None:
@@ -318,7 +318,7 @@ class TestApplyProviderPreferencesWithResolution:
         )
 
         # Exact model should pass through
-        assert result["providers"][0]["config"]["model"] == "claude-3-haiku-20240307"
+        assert result["providers"][0]["config"]["default_model"] == "claude-3-haiku-20240307"
 
     @pytest.mark.asyncio
     async def test_fallback_with_resolution(self) -> None:
@@ -348,4 +348,4 @@ class TestApplyProviderPreferencesWithResolution:
         # Should use openai with resolved model (gpt-4o sorts after gpt-4o-mini descending)
         assert result["providers"][0]["config"]["priority"] == 0
         # gpt-4o-mini > gpt-4o when sorted descending
-        assert result["providers"][0]["config"]["model"] == "gpt-4o-mini"
+        assert result["providers"][0]["config"]["default_model"] == "gpt-4o-mini"


### PR DESCRIPTION
## Summary

- **Bug:** When using `provider_preferences` in the `delegate` tool to request a specific model (e.g., `claude-sonnet-4-6-20250514`), the model was silently ignored. The correct provider was selected, but it used its default model instead of the requested one.
- **Root cause:** `spawn_utils._apply_single_override()` wrote `config["model"]` but all provider modules (Anthropic, OpenAI) read `config["default_model"]` at init time.
- **Fix:** Change the config key from `"model"` to `"default_model"` in `_apply_single_override()` (line 382 of `spawn_utils.py`). Update 9 test assertions to match the corrected key name.

Fixes microsoft-amplifier/amplifier-support#73

## Changes

| File | Change |
|------|--------|
| `amplifier_foundation/spawn_utils.py` | `config["model"]` → `config["default_model"]` (1 line) |
| `tests/test_spawn_utils.py` | 9 assertion updates: 7 positive checks + 2 negative checks |

## Test plan

- [x] All 300 existing tests pass with 0 failures
- [x] 7 positive assertions updated (`config["model"]` → `config["default_model"]`)
- [x] 2 negative assertions updated (`"model" not in config` → `"default_model" not in config`)
- [x] No new tests needed — existing coverage already exercises all affected code paths

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)