### PR TITLE
feat: Wire routing config through ProviderPreference to provider mount config

### DIFF
--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -19,13 +19,36 @@ logger = logging.getLogger(__name__)
 
 PROTECTED_CONFIG_KEYS = frozenset(
     {
+        # Credentials
         "api_key",
+        "secret",
+        "password",
+        "token",
+        "access_token",
+        "bearer_token",
+        "client_id",
+        "client_secret",
+        "tenant_id",
+        # Endpoints / infrastructure
         "base_url",
         "host",
         "azure_endpoint",
         "api_version",
         "deployment_name",
-        "secret",
+        "organization",
+        "project",
+        # Azure auth control
+        "managed_identity_client_id",
+        "use_managed_identity",
+        "use_default_credential",
+        # Network control
+        "proxy",
+        "http_proxy",
+        "https_proxy",
+        "verify_ssl",
+        "ssl_verify",
+        "verify",
+        "ca_bundle",
     }
 )
 
@@ -46,6 +69,10 @@ class ProviderPreference:
             Supports flexible matching - "anthropic" matches "provider-anthropic".
         model: Model name or glob pattern (e.g., "claude-haiku-*", "gpt-4o-mini").
             Patterns are resolved to concrete model names at runtime.
+        config: Optional routing/preference config to merge into the provider's
+            mount config (e.g., {"reasoning_effort": "high", "temperature": 0.3}).
+            Keys in PROTECTED_CONFIG_KEYS (credentials, infrastructure) are never
+            overridden. Omitted from to_dict() when empty for backward compatibility.
 
     Example:
         >>> prefs = [
@@ -56,7 +83,7 @@ class ProviderPreference:
 
     provider: str
     model: str
-    config: dict = field(default_factory=dict)
+    config: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary representation."""
@@ -411,14 +438,14 @@ def _apply_single_override(
         p_copy["config"] = dict(p.get("config", {}))
 
         if i == target_idx:
-            # Promote to priority 0 (highest)
-            p_copy["config"]["priority"] = 0
-            p_copy["config"]["default_model"] = model
-            # Merge routing/preference config — preference wins over base
+            # Merge routing config first (lower precedence)
             if pref_config:
                 for key, value in pref_config.items():
                     if key not in PROTECTED_CONFIG_KEYS:
                         p_copy["config"][key] = value
+            # Then enforce invariants — these always win
+            p_copy["config"]["priority"] = 0
+            p_copy["config"]["default_model"] = model
             logger.info(
                 "Provider preference applied: %s (priority=0, model=%s)",
                 p_copy.get("module"),

--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -17,6 +17,18 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+PROTECTED_CONFIG_KEYS = frozenset(
+    {
+        "api_key",
+        "base_url",
+        "host",
+        "azure_endpoint",
+        "api_version",
+        "deployment_name",
+        "secret",
+    }
+)
+
 
 @dataclass
 class ProviderPreference:
@@ -371,6 +383,7 @@ def _apply_single_override(
     providers: list[dict[str, Any]],
     target_idx: int,
     model: str,
+    pref_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Apply a single provider/model override to the mount plan.
 
@@ -379,6 +392,10 @@ def _apply_single_override(
         providers: Original providers list.
         target_idx: Index of provider to promote.
         model: Model to set for the provider.
+        pref_config: Optional routing/preference config to merge into the
+            provider config. Preference wins over base config for non-protected
+            keys. Keys in PROTECTED_CONFIG_KEYS (credentials, infrastructure)
+            are never overridden.
 
     Returns:
         New mount plan with override applied.
@@ -395,6 +412,11 @@ def _apply_single_override(
             # Promote to priority 0 (highest)
             p_copy["config"]["priority"] = 0
             p_copy["config"]["default_model"] = model
+            # Merge routing/preference config — preference wins over base
+            if pref_config:
+                for key, value in pref_config.items():
+                    if key not in PROTECTED_CONFIG_KEYS:
+                        p_copy["config"][key] = value
             logger.info(
                 "Provider preference applied: %s (priority=0, model=%s)",
                 p_copy.get("module"),

--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import fnmatch
 import logging
 from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -43,17 +44,21 @@ class ProviderPreference:
 
     provider: str
     model: str
+    config: dict = field(default_factory=dict)
 
-    def to_dict(self) -> dict[str, str]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary representation."""
-        return {"provider": self.provider, "model": self.model}
+        result: dict[str, Any] = {"provider": self.provider, "model": self.model}
+        if self.config:
+            result["config"] = self.config
+        return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, str]) -> ProviderPreference:
+    def from_dict(cls, data: dict[str, Any]) -> ProviderPreference:
         """Create from dictionary representation.
 
         Args:
-            data: Dictionary with 'provider' and 'model' keys.
+            data: Dictionary with 'provider' and 'model' keys, and optional 'config'.
 
         Returns:
             ProviderPreference instance.
@@ -65,7 +70,11 @@ class ProviderPreference:
             raise ValueError("ProviderPreference requires 'provider' key")
         if "model" not in data:
             raise ValueError("ProviderPreference requires 'model' key")
-        return cls(provider=data["provider"], model=data["model"])
+        return cls(
+            provider=data["provider"],
+            model=data["model"],
+            config=data.get("config", {}),
+        )
 
 
 @dataclass

--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -367,7 +367,9 @@ def apply_provider_preferences(
     for pref in preferences:
         if pref.provider in lookup:
             target_idx = lookup[pref.provider]
-            return _apply_single_override(mount_plan, providers, target_idx, pref.model)
+            return _apply_single_override(
+                mount_plan, providers, target_idx, pref.model, pref.config
+            )
 
     # No preferences matched
     logger.warning(
@@ -482,7 +484,7 @@ async def apply_provider_preferences_with_resolution(
                 resolved_model = result.resolved_model
 
             return _apply_single_override(
-                mount_plan, providers, target_idx, resolved_model
+                mount_plan, providers, target_idx, resolved_model, pref.config
             )
 
     # No preferences matched

--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -715,10 +715,14 @@ Agent usage notes:
         # provider_preferences wins when both are provided (explicit pin overrides matrix)
         raw_model_role = input.get("model_role", "").strip()
         if raw_model_role and provider_preferences is None:
-            routing_state = getattr(self.coordinator, "session_state", {}).get("routing_matrix")
+            routing_state = getattr(self.coordinator, "session_state", {}).get(
+                "routing_matrix"
+            )
             if routing_state:
                 try:
-                    from amplifier_module_hooks_routing.resolver import resolve_model_role
+                    from amplifier_module_hooks_routing.resolver import (
+                        resolve_model_role,
+                    )
 
                     roles = [raw_model_role]
                     matrix = routing_state.get("roles", {})
@@ -727,7 +731,9 @@ Agent usage notes:
                     if resolved:
                         provider_preferences = [
                             ProviderPreference(
-                                provider=r["provider"], model=r["model"]
+                                provider=r["provider"],
+                                model=r["model"],
+                                config=r.get("config", {}),
                             )
                             for r in resolved
                         ]

--- a/modules/tool-delegate/tests/test_delegate_model_role.py
+++ b/modules/tool-delegate/tests/test_delegate_model_role.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 import types
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -74,7 +74,10 @@ def _install_mock_resolver(mock_resolve_fn):
     mock_hooks_routing_mod = types.ModuleType("amplifier_module_hooks_routing")
 
     originals = {}
-    for mod_name in ("amplifier_module_hooks_routing", "amplifier_module_hooks_routing.resolver"):
+    for mod_name in (
+        "amplifier_module_hooks_routing",
+        "amplifier_module_hooks_routing.resolver",
+    ):
         if mod_name in sys.modules:
             originals[mod_name] = sys.modules[mod_name]
 
@@ -82,7 +85,10 @@ def _install_mock_resolver(mock_resolve_fn):
     sys.modules["amplifier_module_hooks_routing.resolver"] = mock_resolver_mod
 
     def cleanup():
-        for mod_name in ("amplifier_module_hooks_routing", "amplifier_module_hooks_routing.resolver"):
+        for mod_name in (
+            "amplifier_module_hooks_routing",
+            "amplifier_module_hooks_routing.resolver",
+        ):
             if mod_name in originals:
                 sys.modules[mod_name] = originals[mod_name]
             elif mod_name in sys.modules:
@@ -145,9 +151,9 @@ class TestDelegateModelRole:
             )
             # Wire up providers on coordinator.get("providers")
             tool.coordinator.get = MagicMock(
-                side_effect=lambda key: {"provider-anthropic": MagicMock()}
-                if key == "providers"
-                else None
+                side_effect=lambda key: (
+                    {"provider-anthropic": MagicMock()} if key == "providers" else None
+                )
             )
 
             await tool.execute(
@@ -162,7 +168,9 @@ class TestDelegateModelRole:
             spawn_fn.assert_called_once()
             _, kwargs = spawn_fn.call_args
             prefs = kwargs["provider_preferences"]
-            assert prefs is not None, "Expected resolved provider_preferences from model_role"
+            assert prefs is not None, (
+                "Expected resolved provider_preferences from model_role"
+            )
             assert len(prefs) >= 1
             assert prefs[0].provider == "anthropic"
             assert prefs[0].model == "claude-haiku-3.5"
@@ -202,7 +210,10 @@ class TestDelegateModelRole:
                         "roles": {
                             "fast": {
                                 "candidates": [
-                                    {"provider": "anthropic", "model": "claude-haiku-3.5"},
+                                    {
+                                        "provider": "anthropic",
+                                        "model": "claude-haiku-3.5",
+                                    },
                                 ]
                             }
                         }
@@ -231,6 +242,83 @@ class TestDelegateModelRole:
 
             # Resolver should NOT have been called
             mock_resolve.assert_not_called()
+        finally:
+            cleanup()
+
+    @pytest.mark.asyncio
+    async def test_model_role_resolution_includes_config(self):
+        """Config from resolved model_role is preserved in ProviderPreference."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+
+        # Resolver returns a result with non-empty config
+        mock_resolve = AsyncMock(
+            return_value=[
+                {
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4-6",
+                    "config": {"reasoning_effort": "high"},
+                }
+            ]
+        )
+        cleanup = _install_mock_resolver(mock_resolve)
+
+        try:
+            tool = _make_delegate_tool(
+                spawn_fn=spawn_fn,
+                agents={
+                    "coding-agent": {"description": "A coding agent"},
+                },
+                session_state={
+                    "routing_matrix": {
+                        "roles": {
+                            "coding": {
+                                "candidates": [
+                                    {
+                                        "provider": "anthropic",
+                                        "model": "claude-sonnet-4-6",
+                                        "config": {"reasoning_effort": "high"},
+                                    },
+                                ]
+                            }
+                        }
+                    }
+                },
+            )
+            tool.coordinator.get = MagicMock(
+                side_effect=lambda key: (
+                    {"provider-anthropic": MagicMock()} if key == "providers" else None
+                )
+            )
+
+            await tool.execute(
+                {
+                    "agent": "coding-agent",
+                    "instruction": "Write a function",
+                    "context_depth": "none",
+                    "model_role": "coding",
+                }
+            )
+
+            spawn_fn.assert_called_once()
+            _, kwargs = spawn_fn.call_args
+            prefs = kwargs["provider_preferences"]
+            assert prefs is not None, (
+                "Expected resolved provider_preferences from model_role"
+            )
+            assert len(prefs) == 1
+            assert prefs[0].provider == "anthropic"
+            assert prefs[0].model == "claude-sonnet-4-6"
+            assert prefs[0].config == {"reasoning_effort": "high"}, (
+                f"Expected config={{'reasoning_effort': 'high'}}, got {prefs[0].config!r}"
+            )
         finally:
             cleanup()
 

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -530,6 +530,55 @@ class TestApplySingleOverrideConfig:
         result_config = result["providers"][0]["config"]
         assert result_config["reasoning_effort"] == "high"
 
