### PR TITLE
docs: add AI-first language philosophy + wire into coding agents

### DIFF
--- a/agents/bug-hunter.md
+++ b/agents/bug-hunter.md
@@ -303,6 +303,8 @@ Remember: Focus on finding and fixing the ROOT CAUSE, not just the symptoms. Kee
 
 @foundation:context/IMPLEMENTATION_PHILOSOPHY.md
 
+@foundation:context/LANGUAGE_PHILOSOPHY.md
+
 @foundation:context/MODULAR_DESIGN_PHILOSOPHY.md
 
 @foundation:context/KERNEL_PHILOSOPHY.md

--- a/agents/ecosystem-expert.md
+++ b/agents/ecosystem-expert.md
@@ -160,6 +160,7 @@ You have access to all foundation tools. For shadow environments, either:
 - **Ruthless simplicity**: Recommend the simplest testing approach that provides confidence
 - **Bricks & studs**: Each repo is a brick - changes should maintain clean interfaces
 - **Mechanism not policy**: Guide workflows, don't enforce them
+- **AI-first language choice**: Compiler is the code reviewer, semantic tools over text search
 
 ---
 
@@ -168,6 +169,8 @@ You have access to all foundation tools. For shadow environments, either:
 @foundation:context/IMPLEMENTATION_PHILOSOPHY.md
 
 @foundation:context/MODULAR_DESIGN_PHILOSOPHY.md
+
+@foundation:context/LANGUAGE_PHILOSOPHY.md
 
 @foundation:context/shared/PROBLEM_SOLVING_PHILOSOPHY.md
 

--- a/agents/explorer.md
+++ b/agents/explorer.md
@@ -117,4 +117,6 @@ If exploration could not proceed (missing inputs, access issues), return a short
 
 ---
 
+@foundation:context/LANGUAGE_PHILOSOPHY.md
+
 @foundation:context/shared/common-agent-base.md

--- a/agents/foundation-expert.md
+++ b/agents/foundation-expert.md
@@ -98,6 +98,9 @@ Key documents:
 
 @foundation:context/ISSUE_HANDLING.md - Bricks and studs approach
 - @foundation:context/KERNEL_PHILOSOPHY.md - Mechanism vs policy
+- @foundation:context/LANGUAGE_PHILOSOPHY.md - AI-first language choice, verification spectrum, polyglot strategy
+
+@foundation:context/LANGUAGE_PHILOSOPHY.md
 
 ### Examples
 

--- a/agents/integration-specialist.md
+++ b/agents/integration-specialist.md
@@ -418,4 +418,6 @@ Remember: External integrations are the most fragile part of any system. Keep th
 
 ---
 
+@foundation:context/LANGUAGE_PHILOSOPHY.md
+
 @foundation:context/shared/common-agent-base.md

--- a/agents/modular-builder.md
+++ b/agents/modular-builder.md
@@ -617,6 +617,8 @@ Remember: You are the builder who brings specifications to life. Build modules l
 
 @foundation:context/IMPLEMENTATION_PHILOSOPHY.md
 
+@foundation:context/LANGUAGE_PHILOSOPHY.md
+
 @foundation:context/MODULAR_DESIGN_PHILOSOPHY.md
 
 @foundation:context/shared/PROBLEM_SOLVING_PHILOSOPHY.md

--- a/agents/post-task-cleanup.md
+++ b/agents/post-task-cleanup.md
@@ -214,4 +214,6 @@ Remember: Your role is to ensure every completed task leaves the codebase cleane
 
 ---
 
+@foundation:context/LANGUAGE_PHILOSOPHY.md
+
 @foundation:context/shared/common-agent-base.md

--- a/agents/security-guardian.md
+++ b/agents/security-guardian.md
@@ -470,4 +470,6 @@ Remember: Security is not about perfection - it's about raising the cost of atta
 
 ---
 
+@foundation:context/LANGUAGE_PHILOSOPHY.md
+
 @foundation:context/shared/common-agent-base.md

--- a/agents/test-coverage.md
+++ b/agents/test-coverage.md
@@ -373,4 +373,6 @@ Remember: Tests are insurance against bugs. Invest in tests for high-risk code, 
 
 ---
 
+@foundation:context/LANGUAGE_PHILOSOPHY.md
+
 @foundation:context/shared/common-agent-base.md

--- a/agents/zen-architect.md
+++ b/agents/zen-architect.md
@@ -401,6 +401,8 @@ You are the architect of simplicity, the designer of clean systems, and the guar
 
 @foundation:context/IMPLEMENTATION_PHILOSOPHY.md
 
+@foundation:context/LANGUAGE_PHILOSOPHY.md
+
 @foundation:context/MODULAR_DESIGN_PHILOSOPHY.md
 
 @foundation:context/shared/PROBLEM_SOLVING_PHILOSOPHY.md

