### PR TITLE
feat: Update foundation provider bundles and examples for GPT-5.4

### DIFF
--- a/amplifier_foundation/bundle.py
+++ b/amplifier_foundation/bundle.py
@@ -1238,7 +1238,7 @@ class PreparedBundle:
                 "Analyze this code",
                 provider_preferences=[
                     ProviderPreference(provider="anthropic", model="claude-haiku-*"),
-                    ProviderPreference(provider="openai", model="gpt-4o-mini"),
+                    ProviderPreference(provider="openai", model="gpt-5-mini"),
                 ],
             )
         """

--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -31,13 +31,13 @@ class ProviderPreference:
     Attributes:
         provider: Provider identifier (e.g., "anthropic", "openai", "azure").
             Supports flexible matching - "anthropic" matches "provider-anthropic".
-        model: Model name or glob pattern (e.g., "claude-haiku-*", "gpt-4o-mini").
+        model: Model name or glob pattern (e.g., "claude-haiku-*", "gpt-5-mini").
             Patterns are resolved to concrete model names at runtime.
 
     Example:
         >>> prefs = [
         ...     ProviderPreference(provider="anthropic", model="claude-haiku-*"),
-        ...     ProviderPreference(provider="openai", model="gpt-4o-mini"),
+        ...     ProviderPreference(provider="openai", model="gpt-5-mini"),
         ... ]
     """
 
