### PR TITLE
refactor: simplify agent configs to class-only provider preferences

### DIFF
--- a/agents/amplifier-smoke-test.md
+++ b/agents/amplifier-smoke-test.md
@@ -30,18 +30,6 @@ meta:
 
 provider_preferences:
   - class: fast
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
 
 tools:
   - module: tool-bash

--- a/agents/bug-hunter.md
+++ b/agents/bug-hunter.md
@@ -3,25 +3,6 @@ meta:
   name: bug-hunter
   description: "Specialized debugging expert focused on finding and fixing bugs systematically. Use PROACTIVELY. It MUST BE USED when user has reported or you are encountering errors, unexpected behavior, or test failures. Examples: <example>user: 'The synthesis pipeline is throwing a KeyError somewhere' assistant: 'I'll use the bug-hunter agent to systematically track down and fix this KeyError.' <commentary>The bug-hunter uses hypothesis-driven debugging to efficiently locate and resolve issues.</commentary></example> <example>user: 'Tests are failing after the recent changes' assistant: 'Let me use the bug-hunter agent to investigate and fix the test failures.' <commentary>Perfect for methodical debugging without adding unnecessary complexity.</commentary></example>"
 
-provider_preferences:
-  - class: reasoning
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]-codex
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]-codex
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/ecosystem-expert.md
+++ b/agents/ecosystem-expert.md
@@ -40,21 +40,6 @@ meta:
     </commentary>
     </example>
 
-provider_preferences:
-  - class: reasoning
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-bash
     source: git+https://github.com/microsoft/amplifier-module-tool-bash@main

--- a/agents/explorer.md
+++ b/agents/explorer.md
@@ -3,20 +3,6 @@ meta:
   name: explorer
   description: "Deep local-context reconnaissance agent. IMPORTANT: This agent has zero prior context—every invocation must include the full objective, scope hints (directories, file types, keywords), and any constraints the agent should respect. Without that information it will not be aware of such. MUST be used for multi-file exploration. Use this agent whenever the user needs a comprehensive survey of local code, documentation, configuration, or user-provided content (not a precise single-file lookup). Examples:\n\n<example>\nuser: 'What does the overall event handling flow look like?'\nassistant: 'I'll delegate to the foundation:explorer agent to map the event handling modules and summarize the flow.'\n<commentary>The agent conducts a structured sweep of relevant packages and reports the flow.</commentary>\n</example>\n\n<example>\nuser: 'Gather everything we have about client-facing SLAs across docs and configs.'\nassistant: 'I'll use the foundation:explorer agent to survey documentation and configuration files related to client SLAs and summarize the findings.'\n<commentary>The agent spans code, docs, and content to answer the request.</commentary>\n</example>"
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/file-ops.md
+++ b/agents/file-ops.md
@@ -32,18 +32,6 @@ File-ops provides grep capabilities for content search with context lines.
 
 provider_preferences:
   - class: fast
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
 
 tools:
   - module: tool-filesystem

--- a/agents/foundation-expert.md
+++ b/agents/foundation-expert.md
@@ -3,21 +3,6 @@ meta:
   name: foundation-expert
   description: "**THE authoritative expert for Amplifier Foundation applications.** Also the expert on agent authoring since agents ARE bundles. MUST be consulted for bundle composition, agent authoring, patterns, and design decisions.\n\n**Use PROACTIVELY when**:\n- Creating or modifying bundles (REQUIRED before writing bundle YAML)\n- Writing agent descriptions (this is THE expert on agent authoring)\n- Making design decisions about context or composition\n- Understanding the thin bundle pattern\n- Finding working examples and patterns\n\nDO NOT attempt bundle or agent authoring without consulting this expert first.\n\nExamples:\n\n<example>\nContext: Building a new bundle\nuser: 'I want to create a bundle for code review capabilities'\nassistant: 'I'll consult foundation:foundation-expert for bundle composition patterns and the thin bundle approach.'\n<commentary>\nfoundation:foundation-expert knows the thin bundle pattern and behavior composition.\n</commentary>\n</example>\n\n<example>\nContext: Finding working examples\nuser: 'Show me how to set up a multi-provider configuration'\nassistant: 'Let me ask foundation:foundation-expert - it has access to all the working examples.'\n<commentary>\nfoundation:foundation-expert can point to specific examples and patterns.\n</commentary>\n</example>\n\n<example>\nContext: Philosophy question\nuser: 'Should I inline my instructions or create separate context files?'\nassistant: 'I'll consult foundation:foundation-expert for the recommended approach based on modular design philosophy.'\n<commentary>\nfoundation:foundation-expert applies philosophy principles to practical decisions.\n</commentary>\n</example>\n\n<example>\nContext: Creating a new agent\nuser: 'How do I write a good agent description?'\nassistant: 'I'll consult foundation:foundation-expert for agent authoring guidance - it knows the description requirements (WHY, WHEN, WHAT, HOW) and context sink pattern.'\n<commentary>\nfoundation:foundation-expert is authoritative on agent authoring since agents ARE bundles.\n</commentary>\n</example>"
 
