### PR TITLE
feat: add bash timeout guidance to agent context

### DIFF
--- a/context/shared/common-agent-base.md
+++ b/context/shared/common-agent-base.md
@@ -93,6 +93,7 @@ The `source` attribute identifies which component generated the reminder.
 - **File operations**: Use read_file (not cat/head/tail), edit_file (not sed/awk), write_file (not echo/heredoc)
 - **Search**: Use grep tool (not bash grep/rg) - it has output limits and smart exclusions
 - **Web content**: Use web_fetch tool (not curl/wget)
+- **Bash timeouts**: Commands time out after 30 seconds by default. Pass `timeout` to increase for long-running commands like builds, tests, or monitoring (e.g., `bash(command="cargo test", timeout=300)`). For truly indefinite processes (dev servers, watchers), use `run_in_background: true` — this returns a PID immediately; poll with separate bash calls (`ps`, `cat logfile`, etc.). Never use `sleep` for long waits — use `timeout` for finite waits or `run_in_background` + polling for observation.
 
 **Direct execution exception**: Single-command operations with known outcomes (e.g., `git status`, `ls`, `pwd`, reading a single known file) may be executed directly. Multi-step work, exploration, or any task matching an agent's domain MUST be delegated.
 


### PR DESCRIPTION
## Summary

- Add bash timeout guidance to the Tool Selection Philosophy section in `common-agent-base.md`
- Documents the 30s default, how to override with `timeout` parameter, when to use `run_in_background`, and never use `sleep` for long waits

## Motivation

Agents frequently hit the 30-second bash timeout on long-running commands and don't know they can override it. This adds practical guidance alongside existing tool selection tips (file ops, search, web content).

Companion to microsoft/amplifier-module-tool-bash#10 which adds the per-invocation `timeout` parameter to the bash tool schema.

## Changes

| File | Change |
|------|--------|
| `context/shared/common-agent-base.md` | Added bash timeout bullet to Specific guidance list |

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)