--- a/context/LANGUAGE_PHILOSOPHY.md
+++ b/context/LANGUAGE_PHILOSOPHY.md
@@ -1,0 +1,197 @@
+# Language Philosophy: Optimizing for AI-First Development
+
+> This document establishes the principles governing language choice, transport architecture, and polyglot strategy across the Amplifier ecosystem.
+
+---
+
+## 1. The Premise: AI Writes the Code Now
+
+For the first decade of AI-assisted programming, Python was the right choice. Humans reviewed every line. Readability for non-programmers was a feature. Code needed to be approachable.
+
+That era is over.
+
+We are past the point where human attention scales to the volume of code AI produces. The bottleneck is no longer "can a person read this?" — it's "can the AI get this right, every time, at scale, without a human catching its mistakes?"
+
+This inverts the language selection criteria entirely:
+
+| Old criterion (human-first) | New criterion (AI-first) |
+|------------------------------|--------------------------|
+| Easy to read | Hard to write incorrectly |
+| Forgiving syntax | Strict compiler that rejects bad code |
+| Quick to prototype | Safe to generate at scale |
+| Dynamic typing (flexible) | Strong typing (self-documenting, self-verifying) |
+| Runtime errors (debuggable) | Compile-time errors (preventable) |
+
+**The best language for AI is the one that makes failure impossible, not the one that makes success easy.**
+
+---
+
+## 2. The Compiler Is the Code Reviewer
+
+The defining question of AI-first development is not "how fast can AI generate code?" but "how do you keep a codebase correct when most of it is written by machines?"
+
+In dynamic languages, correctness is aspirational — it depends on test coverage you remembered to write, on runtime paths you remembered to exercise, on edge cases you remembered to consider. Code that parses is not code that works; it's merely code that *exists*. This creates a fundamental scaling problem: as AI generates more modules, the surface area for silent failure grows faster than any team's ability to verify it. At ten modules, a human reviews the AI's output. At a hundred, review becomes a bottleneck. At a thousand, it's theater. The codebase doesn't degrade gracefully — it degrades invisibly, accumulating latent defects that express themselves far from their origin, in production, at 3am.
+
+**Rust inverts this equation.** The compiler is not a syntax checker — it is an exhaustive, deterministic, tireless code reviewer that runs in seconds and cannot be negotiated with. When AI generates Rust, it cannot forget to handle a variant in a match arm — the compiler rejects it. It cannot create a data race — the ownership model makes it structurally unrepresentable. It cannot leave dangling references, pass the wrong type across a module boundary, or quietly ignore an error. It cannot leave dead code behind after a refactoring — the compiler warns. These are not "nice to have" guardrails; they are mechanical guarantees that hold whether the codebase has ten files or ten thousand.
+
+The AI does not need to "get it right" on the first attempt — it needs to iterate against a reviewer that catches everything. Rust's compiler is exactly that reviewer. The feedback loop is not "generate, run, observe failure, debug" — it is "generate, compile, fix, compile, fix, done." By the time code enters the codebase, entire categories of defect are not merely unlikely but *impossible*.
+
+**This is why Rust is not incrementally better for AI-first development — it is categorically different.** At scale, the bottleneck is never code generation but code *verification*. Dynamic languages place verification burden on humans and tests — resources that are finite, fallible, and slow. Rust places it on the compiler — a resource that is infinite, infallible within its domain, and fast. The compiler doesn't get tired. It doesn't skip reviews on Friday afternoon. It enforces the same standard on line one and line one million. For a system where AI is the primary author of code, this isn't a language preference — it's a load-bearing architectural decision.
+
+---
+
+## 3. Bricks and Studs Require Mechanical Verification
+
+Amplifier's Bricks and Studs architecture makes a bet: that modules can be regenerated wholesale from specification, snapped back into place, and the system continues to work. This bet has a hidden dependency — *something* must verify that the regenerated brick's studs still match the sockets it connects to.
+
+In Rust, that something is the compiler. When AI regenerates a module, the compiler checks every interface contract exhaustively: every trait implementation matches its declaration, every function signature aligns with its callers, every type flows correctly through every boundary. The result is binary and immediate — it compiles or it doesn't. There is no middle ground, no "works but is subtly wrong," no silent degradation. The studs are physical. They either click into place or they visibly don't fit. Regeneration becomes a *mechanically trustworthy* operation: throw away a module, rebuild it from scratch, and have structural confidence that it still honors every contract the system depends on.
+
+In a dynamically typed language, the studs are painted on. A regenerated module can parse, import, and even execute its happy path while silently violating the contracts it claims to fulfill. A misspelled method name becomes a latent `AttributeError`. A return type that drifts from `list[str]` to `list[Any]` passes every check until a downstream consumer indexes into the wrong shape three layers away. A missing protocol method goes unnoticed until the one code path that calls it fires in production. The module *looks* like it fits — the studs appear to be the right shape — but under load, under edge cases, under the combinatorial reality of a system at scale, the connections fail.
+
+This isn't an argument against testing — it's about what testing should be *for*. In a statically typed system, the compiler handles the exhaustive verification of every interface contract, freeing tests to focus on *behavior*: does the module do the right thing, not does it have the right shape? In a dynamically typed system, the test suite must first reimplement the compiler's job — asserting types, verifying signatures, checking that protocols are satisfied — before it can even begin testing behavior. The Bricks and Studs philosophy doesn't merely *prefer* static types; it requires mechanically verified contracts to function as designed. The compiler is the stud inspector on the factory floor.
+
+---
+
+## 4. The Verification Spectrum
+
+Languages exist on a spectrum of how much the toolchain independently verifies before code reaches production. In an AI-first workflow, this spectrum becomes the dominant factor in codebase quality, because AI generates code faster than any human can review it. The only thing that scales with AI generation speed is automated, compiler-level verification.
+
+**Rust** — the compiler enforces memory safety, thread safety, exhaustive pattern matching, ownership, lifetime correctness, and type correctness. AI cannot produce code that violates any of these. The surface area for "compiles but wrong" is confined to pure logic errors.
+
+**Go** — the compiler enforces type correctness and catches unused variables and imports. But it lacks exhaustive matching, has nil pointer risks, and error handling is convention not enforcement. AI can still produce subtly wrong Go code, but the most common categories are caught.
+
+**TypeScript** — the compiler enforces types within the TypeScript boundary, but the boundary is porous. `any` casts, `as` assertions, and raw JavaScript files break the guarantees. AI working in a mixed TS/JS codebase can silently abandon the type system when it becomes inconvenient, and the compiler will not object.
+
+**Python** — types are optional. The runtime is maximally permissive. AI can produce syntactically valid Python that passes every optional check yet fails at runtime with `AttributeError`, `TypeError`, or worse, returns silently wrong results that propagate undetected through the system.
+
+This is not a judgment of language quality — each solves real problems well. It is a statement about where the verification burden falls. At the strict end, the compiler carries that burden. At the permissive end, the burden falls entirely on humans — through code review, through exhaustive test suites that replicate what a stricter compiler would have caught for free, through runtime monitoring that detects failures only after they occur. As AI generates more code faster, the gap between these positions is not linear but multiplicative. Every defect category that the compiler doesn't catch becomes a category that scales with AI output volume.
+
+**Choose the language whose compiler does the most reviewing, because the compiler is the only reviewer that keeps pace with the machine.**
+
+---
+
+## 5. Semantic Understanding, Not Text Search
+
+The compiler verifies that code is structurally correct. But AI also needs to *understand* code — to trace what calls what, to know which implementation is live and which is dead, to distinguish the current version of a function from three abandoned predecessors left in the codebase.
+
+Text-based search (grep, file browsing, keyword matching) is the most dangerous tool an AI has for this purpose. It finds *text*, not *truth*. When a codebase contains dead code, abandoned implementations, or multiple versions of the same function — and they all do, eventually — text search treats every match as equally valid. The AI discovers a function via grep, builds understanding on it, generates code that uses it, and the result compiles (or worse, runs) while calling the wrong version. This is context poisoning: bad knowledge propagated through the system, perpetuated by every AI interaction that touches it, spreading like an infection as the AI generates more code based on the poisoned understanding.
+
+**Semantic tools — AST analysis, Language Server Protocol (LSP), call hierarchy tracing, type-flow analysis — are the antidote.** These tools don't search for text; they walk the actual code graph. They know which functions are reachable, which implementations are live, which call paths exist at runtime. When AI needs to understand existing code, the question is never "where does this string appear?" but "what does the compiler/language server actually resolve this symbol to?" The difference between grep finding 12 matches for `process_request` and LSP tracing the one live call path through the actual type hierarchy is the difference between understanding and guessing.
+
+This is non-negotiable. AI agents and tools in the Amplifier ecosystem must:
+
+- **Use semantic tools first.** LSP for navigation, AST for structure, call hierarchy for tracing. Text search is a fallback, not a starting point.
+- **Validate text-search results semantically.** If grep finds a function, verify it's reachable via the actual call graph before building on it.
+- **Report tool gaps honestly.** If semantic tooling is unavailable for a language or codebase, the AI must say "I don't have LSP/AST access and cannot verify code paths" — not silently fall back to grep and hope for the best.
+- **Treat dead code as a defect, not a reference.** Code that isn't reachable from any live path is not "alternative implementation" — it's context poison. The AI's job is to identify and flag it, not learn from it.
+
+This principle connects directly to the verification spectrum. Languages with strong LSP support (Rust via rust-analyzer, TypeScript via tsserver, Go via gopls) give AI semantic understanding. Languages with weaker tooling force AI to rely more on text search — which means more room for context poisoning. The quality of a language's semantic tooling is as important as the strictness of its compiler, because the compiler verifies what you write and the language server verifies what you understand.
+
+---
+
+## 6. Language Roles in the Ecosystem (Current Application)
+
+These roles reflect the current application of the principles above. As the landscape evolves — as compilers improve, as new languages emerge, as WASM capabilities expand — specific roles may shift. The principles don't.
+
+### Rust — Primary. The compiler IS the code review.
+
+Not for performance. For correctness at scale. The Rust compiler is the only tool that can review AI-generated code exhaustively, instantly, and without fatigue. Performance is a welcome side effect. The real value is that if it compiles, entire categories of defect are structurally impossible. This is why the kernel, all module traits, and all new systems code are written in Rust.
+
+### Go — Strong alternative for networked services and infrastructure.
+
+Statically typed, compiled, excellent concurrency model. Where Rust's ownership model is more than the problem requires — simple request handlers, CLI tools, infrastructure glue — Go provides meaningful compiler verification with less ceremony.
+
+### TypeScript — Essential for the web ecosystem.
+
+TypeScript's type safety has real limits — JavaScript escape hatches break the guarantees, and AI working in mixed TS/JS codebases can miss or create those escape hatches. Despite this, the web ecosystem has no peer. UI frameworks, browser APIs, and developer tooling in TypeScript far outshine what's available in any other language (with the possible exception of platform-native languages like Swift and Kotlin for their respective mobile platforms). We use TypeScript where its ecosystem value is the deciding factor.
+
+### Python — Legacy. Fully supported. Not the future.
+
+This is not a judgment on Python — it's a recognition of where we are. Our entire module ecosystem, community contributions, and user base are built on Python. We support Python as if the ecosystem were pure Python. Existing code requires zero changes. New Python modules are welcome. But we are not investing in Python as the path forward — we are preserving seamless compatibility with the enormous body of work that already exists.
+
+### WASM — The universal portable module format.
+
+Any language that compiles to WebAssembly becomes a first-class module author. One `.wasm` binary runs on every platform, in every host language, with sandboxed safety and resource limits. WASM is what makes "best language for the job" practical — it's the universal adapter that lets a Go module run in a Rust host, a C# module run in a TypeScript app, without anyone running a service or thinking about protocol translation. In the browser, WASM enables Amplifier to run entirely client-side.
+
+---
+
+## 7. Transport Is Invisible
+
+The developer should never think about how modules communicate. Transport is an implementation detail managed by the framework, not a choice the developer makes.
+
+When you mount a module, you say `{"module": "tool-bash"}` and the framework figures out the optimal path:
+
+| Situation | Transport chosen | Why |
+|-----------|-----------------|-----|
+| Module is in the same language as the app | **Native bindings** | Zero overhead, direct function calls |
+| Module is compiled Rust | **Native** | Compiled into the kernel, always available |
+| Module is in a different language | **WASM** | In-process, sandboxed, portable |
+| Module is an existing running service | **gRPC** | Out-of-process, opt-in |
+
+**gRPC is infrastructure, not interface.** It serves three purposes:
+
+1. **Internal protocol** between the kernel and out-of-process modules — like TCP is to HTTP. The SDK uses it; developers don't touch it.
+2. **Microservice deployments** where process isolation is an architectural requirement, not a language constraint.
+3. **The escape hatch** for languages or runtimes that can't compile to WASM and aren't worth native bindings.
+
+No module author should ever need to think about gRPC, proto definitions, or service hosting. They implement a Tool, a Provider, a Hook — in their language, with their SDK — and it works everywhere.
+
+---
+
+## 8. One Mental Model, Every Language
+
+AmplifierSession, Coordinator, Tool, Provider, Hook — the same nouns and verbs in every SDK. Learn it once, use it anywhere.
+
+```python
+# Python
+async with AmplifierSession(config) as session:
+    result = await session.execute("Hello")
+```
+
+```rust
+// Rust
+let result = session.execute("Hello").await?;
+```
+
+```typescript
+// TypeScript
+const result = await session.execute("Hello");
+```
+
+Same config shape. Same lifecycle. Same module interfaces. The language changes; the mental model doesn't.
+
+---
+
+## 9. The Compatibility Guarantee
+
+Every existing Python module, bundle, and application works unchanged. This is not negotiable.
+
+The polyglot future is additive. We are not rewriting the ecosystem — we are opening it. A Python developer who has never heard of Rust, WASM, or gRPC should experience zero friction. Their modules load. Their bundles compose. Their apps run. The Rust kernel is invisible to them — same imports, same API, same behavior.
+
+This guarantee extends forward: as we add language SDKs, each new language joins the ecosystem without disturbing the existing one. A Go tool works alongside a Python tool works alongside a Rust tool. The module author doesn't know. The app developer doesn't know. The bundle YAML doesn't change.
+
+**Polyglot is a capability, not a migration.**
+
+---
+
+## Summary of Principles
+
+1. **Optimize for AI, not humans.** The compiler is the code reviewer. Choose languages where the toolchain catches what humans can't keep up with.
+
+2. **The compiler is the only reviewer that scales.** At AI generation speed, human review is a bottleneck. Static analysis, exhaustive pattern matching, and type enforcement aren't nice-to-haves — they're the quality gate.
+
+3. **Bricks and Studs require mechanical verification.** Module regeneration only works when the compiler verifies interface contracts. Painted-on studs (structural typing, duck typing) break under regeneration at scale.
+
+4. **The verification spectrum determines trust.** The stricter the compiler, the more you can trust AI output without additional verification. Rust > Go > TypeScript > Python on this axis.
+
+5. **Semantic understanding, not text search.** AI must use LSP, AST, and call hierarchy to understand code — not grep. Text search finds text; semantic tools find truth. When semantic tools aren't available, say so — don't guess.
+
+6. **Dead code is context poison.** Unreachable code isn't harmless — it's a virus that infects AI understanding and propagates errors through every interaction that touches it. Identify it, flag it, remove it.
+
+7. **Best language for the job — applied, not prescribed.** Specific language roles reflect the current application of these principles. As toolchains evolve, roles may shift. The principles don't.
+
+8. **Transport is invisible.** Module authors implement interfaces in their language. The framework handles communication. No one writes gRPC services or proto definitions.
+
+9. **One mental model, every language.** Same nouns, same verbs, same config, same lifecycle. Learn it once.
+
+10. **Backward compatibility is sacred.** Every existing Python module, bundle, and application works unchanged. Polyglot is additive, never subtractive.

