### PR TITLE
docs(session-repair): enforce script-only repair workflow for session-analyst

### DIFF
--- a/agents/session-analyst.md
+++ b/agents/session-analyst.md
@@ -376,7 +376,7 @@ See @foundation:context/agents/session-storage-knowledge.md for complete safe ex
 ## Important Constraints
 
 - **Read-only by default**: Do not modify session files unless explicitly asked to repair/rewind
-- **Backup before repair**: When modifying files for repair, ALWAYS create a `.bak` backup first
+- **Backup before repair**: The repair script creates timestamped backups automatically before any modification
 - **Privacy-aware**: Sessions may contain sensitive information - present findings without editorializing
 - **Scoped search**: Only search within ~/.amplifier/ directories
 - **Efficient**: Use metadata filtering before content search to minimize file I/O
@@ -401,73 +401,89 @@ See @foundation:context/agents/session-storage-knowledge.md for complete safe ex
 → Metadata search filtering by created date
 
 **"Rewind session X to before my last message"**
-→ Find last user message in events.jsonl, backup file, truncate to remove that message and everything after
+→ Run session-repair.py with --diagnose first, then --rewind to truncate history to before the issue
 
 ---
 
 ## Session Repair (Default) / Rewind (Explicit Only)
 
-Sessions break in three predictable ways. Your job is to detect which failure mode(s) are present, then repair (default) or rewind (only when the user explicitly asks).
+Sessions break in three predictable ways. Your job is to use the repair script to detect which failure mode(s) are present, then repair (default) or rewind (only when the user explicitly asks).
 
-### Three Failure Modes
+### ⚠️ MANDATORY: Use the Script — No Manual Repair
 
-| Failure Mode | Description | Detection |
-|-------------|-------------|-----------|
-| **FM1: Missing tool results** | Assistant issued `tool_calls` but matching `tool_result` entries are absent | `comm -23 <(jq -r '.tool_calls[]?.id' transcript.jsonl \| sort -u) <(jq -r 'select(.role=="tool") \| .tool_call_id' transcript.jsonl \| sort -u)` |
-| **FM2: Ordering violations** | Consecutive messages with the same role (e.g., two assistant messages in a row) | `jq -r .role transcript.jsonl \| uniq -d` |
-| **FM3: Incomplete assistant turns** | Assistant message has neither `.content` nor `.tool_calls` | `jq -c 'select(.role=="assistant" and (.content == null or .content == "") and (.tool_calls == null or (.tool_calls \| length == 0)))' transcript.jsonl` |
+**NEVER attempt to manually edit transcript.jsonl or events.jsonl for repair or rewind.**
 
-### Repair Workflow (Default)
+The repair script at `scripts/session-repair.py` (in the amplifier-foundation repo) handles all diagnosis, repair, and rewind operations. It creates timestamped backups automatically before any modification.
 
-When a session won't resume, **repair first** (inject synthetic entries to complete broken turns). Only rewind if the user explicitly requests it.
+**If the script fails, report the error and STOP. Do not attempt manual repair as a fallback.**
 
-**Script-assisted repair (preferred):**
+Manual JSONL editing by a fast-model agent has proven to break sessions further. The script is the only safe path.
 
-```bash
-# scripts/session-repair.py is in the amplifier-foundation repo root
-# 1. Diagnose
-python scripts/session-repair.py diagnose /path/to/session/
+### Three Failure Modes (Conceptual Awareness)
 
-# 2. Repair (dry-run first, then apply)
-python scripts/session-repair.py repair /path/to/session/ --dry-run
-python scripts/session-repair.py repair /path/to/session/
+These are the structural problems the script detects and repairs. You need to understand them to interpret `--diagnose` output and explain findings to the user — but you do NOT detect or fix them manually.
 
-# 3. Verify
-python scripts/session-repair.py diagnose /path/to/session/
-```
+| Failure Mode | What It Means |
+|-------------|---------------|
+| **FM1: Missing tool results** | Assistant issued `tool_calls` but matching `tool_result` entries are absent — provider will reject the transcript |
+| **FM2: Ordering violations** | A `tool_result` exists but is in the wrong position (a real user message appears between the `tool_use` and its result) |
+| **FM3: Incomplete assistant turns** | Tool results are present and correctly ordered, but there is no final assistant text response before the next real user message |
 