+    def test_apply_single_override_protects_azure_auth(self) -> None:
+        """Azure auth fields like managed_identity_client_id cannot be overridden."""
+        mount_plan, providers = self._make_mount_plan(
+            {
+                "api_key": "sk-test",
+                "default_model": "gpt-4",
+                "priority": 10,
+                "managed_identity_client_id": "original-id",
+            }
+        )
+        result = _apply_single_override(
+            mount_plan,
+            providers,
+            0,
+            "gpt-5",
+            pref_config={
+                "managed_identity_client_id": "evil-id",
+                "reasoning_effort": "high",
+            },
+        )
+        result_config = result["providers"][0]["config"]
+        assert (
+            result_config["managed_identity_client_id"] == "original-id"
+        )  # NOT overridden
+        assert result_config["reasoning_effort"] == "high"  # non-protected key merged
+
+    def test_apply_single_override_priority_cannot_be_overridden(self) -> None:
+        """priority and default_model are enforced even if pref_config tries to override them."""
+        mount_plan, providers = self._make_mount_plan(
+            {"api_key": "sk-test", "default_model": "gpt-4", "priority": 10}
+        )
+        result = _apply_single_override(
+            mount_plan,
+            providers,
+            0,
+            "gpt-5",
+            pref_config={
+                "priority": 99,
+                "default_model": "gpt-3.5",
+                "reasoning_effort": "high",
+            },
+        )
+        result_config = result["providers"][0]["config"]
+        assert result_config["priority"] == 0  # enforced, not 99
+        assert result_config["default_model"] == "gpt-5"  # enforced, not gpt-3.5
+        assert (
+            result_config["reasoning_effort"] == "high"
+        )  # non-protected merged normally
+
 
 class TestProviderPreferenceConfigWiring:
     """Tests that pref.config is wired through apply_provider_preferences callers."""

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from amplifier_foundation.spawn_utils import ProviderPreference
+from amplifier_foundation.spawn_utils import _apply_single_override
 from amplifier_foundation.spawn_utils import _build_provider_lookup
 from amplifier_foundation.spawn_utils import _find_provider_index
 from amplifier_foundation.spawn_utils import apply_provider_preferences
