### PR TITLE
Add on_child_initialized callback to PreparedBundle.spawn()

### DIFF
--- a/amplifier_foundation/bundle.py
+++ b/amplifier_foundation/bundle.py
@@ -670,6 +670,7 @@ class PreparedBundle:
         compose: bool = True,
         parent_session: Any = None,
         session_id: str | None = None,
+        on_child_initialized: Any = None,
     ) -> dict[str, Any]:
         """Spawn a sub-session with a child bundle.
 
@@ -741,6 +742,10 @@ class PreparedBundle:
         # Mount resolver and initialize
         await child_session.coordinator.mount("module-source-resolver", self.resolver)
         await child_session.initialize()
+
+        # Call on_child_initialized callback if provided
+        if on_child_initialized:
+            await on_child_initialized(child_session)
 
         # Inject system instruction with resolved @mentions (if present)
         # Also inject context.include files (accumulated from all composed bundles)


### PR DESCRIPTION
## Summary

Adds optional `on_child_initialized` callback parameter to `PreparedBundle.spawn()` that is invoked after child session initialization but before execution begins.

This enables apps (like Kepler) to inject hooks (streaming, observability, approval) on child sessions without inlining spawn internals or creating maintenance burden as foundation evolves.

## Changes

- Add `on_child_initialized: Any = None` parameter to `spawn()` signature
- Invoke callback after `child_session.initialize()` and before instruction injection
- Callback receives initialized `AmplifierSession` for clean hook injection

## Impact

Enables clean elimination of ~60 lines of inlined spawn logic in desktop apps that need child-session hooks. Any app requiring post-initialization, pre-execution injection gets the same benefit.

## Example

```python
prepared.spawn(
    instruction=task,
    on_child_initialized=lambda session: bridge.register_on_coordinator(
        session.coordinator, is_child=True, agent_name=agent
    )
)
```