--- a/context/LANGUAGE_PHILOSOPHY.md
+++ b/context/LANGUAGE_PHILOSOPHY.md
@@ -1,6 +1,6 @@
 # Language Philosophy: Optimizing for AI-First Development
 
-> This document establishes the principles governing language choice, transport architecture, and polyglot strategy across the Amplifier ecosystem.
+> Principles for language choice and code understanding in an AI-first world. These are decision frameworks, not prescriptions — the specific languages that best satisfy these principles today may not be the same ones tomorrow.
 
 ---
 
@@ -32,11 +32,11 @@ The defining question of AI-first development is not "how fast can AI generate c
 
 In dynamic languages, correctness is aspirational — it depends on test coverage you remembered to write, on runtime paths you remembered to exercise, on edge cases you remembered to consider. Code that parses is not code that works; it's merely code that *exists*. This creates a fundamental scaling problem: as AI generates more modules, the surface area for silent failure grows faster than any team's ability to verify it. At ten modules, a human reviews the AI's output. At a hundred, review becomes a bottleneck. At a thousand, it's theater. The codebase doesn't degrade gracefully — it degrades invisibly, accumulating latent defects that express themselves far from their origin, in production, at 3am.
 
-**Rust inverts this equation.** The compiler is not a syntax checker — it is an exhaustive, deterministic, tireless code reviewer that runs in seconds and cannot be negotiated with. When AI generates Rust, it cannot forget to handle a variant in a match arm — the compiler rejects it. It cannot create a data race — the ownership model makes it structurally unrepresentable. It cannot leave dangling references, pass the wrong type across a module boundary, or quietly ignore an error. It cannot leave dead code behind after a refactoring — the compiler warns. These are not "nice to have" guardrails; they are mechanical guarantees that hold whether the codebase has ten files or ten thousand.
+**Languages with strict compilers invert this equation.** The compiler is not a syntax checker — it is an exhaustive, deterministic, tireless code reviewer that runs in seconds and cannot be negotiated with. When the compiler enforces exhaustive pattern matching, AI cannot forget to handle a case. When it enforces ownership and borrowing, data races become structurally unrepresentable. When it enforces type bounds at every boundary, wrong types cannot cross module lines. These are not "nice to have" guardrails; they are mechanical guarantees that hold whether the codebase has ten files or ten thousand.
 
