### PR TITLE
fix: remove hardcoded haiku model from validation recipe quick-approval steps

### DIFF
--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -1,8 +1,12 @@
 # validate-agents.yaml
-# Agent Definition Validator Recipe v1.2.3
+# Agent Definition Validator Recipe v1.2.5
 # Validates agent definitions in a bundle repository for quality, tool access, and structural requirements
 #
 # CHANGELOG:
+# v1.2.5 - Removed hardcoded provider/model from quick-approval step
+#        - "claude-haiku" is not a valid model ID and breaks execution
+#        - Quick-approval now uses session default model for portability
+#
 # v1.2.3 - Fixed multiline string interpolation bug
 #        - Remove frontmatter and meta fields from structural_results before JSON output
 #        - These fields contain multiline descriptions that break JSON parsing in downstream steps
@@ -64,7 +68,7 @@ description: |
   
   This recipe helps maintain agent quality across the Amplifier ecosystem by codifying
   the audit criteria discovered in manual reviews.
-version: "1.2.4"
+version: "1.2.5"
 author: "Amplifier Foundation Team"
 tags: ["agents", "validation", "quality", "audit", "tools", "descriptions"]
 
@@ -793,14 +797,13 @@ steps:
   # ============================================================================
   # PHASE 3: Quick Approval (When All Agents Pass)
   # Fast-track path for bundles that meet all quality thresholds
-  # Model: haiku - simple summary, no complex reasoning needed
+  # Simple summary task - uses session default model (no provider/model pinning
+  # for portability across provider configurations)
   # ============================================================================
 
   - id: "quick-approval"
     agent: "foundation:zen-architect"
     mode: "REVIEW"
-    provider: "anthropic"
-    model: "claude-haiku"
     condition: "{{quality_classification.requires_llm_analysis}} == false"
     depends_on: ["set-default-approval-summary"]
     prompt: |

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -2386,8 +2386,6 @@ steps:
   - id: "quick-approval"
     agent: "foundation:zen-architect"
     mode: "REVIEW"
-    provider: "anthropic"
-    model: "claude-haiku"
     condition: "{{quality_classification.requires_llm_analysis}} == false"
     depends_on: ["set-default-approval-summary"]
     prompt: |


### PR DESCRIPTION
## Summary
- Fixed invalid Anthropic model ID ('claude-haiku') that caused not_found_error in validation recipes
- Removed hardcoded provider/model pinning to use session default, improving portability
- Updated validate-agents.yaml version from 1.2.4 to 1.2.5

## Details
The 'claude-haiku' model identifier in `validate-agents.yaml` and `validate-bundle-repo.yaml` is not a valid Anthropic model ID. This caused validation failures when running:
- `validate-agents` recipe
- `validate-bundle-repo` recipe

The quick-approval step performs a simple summary task that doesn't require model optimization, so we removed the hardcoded provider/model constraint and let it use the session default. This makes the recipes portable across different provider configurations.

## Changes
- `recipes/validate-agents.yaml`: Removed `provider` and `model` fields from quick-approval step, bumped version to 1.2.5
- `recipes/validate-bundle-repo.yaml`: Removed `provider` and `model` fields from quick-approval step

## Test plan
- [x] Validation recipes should no longer throw not_found_error
- [x] Can rerun routing-matrix bundle validation with updated recipes
- [x] Can rerun agent validation with updated recipes

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)