### PR TITLE
fix: Skip editable install for packages already available in environment

### DIFF
--- a/amplifier_foundation/modules/activator.py
+++ b/amplifier_foundation/modules/activator.py
@@ -184,6 +184,23 @@ class ModuleActivator:
             )
             return
 
+        # Skip packages that are already importable in the current environment.
+        # This prevents editable-installing packages (like amplifier-core) that were
+        # already installed from PyPI as prebuilt wheels. Without this check, a repo
+        # cloned into the cache for its YAML/context files (via bundle includes) would
+        # trigger a source build that may require native toolchains (Rust, protobuf, etc).
+        pkg_name = pyproject_data.get("project", {}).get("name", "")
+        if pkg_name:
+            import importlib.util
+
+            normalized = pkg_name.replace("-", "_")
+            if importlib.util.find_spec(normalized) is not None:
+                logger.debug(
+                    f"Package '{pkg_name}' already installed, "
+                    f"skipping editable install from {bundle_path}"
+                )
+                return
+
         logger.debug(f"Installing bundle package from {bundle_path}")
         await self._install_dependencies(bundle_path)
 


### PR DESCRIPTION
## Summary

When `bundle.prepare()` processes `source_base_paths` (which includes cached repos cloned for their YAML/context files), it unconditionally calls `activate_bundle_package()` on each one. If a package is already installed in the current environment (e.g., amplifier-core from PyPI as a prebuilt wheel), this would trigger an unnecessary editable install that may require native build toolchains (Rust, protobuf, etc).

## Changes

This fix adds a check using `importlib.util.find_spec()` in `activate_bundle_package()` to detect packages already available in the environment and skips the editable install, preventing spurious build attempts that fail without required toolchains.

## Root Cause

- The foundation bundle includes amplifier-core as a nested bundle (to get its core-expert agent YAML)
- This causes the entire amplifier-core repo to be cloned into ~/.amplifier/cache/
- During bundle preparation, the amplifier-core cache path is added to `source_base_paths`
- `bundle.prepare()` iterates `source_base_paths` and calls `activate_bundle_package()` unconditionally
- Since amplifier-core has a maturin/Rust build system, this triggered a Rust compilation requiring protoc
- This happened even though amplifier-core was already installed from PyPI as a prebuilt wheel

## Validation

- Tested in shadow environment
- Smoke test: 100/100 points
- No maturin/Rust/protoc errors
- No build artifacts in cache
- amplifier-core imports from PyPI wheel (site-packages), not from source