-The AI does not need to "get it right" on the first attempt — it needs to iterate against a reviewer that catches everything. Rust's compiler is exactly that reviewer. The feedback loop is not "generate, run, observe failure, debug" — it is "generate, compile, fix, compile, fix, done." By the time code enters the codebase, entire categories of defect are not merely unlikely but *impossible*.
+The AI does not need to "get it right" on the first attempt — it needs to iterate against a reviewer that catches everything. A strict compiler is exactly that reviewer. The feedback loop is not "generate, run, observe failure, debug" — it is "generate, compile, fix, compile, fix, done." By the time code enters the codebase, entire categories of defect are not merely unlikely but *impossible*.
 
-**This is why Rust is not incrementally better for AI-first development — it is categorically different.** At scale, the bottleneck is never code generation but code *verification*. Dynamic languages place verification burden on humans and tests — resources that are finite, fallible, and slow. Rust places it on the compiler — a resource that is infinite, infallible within its domain, and fast. The compiler doesn't get tired. It doesn't skip reviews on Friday afternoon. It enforces the same standard on line one and line one million. For a system where AI is the primary author of code, this isn't a language preference — it's a load-bearing architectural decision.
+**At scale, the bottleneck is never code generation but code *verification*.** Dynamic languages place verification burden on humans and tests — resources that are finite, fallible, and slow. Strict compilers place it on machinery — a resource that is infinite, infallible within its domain, and fast. The compiler doesn't get tired. It doesn't skip reviews on Friday afternoon. It enforces the same standard on line one and line one million. For a system where AI is the primary author of code, this isn't a language preference — it's a load-bearing architectural decision.
 
 ---
 
