### PR TITLE
fix: use Path.replace() for cross-platform atomic write in install_state.py

### DIFF
--- a/amplifier_foundation/modules/install_state.py
+++ b/amplifier_foundation/modules/install_state.py
@@ -192,7 +192,7 @@ class InstallStateManager:
         # Ensure parent directory exists
         self._state_file.parent.mkdir(parents=True, exist_ok=True)
 
-        # Atomic write: write to temp file, then rename
+        # Atomic write: write to temp file, then replace (cross-platform safe)
         try:
             fd, temp_path = tempfile.mkstemp(
                 dir=self._state_file.parent,
@@ -202,7 +202,7 @@ class InstallStateManager:
             try:
                 with open(fd, "w") as f:
                     json.dump(self._state, f, indent=2)
-                Path(temp_path).rename(self._state_file)
+                Path(temp_path).replace(self._state_file)
                 self._dirty = False
             except Exception:
                 # Clean up temp file on failure

--- a/tests/test_install_state.py
+++ b/tests/test_install_state.py
@@ -217,6 +217,36 @@ class TestInstallStateManager:
             manager2 = InstallStateManager(cache_dir)
             assert manager2.is_installed(module_dir)
 
+    def test_save_overwrites_existing_state_file(self) -> None:
+        """save() works when install-state.json already exists (Windows regression).
+
+        On Windows, Path.rename() raises FileExistsError when the destination
+        exists. Path.replace() works cross-platform. This test verifies the
+        overwrite path that was broken before the .rename() -> .replace() fix.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            state_file = cache_dir / "install-state.json"
+
+            # First save — creates the file
+            manager1 = InstallStateManager(cache_dir)
+            manager1.save()
+            assert state_file.exists()
+            first_content = json.loads(state_file.read_text())
+            assert first_content["modules"] == {}
+
+            # Mark a module installed and save again — overwrites the file
+            module_dir = Path(tmpdir) / "test-module"
+            module_dir.mkdir()
+            (module_dir / "pyproject.toml").write_text('[project]\nname = "test"\n')
+            manager1.mark_installed(module_dir)
+            manager1.save()
+
+            # Verify the overwrite succeeded
+            second_content = json.loads(state_file.read_text())
+            assert second_content["modules"] != {}
+            assert str(module_dir.resolve()) in second_content["modules"]
+
     def test_invalidate_specific_module(self) -> None:
         """Can invalidate a specific module."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

`Path.rename()` on line 205 of `install_state.py` fails on Windows when the target file already exists (`WinError 183`). After the first successful save, every subsequent `save()` call silently fails, causing Amplifier to re-download and re-install all modules on every launch.

## Fix

One-word change: `.rename()` → `.replace()` (line 205). `Path.replace()` is backed by `os.replace()`, which atomically overwrites the destination on all platforms. This matches the pattern already established in `amplifier_foundation/io/files.py:158` (`_write_atomic()`).

Also updates the comment on line 195 and adds a regression test that exercises the overwrite path.

## Changes

| File | Change |
|------|--------|
| `amplifier_foundation/modules/install_state.py:195` | Comment: "then rename" → "then replace (cross-platform safe)" |
| `amplifier_foundation/modules/install_state.py:205` | `.rename()` → `.replace()` |
| `tests/test_install_state.py` | Added `test_save_overwrites_existing_state_file` |

## Testing

- All 13 install state tests pass (12 existing + 1 new regression test)
- Code quality checks clean (ruff format, ruff lint, pyright, stub check)

## Risk

None. `Path.replace()` is identical to `Path.rename()` on POSIX — the only difference is that it also works on Windows.