### PR TITLE
feat: integrate recipe validation into validate-bundle-repo.yaml (v3.3.0)

### DIFF
--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -2012,6 +2012,7 @@ steps:
 
   - id: "set-default-recipe-validation"
     type: "bash"
+    condition: "{{validation_flags.validate_recipes}} != 'true'"
     command: |
       python3 << 'EOF'
       import json

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -123,6 +123,10 @@ tags: ["bundle", "validation", "quality", "conventions", "repository", "packagin
 context:
   repo_path: ""  # Required: Path to bundle repository root
   validate_agents: "false"  # Optional: Also run agent validation (true/false)
+  validate_recipes: "false"  # Optional: Also run recipe validation (true/false)
+  validate_all: "false"  # Optional: Convenience flag — enables both agent and recipe validation
+  recipes_dir: "recipes"  # Optional: Subdirectory containing recipes (default: 'recipes')
+  known_agents: ""  # Optional: JSON list of known external namespace:agent patterns for recipe validation
 
 steps:
   # ============================================================================
@@ -266,6 +270,39 @@ steps:
     output: "env_check"
     parse_json: true
     timeout: 30
+
+  # ============================================================================
+  # PHASE 0.1: Validate-All Flags Expansion
+  # Expands validate_all='true' to enable both agent and recipe validation
+  # ============================================================================
+
+  - id: "validate-all-flags"
+    type: "bash"
+    command: |
+      python3 << 'EOF'
+      import json
+
+      validate_all = "{{validate_all}}"
+      validate_agents = "{{validate_agents}}"
+      validate_recipes = "{{validate_recipes}}"
+
+      # If validate_all is 'true', enable both agent and recipe validation
+      if validate_all == "true":
+          validate_agents = "true"
+          validate_recipes = "true"
+
+      result = {
+          "validate_agents": validate_agents,
+          "validate_recipes": validate_recipes,
+          "validate_all": validate_all
+      }
+
+      print(json.dumps(result))
+      EOF
+    output: "validation_flags"
+    parse_json: true
+    timeout: 10
+    depends_on: ["environment-check"]
 
   # ============================================================================
   # PHASE 0.5: Packaging Consistency Check
@@ -1948,6 +1985,44 @@ steps:
     depends_on: ["validate-all-bundles"]
 
   # ============================================================================
+  # PHASE 2.6.0: Recipe Validation (Opt-In via validate_recipes or validate_all)
+  # Runs validate-recipes.yaml as a sub-recipe when requested
+  # ============================================================================
+
+  - id: "validate-recipes"
+    type: "recipe"
+    recipe: "recipes:recipes/validate-recipes.yaml"
+    condition: "{{validation_flags.validate_recipes}} == 'true'"
+    context:
+      repo_path: "{{repo_path}}"
+      recipes_dir: "{{recipes_dir}}"
+      known_agents: "{{known_agents}}"
+    output: "recipe_validation"
+    timeout: 600
+    on_error: "continue"
+    depends_on: ["repo-discovery"]
+
+  - id: "set-default-recipe-validation"
+    type: "bash"
+    command: |
+      python3 << 'EOF'
+      import json
+
+      result = {
+          "quality_level": "good",
+          "summary": "Recipe validation not performed",
+          "recipes_validated": 0,
+          "skipped": True
+      }
+
+      print(json.dumps(result))
+      EOF
+    output: "recipe_validation"
+    parse_json: true
+    timeout: 10
+    depends_on: ["validate-all-flags"]
+
+  # ============================================================================
   # PHASE 2.6: Quality Classification (Deterministic)
   # Enhanced in v3.0.0 to incorporate all new validation phases
   # ============================================================================
@@ -2007,6 +2082,12 @@ steps:
           tool_placement = json.loads(tool_placement_raw)
       except (json.JSONDecodeError, ValueError):
           tool_placement = {"passed": True, "skipped": True}
+
+      recipe_validation_raw = '''{{recipe_validation}}'''
+      try:
+          recipe_validation = json.loads(recipe_validation_raw)
+      except (json.JSONDecodeError, ValueError):
+          recipe_validation = {"quality_level": "good", "skipped": True, "summary": "Recipe validation not performed"}
 
       # Handle case where individual validation was skipped
       if individual.get("skipped", False):
@@ -2266,14 +2347,23 @@ steps:
           critical_count += len([i for i in results["hygiene_issues"] if i.get("severity") == "ERROR"])
           critical_count += len([i for i in results["completeness_issues"] if i.get("severity") == "ERROR"])
           critical_count += len([i for i in results["experiment_issues"] if i.get("severity") == "ERROR"])
+
+          # Recipe validation impact
+          recipe_quality = recipe_validation.get("quality_level", "good")
+          if recipe_quality == "critical":
+              critical_count += 1
           
           needs_work_count = results["summary"]["needs_work"]
           needs_work_count += len([i for i in results["structural_issues"] if i.get("severity") == "needs_work"])
+          if recipe_quality == "needs_work":
+              needs_work_count += 1
           
           warning_count = results["summary"]["polish"]
           warning_count += len([i for i in results["hygiene_issues"] if i.get("severity") == "WARNING"])
           warning_count += len([i for i in results["context_sink_issues"] if i.get("severity") == "WARNING"])
           warning_count += len([i for i in results["experiment_issues"] if i.get("severity") == "WARNING"])
+          if recipe_quality == "polish":
+              warning_count += 1
           
           if critical_count > 0:
               results["quality_level"] = "critical"
@@ -2314,6 +2404,14 @@ steps:
               "context_sink_warnings": len([i for i in results["context_sink_issues"] if i.get("severity") == "WARNING"]),
               "tool_placement_suggestions": len(results["tool_placement_issues"])
           }