@@ -442,3 +443,89 @@ class TestFindProviderIndexMultiInstance:
         ]
         assert _find_provider_index(providers, "anthropic-team-a") == 0
         assert _find_provider_index(providers, "anthropic-team-b") == 1
+
+
+class TestApplySingleOverrideConfig:
+    """Tests for _apply_single_override pref_config merging and protected keys."""
+
+    def _make_mount_plan(self, provider_config: dict) -> tuple[dict, list]:
+        """Build a minimal mount plan with one provider."""
+        mount_plan = {
+            "providers": [{"module": "provider-openai", "config": provider_config}],
+            "session": {"orchestrator": {"module": "loop-basic"}},
+        }
+        return mount_plan, mount_plan["providers"]
+
+    def test_apply_single_override_merges_pref_config(self) -> None:
+        """pref_config keys are merged into provider config."""
+        mount_plan, providers = self._make_mount_plan(
+            {"api_key": "sk-test", "default_model": "gpt-4", "priority": 10}
+        )
+        result = _apply_single_override(
+            mount_plan,
+            providers,
+            0,
+            "gpt-5",
+            pref_config={"reasoning_effort": "high", "temperature": 0.3},
+        )
+        result_config = result["providers"][0]["config"]
+        assert result_config["reasoning_effort"] == "high"
+        assert result_config["temperature"] == 0.3
+
+    def test_apply_single_override_protects_credentials(self) -> None:
+        """api_key is protected — pref_config cannot override it."""
+        mount_plan, providers = self._make_mount_plan(
+            {"api_key": "sk-test", "default_model": "gpt-4", "priority": 10}
+        )
+        result = _apply_single_override(
+            mount_plan,
+            providers,
+            0,
+            "gpt-5",
+            pref_config={"api_key": "EVIL", "reasoning_effort": "high"},
+        )
+        result_config = result["providers"][0]["config"]
+        assert result_config["api_key"] == "sk-test"
+        assert result_config["reasoning_effort"] == "high"
+
+    def test_apply_single_override_protects_base_url(self) -> None:
+        """base_url is protected — pref_config cannot override it."""
+        mount_plan, providers = self._make_mount_plan(
+            {"api_key": "sk-test", "base_url": "http://real.com", "priority": 10}
+        )
+        result = _apply_single_override(
+            mount_plan,
+            providers,
+            0,
+            "gpt-5",
+            pref_config={"base_url": "http://evil.com", "temperature": 0.5},
+        )
+        result_config = result["providers"][0]["config"]
+        assert result_config["base_url"] == "http://real.com"
+        assert result_config["temperature"] == 0.5
+
+    def test_apply_single_override_no_config_backward_compat(self) -> None:
+        """Calling without pref_config works exactly as before."""
+        mount_plan, providers = self._make_mount_plan(
+            {"api_key": "sk-test", "default_model": "gpt-4", "priority": 10}
+        )
+        result = _apply_single_override(mount_plan, providers, 0, "gpt-5")
+        result_config = result["providers"][0]["config"]
+        assert result_config["priority"] == 0
+        assert result_config["default_model"] == "gpt-5"
+        assert result_config["api_key"] == "sk-test"
+
+    def test_apply_single_override_preference_wins_over_base(self) -> None:
+        """pref_config value wins over same key already in provider config."""
+        mount_plan, providers = self._make_mount_plan(
+            {"api_key": "sk-test", "reasoning_effort": "low", "priority": 10}
+        )
+        result = _apply_single_override(
+            mount_plan,
+            providers,
+            0,
+            "gpt-5",
+            pref_config={"reasoning_effort": "high"},
+        )
+        result_config = result["providers"][0]["config"]
+        assert result_config["reasoning_effort"] == "high"

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -359,6 +359,64 @@ class TestApplyProviderPreferencesWithResolution:
         assert result["providers"][0]["config"]["default_model"] == "gpt-4o-mini"
 
 
