### PR TITLE
test: update fast class tests for cost-tier resolution

### DIFF
--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -289,7 +289,7 @@ async def resolve_model_class(
 
             # Filter by capability or cost tier
             if matching_caps is not None:
-                # Capability-based matching (reasoning, fast, vision, research)
+                # Capability-based matching (vision, research)
                 if not model_caps.intersection(matching_caps):
                     continue
             elif required_cost_tier is not None:

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -629,6 +629,7 @@ class TestResolveModelClass:
 
     @pytest.mark.asyncio
     async def test_fast_class_filters_to_fast_models(self):
+        """Fast class resolves by cost_tier=low, not capability tags."""
         from amplifier_core import ModelInfo
 
         provider = self._make_mock_provider(
@@ -647,7 +648,7 @@ class TestResolveModelClass:
                     display_name="Claude Haiku 4.5",
                     context_window=200000,
                     max_output_tokens=64000,
-                    capabilities=["tools", "fast"],
+                    capabilities=["tools"],
                     metadata={"cost_tier": "low"},
                 ),
             ],
@@ -844,7 +845,7 @@ class TestResolveModelClass:
                     display_name="Haiku",
                     context_window=200000,
                     max_output_tokens=64000,
-                    capabilities=["tools", "fast"],
+                    capabilities=["tools"],
                     metadata={"cost_tier": "low"},
                 ),
             ],
@@ -882,7 +883,7 @@ class TestApplyPreferencesWithClassResolution:
                     display_name="Claude Haiku 4.5",
                     context_window=200000,
                     max_output_tokens=64000,
-                    capabilities=["tools", "fast"],
+                    capabilities=["tools"],
                     metadata={"cost_tier": "low"},
                 ),
             ]


### PR DESCRIPTION
Tests updated to match fast=low cost tier resolution. Removes 'fast' from capabilities in test fixtures — fast class now resolves by cost_tier=low, matching the pattern used by standard and reasoning classes.