### PR TITLE
docs: Add Plain English summary requirement to Gate 1 process

### DIFF
--- a/context/ISSUE_HANDLING.md
+++ b/context/ISSUE_HANDLING.md
@@ -118,6 +118,17 @@ an agent to retrieve the specific lessons from that case study before designing 
 
 **Wait for explicit approval before proceeding.**
 
+**Plain English summary:** After presenting the formal Gate 1 findings, always include
+a plain English explanation. Drop the technical jargon, file:line references, tables,
+and formal structure. Explain in conversational language:
+- What's actually happening (the problem)
+- Why it matters (the impact)
+- What should be done about it (the recommendation)
+
+The user should understand the issue from this summary alone, without needing to parse
+the technical detail above it. The formal structure is for the record; the plain English
+summary is for the human.
+
 **Gate efficiency rule:** If the investigation concludes with a GH interaction (close,
 request info, etc.), the user approves the action AND the text in one pass. Never
 present the decision in one round and the text in a follow-up.


### PR DESCRIPTION
## Summary
- Adds a "Plain English summary" requirement to the Gate 1 section of the issue handling process
- After presenting formal investigation findings, agents must provide a conversational explanation
- Explanation should cover: what's happening, why it matters, and what should be done
- Goal: users understand issues without parsing technical detail

## Rationale
The formal, structured Gate 1 findings are essential for the record, but they can be hard for users to understand. A plain English summary bridges that gap, making the issue accessible without sacrificing technical accuracy.

## Test plan
- [x] Documentation change reviewed for clarity and tone
- [x] Change fits within existing Gate 1 workflow
- [x] No technical details removed or altered

🤖 Generated with Amplifier