+class TestProviderPreferenceConfig:
+    """Tests for ProviderPreference config field."""
+
+    def test_provider_preference_config_default_empty(self) -> None:
+        """Config defaults to empty dict when not specified."""
+        pref = ProviderPreference(provider="openai", model="gpt-5")
+        assert pref.config == {}
+
+    def test_provider_preference_with_config(self) -> None:
+        """Config field holds provided values."""
+        pref = ProviderPreference(
+            provider="openai", model="gpt-5", config={"reasoning_effort": "high"}
+        )
+        assert pref.config == {"reasoning_effort": "high"}
+
+    def test_from_dict_with_config(self) -> None:
+        """from_dict populates config from dict key."""
+        pref = ProviderPreference.from_dict(
+            {
+                "provider": "openai",
+                "model": "gpt-5",
+                "config": {"reasoning_effort": "high"},
+            }
+        )
+        assert pref.config == {"reasoning_effort": "high"}
+
+    def test_from_dict_without_config_key(self) -> None:
+        """from_dict defaults config to empty dict when key absent (backward compat)."""
+        pref = ProviderPreference.from_dict({"provider": "openai", "model": "gpt-5"})
+        assert pref.config == {}
+
+    def test_to_dict_includes_config_when_present(self) -> None:
+        """to_dict includes config key when config is non-empty."""
+        pref = ProviderPreference(
+            provider="openai", model="gpt-5", config={"reasoning_effort": "high"}
+        )
+        assert pref.to_dict() == {
+            "provider": "openai",
+            "model": "gpt-5",
+            "config": {"reasoning_effort": "high"},
+        }
+
+    def test_to_dict_excludes_config_when_empty(self) -> None:
+        """to_dict omits config key when config is empty (backward compat)."""
+        pref = ProviderPreference(provider="openai", model="gpt-5")
+        assert pref.to_dict() == {"provider": "openai", "model": "gpt-5"}
+
+    def test_roundtrip_with_config(self) -> None:
+        """Roundtrip through to_dict/from_dict preserves all fields including config."""
+        original = ProviderPreference(
+            provider="openai", model="gpt-5", config={"reasoning_effort": "high"}
+        )
+        roundtripped = ProviderPreference.from_dict(original.to_dict())
+        assert roundtripped.provider == original.provider
+        assert roundtripped.model == original.model
+        assert roundtripped.config == original.config
+
+
 class TestBuildProviderLookupMultiInstance:
     """Tests for _build_provider_lookup with id-based lookup."""
 

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -529,3 +529,68 @@ class TestApplySingleOverrideConfig:
         )
         result_config = result["providers"][0]["config"]
         assert result_config["reasoning_effort"] == "high"
