### PR TITLE
fix: add explicit on_error handlers to all validation recipe steps

### DIFF
--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -121,6 +121,7 @@ steps:
     output: "env_check"
     parse_json: true
     timeout: 30
+    on_error: "fail"
 
   # ============================================================================
   # PHASE 1: Agent Discovery
@@ -216,6 +217,7 @@ steps:
     output: "discovery_results"
     parse_json: true
     timeout: 60
+    on_error: "fail"
     depends_on: ["environment-check"]
 
   # ============================================================================
@@ -736,6 +738,7 @@ steps:
     output: "quality_classification"
     parse_json: true
     timeout: 60
+    on_error: "fail"
     depends_on: ["structural-validation"]
 
   # ============================================================================
@@ -763,6 +766,7 @@ steps:
     output: "optional_defaults"
     parse_json: true
     timeout: 30
+    on_error: "fail"
     depends_on: ["quality-classification"]
 
   # Set individual default values (will be overwritten by conditional steps if they run)
@@ -772,6 +776,7 @@ steps:
       echo "_Quick approval not performed - detailed LLM analysis was run instead._"
     output: "approval_summary"
     timeout: 10
+    on_error: "fail"
     depends_on: ["initialize-optional-outputs"]
 
   - id: "set-default-quality-results"
@@ -780,6 +785,7 @@ steps:
       echo "_Description quality analysis not performed - all agents met quality thresholds via deterministic checks._"
     output: "quality_results"
     timeout: 10
+    on_error: "fail"
     depends_on: ["initialize-optional-outputs"]
 
   - id: "set-default-tool-analysis"
@@ -788,6 +794,7 @@ steps:
       echo "_Tool access analysis not performed - all agents have explicit tool declarations._"
     output: "tool_analysis"
     timeout: 10
+    on_error: "fail"
     depends_on: ["initialize-optional-outputs"]
 
   # ============================================================================
@@ -838,6 +845,7 @@ steps:
       - [0-2 minor suggestions, or "None - agents are exemplary"]
     output: "approval_summary"
     timeout: 120
+    on_error: "continue"
 
   # ============================================================================
   # PHASE 4: Description Quality Analysis (Agent-Based, Conditional)
@@ -958,6 +966,7 @@ steps:
       List agents with quality == "good" - acknowledge they meet standards, do NOT suggest changes.
     output: "quality_results"
     timeout: 600
+    on_error: "continue"
     depends_on: ["quality-classification"]
 
   # ============================================================================
@@ -1047,6 +1056,7 @@ steps:
       List agents with has_explicit_tools == true - acknowledge they're correct.
     output: "tool_analysis"
     timeout: 600
+    on_error: "continue"
     depends_on: ["description-quality-check"]
 
   # ============================================================================
@@ -1199,4 +1209,5 @@ steps:
       **IMPORTANT:** If verdict is PASS, emphasize that the agents are GOOD and any suggestions are truly optional polish, not required changes.
     output: "final_report"
     timeout: 300
+    on_error: "fail"
     depends_on: ["quality-classification", "quick-approval", "description-quality-check", "tool-access-analysis", "set-default-approval-summary", "set-default-quality-results", "set-default-tool-analysis"]

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -278,6 +278,7 @@ steps:
     output: "env_check"
     parse_json: true
     timeout: 30
+    on_error: "fail"
 
   # ============================================================================
   # PHASE 0.1: Validate-All Flags Expansion
@@ -413,6 +414,7 @@ steps:
     output: "packaging_check"
     parse_json: true
     timeout: 30
+    on_error: "continue"
     depends_on: ["environment-check"]
 
   # ============================================================================
@@ -581,6 +583,7 @@ steps:
     output: "build_check"
     parse_json: true
     timeout: 10
+    on_error: "fail"
     depends_on: ["packaging-check"]
 
   # ============================================================================
@@ -722,6 +725,7 @@ steps:
     output: "discovery_results"
     parse_json: true
     timeout: 60
+    on_error: "fail"
     depends_on: ["packaging-check", "build-check", "set-default-build-check"]
 
   # ============================================================================
@@ -1170,6 +1174,7 @@ steps:
     output: "behavior_hygiene_results"
     parse_json: true
     timeout: 120
+    on_error: "continue"
     depends_on: ["validate-all-bundles"]
 
   # ============================================================================
@@ -1385,6 +1390,7 @@ steps:
     output: "standalone_completeness_results"
     parse_json: true
     timeout: 180
+    on_error: "continue"
     depends_on: ["validate-all-bundles"]
 
   # ============================================================================
@@ -1523,6 +1529,7 @@ steps:
     output: "experiments_validation_results"
     parse_json: true
     timeout: 120
+    on_error: "continue"
     depends_on: ["validate-all-bundles"]
 
   # ============================================================================
@@ -1702,6 +1709,7 @@ steps:
     output: "context_sink_results"
     parse_json: true
     timeout: 120
+    on_error: "continue"
     depends_on: ["validate-all-bundles"]
 
   # ============================================================================
@@ -1990,6 +1998,7 @@ steps:
     output: "tool_placement_results"
     parse_json: true
     timeout: 120
+    on_error: "continue"
     depends_on: ["validate-all-bundles"]
 
   # ============================================================================