-**Manual repair fallback:** If the script is unavailable or you need finer control, follow the manual procedures in @foundation:context/agents/session-repair-knowledge.md which covers the full COMPLETE workflow including when to add synthetic assistant responses and tool results.
+### Required Workflow
 
-### Rewind Workflow (Only When Explicitly Requested)
+**Always follow this exact sequence. No exceptions.**
 
-Rewind truncates session history to a point before the issue. **Only use when the user explicitly asks to rewind/rollback.**
-
-**Script-assisted rewind:**
+#### Step 1: Locate the script and session
 
 ```bash
-python scripts/session-repair.py rewind /path/to/session/ --to-line N
+# Find the script (it's in the amplifier-foundation repo)
+SCRIPT="$(find / -path '*/amplifier-foundation/scripts/session-repair.py' -type f 2>/dev/null | head -1)"
+
+# Find the session directory
+SESSION_DIR="$(find ~/.amplifier/projects/*/sessions -name '*SESSION_ID*' -type d 2>/dev/null | head -1)"
 ```
 
-**Manual rewind procedure:**
+#### Step 2: Diagnose FIRST (always)
 
-1. **Locate the session** - Find the session directory by ID
-2. **Find the target point** - Locate the message to rewind to in BOTH `transcript.jsonl` and `events.jsonl`
-3. **Create backups** - ALWAYS backup before modification: `cp transcript.jsonl transcript.jsonl.bak && cp events.jsonl events.jsonl.bak`
-4. **Truncate transcript.jsonl** - `head -n $((TARGET_LINE - 1)) transcript.jsonl > transcript.jsonl.tmp && mv transcript.jsonl.tmp transcript.jsonl`
-5. **Truncate events.jsonl** - Find corresponding event line, truncate similarly
-6. **Verify integrity** - Check line counts, ensure tool event pre/post pairs are balanced
+```bash
+python "$SCRIPT" --diagnose "$SESSION_DIR"
+```
 
-### Repair Strategies
+**Report the full diagnosis output to the caller.** This is read-only and safe.
+- Exit code 0 = healthy (no repair needed)
+- Exit code 1 = broken (proceed to Step 3)
 
-| Strategy | Action | Best For |
-|----------|--------|----------|
-| **REPLACE** | Remove broken turn, insert error summary message | Turn is garbage, minimal value to preserve |
-| **COMPLETE** | Add synthetic `tool_result` entries to fill gaps | Preserve context, just fix the incomplete state |
-| **REWIND** | Truncate back to earlier point | User explicitly wants to retry from a clean slate |
+#### Step 3: Repair or Rewind
 
-**CRITICAL: Every orphaned `tool_call` MUST have a synthetic `tool_result`.** If the actual error cannot be determined, use an unknown error - an unknown error result is infinitely better than no result at all, as the provider will reject transcripts with missing `tool_results`.
+**If repair** (the default — use unless user explicitly says "rewind"):
+```bash
+python "$SCRIPT" --repair "$SESSION_DIR"
+```
 
-See @foundation:context/agents/session-repair-knowledge.md for detailed repair procedures and @foundation:context/agents/session-storage-knowledge.md for session file format and safe extraction patterns.
+**If rewind** (only when user explicitly requests rewind/rollback/truncate):
+```bash
+python "$SCRIPT" --rewind "$SESSION_DIR"
+```
+
+**Report the full output to the caller.**
+
+#### Step 4: Verify
+
+Run `--diagnose` again to confirm the fix worked:
+```bash
+python "$SCRIPT" --diagnose "$SESSION_DIR"
+```
+
+**Report the verification result.** Exit code 0 = success.
+
+### If the Script Fails
+
+**STOP. Do not attempt manual repair.**
+
+Report to the caller:
+1. The exact error message from the script
+2. The exit code
+3. Suggest they escalate or file an issue — the script may need to be updated for this edge case
 
 ### Important: Parent Session Modifications
 