@@ -44,11 +44,11 @@ The AI does not need to "get it right" on the first attempt — it needs to iter
 
 Amplifier's Bricks and Studs architecture makes a bet: that modules can be regenerated wholesale from specification, snapped back into place, and the system continues to work. This bet has a hidden dependency — *something* must verify that the regenerated brick's studs still match the sockets it connects to.
 
-In Rust, that something is the compiler. When AI regenerates a module, the compiler checks every interface contract exhaustively: every trait implementation matches its declaration, every function signature aligns with its callers, every type flows correctly through every boundary. The result is binary and immediate — it compiles or it doesn't. There is no middle ground, no "works but is subtly wrong," no silent degradation. The studs are physical. They either click into place or they visibly don't fit. Regeneration becomes a *mechanically trustworthy* operation: throw away a module, rebuild it from scratch, and have structural confidence that it still honors every contract the system depends on.
+In a language with a strict compiler, the compiler checks every interface contract exhaustively: every trait/interface implementation matches its declaration, every function signature aligns with its callers, every type flows correctly through every boundary. The result is binary and immediate — it compiles or it doesn't. There is no middle ground, no "works but is subtly wrong," no silent degradation. The studs are physical. They either click into place or they visibly don't fit. Regeneration becomes a *mechanically trustworthy* operation.
 
-In a dynamically typed language, the studs are painted on. A regenerated module can parse, import, and even execute its happy path while silently violating the contracts it claims to fulfill. A misspelled method name becomes a latent `AttributeError`. A return type that drifts from `list[str]` to `list[Any]` passes every check until a downstream consumer indexes into the wrong shape three layers away. A missing protocol method goes unnoticed until the one code path that calls it fires in production. The module *looks* like it fits — the studs appear to be the right shape — but under load, under edge cases, under the combinatorial reality of a system at scale, the connections fail.
+In a dynamically typed language, the studs are painted on. A regenerated module can parse, import, and even execute its happy path while silently violating the contracts it claims to fulfill. A misspelled method name becomes a latent `AttributeError`. A return type that drifts from `list[str]` to `list[Any]` passes every check until a downstream consumer indexes into the wrong shape three layers away. The module *looks* like it fits — but under load, under edge cases, under the combinatorial reality of a system at scale, the connections fail.
 
-This isn't an argument against testing — it's about what testing should be *for*. In a statically typed system, the compiler handles the exhaustive verification of every interface contract, freeing tests to focus on *behavior*: does the module do the right thing, not does it have the right shape? In a dynamically typed system, the test suite must first reimplement the compiler's job — asserting types, verifying signatures, checking that protocols are satisfied — before it can even begin testing behavior. The Bricks and Studs philosophy doesn't merely *prefer* static types; it requires mechanically verified contracts to function as designed. The compiler is the stud inspector on the factory floor.
+This isn't an argument against testing — it's about what testing should be *for*. When the compiler handles exhaustive verification of every interface contract, tests are freed to focus on *behavior*: does the module do the right thing, not does it have the right shape? Without that compiler, the test suite must first reimplement the compiler's job — asserting types, verifying signatures, checking that protocols are satisfied — before it can even begin testing behavior. The Bricks and Studs philosophy requires mechanically verified contracts to function as designed. The compiler is the stud inspector on the factory floor.
 
 ---
 
@@ -56,121 +56,63 @@ This isn't an argument against testing — it's about what testing should be *fo
 
 Languages exist on a spectrum of how much the toolchain independently verifies before code reaches production. In an AI-first workflow, this spectrum becomes the dominant factor in codebase quality, because AI generates code faster than any human can review it. The only thing that scales with AI generation speed is automated, compiler-level verification.
 
-**Rust** — the compiler enforces memory safety, thread safety, exhaustive pattern matching, ownership, lifetime correctness, and type correctness. AI cannot produce code that violates any of these. The surface area for "compiles but wrong" is confined to pure logic errors.
+The spectrum runs from languages where the compiler catches nearly everything (memory safety, thread safety, exhaustive matching, type correctness) to languages where the runtime is maximally permissive and types are optional. At each step down the spectrum, new categories of defect become possible in AI-generated code:
 
-**Go** — the compiler enforces type correctness and catches unused variables and imports. But it lacks exhaustive matching, has nil pointer risks, and error handling is convention not enforcement. AI can still produce subtly wrong Go code, but the most common categories are caught.
+- **Strictest**: Exhaustive pattern matching, ownership/borrowing, lifetime enforcement, full type safety. Surface area for "compiles but wrong" confined to pure logic errors.
+- **Strong static**: Type correctness enforced, but nil/null risks remain, error handling is convention not enforcement, pattern matching is non-exhaustive. AI can produce subtly wrong code in gaps the compiler doesn't cover.
+- **Porous static**: Types enforced within the language boundary, but escape hatches (type casts, untyped interop files) break the guarantees. AI can silently abandon the type system when it becomes inconvenient.
+- **Dynamic**: Types are optional. The runtime accepts nearly anything. AI can produce syntactically valid code that fails at runtime or, worse, returns silently wrong results that propagate undetected.
 
