### PR TITLE
docs: fix foundation guide inconsistencies for agents, imports, and delegate tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ async def main():
 asyncio.run(main())
 ```
 
-For the complete workflow with provider selection and advanced features, see [`examples/04_full_workflow/`](examples/04_full_workflow/).
+For the complete workflow with provider selection and advanced features, see [`examples/07_full_workflow.py`](examples/07_full_workflow.py).
 
 ### Use Utilities Directly
 

--- a/docs/APPLICATION_INTEGRATION_GUIDE.md
+++ b/docs/APPLICATION_INTEGRATION_GUIDE.md
@@ -74,7 +74,7 @@ Every Amplifier application follows this core pattern, regardless of application
 ### Minimal Example
 
 ```python
-from amplifier_core import load_bundle
+from amplifier_foundation import load_bundle
 
 # Steps 1-3: Once at startup
 bundle = await load_bundle("./bundle.md")
@@ -143,7 +143,7 @@ bundle:
 
 includes:
   - bundle: git+https://github.com/microsoft/amplifier-foundation@main
-  - behavior: my-app:behaviors/domain-expert
+  - bundle: my-app:behaviors/domain-expert
 
 session:
   orchestrator: {module: loop-streaming}
@@ -160,7 +160,7 @@ You are a helpful domain expert.
 Build bundles in Python at startup. Good for dynamic configuration based on environment, user, or runtime conditions.
 
 ```python
-from amplifier_core import Bundle
+from amplifier_foundation import Bundle
 
 base = Bundle(
     name="my-app",

--- a/docs/BUNDLE_GUIDE.md
+++ b/docs/BUNDLE_GUIDE.md
@@ -917,7 +917,7 @@ tools:
 
 # Control what tools spawned agents inherit
 spawn:
-  exclude_tools: [tool-task]        # Agents inherit all EXCEPT these
+  exclude_tools: [tool-delegate]        # Agents inherit all EXCEPT these
   # OR use explicit list:
   # tools: [tool-a, tool-b]         # Agents get ONLY these tools
 
@@ -1310,5 +1310,5 @@ amplifier-bundle-recipes/
 
 - **[amplifier-bundle-recipes](https://github.com/microsoft/amplifier-bundle-recipes)** - Canonical example of thin bundle + behavior pattern
 - **[URI Formats](URI_FORMATS.md)** - Complete source URI documentation
-- **[Validation](VALIDATION.md)** - Bundle validation rules
+- **[Validation](API_REFERENCE.md)** - Bundle validation rules
 - **[API Reference](API_REFERENCE.md)** - Programmatic bundle loading

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -221,7 +221,7 @@ In `agents/bug-hunter.md`:
 
 ```markdown
 ---
-agent:
+meta:
   name: bug-hunter
   description: Finds and fixes bugs
 
@@ -278,22 +278,22 @@ result = await prepared.spawn(
 ### Controlling Agent Tool Inheritance
 
 By default, spawned agents inherit all tools from their parent. Configure tool inheritance
-in the task tool's config section:
+in the delegate tool's config section:
 
 ```yaml
 # In your bundle.md
 tools:
-  - module: tool-task
-    source: git+https://github.com/microsoft/amplifier-module-tool-task@main
+  - module: tool-delegate
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/tool-delegate
     config:
-      exclude_tools: [tool-task]  # Agents inherit all EXCEPT these
+      exclude_tools: [tool-delegate]  # Agents inherit all EXCEPT these
 ```
 
 Or specify an explicit allowlist:
 
 ```yaml
 tools:
-  - module: tool-task
+  - module: tool-delegate
     config:
       inherit_tools: [tool-filesystem, tool-bash]  # Agents get ONLY these
 ```
@@ -301,21 +301,21 @@ tools:
 **Common pattern**: Prevent agents from delegating further:
 
 ```yaml
-# Coordinator has task tool for orchestration
+# Coordinator has delegate tool for orchestration
 tools:
   - module: tool-filesystem
   - module: tool-bash
-  - module: tool-task
+  - module: tool-delegate
     config:
-      exclude_tools: [tool-task]  # Spawned agents can't delegate
+      exclude_tools: [tool-delegate]  # Spawned agents can't delegate
 ```
 
 This ensures agents do the work themselves rather than trying to spawn sub-agents.
 
-**Design rationale**: Tool inheritance config belongs in tool-task's config section because:
-- The task tool is the module that consumes this config
+**Design rationale**: Tool inheritance config belongs in tool-delegate's config section because:
+- The delegate tool is the module that consumes this config
 - Follows the pattern of all other tool configs
-- Without tool-task mounted, this config is meaningless
+- Without tool-delegate mounted, this config is meaningless
 - Standard module-config merge rules apply during bundle composition
 
 ### Agent Resolution Pattern


### PR DESCRIPTION
## Summary

- **PATTERNS.md**: fixed agent frontmatter key to `meta`
- **APPLICATION_INTEGRATION_GUIDE.md**: corrected imports to `amplifier_foundation`
- **BUNDLE_GUIDE.md**: corrected `includes` key to `bundle`
- **docs examples**: migrated `tool-task` references to `tool-delegate`
- **README.md**: corrected full-workflow example link
- **README.md**: replaced dead `VALIDATION.md` link with existing API reference

## Test plan

- [x] Verified all four files diff cleanly against main
- [x] Confirmed no other untracked or staged changes included
- [ ] Visual review of rendered markdown on GitHub

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)