@@ -2029,6 +2038,7 @@ steps:
     output: "recipe_validation"
     parse_json: true
     timeout: 10
+    on_error: "fail"
     depends_on: ["validate-all-flags"]
 
   # ============================================================================
@@ -2437,6 +2447,7 @@ steps:
     output: "quality_classification"
     parse_json: true
     timeout: 60
+    on_error: "fail"
     depends_on: ["validate-all-bundles", "behavior-hygiene-validation", "standalone-completeness-validation", "experiments-validation", "context-sink-compliance", "tool-placement-analysis", "validate-recipes", "set-default-recipe-validation"]
 
   # ============================================================================
@@ -2460,6 +2471,7 @@ steps:
     output: "optional_defaults"
     parse_json: true
     timeout: 30
+    on_error: "fail"
     depends_on: ["quality-classification"]
 
   - id: "set-default-approval-summary"
@@ -2468,6 +2480,7 @@ steps:
       echo "_Quick approval not performed - detailed LLM analysis was run instead._"
     output: "approval_summary"
     timeout: 10
+    on_error: "fail"
     depends_on: ["initialize-optional-outputs"]
 
   - id: "set-default-composition-analysis"
@@ -2476,6 +2489,7 @@ steps:
       echo "_Composition analysis not performed - all bundles met quality thresholds via deterministic checks._"
     output: "composition_analysis"
     timeout: 10
+    on_error: "fail"
     depends_on: ["initialize-optional-outputs"]
 
   - id: "set-default-repo-conventions"
@@ -2484,6 +2498,7 @@ steps:
       echo "_Convention analysis not performed - all bundles met quality thresholds._"
     output: "repo_conventions"
     timeout: 10
+    on_error: "fail"
     depends_on: ["initialize-optional-outputs"]
 
   # ============================================================================
@@ -2548,6 +2563,7 @@ steps:
       - [0-2 minor suggestions, or "None - repository is exemplary"]
     output: "approval_summary"
     timeout: 120
+    on_error: "continue"
 
   # ============================================================================
   # PHASE 4: Repository Composition Analysis (Conditional)
@@ -2644,6 +2660,7 @@ steps:
       - **Fix**: How to resolve
     output: "composition_analysis"
     timeout: 300
+    on_error: "continue"
     depends_on: ["quality-classification"]
 
   # ============================================================================
@@ -2703,6 +2720,7 @@ steps:
       Only list FAIL items if they genuinely break functionality or violate hygiene rules.
     output: "repo_conventions"
     timeout: 300
+    on_error: "continue"
     depends_on: ["composition-analysis"]
 
   # ============================================================================
@@ -2926,4 +2944,5 @@ steps:
         - Python packaging must build successfully (if present)
     output: "final_report"
     timeout: 300
+    on_error: "fail"
     depends_on: ["quality-classification", "quick-approval", "composition-analysis", "repo-conventions", "set-default-approval-summary", "set-default-composition-analysis", "set-default-repo-conventions", "set-default-recipe-validation"]

--- a/recipes/validate-bundle.yaml
+++ b/recipes/validate-bundle.yaml
@@ -92,6 +92,7 @@ steps:
     output: "env_check"
     parse_json: true
     timeout: 180
+    on_error: "fail"
 
   # ============================================================================
   # PHASE 2: Bundle Discovery
@@ -176,6 +177,7 @@ steps:
     output: "discovery"
     parse_json: true
     timeout: 30
+    on_error: "fail"
     depends_on: ["environment-check"]
 
   # ============================================================================
@@ -196,6 +198,7 @@ steps:
       bundle_type: "{{bundle.bundle_type}}"
       repo_root: "{{bundle.repo_root}}"
     timeout: 600
+    on_error: "continue"
     depends_on: ["discover-bundles"]
 
   # ============================================================================
@@ -273,4 +276,5 @@ steps:
       - Dependency tracing: enabled
     output: "final_report"
     timeout: 300
+    on_error: "fail"
     depends_on: ["validate-bundles"]

--- a/recipes/validate-single-bundle.yaml
+++ b/recipes/validate-single-bundle.yaml
@@ -256,6 +256,7 @@ steps:
     output: "traced_deps"
     parse_json: true
     timeout: 60
+    on_error: "fail"
 
   # ============================================================================
   # STEP 2: Context analysis using ONLY traced dependencies
@@ -471,6 +472,7 @@ steps:
     output: "context_results"
     parse_json: true
     timeout: 60
+    on_error: "fail"
     depends_on: ["trace-dependencies"]
 
   # ============================================================================
@@ -527,4 +529,5 @@ steps:
       This helps identify where context bloat originates.
     output: "bundle_report"
     timeout: 180
+    on_error: "fail"
     depends_on: ["context-analysis"]


### PR DESCRIPTION
Added on_error handlers to all 4 validation recipes per recipe-author's recommendations: validate-single-bundle.yaml (3 steps → fail), validate-bundle.yaml (4 steps, foreach → continue), validate-agents.yaml (12 steps, LLM analysis steps → continue), validate-bundle-repo.yaml (20 steps, validation phases → continue, setup/classification/report → fail). Validation results improved from 19 warnings to 1 warning. 2 of 4 recipes now PASS clean.