### PR TITLE
fix: use module identifier in exclude_tools config

### DIFF
--- a/behaviors/agents.yaml
+++ b/behaviors/agents.yaml
@@ -29,7 +29,7 @@ tools:
         provider_selection:
           enabled: true
       settings:
-        exclude_tools: [delegate]  # Spawned agents can't further delegate by default
+        exclude_tools: [tool-delegate]  # Spawned agents can't further delegate by default
         exclude_hooks: []
 
 context:

--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -17,7 +17,7 @@ Config Options:
 - features.context_inheritance.enabled: Allow context passing (default: True)
 - features.context_inheritance.max_turns: Maximum turns for "recent" mode (default: 10)
 - features.provider_selection.enabled: Allow provider preferences (default: True)
-- settings.exclude_tools: Tools spawned agents should NOT inherit (default: ["delegate"])
+- settings.exclude_tools: Tools spawned agents should NOT inherit (default: ["tool-delegate"])
 - settings.exclude_hooks: Hooks spawned agents should NOT inherit (default: [])
 - settings.timeout: Maximum total execution time for child session in seconds (default: None/disabled)
 
@@ -122,7 +122,7 @@ class DelegateTool:
         )
 
         # Settings
-        self.exclude_tools: list[str] = settings.get("exclude_tools", ["delegate"])
+        self.exclude_tools: list[str] = settings.get("exclude_tools", ["tool-delegate"])
         self.exclude_hooks: list[str] = settings.get("exclude_hooks", [])
         self.timeout: int | None = settings.get("timeout", None)
 


### PR DESCRIPTION
## Problem

The `exclude_tools` mechanism prevents spawned sub-agents from inheriting specified tools. The filtering in `session_spawner.py` compares against module identifiers (`t.get("module")`), but the config value and default used the tool's runtime API name (`"delegate"`) instead of the module identifier (`"tool-delegate"`).

Since `"tool-delegate" not in ["delegate"]` is always `True`, the filter never matched. Every spawned agent inherited the delegate tool regardless of configuration.

## Impact

This caused infinite delegation cascades in production. Agents that should not have been able to delegate (like `foundation:file-ops`, which declares only `tool-filesystem` and `tool-search`) could spawn sub-agents indefinitely:

- **Incident 1**: 842 sessions, zero output files, ~1.3 GB session data
- **Incident 2**: 469-worker linear chain, ~13.7M input tokens consumed, 94 minutes of wall time, zero work performed

## Fix

Change the `exclude_tools` value from `"delegate"` (tool API name) to `"tool-delegate"` (module identifier) in two locations:

- `behaviors/agents.yaml:32` — the config value
- `modules/tool-delegate/__init__.py:125` — the Python default

Note: provider filtering in the same `session_spawner.py` file already has normalization for `"anthropic"` vs `"provider-anthropic"`, but tool filtering has none. This fix uses the correct identifier rather than adding normalization.

## Testing

The fix is a config value change — no logic changes. The filtering code in `session_spawner.py` (app-cli) is unchanged; it was already correct, just receiving the wrong input.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)