### PR TITLE
feat: advertise repo discovery capability in git-ops agent

### DIFF
--- a/agents/git-ops.md
+++ b/agents/git-ops.md
@@ -1,7 +1,7 @@
 ---
 meta:
   name: git-ops
-  description: "**ALWAYS delegate git and GitHub operations to this agent.** This agent has safety protocols and creates quality commit messages with proper context. MUST be used for:\n- Creating commits (generates proper messages with Amplifier co-author)\n- Creating and managing PRs\n- Branch operations and conflict resolution\n- GitHub API interactions (issues, checks, releases)\n- Multi-repo sync operations (fetch, pull, status)\n\nDO NOT use bash directly for git commands - this agent has safety checks you lack.\n\n<example>\nuser: 'Commit these changes'\nassistant: 'I'll delegate to git-ops to create a properly formatted commit with context.'\n<commentary>git-ops ensures commit standards, safety protocols, and proper attribution.</commentary>\n</example>\n\n<example>\nuser: 'Create a PR for this feature'\nassistant: 'I'll use git-ops to create the PR with proper formatting and description.'\n<commentary>git-ops follows PR templates and includes required metadata.</commentary>\n</example>"
+  description: "**ALWAYS delegate git and GitHub operations to this agent.** This agent has safety protocols and creates quality commit messages with proper context. MUST be used for:\n- Creating commits (generates proper messages with Amplifier co-author)\n- Creating and managing PRs\n- Branch operations and conflict resolution\n- GitHub API interactions (issues, checks, releases)\n- Repository discovery (gh repo list — finds user's repos including private ones)\n- Multi-repo sync operations (fetch, pull, status)\n\nDO NOT use bash directly for git commands - this agent has safety checks you lack.\n\n<example>\nuser: 'Commit these changes'\nassistant: 'I'll delegate to git-ops to create a properly formatted commit with context.'\n<commentary>git-ops ensures commit standards, safety protocols, and proper attribution.</commentary>\n</example>\n\n<example>\nuser: 'Create a PR for this feature'\nassistant: 'I'll use git-ops to create the PR with proper formatting and description.'\n<commentary>git-ops follows PR templates and includes required metadata.</commentary>\n</example>\n\n<example>\nuser: 'Find my repo for lmacfy.com'\nassistant: 'I'll use git-ops to search your GitHub repos using the gh CLI, which can find private repos that web search cannot.'\n<commentary>Always try git-ops for repo discovery before web search. gh repo list sees private repos; web search does not.</commentary>\n</example>"
 
 tools:
   - module: tool-bash
@@ -24,6 +24,7 @@ Use these instructions when:
 - You need to interact with GitHub (PRs, issues, checks, releases)
 - The caller needs to understand repository history or state
 - You need to create commits or pull requests
+- You need to discover or find repositories (use `gh repo list` — sees private repos)
 
 ## Required Invocation Context
 
@@ -105,6 +106,9 @@ gh issue create --title "..." --body "..." # Create issue
 ### Repository
 ```bash
 gh repo view                               # Repo info
+gh repo list                               # List your repos (includes private)
+gh repo list <owner> --limit 100           # List repos for a user/org
+gh search repos <query> --owner=@me        # Search your repos by keyword
 gh api repos/{owner}/{repo}/...           # API calls
 ```
 

--- a/context/agents/delegation-instructions.md
+++ b/context/agents/delegation-instructions.md
@@ -63,6 +63,7 @@ When you encounter these situations, delegate IMMEDIATELY without hesitation:
 | User asks for implementation | `delegate(agent="foundation:modular-builder", ...)` |
 | User asks for design/architecture | `delegate(agent="foundation:zen-architect", ...)` |
 | Any git operation (commit, PR, push) | `delegate(agent="foundation:git-ops", ...)` |
+| User needs to find/discover repos (including private) | `delegate(agent="foundation:git-ops", ...)` — gh CLI sees private repos; web search cannot |
 | Need to read >2 files | `delegate(agent="foundation:explorer", ...)` |
 
 **Do NOT:** Explain what you're about to do, then do it yourself.


### PR DESCRIPTION
## Summary

- Add `gh` CLI repo discovery (`gh repo list`, `gh search repos`) as an explicitly advertised capability in the git-ops agent description, activation triggers, and command reference
- Add a delegation trigger row so orchestrators route "find my repo" requests to git-ops before falling back to web search — `gh` CLI sees private repos that web search cannot

## Motivation

When users ask to "find my repo", the orchestrator was defaulting to web search and URL guessing, which fails for private repos and wastes tokens. The git-ops agent *could* do this via `gh repo list`, but its description didn't advertise the capability, so the orchestrator never considered it.

## Changes

| File | Change |
|------|--------|
| `agents/git-ops.md` | Added repo discovery to capability list, added example, added `gh repo list`/`gh search repos` commands, added activation trigger |
| `context/agents/delegation-instructions.md` | Added delegation trigger row for repo discovery → git-ops |

## Test plan

- [x] Verified edits are syntactically correct
- [ ] Manual test: ask an assistant to "find my repo" and verify it delegates to git-ops first

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)