-**TypeScript** — the compiler enforces types within the TypeScript boundary, but the boundary is porous. `any` casts, `as` assertions, and raw JavaScript files break the guarantees. AI working in a mixed TS/JS codebase can silently abandon the type system when it becomes inconvenient, and the compiler will not object.
+This is not a ranking of language quality — each level solves real problems. It is a statement about where the verification burden falls. At the strict end, the compiler carries it. At the permissive end, humans carry it — through code review, exhaustive test suites, and runtime monitoring. As AI generates more code faster, the gap between these levels is not linear but multiplicative. Every defect category the compiler doesn't catch scales with AI output volume.
 
-**Python** — types are optional. The runtime is maximally permissive. AI can produce syntactically valid Python that passes every optional check yet fails at runtime with `AttributeError`, `TypeError`, or worse, returns silently wrong results that propagate undetected through the system.
-
-This is not a judgment of language quality — each solves real problems well. It is a statement about where the verification burden falls. At the strict end, the compiler carries that burden. At the permissive end, the burden falls entirely on humans — through code review, through exhaustive test suites that replicate what a stricter compiler would have caught for free, through runtime monitoring that detects failures only after they occur. As AI generates more code faster, the gap between these positions is not linear but multiplicative. Every defect category that the compiler doesn't catch becomes a category that scales with AI output volume.
-
-**Choose the language whose compiler does the most reviewing, because the compiler is the only reviewer that keeps pace with the machine.**
+**Choose the language whose toolchain does the most verification, because the toolchain is the only reviewer that keeps pace with the machine.**
 
 ---
 
-## 5. Semantic Understanding, Not Text Search
+## 5. Deterministic Code Understanding, Not Probabilistic Search
 
 The compiler verifies that code is structurally correct. But AI also needs to *understand* code — to trace what calls what, to know which implementation is live and which is dead, to distinguish the current version of a function from three abandoned predecessors left in the codebase.
 
-Text-based search (grep, file browsing, keyword matching) is the most dangerous tool an AI has for this purpose. It finds *text*, not *truth*. When a codebase contains dead code, abandoned implementations, or multiple versions of the same function — and they all do, eventually — text search treats every match as equally valid. The AI discovers a function via grep, builds understanding on it, generates code that uses it, and the result compiles (or worse, runs) while calling the wrong version. This is context poisoning: bad knowledge propagated through the system, perpetuated by every AI interaction that touches it, spreading like an infection as the AI generates more code based on the poisoned understanding.
+**This is not "semantic search."** We are not talking about embedding vectors, similarity matching, RAG retrieval, or any probabilistic method. We are talking about *deterministic code-graph navigation* — tools that walk the actual structure of the program with zero ambiguity:
 
-**Semantic tools — AST analysis, Language Server Protocol (LSP), call hierarchy tracing, type-flow analysis — are the antidote.** These tools don't search for text; they walk the actual code graph. They know which functions are reachable, which implementations are live, which call paths exist at runtime. When AI needs to understand existing code, the question is never "where does this string appear?" but "what does the compiler/language server actually resolve this symbol to?" The difference between grep finding 12 matches for `process_request` and LSP tracing the one live call path through the actual type hierarchy is the difference between understanding and guessing.
+- **AST (Abstract Syntax Tree)** — the parsed structure of the code. Deterministic. No interpretation.
+- **LSP (Language Server Protocol)** — go-to-definition, find-references, call hierarchy. Resolves the actual symbol, not a text match.
+- **Type-flow analysis** — traces what types flow through a function boundary. The compiler/language server knows; grep does not.
+- **Call hierarchy tracing** — incoming calls, outgoing calls. The actual call graph, not string matches.
 
-This is non-negotiable. AI agents and tools in the Amplifier ecosystem must:
+Text-based search (grep, file browsing, keyword matching) is the most dangerous tool an AI has for understanding code. It finds *text*, not *truth*. When a codebase contains dead code, abandoned implementations, or multiple versions of the same function — and they all do, eventually — text search treats every match as equally valid. The AI discovers a function via grep, builds understanding on it, generates code that uses it, and the result compiles (or worse, runs) while calling the wrong version. This is **context poisoning**: bad knowledge propagated through the system, perpetuated by every AI interaction that touches it, spreading like an infection as the AI generates more code based on the poisoned understanding.
 
-- **Use semantic tools first.** LSP for navigation, AST for structure, call hierarchy for tracing. Text search is a fallback, not a starting point.
-- **Validate text-search results semantically.** If grep finds a function, verify it's reachable via the actual call graph before building on it.
-- **Report tool gaps honestly.** If semantic tooling is unavailable for a language or codebase, the AI must say "I don't have LSP/AST access and cannot verify code paths" — not silently fall back to grep and hope for the best.
-- **Treat dead code as a defect, not a reference.** Code that isn't reachable from any live path is not "alternative implementation" — it's context poison. The AI's job is to identify and flag it, not learn from it.
+**Deterministic code-graph tools are the antidote.** They know which functions are reachable, which implementations are live, which call paths exist. The difference between grep finding 12 matches for `process_request` and the language server tracing the one live call path through the actual type hierarchy is the difference between understanding and guessing.
 
-This principle connects directly to the verification spectrum. Languages with strong LSP support (Rust via rust-analyzer, TypeScript via tsserver, Go via gopls) give AI semantic understanding. Languages with weaker tooling force AI to rely more on text search — which means more room for context poisoning. The quality of a language's semantic tooling is as important as the strictness of its compiler, because the compiler verifies what you write and the language server verifies what you understand.
+This is non-negotiable:
 
