### PR TITLE
feat: remove amplifier-core git source override (PyPI switch)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-amplifier-core = { git = "https://github.com/microsoft/amplifier-core", branch = "main" }
 
 [project.urls]
 Homepage = "https://github.com/microsoft/amplifier-foundation"


### PR DESCRIPTION
Removes amplifier-core from [tool.uv.sources] so it resolves from PyPI (Rust kernel wheel) instead of git source.

Also includes 40 commits of feature work: model routing, provider preferences, agent authoring docs, bug fixes.