@@ -327,7 +327,7 @@ def apply_provider_preferences(
     Example:
         >>> prefs = [
         ...     ProviderPreference(provider="anthropic", model="claude-haiku-3"),
-        ...     ProviderPreference(provider="openai", model="gpt-4o-mini"),
+        ...     ProviderPreference(provider="openai", model="gpt-5-mini"),
         ... ]
         >>> new_plan = apply_provider_preferences(plan, prefs)
     """
@@ -420,7 +420,7 @@ async def apply_provider_preferences_with_resolution(
     Example:
         >>> prefs = [
         ...     ProviderPreference(provider="anthropic", model="claude-haiku-*"),
-        ...     ProviderPreference(provider="openai", model="gpt-4o-mini"),
+        ...     ProviderPreference(provider="openai", model="gpt-5-mini"),
         ... ]
         >>> new_plan = await apply_provider_preferences_with_resolution(
         ...     plan, prefs, coordinator

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -152,7 +152,7 @@ providers:
   - module: provider-openai
     source: git+...
     config:
-      default_model: gpt-5.2
+      default_model: gpt-5.4
       priority: 2
 ```
 
@@ -267,7 +267,7 @@ result = await prepared.spawn(
     instruction="Quick analysis task",
     provider_preferences=[
         ProviderPreference(provider="anthropic", model="claude-haiku-*"),
-        ProviderPreference(provider="openai", model="gpt-4o-mini"),
+        ProviderPreference(provider="openai", model="gpt-5-mini"),
     ],
 )
 

--- a/examples/18_custom_hooks.py
+++ b/examples/18_custom_hooks.py
@@ -105,7 +105,9 @@ class PerformanceMonitor:
             for tool, timings in sorted(self.tool_timings.items()):
                 avg_time = sum(timings) / len(timings)
                 total_time = sum(timings)
-                print(f"  {tool:30} {len(timings):3} calls, avg: {avg_time:.3f}s, total: {total_time:.3f}s")
+                print(
+                    f"  {tool:30} {len(timings):3} calls, avg: {avg_time:.3f}s, total: {total_time:.3f}s"
+                )
 
         # Token usage
         print("\n💰 Token Usage:")
@@ -139,7 +141,9 @@ class RateLimiter:
         self.call_times = [t for t in self.call_times if now - t < 60]
 
         if len(self.call_times) >= self.max_calls:
-            print(f"\n⚠️  RATE LIMIT: Tool {data.get('name')} blocked ({len(self.call_times)} calls in last minute)")
+            print(
+                f"\n⚠️  RATE LIMIT: Tool {data.get('name')} blocked ({len(self.call_times)} calls in last minute)"
+            )
             # Could raise an error or return stop action
             # For demo, just warn and continue
 
@@ -159,7 +163,8 @@ class CostTracker:
         "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
         "claude-haiku": {"input": 0.25, "output": 1.25},
         "claude-opus": {"input": 15.00, "output": 75.00},
-        "gpt-5.2": {"input": 5.00, "output": 15.00},
+        "gpt-5.4": {"input": 2.50, "output": 15.00},
+        "gpt-5.4-pro": {"input": 30.00, "output": 180.00},
     }
 
     def __init__(self, model: str = "claude-sonnet-4-5"):
@@ -281,7 +286,10 @@ class RetryHandler:
         error = data.get("error", "")
 
         # Check if this is a retryable error
-        retryable = any(pattern in str(error).lower() for pattern in ["rate limit", "timeout", "503", "429"])
+        retryable = any(
+            pattern in str(error).lower()
+            for pattern in ["rate limit", "timeout", "503", "429"]
+        )
 
         if retryable:
             key = data.get("name", event)
@@ -291,7 +299,9 @@ class RetryHandler:
                 self.retry_counts[key] = retry_count + 1
                 wait_time = self.backoff_factor**retry_count
 
-                print(f"\n🔄 RETRY: Attempt {retry_count + 1}/{self.max_retries} after {wait_time:.1f}s")
+                print(
+                    f"\n🔄 RETRY: Attempt {retry_count + 1}/{self.max_retries} after {wait_time:.1f}s"
+                )
 
                 await asyncio.sleep(wait_time)
                 # Note: "retry" action is aspirational - Amplifier doesn't support it yet

--- a/examples/22_custom_orchestrator_routing.py
+++ b/examples/22_custom_orchestrator_routing.py
@@ -5,7 +5,7 @@ Example 22: Custom Orchestrator (Model Routing)
 
 AUDIENCE: Teams wanting cost/latency control without changing core modules
 VALUE: Shows how to build and use a custom orchestrator module that routes
-       between GPT-5.2 and GPT-5.1-Codex based on the prompt.
+       between GPT-5.4 and GPT-5-mini based on the prompt.
 
 What this demonstrates:
   - Packaging an orchestrator module (mount() + Orchestrator protocol)
@@ -58,7 +58,11 @@ class RoutingObserver:
 async def main():
     """Demonstrate routing via the custom orchestrator module."""
     parser = argparse.ArgumentParser(description="Custom orchestrator routing demo")
-    parser.add_argument("--verbose", action="store_true", help="Show all router logs and enable raw_debug")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show all router logs and enable raw_debug",
+    )
     args = parser.parse_args()
 
     if not os.getenv("OPENAI_API_KEY"):
@@ -70,22 +74,30 @@ async def main():
     # With --verbose, show all logs (including escalation) and enable raw_debug.
     if not logging.getLogger().handlers:
         if args.verbose:
-            logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+            logging.basicConfig(
+                level=logging.INFO, format="%(levelname)s %(name)s: %(message)s"
+            )
         else:
-            logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+            logging.basicConfig(
+                level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s"
+            )
             router_logger = logging.getLogger("amplifier_module_router_orchestrator")
             router_logger.setLevel(logging.INFO)
             router_logger.propagate = False
             handler = logging.StreamHandler()
             handler.setLevel(logging.INFO)
-            handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+            handler.setFormatter(
+                logging.Formatter("%(levelname)s %(name)s: %(message)s")
+            )
             router_logger.addHandler(handler)
 
     repo_root = Path(__file__).parent.parent
 
     # Base + provider bundles (all standard amplifier-foundation)
     foundation = await load_bundle(str(repo_root / "bundles" / "minimal.yaml"))
-    openai_provider = await load_bundle(str(repo_root / "providers" / "openai-gpt-5.yaml"))
+    openai_provider = await load_bundle(
+        str(repo_root / "providers" / "openai-gpt-5.yaml")
+    )
 
     # Overlay: use our local orchestrator module for model routing
     router_overlay = Bundle(
@@ -94,10 +106,12 @@ async def main():
         session={
             "orchestrator": {
                 "module": "router-orchestrator",
-                "source": str(repo_root / "examples" / "modules" / "router-orchestrator"),
+                "source": str(
+                    repo_root / "examples" / "modules" / "router-orchestrator"
+                ),
                 "config": {
-                    "mini_model": "gpt-5.2",
-                    "codex_model": "gpt-5.1-codex",
+                    "mini_model": "gpt-5-mini",
+                    "codex_model": "gpt-5.4",
                     "prefer_mini_first": True,
                     "raw_debug": args.verbose,  # set via --verbose to see all router logs
                 },
@@ -140,7 +154,9 @@ async def main():
     session = await prepared.create_session()
     observer = RoutingObserver()
     session.coordinator.hooks.register(
-        "orchestrator:turn_complete", observer.on_orchestrator_turn_complete, name="routing-observer"
+        "orchestrator:turn_complete",
+        observer.on_orchestrator_turn_complete,
+        name="routing-observer",
     )
 
     async with session:

--- a/examples/modules/router-orchestrator/amplifier_module_router_orchestrator/__init__.py
+++ b/examples/modules/router-orchestrator/amplifier_module_router_orchestrator/__init__.py
@@ -25,8 +25,8 @@ class RoutingOrchestrator:
 
     def __init__(self, config: dict[str, Any] | None = None):
         cfg = config or {}
-        self.mini_model = cfg.get("mini_model", "gpt-5.2")
-        self.codex_model = cfg.get("codex_model", "gpt-5.1-codex")
+        self.mini_model = cfg.get("mini_model", "gpt-5-mini")
+        self.codex_model = cfg.get("codex_model", "gpt-5.4")
         self.prefer_mini_first = cfg.get("prefer_mini_first", True)
         self.raw_debug = cfg.get("raw_debug", False)
 
@@ -100,7 +100,9 @@ class RoutingOrchestrator:
 
         # Get messages using the public API (handles compaction internally)
         messages = await context.get_messages_for_request(provider=provider)
-        logger.info(f"[router-orchestrator] model={target_model} provider={getattr(provider, 'name', 'unknown')}")
+        logger.info(
+            f"[router-orchestrator] model={target_model} provider={getattr(provider, 'name', 'unknown')}"
+        )
 
         request = ChatRequest(messages=messages)
         start = time.perf_counter()
@@ -113,12 +115,20 @@ class RoutingOrchestrator:
         if (
             target_model == self.mini_model
             and self._is_code_prompt(prompt)
-            and ("```" not in reply_text and "def " not in reply_text and "class " not in reply_text)
+            and (
+                "```" not in reply_text
+                and "def " not in reply_text
+                and "class " not in reply_text
+            )
         ):
             if self.raw_debug:
-                logger.info("[router-orchestrator] escalating to codex due to missing code in mini response")
+                logger.info(
+                    "[router-orchestrator] escalating to codex due to missing code in mini response"
+                )
             else:
-                logger.debug("[router-orchestrator] escalating to codex due to missing code in mini response")
+                logger.debug(
+                    "[router-orchestrator] escalating to codex due to missing code in mini response"
+                )
             start = time.perf_counter()
             response = await provider.complete(request, model=self.codex_model)
             latency = time.perf_counter() - start

--- a/providers/openai-gpt-5.yaml
+++ b/providers/openai-gpt-5.yaml
@@ -8,5 +8,5 @@ providers:
     source: git+https://github.com/microsoft/amplifier-module-provider-openai@main
     config:
       # Adjust to the exact model id available in your account
-      default_model: gpt-5.2
+      default_model: gpt-5.4
       raw: true

--- a/providers/openai-gpt-codex.yaml
+++ b/providers/openai-gpt-codex.yaml
@@ -7,5 +7,5 @@ providers:
   - module: provider-openai
     source: git+https://github.com/microsoft/amplifier-module-provider-openai@main
     config:
-      default_model: gpt-5.1-codex
+      default_model: gpt-5.4
       raw: true

--- a/providers/openai-gpt.yaml
+++ b/providers/openai-gpt.yaml
@@ -7,5 +7,5 @@ providers:
   - module: provider-openai
     source: git+https://github.com/microsoft/amplifier-module-provider-openai@main
     config:
-      default_model: gpt-5.2
+      default_model: gpt-5.4
       raw: true

--- a/tests/test_gpt54_provider_updates.py
+++ b/tests/test_gpt54_provider_updates.py
@@ -1,0 +1,129 @@
+"""Tests for GPT-5.4 provider bundle and example updates (task-14)."""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Provider YAML tests
+# ---------------------------------------------------------------------------
+
+
+def test_openai_gpt_yaml_default_model():
+    """providers/openai-gpt.yaml must have default_model: gpt-5.4."""
+    path = REPO_ROOT / "providers" / "openai-gpt.yaml"
+    data = yaml.safe_load(path.read_text())
+    provider_config = data["providers"][0]["config"]
+    assert provider_config["default_model"] == "gpt-5.4"
+
+
+def test_openai_gpt_5_yaml_default_model():
+    """providers/openai-gpt-5.yaml must have default_model: gpt-5.4."""
+    path = REPO_ROOT / "providers" / "openai-gpt-5.yaml"
+    data = yaml.safe_load(path.read_text())
+    provider_config = data["providers"][0]["config"]
+    assert provider_config["default_model"] == "gpt-5.4"
+
+
+def test_openai_gpt_codex_yaml_default_model():
+    """providers/openai-gpt-codex.yaml must have default_model: gpt-5.4."""
+    path = REPO_ROOT / "providers" / "openai-gpt-codex.yaml"
+    data = yaml.safe_load(path.read_text())
+    provider_config = data["providers"][0]["config"]
+    assert provider_config["default_model"] == "gpt-5.4"
+
+
+# ---------------------------------------------------------------------------
+# Example 18 – custom hooks pricing dict
+# ---------------------------------------------------------------------------
+
+
+def test_example18_pricing_has_gpt54():
+    """Example 18 PRICING dict must include gpt-5.4 with correct pricing."""
+    path = REPO_ROOT / "examples" / "18_custom_hooks.py"
+    content = path.read_text()
+    assert '"gpt-5.4"' in content
+    assert '"input": 2.50' in content or "'input': 2.50" in content
+
+
+def test_example18_pricing_has_gpt54_pro():
+    """Example 18 PRICING dict must include gpt-5.4-pro with correct pricing."""
+    path = REPO_ROOT / "examples" / "18_custom_hooks.py"
+    content = path.read_text()
+    assert '"gpt-5.4-pro"' in content
+    assert '"input": 30.00' in content or "'input': 30.00" in content
+
+
+def test_example18_no_stale_gpt52():
+    """Example 18 must not contain gpt-5.2."""
+    path = REPO_ROOT / "examples" / "18_custom_hooks.py"
+    content = path.read_text()
+    assert "gpt-5.2" not in content
+
+
+# ---------------------------------------------------------------------------
+# Example 22 – custom orchestrator routing
+# ---------------------------------------------------------------------------
+
+
+def test_example22_docstring_updated():
+    """Example 22 docstring must reference GPT-5.4 and GPT-5-mini."""
+    path = REPO_ROOT / "examples" / "22_custom_orchestrator_routing.py"
+    content = path.read_text()
+    assert "GPT-5.4" in content
+    assert "GPT-5-mini" in content
+
+
+def test_example22_mini_model_updated():
+    """Example 22 must use gpt-5-mini for mini_model config."""
+    path = REPO_ROOT / "examples" / "22_custom_orchestrator_routing.py"
+    content = path.read_text()
+    assert '"mini_model": "gpt-5-mini"' in content
+
+
+def test_example22_codex_model_updated():
+    """Example 22 must use gpt-5.4 for codex_model config."""
+    path = REPO_ROOT / "examples" / "22_custom_orchestrator_routing.py"
+    content = path.read_text()
+    assert '"codex_model": "gpt-5.4"' in content
+
+
+def test_example22_no_stale_gpt52():
+    """Example 22 must not contain gpt-5.2."""
+    path = REPO_ROOT / "examples" / "22_custom_orchestrator_routing.py"
+    content = path.read_text()
+    assert "gpt-5.2" not in content
+
+
+def test_example22_no_stale_gpt51_codex():
+    """Example 22 must not contain gpt-5.1-codex."""
+    path = REPO_ROOT / "examples" / "22_custom_orchestrator_routing.py"
+    content = path.read_text()
+    assert "gpt-5.1-codex" not in content
+
+
+# ---------------------------------------------------------------------------
+# Cross-file stale string check
+# ---------------------------------------------------------------------------
+
+
+def test_no_stale_strings_in_modified_files():
+    """No stale gpt-5.1-codex or gpt-5.2 references in any modified files."""
+    stale_patterns = ["gpt-5.1-codex", "gpt-5.2"]
+    files_to_check = [
+        REPO_ROOT / "providers" / "openai-gpt.yaml",
+        REPO_ROOT / "providers" / "openai-gpt-5.yaml",
+        REPO_ROOT / "providers" / "openai-gpt-codex.yaml",
+        REPO_ROOT / "examples" / "18_custom_hooks.py",
+        REPO_ROOT / "examples" / "22_custom_orchestrator_routing.py",
+    ]
+    violations = []
+    for fpath in files_to_check:
+        content = fpath.read_text()
+        for pattern in stale_patterns:
+            if pattern in content:
+                violations.append(f"{fpath.name} contains '{pattern}'")
+    assert violations == [], f"Stale strings found: {violations}"

--- a/tests/test_gpt54_provider_updates.py
+++ b/tests/test_gpt54_provider_updates.py
@@ -127,3 +127,42 @@ def test_no_stale_strings_in_modified_files():
             if pattern in content:
                 violations.append(f"{fpath.name} contains '{pattern}'")
     assert violations == [], f"Stale strings found: {violations}"
+
+
+# ---------------------------------------------------------------------------
+# Router-orchestrator module defaults
+# ---------------------------------------------------------------------------
+
+ROUTER_INIT = (
+    REPO_ROOT
+    / "examples"
+    / "modules"
+    / "router-orchestrator"
+    / "amplifier_module_router_orchestrator"
+    / "__init__.py"
+)
+
+
+def test_router_orchestrator_mini_model_default_updated():
+    """RoutingOrchestrator default mini_model must be gpt-5-mini, not gpt-5.2."""
+    content = ROUTER_INIT.read_text()
+    assert '"gpt-5-mini"' in content, "mini_model default should be gpt-5-mini"
+    assert '"gpt-5.2"' not in content, "stale gpt-5.2 default must be removed"
+
+
+def test_router_orchestrator_codex_model_default_updated():
+    """RoutingOrchestrator default codex_model must be gpt-5.4, not gpt-5.1-codex."""
+    content = ROUTER_INIT.read_text()
+    assert '"gpt-5.4"' in content, "codex_model default should be gpt-5.4"
+    assert '"gpt-5.1-codex"' not in content, (
+        "stale gpt-5.1-codex default must be removed"
+    )
+
+
+def test_router_orchestrator_no_stale_model_strings():
+    """router-orchestrator __init__.py must not contain any stale model strings."""
+    content = ROUTER_INIT.read_text()
+    for stale in ("gpt-5.2", "gpt-5.1-codex"):
+        assert stale not in content, (
+            f"Stale model string '{stale}' found in router-orchestrator"
+        )


### PR DESCRIPTION
## Summary

Updates all OpenAI provider bundle defaults and example code for GPT-5.4.

### Provider bundles:
- `openai-gpt.yaml`: `default_model: gpt-5.2` → `gpt-5.4`
- `openai-gpt-5.yaml`: `default_model: gpt-5.2` → `gpt-5.4`
- `openai-gpt-codex.yaml`: `default_model: gpt-5.1-codex` → `gpt-5.4` (codex merged)

### Examples:
- `examples/18_custom_hooks.py` — Added GPT-5.4 pricing ($2.50/$15.00)
- `examples/22_custom_orchestrator_routing.py` — Model strings updated
- `examples/modules/router-orchestrator/__init__.py` — Default model strings updated

### Production code:
- `bundle.py` — ProviderPreference fallback: `gpt-4o-mini` → `gpt-5-mini`
- `spawn_utils.py` — Docstring examples updated
- `docs/PATTERNS.md` — Config and code examples updated

## Test Plan
- 15 GPT-5.4-specific tests passing
- No stale model strings in modified files