-provider_preferences:
-  - class: reasoning
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/git-ops.md
+++ b/agents/git-ops.md
@@ -4,18 +4,7 @@ meta:
   description: "**ALWAYS delegate git and GitHub operations to this agent.** This agent has safety protocols and creates quality commit messages with proper context. MUST be used for:\n- Creating commits (generates proper messages with Amplifier co-author)\n- Creating and managing PRs\n- Branch operations and conflict resolution\n- GitHub API interactions (issues, checks, releases)\n- Repository discovery (gh repo list — finds user's repos including private ones)\n- Multi-repo sync operations (fetch, pull, status)\n\nDO NOT use bash directly for git commands - this agent has safety checks you lack.\n\n<example>\nuser: 'Commit these changes'\nassistant: 'I'll delegate to git-ops to create a properly formatted commit with context.'\n<commentary>git-ops ensures commit standards, safety protocols, and proper attribution.</commentary>\n</example>\n\n<example>\nuser: 'Create a PR for this feature'\nassistant: 'I'll use git-ops to create the PR with proper formatting and description.'\n<commentary>git-ops follows PR templates and includes required metadata.</commentary>\n</example>\n\n<example>\nuser: 'Find my repo for lmacfy.com'\nassistant: 'I'll use git-ops to search your GitHub repos using the gh CLI, which can find private repos that web search cannot.'\n<commentary>Always try git-ops for repo discovery before web search. gh repo list sees private repos; web search does not.</commentary>\n</example>"
 
 provider_preferences:
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
+  - class: fast
 
 tools:
   - module: tool-bash

--- a/agents/integration-specialist.md
+++ b/agents/integration-specialist.md
@@ -3,20 +3,6 @@ meta:
   name: integration-specialist
   description: "Expert at integrating with external services, APIs, and MCP servers while maintaining simplicity. Also analyzes and manages dependencies for security, compatibility, and technical debt. MUST be used when connecting to external services, setting up MCP servers, handling API integrations, or analyzing project dependencies. Examples: <example>user: 'Set up integration with the new payment API' assistant: 'I'll use the integration-specialist agent to create a simple, direct integration with the payment API.' <commentary>The integration-specialist ensures clean, maintainable external connections.</commentary></example> <example>user: 'Connect our system to the MCP notification server' assistant: 'Let me use the integration-specialist agent to set up the MCP server connection properly.' <commentary>Perfect for external system integration without over-engineering.</commentary></example> <example>user: 'Check our dependencies for security vulnerabilities' assistant: 'I'll use the integration-specialist agent to analyze dependencies for vulnerabilities and suggest updates.' <commentary>The agent handles dependency health as part of integration management.</commentary></example>"
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/modular-builder.md
+++ b/agents/modular-builder.md
@@ -47,25 +47,6 @@ meta:
     <commentary>Analysis/design task - NOT for modular-builder. Zen-architect only.</commentary>
     </example>
 
-provider_preferences:
-  - class: reasoning
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]-codex
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]-codex
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/post-task-cleanup.md
+++ b/agents/post-task-cleanup.md
@@ -5,18 +5,6 @@ meta:
 
 provider_preferences:
   - class: fast
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
 
 tools:
   - module: tool-filesystem

--- a/agents/security-guardian.md
+++ b/agents/security-guardian.md
@@ -15,20 +15,6 @@ Covers: OWASP Top 10, hardcoded secrets detection, input/output validation, cryp
 
 provider_preferences:
   - class: reasoning
-  - provider: anthropic
-    model: claude-opus-*
-  - provider: openai
-    model: gpt-5*-pro
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-opus-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
 
 tools:
   - module: tool-filesystem

