### PR TITLE
fix: use glob pattern for haiku model in validator recipe quick-approval steps

### DIFF
--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -800,7 +800,7 @@ steps:
     agent: "foundation:zen-architect"
     mode: "REVIEW"
     provider: "anthropic"
-    model: "claude-haiku"
+    model: "claude-haiku-*"
     condition: "{{quality_classification.requires_llm_analysis}} == false"
     depends_on: ["set-default-approval-summary"]
     prompt: |

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -2387,7 +2387,7 @@ steps:
     agent: "foundation:zen-architect"
     mode: "REVIEW"
     provider: "anthropic"
-    model: "claude-haiku"
+    model: "claude-haiku-*"
     condition: "{{quality_classification.requires_llm_analysis}} == false"
     depends_on: ["set-default-approval-summary"]
     prompt: |


### PR DESCRIPTION
## Summary

Fixes the `not_found_error` from the Anthropic API when running the bundle/agent validator recipes.

## Problem

The `quick-approval` steps in both validator recipes hardcoded `model: "claude-haiku"` — a bare string that is not a valid Anthropic model ID. Since it contains no glob characters (`*`, `?`, `[`), the foundation's `resolve_model_pattern()` passes it verbatim to the API, which rejects it.

## Fix

Changed `"claude-haiku"` → `"claude-haiku-*"` in both files, consistent with every other haiku reference in the codebase (agent files, other recipes, etc.). The glob pattern is resolved at runtime to the latest matching haiku model.

## Files Changed

| File | Line | Change |
|---|---|---|
| `recipes/validate-agents.yaml` | ~803 | `"claude-haiku"` → `"claude-haiku-*"` |
| `recipes/validate-bundle-repo.yaml` | ~2390 | `"claude-haiku"` → `"claude-haiku-*"` |

## Related

- Fixes microsoft-amplifier/amplifier-support#128
- Secondary fix needed in `amplifier-bundle-recipes` to update teaching material that propagates the invalid model name (separate PR)