+
+          # v3.3.0: Recipe validation summary
+          results["recipe_validation_summary"] = {
+              "performed": not recipe_validation.get("skipped", False),
+              "quality_level": recipe_validation.get("quality_level", "good"),
+              "summary": recipe_validation.get("summary", "Recipe validation not performed"),
+              "recipes_validated": recipe_validation.get("recipes_validated", 0)
+          }
           
           # v3.2.0: Add environment limitations summary
           results["environment_summary"] = {
@@ -2330,7 +2428,7 @@ steps:
     output: "quality_classification"
     parse_json: true
     timeout: 60
-    depends_on: ["validate-all-bundles", "behavior-hygiene-validation", "standalone-completeness-validation", "experiments-validation", "context-sink-compliance", "tool-placement-analysis"]
+    depends_on: ["validate-all-bundles", "behavior-hygiene-validation", "standalone-completeness-validation", "experiments-validation", "context-sink-compliance", "tool-placement-analysis", "validate-recipes", "set-default-recipe-validation"]
 
   # ============================================================================
   # PHASE 2.75: Initialize Optional Outputs
@@ -2671,6 +2769,11 @@ steps:
       {{tool_placement_results}}
       ```
 
+      **Recipe Validation (v3.3.0):**
+      ```json
+      {{recipe_validation}}
+      ```
+
       **Quick Approval Summary:**
       {{approval_summary}}
 
@@ -2814,4 +2917,4 @@ steps:
         - Python packaging must build successfully (if present)
     output: "final_report"
     timeout: 300
-    depends_on: ["quality-classification", "quick-approval", "composition-analysis", "repo-conventions", "set-default-approval-summary", "set-default-composition-analysis", "set-default-repo-conventions"]
+    depends_on: ["quality-classification", "quick-approval", "composition-analysis", "repo-conventions", "set-default-approval-summary", "set-default-composition-analysis", "set-default-repo-conventions", "set-default-recipe-validation"]

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -1,9 +1,17 @@
 # validate-bundle-repo.yaml
-# Repository-Wide Bundle Validator Recipe v3.2.0
+# Repository-Wide Bundle Validator Recipe v3.3.0
 # Validates an entire bundle repository against structural requirements, conventions,
 # and Amplifier bundle philosophy (context sink pattern, thin behaviors, tool placement)
 #
 # CHANGELOG:
+# v3.3.0 - Opt-in recipe validation integration
+#        - New context vars: validate_recipes, validate_all, recipes_dir, known_agents
+#        - Phase 0.1: validate-all-flags step expands validate_all convenience flag
+#        - Phase 2.6.0: validate-recipes sub-recipe step (opt-in, on_error: continue)
+#        - set-default-recipe-validation provides no-op default when skipped
+#        - quality-classification incorporates recipe quality_level into scoring
+#        - synthesize-report includes Recipe Validation section
+#
 # v3.2.0 - Graceful environment handling
 #        - Phase 0 now checks prerequisites without auto-install attempts
 #        - Detects hatchling, amplifier_foundation, pip wheel capability
@@ -116,7 +124,7 @@ description: |
   - All measurements use TOKENS (len/4), never line counts
   
   For single bundle validation, use validate-bundle.yaml instead.
-version: "3.2.0"
+version: "3.3.0"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "repository", "packaging", "hygiene", "context-sink"]
 
@@ -2000,7 +2008,7 @@ steps:
     output: "recipe_validation"
     timeout: 600
     on_error: "continue"
-    depends_on: ["repo-discovery"]
+    depends_on: ["repo-discovery", "validate-all-flags"]
 
   - id: "set-default-recipe-validation"
     type: "bash"

--- a/tests/test_validate_bundle_repo_integration.py
+++ b/tests/test_validate_bundle_repo_integration.py
@@ -1,0 +1,343 @@
+"""Integration tests for validate-bundle-repo.yaml v3.3.0 changes.
+
+Verifies:
+- Valid YAML structure
+- Presence and correctness of new context variables
+- Presence and correctness of new steps (validate-all-flags, validate-recipes,
+  set-default-recipe-validation)
+- quality-classification depends_on includes new steps
+- synthesize-report prompt includes Recipe Validation block
+- version metadata is up-to-date
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+RECIPE_PATH = Path(__file__).parent.parent / "recipes" / "validate-bundle-repo.yaml"
+
+
+@pytest.fixture(scope="module")
+def recipe_data():
+    """Load and parse the recipe YAML once for all tests."""
+    if not RECIPE_PATH.exists():
+        pytest.skip("Recipe file not found")
+    content = RECIPE_PATH.read_text(encoding="utf-8")
+    return yaml.safe_load(content), content
+
+
+@pytest.fixture(scope="module")
+def steps_by_id(recipe_data):
+    """Build a dict of steps keyed by id for easy lookup."""
+    data, _ = recipe_data
+    return {step["id"]: step for step in data.get("steps", []) if "id" in step}
+
+
+# ── YAML validity ─────────────────────────────────────────────────────────────
+
+
+class TestYAMLValidity:
+    def test_recipe_is_valid_yaml(self, recipe_data):
+        """Recipe must parse as a valid YAML dict."""
+        data, _ = recipe_data
+        assert isinstance(data, dict), "Top-level must be a dict"
+
+    def test_recipe_has_name(self, recipe_data):
+        """Recipe must have a name field."""
+        data, _ = recipe_data
+        assert "name" in data
+
+    def test_recipe_has_version(self, recipe_data):
+        """Recipe must have a version field."""
+        data, _ = recipe_data
+        assert "version" in data
+
+    def test_recipe_has_steps(self, recipe_data):
+        """Recipe must have a non-empty steps list."""
+        data, _ = recipe_data
+        assert isinstance(data.get("steps"), list)
+        assert len(data["steps"]) > 0
+
+
+# ── Version metadata ──────────────────────────────────────────────────────────
+
+
+class TestVersionMetadata:
+    def test_version_is_3_3_0(self, recipe_data):
+        """version field must be '3.3.0' to reflect v3.3.0 changes."""
+        data, _ = recipe_data
+        assert data["version"] == "3.3.0", (
+            f"Expected version '3.3.0', got '{data['version']}'. "
+            "The version field must be bumped when significant changes are made."
+        )
+
+    def test_header_comment_references_v3_3_0(self, recipe_data):
+        """File header comment must reference v3.3.0."""
+        _, content = recipe_data
+        # The first few lines should mention v3.3.0
+        header_lines = content.split("\n")[:5]
+        header = "\n".join(header_lines)
+        assert "3.3.0" in header, (
+            "Header comment must be updated to reference v3.3.0. "
+            f"Found header:\n{header}"
+        )
+
+    def test_changelog_has_v3_3_0_entry(self, recipe_data):
+        """Changelog section must contain a v3.3.0 entry."""
+        _, content = recipe_data
+        assert "v3.3.0" in content, (
+            "Changelog must contain a v3.3.0 entry describing the recipe validation "
+            "integration changes."
+        )
+
+
+# ── New context variables ─────────────────────────────────────────────────────
+
+
+class TestNewContextVariables:
+    def test_context_has_validate_recipes(self, recipe_data):
+        """Context must include validate_recipes variable."""
+        data, _ = recipe_data
+        ctx = data.get("context", {})
+        assert "validate_recipes" in ctx, (
+            "Context must have validate_recipes variable (opt-in recipe validation flag)"
+        )
+
+    def test_validate_recipes_default_is_false(self, recipe_data):
+        """validate_recipes default must be 'false'."""
+        data, _ = recipe_data
+        ctx = data.get("context", {})
+        assert ctx.get("validate_recipes") == "false"
+
+    def test_context_has_validate_all(self, recipe_data):
+        """Context must include validate_all convenience flag."""
+        data, _ = recipe_data
+        ctx = data.get("context", {})
+        assert "validate_all" in ctx, "Context must have validate_all convenience flag"
+
+    def test_validate_all_default_is_false(self, recipe_data):
+        """validate_all default must be 'false'."""
+        data, _ = recipe_data
+        ctx = data.get("context", {})
+        assert ctx.get("validate_all") == "false"
+
+    def test_context_has_recipes_dir(self, recipe_data):
+        """Context must include recipes_dir variable."""
+        data, _ = recipe_data
+        ctx = data.get("context", {})
+        assert "recipes_dir" in ctx, (
+            "Context must have recipes_dir for sub-recipe invocation"
+        )
+
+    def test_recipes_dir_default_is_recipes(self, recipe_data):
+        """recipes_dir default must be 'recipes'."""
+        data, _ = recipe_data
+        ctx = data.get("context", {})
+        assert ctx.get("recipes_dir") == "recipes"
+
+    def test_context_has_known_agents(self, recipe_data):
+        """Context must include known_agents variable."""
+        data, _ = recipe_data
+        ctx = data.get("context", {})
+        assert "known_agents" in ctx, (
+            "Context must have known_agents for recipe validation"
+        )
+
+    def test_known_agents_default_is_empty_string(self, recipe_data):
+        """known_agents default must be empty string."""
+        data, _ = recipe_data
+        ctx = data.get("context", {})
+        # Default is '' (empty string) - YAML may load as None or ''
+        val = ctx.get("known_agents")
+        assert val == "" or val is None, (
+            f"known_agents default should be '' or None, got {val!r}"
+        )
+
+
+# ── validate-all-flags step ───────────────────────────────────────────────────
+
+
+class TestValidateAllFlagsStep:
+    def test_validate_all_flags_step_exists(self, steps_by_id):
+        """validate-all-flags step must be present."""
+        assert "validate-all-flags" in steps_by_id, (
+            "Step 'validate-all-flags' not found in recipe steps"
+        )
+
+    def test_validate_all_flags_is_bash(self, steps_by_id):
+        """validate-all-flags must be a bash step."""
+        step = steps_by_id.get("validate-all-flags", {})
+        assert step.get("type") == "bash"
+
+    def test_validate_all_flags_output_is_validation_flags(self, steps_by_id):
+        """validate-all-flags output must be 'validation_flags'."""
+        step = steps_by_id.get("validate-all-flags", {})
+        assert step.get("output") == "validation_flags"
+
+    def test_validate_all_flags_parse_json(self, steps_by_id):
+        """validate-all-flags must have parse_json: true."""
+        step = steps_by_id.get("validate-all-flags", {})
+        assert step.get("parse_json") is True
+
+    def test_validate_all_flags_depends_on_environment_check(self, steps_by_id):
+        """validate-all-flags must depend on environment-check."""
+        step = steps_by_id.get("validate-all-flags", {})
+        depends = step.get("depends_on", [])
+        assert "environment-check" in depends
+
+
+# ── validate-recipes step ─────────────────────────────────────────────────────
+
+
+class TestValidateRecipesStep:
+    def test_validate_recipes_step_exists(self, steps_by_id):
+        """validate-recipes step must be present."""
+        assert "validate-recipes" in steps_by_id, (
+            "Step 'validate-recipes' not found in recipe steps"
+        )
+
+    def test_validate_recipes_is_recipe_type(self, steps_by_id):
+        """validate-recipes must be type 'recipe'."""
+        step = steps_by_id.get("validate-recipes", {})
+        assert step.get("type") == "recipe"
+
+    def test_validate_recipes_has_condition(self, steps_by_id):
+        """validate-recipes must have a condition for opt-in behavior."""
+        step = steps_by_id.get("validate-recipes", {})
+        assert "condition" in step, "validate-recipes must have a condition (opt-in)"
+        assert "validate_recipes" in step["condition"]
+
+    def test_validate_recipes_on_error_continue(self, steps_by_id):
+        """validate-recipes must have on_error: continue."""
+        step = steps_by_id.get("validate-recipes", {})
+        assert step.get("on_error") == "continue"
+
+    def test_validate_recipes_output_is_recipe_validation(self, steps_by_id):
+        """validate-recipes output must be 'recipe_validation'."""
+        step = steps_by_id.get("validate-recipes", {})
+        assert step.get("output") == "recipe_validation"
+
+    def test_validate_recipes_depends_on_repo_discovery(self, steps_by_id):
+        """validate-recipes must depend on repo-discovery."""
+        step = steps_by_id.get("validate-recipes", {})
+        depends = step.get("depends_on", [])
+        assert "repo-discovery" in depends
+
+    def test_validate_recipes_depends_on_validate_all_flags(self, steps_by_id):
+        """validate-recipes must depend on validate-all-flags.
+
+        This is required because the condition reads validation_flags.validate_recipes,
+        which is the output of validate-all-flags. Without this dependency, the recipe
+        engine could evaluate the condition before validate-all-flags completes.
+        """
+        step = steps_by_id.get("validate-recipes", {})
+        depends = step.get("depends_on", [])
+        assert "validate-all-flags" in depends, (
+            "validate-recipes depends_on is missing 'validate-all-flags'. "
+            "The condition {{validation_flags.validate_recipes}} consumes the output "
+            "of validate-all-flags; the dependency must be explicit."
+        )
+
+    def test_validate_recipes_context_passes_repo_path(self, steps_by_id):
+        """validate-recipes context must pass repo_path."""
+        step = steps_by_id.get("validate-recipes", {})
+        ctx = step.get("context", {})
+        assert "repo_path" in ctx
+
+    def test_validate_recipes_context_passes_recipes_dir(self, steps_by_id):
+        """validate-recipes context must pass recipes_dir."""
+        step = steps_by_id.get("validate-recipes", {})
+        ctx = step.get("context", {})
+        assert "recipes_dir" in ctx
+
+    def test_validate_recipes_context_passes_known_agents(self, steps_by_id):
+        """validate-recipes context must pass known_agents."""
+        step = steps_by_id.get("validate-recipes", {})
+        ctx = step.get("context", {})
+        assert "known_agents" in ctx
+
+
+# ── set-default-recipe-validation step ───────────────────────────────────────
+
+
+class TestSetDefaultRecipeValidationStep:
+    def test_set_default_step_exists(self, steps_by_id):
+        """set-default-recipe-validation step must be present."""
+        assert "set-default-recipe-validation" in steps_by_id, (
+            "Step 'set-default-recipe-validation' not found in recipe steps"
+        )
+
+    def test_set_default_is_bash(self, steps_by_id):
+        """set-default-recipe-validation must be a bash step."""
+        step = steps_by_id.get("set-default-recipe-validation", {})
+        assert step.get("type") == "bash"
+
+    def test_set_default_output_is_recipe_validation(self, steps_by_id):
+        """set-default-recipe-validation output must be 'recipe_validation'."""
+        step = steps_by_id.get("set-default-recipe-validation", {})
+        assert step.get("output") == "recipe_validation"
+
+    def test_set_default_parse_json(self, steps_by_id):
+        """set-default-recipe-validation must have parse_json: true."""
+        step = steps_by_id.get("set-default-recipe-validation", {})
+        assert step.get("parse_json") is True
+
+    def test_set_default_depends_on_validate_all_flags(self, steps_by_id):
+        """set-default-recipe-validation must depend on validate-all-flags."""
+        step = steps_by_id.get("set-default-recipe-validation", {})
+        depends = step.get("depends_on", [])
+        assert "validate-all-flags" in depends
+
+
+# ── quality-classification depends_on ────────────────────────────────────────
+
+
+class TestQualityClassificationDependsOn:
+    def test_quality_classification_exists(self, steps_by_id):
+        """quality-classification step must be present."""
+        assert "quality-classification" in steps_by_id
+
+    def test_quality_classification_depends_on_validate_recipes(self, steps_by_id):
+        """quality-classification must depend on validate-recipes."""
+        step = steps_by_id.get("quality-classification", {})
+        depends = step.get("depends_on", [])
+        assert "validate-recipes" in depends, (
+            "quality-classification depends_on must include 'validate-recipes'"
+        )
+
+    def test_quality_classification_depends_on_set_default_recipe_validation(
+        self, steps_by_id
+    ):
+        """quality-classification must depend on set-default-recipe-validation."""
+        step = steps_by_id.get("quality-classification", {})
+        depends = step.get("depends_on", [])
+        assert "set-default-recipe-validation" in depends, (
+            "quality-classification depends_on must include 'set-default-recipe-validation'"
+        )
+
+
+# ── synthesize-report prompt ──────────────────────────────────────────────────
+
+
+class TestSynthesizeReportPrompt:
+    def test_synthesize_report_exists(self, steps_by_id):
+        """synthesize-report step must be present."""
+        assert "synthesize-report" in steps_by_id
+
+    def test_synthesize_report_includes_recipe_validation_block(self, recipe_data):
+        """synthesize-report prompt must include Recipe Validation section."""
+        _, content = recipe_data
+        assert "Recipe Validation" in content, (
+            "synthesize-report prompt must include a Recipe Validation section"
+        )
+
+    def test_synthesize_report_depends_on_set_default_recipe_validation(
+        self, steps_by_id
+    ):
+        """synthesize-report must depend on set-default-recipe-validation."""
+        step = steps_by_id.get("synthesize-report", {})
+        depends = step.get("depends_on", [])
+        assert "set-default-recipe-validation" in depends, (
+            "synthesize-report depends_on must include 'set-default-recipe-validation'"
+        )


### PR DESCRIPTION
## Summary
- New Phase 2.7: calls validate-recipes.yaml from amplifier-bundle-recipes as opt-in sub-recipe
- New context variables: validate_recipes, validate_all, recipes_dir, known_agents
- Updated quality-classification and synthesize-report phases to incorporate recipe validation results

## Test plan
- Integration with validate-recipes.yaml verified ✓
- Race condition prevented with explicit condition in set-default-recipe-validation ✓
- Code quality review issues addressed ✓

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)