--- a/agents/session-analyst.md
+++ b/agents/session-analyst.md
@@ -4,18 +4,7 @@ meta:
   description: "REQUIRED agent for analyzing, debugging, searching, and REPAIRING Amplifier sessions. MUST be used when:\\n- Investigating why a session failed or won't resume\\n- Analyzing events.jsonl files (contains 100k+ token lines that WILL crash other tools)\\n- Diagnosing API errors, missing tool results, or corrupted transcripts\\n- Understanding what happened in a past conversation\\n- Searching for sessions by ID, project, date, or topic\\n- REWINDING a session to a prior point (truncating history to retry from a clean state)\\n\\nThis agent has specialized knowledge for safely extracting data from large session logs without context overflow. DO NOT attempt to read events.jsonl directly - delegate to this agent.\\n\\nExamples:\\n\\n<example>\\nuser: 'Why did my session fail?' or 'Session X won't resume'\\nassistant: 'I'll use the session-analyst agent to investigate the failure - it has specialized tools for safely analyzing large event logs.'\\n<commentary>MUST delegate session debugging to this agent. It knows how to handle 100k+ token event lines safely.</commentary>\\n</example>\\n\\n<example>\\nuser: 'What's in events.jsonl?' or asks about session event logs\\nassistant: 'I'll delegate this to session-analyst - events.jsonl files can have lines with 100k+ tokens that require special handling.'\\n<commentary>NEVER attempt to read events.jsonl directly. Always delegate to session-analyst.</commentary>\\n</example>\\n\\n<example>\\nuser: 'Find the conversation where I worked on authentication'\\nassistant: 'I'll use the session-analyst agent to search through your Amplifier sessions for authentication-related conversations.'\\n<commentary>The agent searches session metadata and transcripts for relevant conversations.</commentary>\\n</example>\\n\\n<example>\\nuser: 'What sessions do I have from last week in the azure project?'\\nassistant: 'Let me use the session-analyst agent to locate sessions from the azure project directory from last week.'\\n<commentary>The agent scopes search to specific project and timeframe.</commentary>\\n</example>\\n\\n<example>\\nuser: 'Rewind session X to before my last message' or 'Fix my broken session by removing the problematic exchange'\\nassistant: 'I'll use the session-analyst agent to rewind that session - it can safely truncate the events.jsonl to remove history from a specific point so you can retry.'\\n<commentary>The agent can repair sessions by rewinding to a prior state, creating backups before modification.</commentary>\\n</example>"
 
 provider_preferences:
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
+  - class: fast
 
 tools:
   - module: tool-filesystem

--- a/agents/shell-exec.md
+++ b/agents/shell-exec.md
@@ -40,18 +40,6 @@ Shell-exec handles system commands safely with proper output capture.
 
 provider_preferences:
   - class: fast
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
 
 tools:
   - module: tool-bash

--- a/agents/test-coverage.md
+++ b/agents/test-coverage.md
@@ -3,24 +3,6 @@ meta:
   name: test-coverage
   description: "Expert at analyzing test coverage, identifying gaps, and suggesting comprehensive test cases. MUST be used when writing new features, after bug fixes, or during test reviews. Examples: <example>user: 'Check if our synthesis pipeline has adequate test coverage' assistant: 'I'll use the test-coverage agent to analyze the test coverage and identify gaps in the synthesis pipeline.' <commentary>The test-coverage agent ensures thorough testing without over-testing.</commentary></example> <example>user: 'What tests should I add for this new authentication module?' assistant: 'Let me use the test-coverage agent to analyze your module and suggest comprehensive test cases.' <commentary>Perfect for ensuring quality through strategic testing.</commentary></example>"
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]-codex
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]-codex
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/web-research.md
+++ b/agents/web-research.md
@@ -31,18 +31,7 @@ Web-research excels at finding external examples and community best practices.
 </example>"
 
 provider_preferences:
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
+  - class: fast
 
 tools:
   - module: tool-web

--- a/agents/zen-architect.md
+++ b/agents/zen-architect.md
@@ -5,20 +5,6 @@ meta:
 
 provider_preferences:
   - class: reasoning
-  - provider: anthropic
-    model: claude-opus-*
-  - provider: openai
-    model: gpt-5*-pro
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-opus-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
 
 tools:
   - module: tool-filesystem


### PR DESCRIPTION
Removes explicit provider/model fallback chains from all 16 agent .md files.

- **Reasoning** (zen-architect, security-guardian): `class: reasoning` only
- **Fast** (file-ops, shell-exec, post-task-cleanup, amplifier-smoke-test, git-ops, session-analyst, web-research): `class: fast` only
- **Standard** (explorer, bug-hunter, modular-builder, foundation-expert, ecosystem-expert, integration-specialist, test-coverage): provider_preferences removed entirely (use session default)

The class-based routing system handles provider/model selection dynamically — explicit fallback chains are no longer needed.