### PR TITLE
fix: prevent subdirectory bundle from overwriting root registry entry

### DIFF
--- a/amplifier_foundation/registry.py
+++ b/amplifier_foundation/registry.py
@@ -505,14 +505,24 @@ class BundleRegistry:
             )
             if update_name:
                 state = self._registry[update_name]
-                if state.uri != uri:
+                # Don't let a subdirectory bundle overwrite its own root's entry.
+                # The root URI is authoritative for update tracking (it represents
+                # the git repo boundary). The behavior's tools/hooks/context still
+                # load through the include chain, independent of the registry.
+                if state.is_root and "#subdirectory=" in uri:
                     logger.debug(
-                        f"Updating URI for '{update_name}': {state.uri} → {uri}"
+                        f"Skipping registry update for '{update_name}': "
+                        f"root entry preserved over subdirectory load"
                     )
-                    state.uri = uri
-                state.version = bundle.version
-                state.loaded_at = datetime.now()
-                state.local_path = str(local_path)
+                else:
+                    if state.uri != uri:
+                        logger.debug(
+                            f"Updating URI for '{update_name}': {state.uri} → {uri}"
+                        )
+                        state.uri = uri
+                    state.version = bundle.version
+                    state.loaded_at = datetime.now()
+                    state.local_path = str(local_path)
 
             # Load includes and compose (pass the chain for per-chain cycle detection)
             if auto_include and bundle.includes:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -958,3 +958,117 @@ class TestNestedBundleURIUpdate:
             state2 = registry.get_state("my-bundle")
             assert state2 is not None
             assert state2.uri == uri
+
+
+class TestRootURIPreservedOnNameCollision:
+    """Tests that root registry entry is preserved when behavior shares the same name.
+
+    Regression tests for the thin bundle pattern where root bundle.md and
+    behaviors/X.yaml both declare the same bundle.name. The root URI must
+    be preserved in the registry for update tracking, even when the behavior
+    loads afterward and triggers the "update state" block.
+    """
+
+    @pytest.mark.asyncio
+    async def test_root_uri_not_overwritten_by_same_name_behavior(self) -> None:
+        """Root URI preserved when behavior with same name loads via subdirectory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+
+            # Create root bundle with name "issues"
+            (base / "bundle.md").write_text(
+                "---\nbundle:\n  name: issues\n  version: 1.0.0\n---\n# Root"
+            )
+
+            # Create behavior with SAME name "issues" in subdirectory
+            behaviors = base / "behaviors"
+            behaviors.mkdir()
+            (behaviors / "issues.yaml").write_text(
+                "bundle:\n  name: issues\n  version: 1.0.0\n"
+            )
+
+            registry = BundleRegistry(home=base / "home")
+            root_uri = f"file://{base}"
+            subdirectory_uri = f"file://{base}#subdirectory=behaviors/issues.yaml"
+
+            # Load root first (simulates full bundle install)
+            await registry._load_single(root_uri)
+
+            # Verify root registered correctly
+            state = registry.get_state("issues")
+            assert state is not None
+            assert state.is_root is True
+            assert "#subdirectory=" not in state.uri
+
+            # Now load the behavior (simulates include processing)
+            await registry._load_single(subdirectory_uri)
+
+            # Root URI must be preserved — not overwritten by behavior's URI
+            state_after = registry.get_state("issues")
+            assert state_after is not None
+            assert state_after.is_root is True
+            assert "#subdirectory=" not in state_after.uri
+
+    @pytest.mark.asyncio
+    async def test_behavior_only_install_preserves_auto_detected_root(self) -> None:
+        """When only behavior is loaded, auto-detected root URI is preserved."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+
+            # Create root bundle with name "issues"
+            (base / "bundle.md").write_text(
+                "---\nbundle:\n  name: issues\n  version: 1.0.0\n---\n# Root"
+            )
+
+            # Create behavior with SAME name "issues" in subdirectory
+            behaviors = base / "behaviors"
+            behaviors.mkdir()
+            (behaviors / "issues.yaml").write_text(
+                "bundle:\n  name: issues\n  version: 1.0.0\n"
+            )
+
+            registry = BundleRegistry(home=base / "home")
+            subdirectory_uri = f"file://{base}#subdirectory=behaviors/issues.yaml"
+
+            # Load ONLY the behavior (simulates behavior-only install)
+            # Root auto-detection at line 435 should find bundle.md and register it
+            await registry._load_single(subdirectory_uri)
+
+            # The auto-detected root URI should be preserved
+            state = registry.get_state("issues")
+            assert state is not None
+            assert state.is_root is True
+            assert "#subdirectory=" not in state.uri
+
+    @pytest.mark.asyncio
+    async def test_different_name_behavior_still_updates_normally(self) -> None:
+        """Behavior with a DIFFERENT name from root still updates its own entry."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+
+            # Create root bundle with name "my-bundle"
+            (base / "bundle.md").write_text(
+                "---\nbundle:\n  name: my-bundle\n  version: 1.0.0\n---\n# Root"
+            )
+
+            # Create behavior with DIFFERENT name "my-behavior"
+            behaviors = base / "behaviors"
+            behaviors.mkdir()
+            (behaviors / "my-behavior.yaml").write_text(
+                "bundle:\n  name: my-behavior\n  version: 1.0.0\n"
+            )
+
+            registry = BundleRegistry(home=base / "home")
+            subdirectory_uri = f"file://{base}#subdirectory=behaviors/my-behavior.yaml"
+
+            # Load behavior (different name from root — no collision)
+            await registry._load_single(subdirectory_uri)
+
+            # Root should be registered under its own name
+            root_state = registry.get_state("my-bundle")
+            assert root_state is not None
+            assert root_state.is_root is True
+
+            # Behavior should be registered under its own name with subdirectory URI
+            behavior_state = registry.get_state("my-behavior")
+            assert behavior_state is not None


### PR DESCRIPTION
When a behavior bundle shares `bundle.name` with its root (the thin bundle pattern used by issues, made-support, etc.), the root loads first and registers correctly in the bundle registry. But when the behavior loads via includes, the "update state" block (Site 3, `registry.py:506`) unconditionally overwrites the registry entry's URI with the behavior's `#subdirectory=` URI.

This causes `amplifier update` to silently omit the bundle — `list_cached_root_bundles()` Step 4 filters entries with `#subdirectory=` in their URI, so the bundle disappears from update checks.

The same bug occurs when users install just the behavior via `#subdirectory=`. The root is auto-detected and registered correctly for update tracking (by design — see comment at line 445-447), but Site 3 still overwrites it.

## Fix

When Site 3 detects a subdirectory URI (`#subdirectory=` in the incoming URI) about to update an existing root entry (`state.is_root`), skip the entire update block. The root's entry is authoritative for update tracking because it represents the git repo boundary. The behavior's tools, hooks, and context still load through the include chain, which is independent of the registry.

This is a full skip (not a partial field update) because the behavior doesn't bring better information to any field — the root was already registered with the correct URI, version, local_path, and timestamp.

## Testing

- All 29 registry tests pass (4 pre-existing macOS symlink failures unrelated)
- Shadow environment verified the fix is present in installed package
- `amplifier --version` works correctly in shadow