+
+
+class TestProviderPreferenceConfigWiring:
+    """Tests that pref.config is wired through apply_provider_preferences callers."""
+
+    def _make_mount_plan(self) -> dict:
+        """Build a minimal mount plan with one openai provider."""
+        return {
+            "providers": [
+                {
+                    "module": "provider-openai",
+                    "config": {"api_key": "sk-test", "priority": 10},
+                }
+            ],
+            "session": {"orchestrator": {"module": "loop-basic"}},
+        }
+
+    def test_apply_provider_preferences_passes_config(self) -> None:
+        """apply_provider_preferences passes pref.config to _apply_single_override."""
+        mount_plan = self._make_mount_plan()
+        pref = ProviderPreference(
+            provider="openai", model="gpt-5", config={"reasoning_effort": "high"}
+        )
+        result = apply_provider_preferences(mount_plan, [pref])
+
+        result_config = result["providers"][0]["config"]
+        assert result_config["reasoning_effort"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_apply_provider_preferences_with_resolution_passes_config(
+        self,
+    ) -> None:
+        """apply_provider_preferences_with_resolution passes pref.config."""
+        mount_plan = self._make_mount_plan()
+        pref = ProviderPreference(
+            provider="openai",
+            model="gpt-5",  # exact model, no glob — resolution is a no-op
+            config={"reasoning_effort": "high"},
+        )
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.get.return_value = {}
+
+        result = await apply_provider_preferences_with_resolution(
+            mount_plan, [pref], mock_coordinator
+        )
+
+        result_config = result["providers"][0]["config"]
+        assert result_config["reasoning_effort"] == "high"
+
+    def test_config_flows_end_to_end(self) -> None:
+        """Multiple config values flow end-to-end alongside existing provider keys."""
+        mount_plan = self._make_mount_plan()
+        pref = ProviderPreference(
+            provider="openai",
+            model="gpt-5",
+            config={"reasoning_effort": "high", "temperature": 0.3},
+        )
+        result = apply_provider_preferences(mount_plan, [pref])
+
+        result_config = result["providers"][0]["config"]
+        assert result_config["reasoning_effort"] == "high"
+        assert result_config["temperature"] == 0.3
+        # Existing protected key untouched
+        assert result_config["api_key"] == "sk-test"


### PR DESCRIPTION
## Summary

Extends `ProviderPreference` to carry a `config: dict` alongside `provider` and `model`, enabling routing matrix config values (like `reasoning_effort`, `enable_1m_context`) to flow through to the provider's mount config at session spawn time.

### Changes

- **`ProviderPreference`** gains `config: dict = field(default_factory=dict)` — backward compatible
- **`_apply_single_override()`** accepts `pref_config` and merges it into the provider's mount plan config with preference-wins precedence + protected keys blocklist (`api_key`, `base_url`, etc. can never be overridden)
- **Both callers** (`apply_provider_preferences`, `apply_provider_preferences_with_resolution`) pass `pref.config` through
- **tool-delegate** includes `config` when building `ProviderPreference` from routing resolution

### Architecture (expert-validated)

`{provider, model, config}` is a single routing decision unit. The config dict carries provider-specific settings that get merged into the provider's mount plan config when a session is created. The provider reads its own config at request time. Three sources, same shape: settings.yaml, preferred provider delegation, routing matrix.

Precedence: routing/preference config overrides base provider config (more specific wins), except protected keys (credentials/infrastructure).

## Stats
- 4 commits, 2 files changed in spawn_utils.py + tool-delegate
- 20 new tests (41 total in test_spawn_utils.py)