### PR TITLE
fix: update routing hook package name in tool-delegate

### DIFF
--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -718,7 +718,7 @@ Agent usage notes:
             routing_state = self.coordinator.session_state.get("routing_matrix")
             if routing_state:
                 try:
-                    from amplifier_hooks_routing.resolver import resolve_model_role
+                    from amplifier_module_hooks_routing.resolver import resolve_model_role
 
                     roles = [raw_model_role]
                     matrix = routing_state.get("roles", {})
@@ -733,7 +733,7 @@ Agent usage notes:
                         ]
                 except ImportError:
                     logger.warning(
-                        "model_role '%s' specified but amplifier_hooks_routing not available",
+                        "model_role '%s' specified but amplifier_module_hooks_routing not available",
                         raw_model_role,
                     )
             else:

--- a/modules/tool-delegate/tests/test_delegate_model_role.py
+++ b/modules/tool-delegate/tests/test_delegate_model_role.py
@@ -64,25 +64,25 @@ def _make_delegate_tool(
 
 
 def _install_mock_resolver(mock_resolve_fn):
-    """Install a mock amplifier_hooks_routing.resolver module in sys.modules.
+    """Install a mock amplifier_module_hooks_routing.resolver module in sys.modules.
 
     Returns a cleanup function to remove it.
     """
-    mock_resolver_mod = types.ModuleType("amplifier_hooks_routing.resolver")
+    mock_resolver_mod = types.ModuleType("amplifier_module_hooks_routing.resolver")
     mock_resolver_mod.resolve_model_role = mock_resolve_fn  # type: ignore[attr-defined]
 
-    mock_hooks_routing_mod = types.ModuleType("amplifier_hooks_routing")
+    mock_hooks_routing_mod = types.ModuleType("amplifier_module_hooks_routing")
 
     originals = {}
-    for mod_name in ("amplifier_hooks_routing", "amplifier_hooks_routing.resolver"):
+    for mod_name in ("amplifier_module_hooks_routing", "amplifier_module_hooks_routing.resolver"):
         if mod_name in sys.modules:
             originals[mod_name] = sys.modules[mod_name]
 
-    sys.modules["amplifier_hooks_routing"] = mock_hooks_routing_mod
-    sys.modules["amplifier_hooks_routing.resolver"] = mock_resolver_mod
+    sys.modules["amplifier_module_hooks_routing"] = mock_hooks_routing_mod
+    sys.modules["amplifier_module_hooks_routing.resolver"] = mock_resolver_mod
 
     def cleanup():
-        for mod_name in ("amplifier_hooks_routing", "amplifier_hooks_routing.resolver"):
+        for mod_name in ("amplifier_module_hooks_routing", "amplifier_module_hooks_routing.resolver"):
             if mod_name in originals:
                 sys.modules[mod_name] = originals[mod_name]
             elif mod_name in sys.modules:


### PR DESCRIPTION
## Summary

- Update `amplifier_hooks_routing` → `amplifier_module_hooks_routing` in tool-delegate module
- The routing-matrix bundle renamed its hook package to follow the standard `amplifier_module_*` naming convention
- Without this fix, model_role delegation produces: `model_role 'fast' specified but amplifier_hooks_routing not available`

## Test plan

- [x] All 306 tests pass
- [x] Verified the renamed package `amplifier_module_hooks_routing` is the correct import target

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)