----
+- **Use code-graph tools first.** LSP for navigation, AST for structure, call hierarchy for tracing. Text search is a fallback for discovery, not a source of truth.
+- **Validate text-search results deterministically.** If grep finds a function, verify it's reachable via the actual call graph before building on it.
+- **Report tool gaps honestly.** If code-graph tooling is unavailable for a language or codebase, say "I cannot verify code paths deterministically and my understanding may be unreliable" — not silently fall back to grep and hope for the best.
+- **Treat dead code as a defect, not a reference.** Code that isn't reachable from any live path is not "alternative implementation" — it's context poison. Identify it, flag it, remove it.
 
-## 6. Language Roles in the Ecosystem (Current Application)
-
-These roles reflect the current application of the principles above. As the landscape evolves — as compilers improve, as new languages emerge, as WASM capabilities expand — specific roles may shift. The principles don't.
-
-### Rust — Primary. The compiler IS the code review.
-
-Not for performance. For correctness at scale. The Rust compiler is the only tool that can review AI-generated code exhaustively, instantly, and without fatigue. Performance is a welcome side effect. The real value is that if it compiles, entire categories of defect are structurally impossible. This is why the kernel, all module traits, and all new systems code are written in Rust.
-
-### Go — Strong alternative for networked services and infrastructure.
-
-Statically typed, compiled, excellent concurrency model. Where Rust's ownership model is more than the problem requires — simple request handlers, CLI tools, infrastructure glue — Go provides meaningful compiler verification with less ceremony.
-
-### TypeScript — Essential for the web ecosystem.
-
-TypeScript's type safety has real limits — JavaScript escape hatches break the guarantees, and AI working in mixed TS/JS codebases can miss or create those escape hatches. Despite this, the web ecosystem has no peer. UI frameworks, browser APIs, and developer tooling in TypeScript far outshine what's available in any other language (with the possible exception of platform-native languages like Swift and Kotlin for their respective mobile platforms). We use TypeScript where its ecosystem value is the deciding factor.
-
-### Python — Legacy. Fully supported. Not the future.
-
-This is not a judgment on Python — it's a recognition of where we are. Our entire module ecosystem, community contributions, and user base are built on Python. We support Python as if the ecosystem were pure Python. Existing code requires zero changes. New Python modules are welcome. But we are not investing in Python as the path forward — we are preserving seamless compatibility with the enormous body of work that already exists.
-
-### WASM — The universal portable module format.
-
-Any language that compiles to WebAssembly becomes a first-class module author. One `.wasm` binary runs on every platform, in every host language, with sandboxed safety and resource limits. WASM is what makes "best language for the job" practical — it's the universal adapter that lets a Go module run in a Rust host, a C# module run in a TypeScript app, without anyone running a service or thinking about protocol translation. In the browser, WASM enables Amplifier to run entirely client-side.
+This connects directly to the verification spectrum. Languages with strong language-server support give AI deterministic code understanding. Languages with weaker tooling force AI to rely more on text search — which means more room for context poisoning. The quality of a language's code-graph tooling is as important as the strictness of its compiler, because the compiler verifies what you write and the language server verifies what you understand.
 
 ---
 
-## 7. Transport Is Invisible
+## 6. Applying These Principles: Language Selection
 
-The developer should never think about how modules communicate. Transport is an implementation detail managed by the framework, not a choice the developer makes.
+These principles produce a decision framework, not a fixed list. When choosing a language for a task, ask:
 
-When you mount a module, you say `{"module": "tool-bash"}` and the framework figures out the optimal path:
+1. **How much does the compiler verify?** The more the toolchain catches at compile time, the more you can trust AI-generated code without additional verification.
+2. **How strong is the code-graph tooling?** Can AI navigate the codebase deterministically (LSP, call hierarchy) or must it rely on text search?
+3. **Does the ecosystem require this language?** Some domains (web UI, mobile, data science) have ecosystems so dominant in one language that the ecosystem value outweighs other factors.
+4. **Can it compile to a portable format?** Languages that compile to WASM gain portability across hosts and platforms.
 
-| Situation | Transport chosen | Why |
-|-----------|-----------------|-----|
-| Module is in the same language as the app | **Native bindings** | Zero overhead, direct function calls |
-| Module is compiled Rust | **Native** | Compiled into the kernel, always available |
-| Module is in a different language | **WASM** | In-process, sandboxed, portable |
-| Module is an existing running service | **gRPC** | Out-of-process, opt-in |
+Today, applying these criteria to the Amplifier ecosystem:
 
-**gRPC is infrastructure, not interface.** It serves three purposes:
+- **Rust** leads on criteria 1 and 2 — strictest compiler, excellent language-server tooling (rust-analyzer). This is why it's our primary language for systems and kernel work.
+- **Go** is strong on criteria 1 and 2 — good compiler, good language server (gopls). Excellent for networked services and infrastructure.
+- **TypeScript** leads on criterion 3 — the web/UI ecosystem is unmatched. Its type safety has real limits (JavaScript escape hatches), but no other language competes for browser and UI work.
+- **Python** scores highest on ecosystem inertia — massive existing codebase and community. We maintain full compatibility but direct new investment toward stricter languages.
+- **WASM** is uniquely strong on criterion 4 — the universal portable format that any language can target.
 