@@ -475,7 +491,7 @@ When you modify a session that is **currently running** (typically the parent se
 
 **Always inform the caller when modifying their parent/current session** to close and resume:
 
-> "I've repaired session `{session_id}` (applied {strategy} to fix {failure_mode}). Since this is your currently active session, you'll need to **close and resume** it:
+> "I've repaired session `{session_id}`. Since this is your currently active session, you'll need to **close and resume** it:
 > 1. Exit your current session (Ctrl-D or `/exit`)
 > 2. Resume with: `amplifier session resume {session_id}`"
 

--- a/context/agents/session-repair-knowledge.md
+++ b/context/agents/session-repair-knowledge.md
@@ -1,121 +1,36 @@
 # Session Repair Deep Knowledge
 
-This context file contains everything needed to diagnose and repair broken Amplifier session transcripts. It covers three failure modes, repair procedures with exact JSON templates, and a verification checklist.
+Reference documentation for the session repair script and the failure modes it handles. This file describes WHAT breaks and HOW THE SCRIPT fixes it — not manual procedures.
 
 **Repair-first default:** ALWAYS attempt REPAIR before REWIND. Repair preserves maximum context. Rewind only when the user explicitly requests it.
 
----
-
-## Diagnostic Framework
-
-When a session fails to resume (typically with provider errors like `"tool_use ids found without tool_result blocks"`), follow this 5-step diagnostic procedure.
-
-### Step 1: Build the tool index
-
-Find every `tool_use` ID and every `tool_result` ID in the transcript, with their line numbers.
-
-```bash
-# All tool_use IDs
-jq -r '.tool_calls[]?.id // empty' transcript.jsonl
-
-# All tool_result IDs
-jq -r 'select(.role == "tool") | .tool_call_id' transcript.jsonl
-```
-
-Or use the programmatic script:
-```bash
-python scripts/session-repair.py /path/to/session --diagnose
-```
-
-### Step 2: Check for orphans (Failure Mode 1)
-
-A `tool_use` ID with **no matching `tool_result` anywhere** in the transcript.
-
-```bash
-comm -23 \
-  <(jq -r '.tool_calls[]?.id' transcript.jsonl 2>/dev/null | sort -u) \
-  <(jq -r 'select(.role == "tool") | .tool_call_id' transcript.jsonl 2>/dev/null | sort -u)
-```
-
-If this outputs IDs, those are orphaned tool_calls needing synthetic results.
-
-### Step 3: Check for ordering violations (Failure Mode 2)
-
-A `tool_result` **exists** but a real user message or a different assistant turn appears between the `tool_use` and its result. This means the results arrived "late" after the conversation moved on.
-
-**Key distinction:** A "real user message" is `role: "user"` AND no `tool_call_id` field AND content not wrapped in `<system-reminder>` tags. System-injected messages and tool results are NOT real user messages.
-
-Detection requires checking the **ordering** of entries, not just existence:
-1. For each `tool_use` ID that HAS a matching `tool_result`, check the entries between them
-2. If any real user message or non-tool-calling assistant message appears between them, it is an ordering violation
-
-### Step 4: Check for incomplete assistant turns (Failure Mode 3)
-
-Tool results are present and in the correct position, but there is **no final assistant text response** before the next real user message. This means the assistant's turn started (tool calls dispatched, results received) but never completed.
-
-Detection:
-1. For each assistant message with `tool_calls`, find the last matching `tool_result`
-2. Check the entry immediately after that last result
-3. If it's a real user message (or end of transcript), the turn is incomplete
-
-### Step 5: Classify
-
-A transcript can have **multiple failure modes simultaneously**. The real `4f63147f` case had all three: some tool results were in the wrong position, some were missing entirely, and an assistant response was missing.
+**Script-only rule:** ALL diagnosis, repair, and rewind operations MUST use `scripts/session-repair.py`. Never attempt manual JSONL editing.
 
 ---
 
-## Repair Procedures
+## Three Failure Modes
 
-### Repairing Missing Tool Results (Failure Mode 1)
+These are the structural problems that cause sessions to fail on resume (typically with provider errors like `"tool_use ids found without tool_result blocks"`). A transcript can have **multiple failure modes simultaneously**.
 
-**Action:** Inject a synthetic `tool_result` entry immediately after the assistant message containing the `tool_use`.
+### FM1: Missing Tool Results
 
-**Synthetic tool_result format:**
-```json
-{
-  "role": "tool",
-  "tool_call_id": "<matching_tool_use_id>",
-  "name": "<tool_name>",
-  "content": "{\"error\": \"unknown_error\", \"message\": \"Tool execution was interrupted and no result was captured.\"}"
-}
-```
+Assistant issued `tool_calls` but matching `tool_result` entries are absent from the transcript. The provider will reject the session on resume because every `tool_use` ID must have a paired result.
 
-**Important details:**
-- `tool_call_id` MUST exactly match the `id` from the `tool_call`
-- `name` MUST match the tool name from the `tool_call`'s `function.name`
-- `content` MUST be a JSON-encoded STRING (double-escaped quotes), not a nested object
-- Insert immediately after the assistant message, before any following entries
+**Script action:** Injects synthetic `tool_result` entries with error content immediately after the assistant message containing the orphaned `tool_calls`.
 
-### Repairing Misplaced Tool Results (Failure Mode 2)
+### FM2: Ordering Violations
 
-**Action:** Remove the late-arriving results from their wrong position. Inject synthetic results in the correct position (immediately after the assistant message with `tool_use`s).
+A `tool_result` exists but a real user message or different assistant turn appears between the `tool_use` and its result. The results arrived "late" after the conversation moved on, putting them in an invalid position.
 
-Steps:
-1. Identify the misplaced `tool_result` entries (those with a real user message between their `tool_use` and themselves)
-2. Remove them from their current positions
-3. Inject synthetic `tool_result` entries immediately after the assistant message, using the same format as Failure Mode 1
-4. If all tool_calls from that assistant message were misplaced and the next entry is a real user message, also inject a synthetic assistant response
+**Key distinction:** A "real user message" is `role: "user"` with no `tool_call_id` field and content not wrapped in `<system-reminder>` tags. System-injected messages and tool results are NOT real user messages.
 
-The real results' content is lost (they were in an invalid position), but the session becomes structurally valid.
+**Script action:** Removes misplaced results and injects synthetic results in the correct position (immediately after the assistant message).
 
-### Repairing Incomplete Assistant Turns (Failure Mode 3)
+### FM3: Incomplete Assistant Turns
 
-**Action:** Inject a synthetic assistant message to close the turn. Insert after the last `tool_result` of the incomplete turn, before the next real user message.
+Tool results are present and correctly ordered, but there is no final assistant text response before the next real user message. The assistant's turn started (tool calls dispatched, results received) but never completed.
 
-**Synthetic assistant response format:**
-```json
-{
-  "role": "assistant",
-  "content": [
-    {
-      "type": "text",
-      "text": "The previous tool calls were interrupted. This response was automatically repaired."
-    }
-  ]
-}
-```
-
-Note the `content` field is a **list** of content blocks (not a plain string). This matches the provider-expected format for assistant messages with structured content.
+**Script action:** Injects a synthetic assistant response to close the incomplete turn.
 
 ---
 
@@ -129,66 +44,26 @@ Note the `content` field is a **list** of content blocks (not a plain string). T
 **Rationale for repair-first:**
 - Preserves maximum conversation context (the assistant's thinking, tool call intentions, partial results)
 - User picks up where things went wrong and steers forward
-- Rewind loses all context after the truncation point -- it's the nuclear option
-- Repair is safe: backups are always created before modification
-
----
-
-## Verification Checklist
-
-After any repair, ALL five checks must pass:
-
-1. [ ] All JSONL lines parse as valid JSON
-2. [ ] Every `tool_use` ID has a matching `tool_result` (no orphans)
-3. [ ] No `tool_result`s appear with a real user message between them and their `tool_use` (no ordering violations)
-4. [ ] No real user messages interrupt an assistant turn (between `tool_use`s and their results)
-5. [ ] Every assistant turn that dispatched tools has a final assistant text response before the next real user message (complete turns)
-
-**Quick verification command:**
-```bash
-python scripts/session-repair.py /path/to/session --diagnose
-# Exit code 0 + {"status": "healthy", ...} = all checks pass
-# Exit code 1 + {"status": "broken", ...} = issues remain
-```
-
-**Manual verification:**
-```bash
-# Check 1: Valid JSONL
-python3 -c "
-import json, sys
-for i, line in enumerate(open('transcript.jsonl'), 1):
-    try: json.loads(line)
-    except json.JSONDecodeError: print(f'Invalid JSON at line {i}'); sys.exit(1)
-print('All lines valid')
-"
-
-# Check 2: No orphaned tool_calls
-comm -23 \
-  <(jq -r '.tool_calls[]?.id' transcript.jsonl 2>/dev/null | sort -u) \
-  <(jq -r 'select(.role == "tool") | .tool_call_id' transcript.jsonl 2>/dev/null | sort -u)
-# Should output nothing
-
-# Check 3-5: Use the script for comprehensive structural verification
-python scripts/session-repair.py /path/to/session --diagnose | jq .
-```
+- Rewind loses all context after the truncation point — it's the nuclear option
+- Repair is safe: the script always creates timestamped backups before modification
 
 ---
 
 ## Programmatic Repair Script
 
-**Location:** `scripts/session-repair.py` (stdlib-only Python, no dependencies)
+**Location:** `scripts/session-repair.py` (in the amplifier-foundation repo, stdlib-only Python, no dependencies)
 
 ### Usage
 
 ```bash
 # Diagnose only (read-only, safe)
-python scripts/session-repair.py /path/to/session --diagnose
+python scripts/session-repair.py --diagnose /path/to/session/
 
-# Repair with COMPLETE strategy (creates backup first)
-python scripts/session-repair.py /path/to/session --repair
+# Repair with COMPLETE strategy (creates timestamped backup first)
+python scripts/session-repair.py --repair /path/to/session/
 
-# Rewind (truncate -- creates backups of both transcript and events)
-python scripts/session-repair.py /path/to/session --rewind
+# Rewind (truncate — creates timestamped backups of both transcript and events)
+python scripts/session-repair.py --rewind /path/to/session/
 ```
 
 ### Exit Codes
@@ -220,12 +95,12 @@ Fields:
 - `incomplete_turns`: list of `{"after_line": N, "missing": "assistant_response"}` entries
 - `recommended_action`: `"none"` (healthy) or `"repair"` (broken)
 
-### When to Fall Back to Manual Repair
+### Verification
 
-Use manual repair (following the procedures in this document) when:
-- The script encounters an edge case it doesn't handle
-- The script fails with an unexpected error
-- The transcript has an unusual structure the script wasn't designed for
-- You need to make selective repairs (e.g., repair some issues but not others)
+After any repair or rewind, run `--diagnose` again to confirm success:
 
-The script always creates timestamped backups (`transcript.jsonl.bak-pre-repair-YYYYMMDDHHMMSS`) before modification, so it's safe to try the script first and fall back to manual if needed.
+```bash
+python scripts/session-repair.py --diagnose /path/to/session/
+# Exit code 0 + {"status": "healthy"} = all checks pass
+# Exit code 1 + {"status": "broken"} = issues remain
+```


### PR DESCRIPTION
## Summary

- **Problem**: session-analyst (Haiku-class/fast model) was choosing to perform manual JSONL transcript editing instead of using the Python repair script, causing it to break sessions further rather than repair them.
- **Solution**: Enforce script-only repair workflow with no manual fallback options and explicit prohibition on manual JSONL editing.
- **Impact**: Prevents session-analyst from inadvertently corrupting session state through manual editing attempts.

## Changes

### 1. agents/session-analyst.md
- Removed all manual repair/rewind procedures (manual JSONL editing, bash detection commands, manual rewind steps)
- Added mandatory script-only workflow requiring the agent to always use `scripts/session-repair.py`
- Defined 4-step sequence: locate → diagnose → repair/rewind → verify
- Added explicit prohibition on manual JSONL editing with rationale: "Manual JSONL editing by a fast-model agent has proven to break sessions further"
- Simplified failure mode table to conceptual awareness only

### 2. context/agents/session-repair-knowledge.md
- Full replacement: 196 lines → 106 lines
- Removed all manual diagnostic procedures, JSON templates, and manual repair steps
- Removed "When to Fall Back to Manual Repair" escape hatch
- Reframed as reference documentation about what breaks and how the script fixes it
- Retained failure mode descriptions, repair-first philosophy, and full script reference

## Test plan
- [x] Reviewed changes to verify script-only workflow is enforced
- [x] Confirmed no manual repair/rewind procedures remain as options
- [x] Verified prohibition on manual JSONL editing is explicit
- [x] Checked that session-analyst guidance aligns with repair-script behavior

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)