-1. **Internal protocol** between the kernel and out-of-process modules — like TCP is to HTTP. The SDK uses it; developers don't touch it.
-2. **Microservice deployments** where process isolation is an architectural requirement, not a language constraint.
-3. **The escape hatch** for languages or runtimes that can't compile to WASM and aren't worth native bindings.
-
-No module author should ever need to think about gRPC, proto definitions, or service hosting. They implement a Tool, a Provider, a Hook — in their language, with their SDK — and it works everywhere.
-
----
-
-## 8. One Mental Model, Every Language
-
-AmplifierSession, Coordinator, Tool, Provider, Hook — the same nouns and verbs in every SDK. Learn it once, use it anywhere.
-
-```python
-# Python
-async with AmplifierSession(config) as session:
-    result = await session.execute("Hello")
-```
-
-```rust
-// Rust
-let result = session.execute("Hello").await?;
-```
-
-```typescript
-// TypeScript
-const result = await session.execute("Hello");
-```
-
-Same config shape. Same lifecycle. Same module interfaces. The language changes; the mental model doesn't.
-
----
-
-## 9. The Compatibility Guarantee
-
-Every existing Python module, bundle, and application works unchanged. This is not negotiable.
-
-The polyglot future is additive. We are not rewriting the ecosystem — we are opening it. A Python developer who has never heard of Rust, WASM, or gRPC should experience zero friction. Their modules load. Their bundles compose. Their apps run. The Rust kernel is invisible to them — same imports, same API, same behavior.
-
-This guarantee extends forward: as we add language SDKs, each new language joins the ecosystem without disturbing the existing one. A Go tool works alongside a Python tool works alongside a Rust tool. The module author doesn't know. The app developer doesn't know. The bundle YAML doesn't change.
-
-**Polyglot is a capability, not a migration.**
+These are the current applications of the principles. As new languages emerge, as compilers improve, as ecosystems shift — the applications will change. The principles won't.
 
 ---
 
@@ -182,16 +124,10 @@ This guarantee extends forward: as we add language SDKs, each new language joins
 
 3. **Bricks and Studs require mechanical verification.** Module regeneration only works when the compiler verifies interface contracts. Painted-on studs (structural typing, duck typing) break under regeneration at scale.
 
-4. **The verification spectrum determines trust.** The stricter the compiler, the more you can trust AI output without additional verification. Rust > Go > TypeScript > Python on this axis.
+4. **The verification spectrum determines trust.** The stricter the toolchain, the more you can trust AI output without additional verification.
 
-5. **Semantic understanding, not text search.** AI must use LSP, AST, and call hierarchy to understand code — not grep. Text search finds text; semantic tools find truth. When semantic tools aren't available, say so — don't guess.
+5. **Deterministic code understanding, not probabilistic search.** AI must use code-graph tools (LSP, AST, call hierarchy) to understand code — not grep, not embedding search, not similarity matching. These tools provide deterministic truth about what the code actually does. When they aren't available, say so — don't guess.
 
 6. **Dead code is context poison.** Unreachable code isn't harmless — it's a virus that infects AI understanding and propagates errors through every interaction that touches it. Identify it, flag it, remove it.
 
-7. **Best language for the job — applied, not prescribed.** Specific language roles reflect the current application of these principles. As toolchains evolve, roles may shift. The principles don't.
-
-8. **Transport is invisible.** Module authors implement interfaces in their language. The framework handles communication. No one writes gRPC services or proto definitions.
-
-9. **One mental model, every language.** Same nouns, same verbs, same config, same lifecycle. Learn it once.
-
-10. **Backward compatibility is sacred.** Every existing Python module, bundle, and application works unchanged. Polyglot is additive, never subtractive.
+7. **Best language for the job — applied, not prescribed.** Specific language choices reflect the current application of these principles. As toolchains evolve, choices may shift. The principles don't.

--- a/context/shared/AWARENESS_INDEX.md
+++ b/context/shared/AWARENESS_INDEX.md
@@ -93,6 +93,7 @@ Load on demand via `read_file` or delegate to expert agents.
 - `foundation:context/IMPLEMENTATION_PHILOSOPHY.md` - Ruthless simplicity
 - `foundation:context/MODULAR_DESIGN_PHILOSOPHY.md` - Bricks and studs
 - `foundation:context/KERNEL_PHILOSOPHY.md` - Mechanism not policy
+- `foundation:context/LANGUAGE_PHILOSOPHY.md` - AI-first language choice, verification spectrum, semantic understanding
 
 ---
 

--- a/context/shared/common-agent-base.md
+++ b/context/shared/common-agent-base.md
@@ -1,6 +1,6 @@
 # Agent Core Instructions
 
-Operational guidance: See foundation:context/IMPLEMENTATION_PHILOSOPHY.md and foundation:context/MODULAR_DESIGN_PHILOSOPHY.md (loaded by specialist agents)
+Operational guidance: See foundation:context/IMPLEMENTATION_PHILOSOPHY.md, foundation:context/MODULAR_DESIGN_PHILOSOPHY.md, and foundation:context/LANGUAGE_PHILOSOPHY.md (loaded by specialist agents)
 
 Problem-solving methodology: See foundation:context/shared/PROBLEM_SOLVING_PHILOSOPHY.md (loaded by specialist agents)
 

--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -715,7 +715,7 @@ Agent usage notes:
         # provider_preferences wins when both are provided (explicit pin overrides matrix)
         raw_model_role = input.get("model_role", "").strip()
         if raw_model_role and provider_preferences is None:
-            routing_state = self.coordinator.session_state.get("routing_matrix")
+            routing_state = getattr(self.coordinator, "session_state", {}).get("routing_matrix")
             if routing_state:
                 try:
                     from amplifier_module_hooks_routing.resolver import resolve_model_role


### PR DESCRIPTION
## Language Philosophy

Adds `context/LANGUAGE_PHILOSOPHY.md` — ecosystem-wide principles for AI-first language choice:

- The compiler is the code reviewer (why strict languages matter for AI-generated code)
- The verification spectrum (how much the toolchain catches vs humans must catch)
- Deterministic code understanding over probabilistic search (LSP/AST not grep/embeddings)
- Dead code as context poison
- Decision framework for language selection (not prescriptions)

### Wiring

- **Soft reference** in `common-agent-base.md` (all sessions aware)
- **Catalog entry** in `AWARENESS_INDEX.md`
- **Hard @mention** in 10 coding-focused agents: bug-hunter, explorer, integration-specialist, modular-builder, post-task-cleanup, security-guardian, test-coverage, zen-architect, foundation-expert, ecosystem-expert

### Also wired in other repos (already pushed)
- superpowers: implementer, code-quality-reviewer, spec-reviewer
- python-dev: python-dev, code-intel
- rust-dev: rust-dev, code-intel
- lsp: code-navigator