### PR TITLE
feat(session): restructure session library with unified CLI and script-only agent workflow

### DIFF
--- a/agents/session-analyst.md
+++ b/agents/session-analyst.md
@@ -292,7 +292,7 @@ See @foundation:context/agents/session-storage-knowledge.md for complete safe ex
 ```bash
 SCRIPT="$(find / -path '*/amplifier-foundation/scripts/amplifier-session.py' -type f 2>/dev/null | head -1)"
 SESSION_DIR="$(find ~/.amplifier/projects/*/sessions -name '*SESSION_ID*' -type d 2>/dev/null | head -1)"
-python "$SCRIPT" --diagnose "$SESSION_DIR"
+python "$SCRIPT" diagnose "$SESSION_DIR"
 ```
 
 **"Find session c3843177"**
@@ -322,7 +322,7 @@ python "$SCRIPT" find --date 2025-11-25
 **"Rewind session X"**
 
 ```bash
-python "$SCRIPT" --rewind "$SESSION_DIR"
+python "$SCRIPT" rewind "$SESSION_DIR"
 ```
 
 ---
@@ -341,7 +341,7 @@ The unified script `scripts/amplifier-session.py` handles all diagnosis, repair,
 
 ### Three Failure Modes (Conceptual Awareness)
 
-These are the structural problems the script detects and repairs. You need to understand them to interpret `--diagnose` output and explain findings to the user — but you do NOT detect or fix them manually.
+These are the structural problems the script detects and repairs. You need to understand them to interpret `diagnose` output and explain findings to the user — but you do NOT detect or fix them manually.
 
 | Failure Mode | What It Means |
 |-------------|---------------|
@@ -358,14 +358,14 @@ SCRIPT="$(find / -path '*/amplifier-foundation/scripts/amplifier-session.py' -ty
 SESSION_DIR="$(find ~/.amplifier/projects/*/sessions -name '*SESSION_ID*' -type d 2>/dev/null | head -1)"
 
 # Step 1: Diagnose (exit 0 = healthy, exit 1 = broken — report output to caller)
-python "$SCRIPT" --diagnose "$SESSION_DIR"
+python "$SCRIPT" diagnose "$SESSION_DIR"
 
 # Step 2: Repair (default) or Rewind (only if user explicitly requests)
-python "$SCRIPT" --repair "$SESSION_DIR"    # default
-python "$SCRIPT" --rewind "$SESSION_DIR"    # only when user asks for rewind/rollback
+python "$SCRIPT" repair "$SESSION_DIR"    # default
+python "$SCRIPT" rewind "$SESSION_DIR"    # only when user asks for rewind/rollback
 
 # Step 3: Verify (exit 0 = success — report output to caller)
-python "$SCRIPT" --diagnose "$SESSION_DIR"
+python "$SCRIPT" diagnose "$SESSION_DIR"
 ```
 
 ### If the Script Fails

--- a/agents/session-analyst.md
+++ b/agents/session-analyst.md
@@ -211,71 +211,11 @@ python "$SCRIPT" find --project azure --date-after 2025-11-20 --keyword caching
 
 ### 3. Synthesize Results
 
-Don't just list sessions — analyze and synthesize conversation content. Produce a structured report:
-
-**Analysis goals:**
-
-- Identify conversation themes and main topics discussed
-- Extract key decisions, conclusions, or insights
-- Note technical details, implementations, or solutions created
-- Summarize outcomes and action items
-- Connect related sessions if multiple found
-
-**Format:**
-
-```
-## Synthesis: [Brief description of what was found]
-
-### Overview
-[2-3 sentences synthesizing the main themes across found sessions]
-
-### Session: [session_id]
-- **Location**: [full path]
-- **Created**: [readable date/time]
-- **Project**: [project name from path]
-- **Bundle**: [bundle name] | **Model**: [model] | **Turns**: [count]
-
-**Conversation Summary:**
-[Paragraph describing what this conversation was about]
-
-**Key Points:**
-- [Important decision/insight 1]
-- [Technical detail/implementation 2]
-- [Outcome/action item 3]
-
-**Notable Exchanges:**
-```
-
-User: [relevant question/request]
-Assistant: [key response excerpt]
-
-```
-
----
-
-### Session: [next_session_id]
-[...]
-
-### Cross-Session Insights
-[If multiple sessions found, note patterns, evolution of thinking, related topics]
-```
+Don't just list sessions — analyze and synthesize. Begin with a brief **Overview** across all results. For each session: metadata (location, created, bundle, model, turns), a conversation summary, and key points. Note **Cross-Session Insights** if multiple sessions found (patterns, evolution of thinking, related topics).
 
 ## Final Response Contract
 
-Your final message must stand on its own for the caller—nothing else from this run is visible. Always include:
-
-1. **Synthesis Summary**: 2-3 sentences capturing the essence of what was discussed across sessions, key insights gained, or problems solved
-2. **Session Analysis**: For each session, provide:
-   - Metadata and location
-   - Conversation summary (not just excerpts)
-   - Key points, decisions, or technical details
-   - Notable exchanges that illustrate the discussion
-3. **Coverage & Context**: Note what was searched, time periods covered, and any patterns across sessions
-4. **Suggested Next Actions**: Concrete follow-ups such as:
-   - "Review full transcript: `cat <path>/transcript.jsonl`"
-   - "Continue this work with zen-architect for [specific next step]"
-   - "Compare with session [ID] which discussed related topic"
-5. **Not Found**: If no matches, explain what was searched and suggest broadening criteria or alternative search strategies
+Your final message must stand on its own. Include: synthesis summary, session analysis (metadata + conversation summary + key points), coverage notes, suggested next actions, and "not found" guidance if no results.
 
 ## Search Strategies
 
@@ -411,46 +351,22 @@ These are the structural problems the script detects and repairs. You need to un
 
 ### Required Workflow
 
-**Always follow this exact sequence. No exceptions.**
-
-First, locate the script and session:
+**Always follow this exact sequence:**
 
 ```bash
 SCRIPT="$(find / -path '*/amplifier-foundation/scripts/amplifier-session.py' -type f 2>/dev/null | head -1)"
 SESSION_DIR="$(find ~/.amplifier/projects/*/sessions -name '*SESSION_ID*' -type d 2>/dev/null | head -1)"
-```
 
-#### Step 1: Diagnose
+# Step 1: Diagnose (exit 0 = healthy, exit 1 = broken — report output to caller)
+python "$SCRIPT" --diagnose "$SESSION_DIR"
 
-```bash
+# Step 2: Repair (default) or Rewind (only if user explicitly requests)
+python "$SCRIPT" --repair "$SESSION_DIR"    # default
+python "$SCRIPT" --rewind "$SESSION_DIR"    # only when user asks for rewind/rollback
+
+# Step 3: Verify (exit 0 = success — report output to caller)
 python "$SCRIPT" --diagnose "$SESSION_DIR"
 ```
-
-**Report the full diagnosis output to the caller.** This is read-only and safe.
-- Exit code 0 = healthy (no repair needed)
-- Exit code 1 = broken (proceed to Step 2)
-
-#### Step 2: Repair or Rewind
-
-**If repair** (the default — use unless user explicitly says "rewind"):
-```bash
-python "$SCRIPT" --repair "$SESSION_DIR"
-```
-
-**If rewind** (only when user explicitly requests rewind/rollback/truncate):
-```bash
-python "$SCRIPT" --rewind "$SESSION_DIR"
-```
-
-**Report the full output to the caller.**
-
-#### Step 3: Verify
-
-```bash
-python "$SCRIPT" --diagnose "$SESSION_DIR"
-```
-
-**Report the verification result.** Exit code 0 = success.
 
 ### If the Script Fails
 

--- a/agents/session-analyst.md
+++ b/agents/session-analyst.md
@@ -165,16 +165,11 @@ If no search criteria provided, ask for at least one constraint.
 
 Amplifier stores sessions at: `~/.amplifier/projects/PROJECT_NAME/sessions/SESSION_ID/`
 
-- `metadata.json`: Contains session_id, created (ISO timestamp), bundle, model, turn_count
-- `transcript.jsonl`: JSONL format with message roles:
-  - `user`: Prompts (human in root sessions, caller agent in sub-sessions)
-  - `assistant`: LLM responses (may include `tool_calls` array)
-  - `tool`: Tool execution results (linked by `tool_call_id`)
-  
-  **Attribution rule**: Check `parent_id` in events.jsonl. If present, this is a 
-  sub-session and "user" = the parent session's assistant. To find the human, 
-  trace up the parent chain until you reach a session with no parent_id.
-- `events.jsonl`: Full event log - **DANGER: lines can be 100k+ tokens**
+- `metadata.json` — session_id, created (ISO timestamp), bundle, model, turn_count
+- `transcript.jsonl` — JSONL conversation messages (user / assistant / tool roles)
+- `events.jsonl` — Full event log — **⚠️ DANGER: lines can be 100k+ tokens**
+
+**Attribution rule**: Check `parent_id` in events.jsonl. If present, this is a sub-session and "user" = the parent session's assistant. To find the human, trace up the parent chain until you reach a session with no parent_id.
 
 ## Operating Principles
 
@@ -189,51 +184,34 @@ Amplifier stores sessions at: `~/.amplifier/projects/PROJECT_NAME/sessions/SESSI
 
 ## Search Workflow
 
-### 1. Clarify Search Scope
+### 1. Locate the Script
 
-Restate the user's search criteria and create a search plan using the todo tool:
-
-```
-Search Plan:
-- Scope: [Project folders or all projects]
-- Time range: [If specified]
-- Search terms: [Keywords or topics]
-- Approach: [Metadata only vs. content search vs. event analysis]
+```bash
+SCRIPT="$(find / -path '*/amplifier-foundation/scripts/amplifier-session.py' -type f 2>/dev/null | head -1)"
 ```
 
-### 2. Locate Candidate Sessions
+### 2. Find Sessions
 
-**If session ID provided:**
+```bash
+# By session ID (partial OK)
+python "$SCRIPT" find --id c3843177
 
-- Search for exact or partial match: `find ~/.amplifier/projects/*/sessions -name "*SESSION_ID*" -type d`
+# By project
+python "$SCRIPT" find --project azure
 
-**If project/folder specified:**
+# By date
+python "$SCRIPT" find --date 2025-11-25
 
-- List sessions in that project: `~/.amplifier/projects/*/sessions/` filtered by project name in path
+# By keyword in transcripts
+python "$SCRIPT" find --keyword authentication
 
-**If date range specified:**
+# Combined filters
+python "$SCRIPT" find --project azure --date-after 2025-11-20 --keyword caching
+```
 
-- Search metadata.json files for created timestamps in range
+### 3. Synthesize Results
 
-**If no constraints:**
-
-- List all sessions with basic metadata
-
-### 3. Filter and Search Content
-
-**For metadata filtering:**
-
-- Read metadata.json files to check: created date, bundle, model, turn_count
-
-**For content search:**
-
-- Grep through transcript.jsonl for keywords
-- Use context flags (-B 2 -A 2) to show surrounding conversation
-- Parse JSONL to extract meaningful exchanges
-
-### 4. Synthesize Results
-
-Don't just list sessions - analyze and synthesize conversation content. Produce a structured report:
+Don't just list sessions — analyze and synthesize conversation content. Produce a structured report:
 
 **Analysis goals:**
 
@@ -304,41 +282,25 @@ Your final message must stand on its own for the caller—nothing else from this
 ### By Session ID
 
 ```bash
-# Find session directory
-find ~/.amplifier/projects/*/sessions -name "*SESSION_ID*" -type d
-
-# Read metadata
-cat PATH/metadata.json | jq .
-
-# Read transcript
-cat PATH/transcript.jsonl
+python "$SCRIPT" find --id SESSION_ID
 ```
 
 ### By Project
 
 ```bash
-# List all sessions in project (replace PROJECT with actual project name)
-ls -lt ~/.amplifier/projects/*/sessions/ | grep PROJECT
-
-# Get metadata for recent sessions in specific project
-find ~/.amplifier/projects/*PROJECT*/sessions -name "metadata.json" -exec cat {} \;
+python "$SCRIPT" find --project PROJECT_NAME
 ```
 
 ### By Date Range
 
 ```bash
-# Find sessions created after date
-find ~/.amplifier/projects/*/sessions -name "metadata.json" -exec grep -l "2025-11-25" {} \;
+python "$SCRIPT" find --date-after 2025-11-01 --date-before 2025-11-30
 ```
 
 ### By Content/Keywords
 
 ```bash
-# Search transcript content (transcript.jsonl is usually safe)
-grep -r "authentication" ~/.amplifier/projects/*/sessions/*/transcript.jsonl
-
-# CAUTION: For events.jsonl, get line numbers only - lines can be 100k+ tokens
-grep -n "authentication" ~/.amplifier/projects/*/sessions/*/events.jsonl | cut -d: -f1 | head -10
+python "$SCRIPT" find --keyword SEARCH_TERM
 ```
 
 ### Deep Event Analysis (events.jsonl)
@@ -386,38 +348,56 @@ See @foundation:context/agents/session-storage-knowledge.md for complete safe ex
 ## Example Queries
 
 **"Why won't session X resume?"**
-→ Analyze events.jsonl for errors, check for orphaned tool calls, examine API responses
+
+```bash
+SCRIPT="$(find / -path '*/amplifier-foundation/scripts/amplifier-session.py' -type f 2>/dev/null | head -1)"
+SESSION_DIR="$(find ~/.amplifier/projects/*/sessions -name '*SESSION_ID*' -type d 2>/dev/null | head -1)"
+python "$SCRIPT" --diagnose "$SESSION_DIR"
+```
 
 **"Find session c3843177"**
-→ Search for directory matching that ID, show metadata and excerpt
 
-**"Sessions from last week in the azure project"**
-→ Filter by project path + created timestamp
+```bash
+python "$SCRIPT" find --id c3843177
+```
+
+**"Sessions from last week"**
+
+```bash
+python "$SCRIPT" find --date-after "$(date -d '7 days ago' +%Y-%m-%d)"
+```
 
 **"Conversation about authentication"**
-→ Content search across transcripts for "authentication" keyword
+
+```bash
+python "$SCRIPT" find --keyword authentication
+```
 
 **"All sessions from November 25"**
-→ Metadata search filtering by created date
 
-**"Rewind session X to before my last message"**
-→ Run session-repair.py with --diagnose first, then --rewind to truncate history to before the issue
+```bash
+python "$SCRIPT" find --date 2025-11-25
+```
+
+**"Rewind session X"**
+
+```bash
+python "$SCRIPT" --rewind "$SESSION_DIR"
+```
 
 ---
 
 ## Session Repair (Default) / Rewind (Explicit Only)
 
-Sessions break in three predictable ways. Your job is to use the repair script to detect which failure mode(s) are present, then repair (default) or rewind (only when the user explicitly asks).
+Sessions break in three predictable ways. Use the unified script to detect and fix them.
 
-### ⚠️ MANDATORY: Use the Script — No Manual Repair
+### ⚠️ MANDATORY: Script Only — No Manual Repair
 
 **NEVER attempt to manually edit transcript.jsonl or events.jsonl for repair or rewind.**
 
-The repair script at `scripts/session-repair.py` (in the amplifier-foundation repo) handles all diagnosis, repair, and rewind operations. It creates timestamped backups automatically before any modification.
+The unified script `scripts/amplifier-session.py` handles all diagnosis, repair, and rewind operations. It creates timestamped backups automatically before any modification.
 
 **If the script fails, report the error and STOP. Do not attempt manual repair as a fallback.**
-
-Manual JSONL editing by a fast-model agent has proven to break sessions further. The script is the only safe path.
 
 ### Three Failure Modes (Conceptual Awareness)
 
@@ -433,17 +413,14 @@ These are the structural problems the script detects and repairs. You need to un
 
 **Always follow this exact sequence. No exceptions.**
 
-#### Step 1: Locate the script and session
+First, locate the script and session:
 
 ```bash
-# Find the script (it's in the amplifier-foundation repo)
-SCRIPT="$(find / -path '*/amplifier-foundation/scripts/session-repair.py' -type f 2>/dev/null | head -1)"
-
-# Find the session directory
+SCRIPT="$(find / -path '*/amplifier-foundation/scripts/amplifier-session.py' -type f 2>/dev/null | head -1)"
 SESSION_DIR="$(find ~/.amplifier/projects/*/sessions -name '*SESSION_ID*' -type d 2>/dev/null | head -1)"
 ```
 
-#### Step 2: Diagnose FIRST (always)
+#### Step 1: Diagnose
 
 ```bash
 python "$SCRIPT" --diagnose "$SESSION_DIR"
@@ -451,9 +428,9 @@ python "$SCRIPT" --diagnose "$SESSION_DIR"
 
 **Report the full diagnosis output to the caller.** This is read-only and safe.
 - Exit code 0 = healthy (no repair needed)
-- Exit code 1 = broken (proceed to Step 3)
+- Exit code 1 = broken (proceed to Step 2)
 
-#### Step 3: Repair or Rewind
+#### Step 2: Repair or Rewind
 
 **If repair** (the default — use unless user explicitly says "rewind"):
 ```bash
@@ -467,9 +444,8 @@ python "$SCRIPT" --rewind "$SESSION_DIR"
 
 **Report the full output to the caller.**
 
-#### Step 4: Verify
+#### Step 3: Verify
 
-Run `--diagnose` again to confirm the fix worked:
 ```bash
 python "$SCRIPT" --diagnose "$SESSION_DIR"
 ```

--- a/amplifier_foundation/session/__init__.py
+++ b/amplifier_foundation/session/__init__.py
@@ -124,6 +124,13 @@ from .store import (
     write_transcript,
 )
 
+# Finder operations (Level 3 — directory conventions)
+from .finder import (
+    find_sessions,
+    resolve_session,
+    session_info,
+)
+
 # Capability helpers (for modules to access session context)
 from .capabilities import (
     WORKING_DIR_CAPABILITY,
@@ -172,6 +179,10 @@ __all__ = [
     "write_jsonl",
     "write_metadata",
     "write_transcript",
+    # Finder operations
+    "resolve_session",
+    "find_sessions",
+    "session_info",
     # Capability helpers
     "WORKING_DIR_CAPABILITY",
     "get_working_dir",

--- a/amplifier_foundation/session/__init__.py
+++ b/amplifier_foundation/session/__init__.py
@@ -1,8 +1,10 @@
 """Session utilities for Amplifier.
 
-This module provides utilities for session fork, slice, and lineage operations.
+This module provides utilities for session management, including fork, slice,
+lineage, diagnosis, and repair operations.
 
 Key concepts:
+
 - **Fork**: Create a new session from an existing session at a specific turn.
   The forked session preserves conversation history up to that turn and is
   independently resumable.
@@ -13,7 +15,24 @@ Key concepts:
 - **Lineage**: Parent-child relationships between sessions, tracked via
   `parent_id` in session metadata. Enables tracing session history.
 
-Example usage:
+- **Diagnosis**: Structured analysis of a transcript to detect failure modes
+  such as missing tool results, ordering violations, and incomplete assistant
+  turns. Produces a ``DiagnosisResult`` with recommended repair action.
+
+Module layers:
+
+- **Level 1 — Message Algebra** (``messages``, ``diagnosis``): Pure functions
+  operating on ``list[dict]`` with zero I/O.  All inputs and outputs are plain
+  Python data structures.
+
+- **Level 2 — JSONL Store** (``store``): Knows file formats and session file
+  naming conventions; performs file I/O but has no knowledge of where sessions
+  live on disk.
+
+- **Level 3 — Session Operations** (``fork``, ``events``): Combines Levels 1
+  and 2 to provide end-to-end session fork, slice, and event operations.
+
+Example usage::
 
     from amplifier_foundation.session import fork_session, ForkResult
 
@@ -30,6 +49,18 @@ Example usage:
     messages = await context.get_messages()
     result = fork_session_in_memory(messages, turn=2)
     await new_context.set_messages(result.messages)
+
+    # Diagnose and repair a broken transcript
+    from amplifier_foundation.session import (
+        load_transcript_with_lines,
+        diagnose_transcript,
+        repair_transcript,
+    )
+
+    entries = load_transcript_with_lines(session_dir)
+    diagnosis = diagnose_transcript(entries)
+    if diagnosis["status"] == "broken":
+        repaired = repair_transcript(entries, diagnosis)
 
 The kernel (amplifier-core) already provides the mechanism for session forking
 via the `parent_id` parameter in AmplifierSession and the `session:fork` event.
@@ -57,14 +88,40 @@ from .events import (
     slice_events_to_timestamp,
 )
 
-# Slice utilities (for advanced use cases)
-from .slice import (
+# Message algebra utilities (Level 1, zero I/O)
+from .messages import (
     add_synthetic_tool_results,
     count_turns,
     find_orphaned_tool_calls,
     get_turn_boundaries,
     get_turn_summary,
+    is_real_user_message,
     slice_to_turn,
+)
+
+# Diagnosis and repair utilities (Level 1, zero I/O)
+from .diagnosis import (
+    DiagnosisResult,
+    IncompleteTurn,
+    build_tool_index,
+    diagnose_transcript,
+    repair_transcript,
+    rewind_transcript,
+)
+
+# JSONL store utilities (Level 2, file I/O)
+from .store import (
+    EVENTS_FILENAME,
+    METADATA_FILENAME,
+    TRANSCRIPT_FILENAME,
+    backup,
+    load_metadata,
+    load_transcript,
+    load_transcript_with_lines,
+    read_jsonl,
+    write_jsonl,
+    write_metadata,
+    write_transcript,
 )
 
 # Capability helpers (for modules to access session context)
@@ -83,18 +140,38 @@ __all__ = [
     "get_session_lineage",
     "list_session_forks",
     # Events utilities
-    "slice_events_to_timestamp",
-    "slice_events_for_fork",
-    "get_last_timestamp_for_turn",
     "count_events",
     "get_event_summary",
-    # Slice utilities
-    "get_turn_boundaries",
-    "count_turns",
-    "slice_to_turn",
-    "find_orphaned_tool_calls",
+    "get_last_timestamp_for_turn",
+    "slice_events_for_fork",
+    "slice_events_to_timestamp",
+    # Message algebra utilities
     "add_synthetic_tool_results",
+    "count_turns",
+    "find_orphaned_tool_calls",
+    "get_turn_boundaries",
     "get_turn_summary",
+    "is_real_user_message",
+    "slice_to_turn",
+    # Diagnosis and repair utilities
+    "DiagnosisResult",
+    "IncompleteTurn",
+    "build_tool_index",
+    "diagnose_transcript",
+    "repair_transcript",
+    "rewind_transcript",
+    # JSONL store utilities
+    "EVENTS_FILENAME",
+    "METADATA_FILENAME",
+    "TRANSCRIPT_FILENAME",
+    "backup",
+    "load_metadata",
+    "load_transcript",
+    "load_transcript_with_lines",
+    "read_jsonl",
+    "write_jsonl",
+    "write_metadata",
+    "write_transcript",
     # Capability helpers
     "WORKING_DIR_CAPABILITY",
     "get_working_dir",

--- a/amplifier_foundation/session/diagnosis.py
+++ b/amplifier_foundation/session/diagnosis.py
@@ -1,0 +1,404 @@
+"""Layer Level 1, pure, zero I/O.
+
+Extract repair algorithms from session transcripts.
+
+This module provides pure functions for diagnosing, repairing, and rewinding
+conversation transcripts. All functions are side-effect free and perform no
+file I/O. Entries must already be parsed and annotated with ``line_num`` keys
+(1-based) before being passed to these functions.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TypedDict
+
+from .messages import is_real_user_message
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+class IncompleteTurn(TypedDict):
+    after_line: int
+    missing: str
+
+
+class DiagnosisResult(TypedDict):
+    status: str  # "healthy" | "broken"
+    failure_modes: list[str]
+    orphaned_tool_ids: list[str]
+    misplaced_tool_ids: list[str]
+    incomplete_turns: list[IncompleteTurn]
+    recommended_action: (
+        str  # "none" | "repair" | "rewind" (rewind reserved for future use)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SYNTHETIC_TOOL_RESULT_CONTENT: str = json.dumps(
+    {
+        "error": "unknown_error",
+        "message": "Tool execution was interrupted and no result was captured.",
+    }
+)
+
+SYNTHETIC_ASSISTANT_RESPONSE: dict = {
+    "role": "assistant",
+    "content": [
+        {
+            "type": "text",
+            "text": (
+                "The previous tool calls were interrupted. "
+                "This response was automatically repaired."
+            ),
+        }
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Index builder
+# ---------------------------------------------------------------------------
+
+
+def build_tool_index(entries: list[dict]) -> dict:
+    """Build an index of tool_use IDs and tool_result IDs from parsed entries.
+
+    Returns:
+        {
+            'tool_uses': {'<id>': {'line_num': N, 'tool_name': '...', 'entry_index': M}},
+            'tool_results': {'<id>': {'line_num': N, 'entry_index': M}},
+        }
+    """
+    tool_uses: dict[str, dict] = {}
+    tool_results: dict[str, dict] = {}
+
+    for idx, entry in enumerate(entries):
+        # Extract tool_use IDs from assistant messages with tool_calls
+        if entry.get("role") == "assistant" and "tool_calls" in entry:
+            for tool_call in entry["tool_calls"]:
+                call_id = tool_call.get("id", "")
+                tool_name = tool_call.get("function", {}).get("name", "")
+                tool_uses[call_id] = {
+                    "line_num": entry.get("line_num"),
+                    "tool_name": tool_name,
+                    "entry_index": idx,
+                }
+
+        # Extract tool_result IDs from tool role messages
+        elif entry.get("role") == "tool" and "tool_call_id" in entry:
+            tool_results[entry["tool_call_id"]] = {
+                "line_num": entry.get("line_num"),
+                "entry_index": idx,
+            }
+
+    return {"tool_uses": tool_uses, "tool_results": tool_results}
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic engine
+# ---------------------------------------------------------------------------
+
+
+def _has_intervening_disruption(
+    entries: list[dict], use_idx: int, result_idx: int
+) -> bool:
+    """Return True if a real user message or unrelated assistant turn appears
+    between entry indices *use_idx* and *result_idx*.
+    """
+    for between_idx in range(use_idx + 1, result_idx):
+        between = entries[between_idx]
+        if is_real_user_message(between):
+            return True
+        if between.get("role") == "assistant" and "tool_calls" not in between:
+            return True
+    return False
+
+
+def diagnose_transcript(entries: list[dict]) -> DiagnosisResult:
+    """Analyse a list of transcript entries and return a structured diagnosis.
+
+    Returns a DiagnosisResult with keys:
+        status: "healthy" | "broken"
+        failure_modes: list of strings
+        orphaned_tool_ids: list of tool_use IDs with no matching tool_result
+        misplaced_tool_ids: list of tool_use IDs whose results are out of order
+        incomplete_turns: list of IncompleteTurn dicts with 'after_line' and 'missing'
+        recommended_action: "none" | "repair" ("rewind" reserved for future use)
+    """
+    index = build_tool_index(entries)
+
+    failure_modes: list[str] = []
+    orphaned_tool_ids: list[str] = []
+    misplaced_tool_ids: list[str] = []
+    incomplete_turns: list[IncompleteTurn] = []
+
+    # --- Failure mode 1: missing tool results ---
+    for tc_id in index["tool_uses"]:
+        if tc_id not in index["tool_results"]:
+            orphaned_tool_ids.append(tc_id)
+    if orphaned_tool_ids:
+        failure_modes.append("missing_tool_results")
+
+    # --- Failure mode 2: ordering violations ---
+    # A tool_result is misplaced if a real user message or a different assistant
+    # turn appears between the tool_use and its result.
+    for tc_id, use_info in index["tool_uses"].items():
+        if tc_id not in index["tool_results"]:
+            continue  # already caught as orphan
+        result_info = index["tool_results"][tc_id]
+        use_idx = use_info["entry_index"]
+        result_idx = result_info["entry_index"]
+
+        if _has_intervening_disruption(entries, use_idx, result_idx):
+            misplaced_tool_ids.append(tc_id)
+    if misplaced_tool_ids:
+        failure_modes.append("ordering_violation")
+
+    # --- Failure mode 3: incomplete assistant turns ---
+    # Walk through entries looking for assistant messages with tool_calls.
+    # For each, verify that after all its tool_results there is a final
+    # assistant text response before the next real user message.
+    orphaned_set = set(orphaned_tool_ids)
+    misplaced_set = set(misplaced_tool_ids)
+    for tc_id, use_info in index["tool_uses"].items():
+        # Only check with the first tool_call in each assistant message
+        # to avoid duplicate detection for multi-tool calls.
+        assistant_idx = use_info["entry_index"]
+        assistant_entry = entries[assistant_idx]
+        first_tc_id = assistant_entry.get("tool_calls", [{}])[0].get("id")
+        if tc_id != first_tc_id:
+            continue
+
+        # Skip if any tool_call from this assistant message is orphaned/misplaced
+        all_tc_ids = [tc["id"] for tc in assistant_entry.get("tool_calls", [])]
+        if any(tid in orphaned_set or tid in misplaced_set for tid in all_tc_ids):
+            continue
+
+        # Find the last tool_result for this assistant message's tool_calls
+        last_result_idx = assistant_idx
+        for tid in all_tc_ids:
+            if tid in index["tool_results"]:
+                res_idx = index["tool_results"][tid]["entry_index"]
+                if res_idx > last_result_idx:
+                    last_result_idx = res_idx
+
+        if last_result_idx == assistant_idx:
+            continue  # No results found (shouldn't happen if we skipped orphans)
+
+        # Check what comes after the last tool result
+        next_idx = last_result_idx + 1
+        if next_idx >= len(entries):
+            # End of transcript — incomplete if we're missing the closing response
+            incomplete_turns.append(
+                {
+                    "after_line": entries[last_result_idx].get("line_num"),
+                    "missing": "assistant_response",
+                }
+            )
+            continue
+
+        next_entry = entries[next_idx]
+        if is_real_user_message(next_entry):
+            # Real user message immediately after tool results = incomplete turn
+            incomplete_turns.append(
+                {
+                    "after_line": entries[last_result_idx].get("line_num"),
+                    "missing": "assistant_response",
+                }
+            )
+
+    if incomplete_turns:
+        failure_modes.append("incomplete_assistant_turn")
+
+    status = "broken" if failure_modes else "healthy"
+    recommended = "repair" if failure_modes else "none"
+
+    return {
+        "status": status,
+        "failure_modes": failure_modes,
+        "orphaned_tool_ids": orphaned_tool_ids,
+        "misplaced_tool_ids": misplaced_tool_ids,
+        "incomplete_turns": incomplete_turns,
+        "recommended_action": recommended,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Repair engine helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_synthetic_tool_result(tool_call_id: str, tool_name: str) -> dict:
+    """Create a synthetic tool result for an orphaned or misplaced tool call."""
+    return {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "name": tool_name,
+        "content": SYNTHETIC_TOOL_RESULT_CONTENT,
+    }
+
+
+def _make_synthetic_assistant_response() -> dict:
+    """Create a fresh synthetic assistant response for an incomplete turn.
+
+    Returns a fresh copy to avoid shared mutable state between injected entries.
+    """
+    return {
+        "role": SYNTHETIC_ASSISTANT_RESPONSE["role"],
+        "content": [dict(block) for block in SYNTHETIC_ASSISTANT_RESPONSE["content"]],
+    }
+
+
+def _strip_line_num(entry: dict) -> dict:
+    """Return a copy of *entry* without the internal ``line_num`` key."""
+    d = entry.copy()
+    d.pop("line_num", None)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Repair engine
+# ---------------------------------------------------------------------------
+
+
+def repair_transcript(entries: list[dict], diagnosis: DiagnosisResult) -> list[dict]:
+    """Apply the COMPLETE repair strategy to a parsed transcript.
+
+    Returns a new list of entries (without ``line_num`` keys) with:
+    - synthetic tool results injected for orphaned/misplaced tool calls
+    - synthetic assistant responses where needed
+    - misplaced tool results removed
+    """
+    # 1. Healthy transcripts are returned unchanged (minus line_num).
+    if diagnosis["status"] == "healthy":
+        return [_strip_line_num(e) for e in entries]
+
+    orphaned_set = set(diagnosis["orphaned_tool_ids"])
+    misplaced_set = set(diagnosis["misplaced_tool_ids"])
+    broken_set = orphaned_set | misplaced_set
+    incomplete_after_lines = {t["after_line"] for t in diagnosis["incomplete_turns"]}
+
+    # 2. Build skip_indices — entry indices of misplaced tool results.
+    skip_indices: set[int] = set()
+    for idx, entry in enumerate(entries):
+        if entry.get("role") == "tool" and entry.get("tool_call_id") in misplaced_set:
+            skip_indices.add(idx)
+
+    # 3–6. Walk entries, applying repairs.
+    result: list[dict] = []
+    for idx, entry in enumerate(entries):
+        # 3. Skip misplaced tool results.
+        if idx in skip_indices:
+            continue
+
+        result.append(_strip_line_num(entry))
+
+        # 4. After assistant messages with tool_calls: inject synthetic
+        #    results for orphaned / misplaced tool_call IDs.
+        if entry.get("role") == "assistant" and "tool_calls" in entry:
+            tool_calls = entry["tool_calls"]
+            all_tc_ids = [tc["id"] for tc in tool_calls]
+            broken_in_msg = [tc for tc in tool_calls if tc["id"] in broken_set]
+
+            for tc in broken_in_msg:
+                tc_id = tc["id"]
+                tc_name = tc.get("function", {}).get("name", "")
+                result.append(_make_synthetic_tool_result(tc_id, tc_name))
+
+            # 5. If ALL tool_calls from this message were broken AND
+            #    the next non-skipped entry is a real user message (or end
+            #    of transcript): inject a synthetic assistant response.
+            if len(broken_in_msg) == len(all_tc_ids) and all_tc_ids:
+                next_entry = None
+                for future_idx in range(idx + 1, len(entries)):
+                    if future_idx not in skip_indices:
+                        next_entry = entries[future_idx]
+                        break
+                if next_entry is None or is_real_user_message(next_entry):
+                    result.append(_make_synthetic_assistant_response())
+
+        # 6. After tool results at incomplete_after_lines: inject synthetic
+        #    assistant response.  (entry still has line_num; only the
+        #    appended copy is stripped.)
+        elif (
+            entry.get("role") == "tool"
+            and entry.get("line_num") in incomplete_after_lines
+        ):
+            result.append(_make_synthetic_assistant_response())
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Rewind engine
+# ---------------------------------------------------------------------------
+
+
+def rewind_transcript(entries: list[dict], diagnosis: DiagnosisResult) -> list[dict]:
+    """Truncate transcript to before the last real user message prior to issues.
+
+    If the transcript is healthy, return all entries stripped of ``line_num``.
+    Otherwise, find the earliest issue, walk backwards to find the last real
+    user message before it, and return ``entries[:rewind_to_idx]`` stripped.
+
+    Returns an empty list if the first turn itself is broken
+    (``rewind_to_idx`` is ``None`` or ``0``).
+    """
+    if diagnosis["status"] == "healthy":
+        return [_strip_line_num(e) for e in entries]
+
+    # 1. Find earliest_issue_idx from orphaned, misplaced, and incomplete turns.
+    index = build_tool_index(entries)
+    issue_indices: list[int] = []
+
+    # Orphaned tool_ids → entry_index of the tool_use (assistant message)
+    for tc_id in diagnosis["orphaned_tool_ids"]:
+        if tc_id in index["tool_uses"]:
+            issue_indices.append(index["tool_uses"][tc_id]["entry_index"])
+
+    # Misplaced tool_ids → entry_index of the tool_use (assistant message)
+    for tc_id in diagnosis["misplaced_tool_ids"]:
+        if tc_id in index["tool_uses"]:
+            issue_indices.append(index["tool_uses"][tc_id]["entry_index"])
+
+    # Incomplete turns → walk back from after_line to find assistant with tool_calls
+    for turn in diagnosis["incomplete_turns"]:
+        after_line = turn["after_line"]
+        # Find the entry with this line_num, then walk backwards
+        for idx in range(len(entries) - 1, -1, -1):
+            if entries[idx].get("line_num") == after_line:
+                # Walk backwards from here to find the assistant with tool_calls
+                for back_idx in range(idx, -1, -1):
+                    e = entries[back_idx]
+                    if e.get("role") == "assistant" and "tool_calls" in e:
+                        issue_indices.append(back_idx)
+                        break
+                break
+
+    if not issue_indices:
+        # Diagnosis says broken but referenced IDs weren't found in entries;
+        # safest fallback is to return the full transcript unchanged.
+        return [_strip_line_num(e) for e in entries]
+
+    earliest_issue_idx = min(issue_indices)
+
+    # 2. Walk backwards from earliest_issue_idx to find the last real user message.
+    rewind_to_idx: int | None = None
+    for idx in range(earliest_issue_idx - 1, -1, -1):
+        if is_real_user_message(entries[idx]):
+            rewind_to_idx = idx
+            break
+
+    # 3. If rewind_to_idx is None or 0, return [] (first turn is broken).
+    if rewind_to_idx is None or rewind_to_idx == 0:
+        return []
+
+    # 4. Return entries[:rewind_to_idx] stripped of line_num.
+    return [_strip_line_num(e) for e in entries[:rewind_to_idx]]

--- a/amplifier_foundation/session/events.py
+++ b/amplifier_foundation/session/events.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
+
+from .store import read_jsonl
 
 
 def slice_events_to_timestamp(
@@ -73,7 +75,9 @@ def slice_events_to_timestamp(
                                     event["parent_session_id"] = (
                                         parent_session_id or original_session_id
                                     )
-                                outfile.write(json.dumps(event, ensure_ascii=False) + "\n")
+                                outfile.write(
+                                    json.dumps(event, ensure_ascii=False) + "\n"
+                                )
                             else:
                                 outfile.write(line + "\n")
                             count += 1
@@ -122,7 +126,7 @@ def get_last_timestamp_for_turn(
     if not transcript_path.exists():
         raise FileNotFoundError(f"Transcript not found: {transcript_path}")
 
-    messages = list(_read_jsonl(transcript_path))
+    messages = list(read_jsonl(transcript_path))
 
     # Find turn boundaries
     boundaries = [i for i, msg in enumerate(messages) if msg.get("role") == "user"]
@@ -211,7 +215,7 @@ def count_events(events_path: Path) -> int:
         return 0
 
     count = 0
-    for _ in _read_jsonl(events_path):
+    for _ in read_jsonl(events_path):
         count += 1
     return count
 
@@ -242,7 +246,7 @@ def get_event_summary(events_path: Path) -> dict[str, Any]:
     last_ts: str | None = None
     total = 0
 
-    for event in _read_jsonl(events_path):
+    for event in read_jsonl(events_path):
         total += 1
 
         # Count event types
@@ -264,25 +268,6 @@ def get_event_summary(events_path: Path) -> dict[str, Any]:
     }
 
 
-def _read_jsonl(path: Path) -> Iterator[dict[str, Any]]:
-    """Read a JSONL file yielding parsed objects.
-
-    Args:
-        path: Path to JSONL file.
-
-    Yields:
-        Parsed JSON objects from each line.
-    """
-    with open(path, "r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if line:
-                try:
-                    yield json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-
-
 def _parse_timestamp(ts: str) -> datetime:
     """Parse an ISO format timestamp string.
 
@@ -298,11 +283,11 @@ def _parse_timestamp(ts: str) -> datetime:
     # Try common formats
     formats = [
         "%Y-%m-%dT%H:%M:%S.%f%z",  # Full with microseconds and tz
-        "%Y-%m-%dT%H:%M:%S%z",      # Without microseconds, with tz
-        "%Y-%m-%dT%H:%M:%S.%fZ",    # With Z suffix
-        "%Y-%m-%dT%H:%M:%SZ",       # Without microseconds, Z suffix
-        "%Y-%m-%dT%H:%M:%S.%f",     # Without timezone
-        "%Y-%m-%dT%H:%M:%S",        # Basic ISO
+        "%Y-%m-%dT%H:%M:%S%z",  # Without microseconds, with tz
+        "%Y-%m-%dT%H:%M:%S.%fZ",  # With Z suffix
+        "%Y-%m-%dT%H:%M:%SZ",  # Without microseconds, Z suffix
+        "%Y-%m-%dT%H:%M:%S.%f",  # Without timezone
+        "%Y-%m-%dT%H:%M:%S",  # Basic ISO
     ]
 
     # Normalize Z to +00:00

--- a/amplifier_foundation/session/finder.py
+++ b/amplifier_foundation/session/finder.py
@@ -247,7 +247,10 @@ def find_sessions(
 
             try:
                 meta = load_metadata(session_dir)
-            except Exception:
+            except Exception:  # noqa: BLE001
+                # Skip sessions with corrupt/unreadable metadata rather than
+                # failing the whole list — a bad session should not prevent
+                # discovery of all other sessions.
                 continue
 
             created_str = meta.get("created")
@@ -320,6 +323,9 @@ def session_info(session_dir: Path) -> dict[str, Any]:
 
     # Derive project from path: sessions_root/<project>/sessions/<session_id>
     # parent = sessions/, parent.parent = <project>/
+    # NOTE: This assumes the standard two-level layout. If session_dir is an
+    # absolute path from a non-standard root, the project name will be whatever
+    # directory happens to be two levels up.
     project = session_dir.parent.parent.name
 
     return {

--- a/amplifier_foundation/session/finder.py
+++ b/amplifier_foundation/session/finder.py
@@ -13,6 +13,7 @@ Directory structure:
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
@@ -23,7 +24,9 @@ from .store import (
     METADATA_FILENAME,
     TRANSCRIPT_FILENAME,
     load_metadata,
+    load_transcript,
     load_transcript_with_lines,
+    read_jsonl,
 )
 
 # ---------------------------------------------------------------------------
@@ -88,10 +91,9 @@ def _transcript_contains_keyword(session_dir: Path, keyword: str) -> bool:
     if not transcript_path.exists():
         return False
     keyword_lower = keyword.lower()
-    with transcript_path.open(encoding="utf-8") as fh:
-        for line in fh:
-            if keyword_lower in line.lower():
-                return True
+    for entry in read_jsonl(transcript_path):
+        if keyword_lower in json.dumps(entry, ensure_ascii=False).lower():
+            return True
     return False
 
 
@@ -308,10 +310,13 @@ def session_info(session_dir: Path) -> dict[str, Any]:
 
     meta = load_metadata(session_dir)
 
+    # Load plain transcript for turn counting (line numbers not needed)
+    messages = load_transcript(session_dir)
+    turn_count = count_turns(messages)
+
     # Load transcript with line numbers for diagnosis
     entries = load_transcript_with_lines(session_dir)
     diagnosis = diagnose_transcript(entries)
-    turn_count = count_turns(entries)
 
     # Derive project from path: sessions_root/<project>/sessions/<session_id>
     # parent = sessions/, parent.parent = <project>/

--- a/amplifier_foundation/session/finder.py
+++ b/amplifier_foundation/session/finder.py
@@ -1,0 +1,330 @@
+"""Layer Level 3 (Session Finder) — session discovery by path, ID, or partial ID.
+
+This module builds on store.py (Level 2) and diagnosis.py (Level 1) to provide
+session discovery and resolution. It knows the `~/.amplifier/projects/` path
+convention.
+
+Directory structure:
+    sessions_root/<project>/sessions/<session_id>/
+        transcript.jsonl
+        metadata.json
+        events.jsonl  (optional)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+from .diagnosis import diagnose_transcript
+from .messages import count_turns
+from .store import (
+    METADATA_FILENAME,
+    TRANSCRIPT_FILENAME,
+    load_metadata,
+    load_transcript_with_lines,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_SESSIONS_ROOT: Path = Path.home() / ".amplifier" / "projects"
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_project_dirs(root: Path, project: str | None) -> Iterator[tuple[str, Path]]:
+    """Yield (project_name, sessions_subdir) tuples.
+
+    Searches root for project directories. If ``project`` is provided, only
+    that single project directory is yielded (if it exists and contains a
+    ``sessions/`` subdirectory). If ``project`` is None, all project
+    directories in root are yielded.
+
+    Args:
+        root: The sessions root directory (DEFAULT_SESSIONS_ROOT).
+        project: Optional project name to narrow scope.
+
+    Yields:
+        Tuples of (project_name, sessions_dir) where sessions_dir is the
+        ``sessions/`` subdirectory within the project directory.
+    """
+    if not root.is_dir():
+        return
+
+    if project is not None:
+        proj_dir = root / project
+        sessions_dir = proj_dir / "sessions"
+        if sessions_dir.is_dir():
+            yield project, sessions_dir
+        return
+
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        sessions_dir = entry / "sessions"
+        if sessions_dir.is_dir():
+            yield entry.name, sessions_dir
+
+
+def _transcript_contains_keyword(session_dir: Path, keyword: str) -> bool:
+    """Return True if transcript.jsonl contains keyword (case-insensitive).
+
+    Searches only transcript.jsonl — never events.jsonl.
+
+    Args:
+        session_dir: Path to the session directory.
+        keyword: Search term (case-insensitive).
+
+    Returns:
+        True if keyword found anywhere in the transcript text.
+    """
+    transcript_path = session_dir / TRANSCRIPT_FILENAME
+    if not transcript_path.exists():
+        return False
+    keyword_lower = keyword.lower()
+    with transcript_path.open(encoding="utf-8") as fh:
+        for line in fh:
+            if keyword_lower in line.lower():
+                return True
+    return False
+
+
+def _is_valid_session_dir(session_dir: Path) -> bool:
+    """Return True if session_dir has a metadata.json."""
+    return (session_dir / METADATA_FILENAME).exists()
+
+
+def _parse_created(created_str: str | None) -> datetime | None:
+    """Parse an ISO-format created string into a timezone-aware datetime."""
+    if not created_str:
+        return None
+    try:
+        dt = datetime.fromisoformat(created_str)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_date_filter(date_str: str) -> datetime:
+    """Parse a date filter string (ISO format) into a timezone-aware datetime.
+
+    If the string has no time component, midnight UTC is assumed.
+    """
+    dt = datetime.fromisoformat(date_str)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def resolve_session(
+    session_ref: str,
+    *,
+    sessions_root: Path | None = None,
+    project: str | None = None,
+) -> Path:
+    """Resolve a session reference to an absolute Path.
+
+    Accepts three forms of reference:
+    - A full absolute path to a session directory.
+    - A full session ID (exact directory name match).
+    - A partial session ID (prefix match).
+
+    Args:
+        session_ref: Full path, full session ID, or partial ID.
+        sessions_root: Root directory containing project subdirectories.
+            Defaults to DEFAULT_SESSIONS_ROOT.
+        project: Optional project name to narrow the search scope.
+
+    Returns:
+        Absolute Path to the resolved session directory.
+
+    Raises:
+        FileNotFoundError: If no session matches the reference.
+        ValueError: If a partial ID matches more than one session.
+    """
+    root = sessions_root if sessions_root is not None else DEFAULT_SESSIONS_ROOT
+
+    # Case 1: absolute path reference
+    ref_path = Path(session_ref)
+    if ref_path.is_absolute():
+        if _is_valid_session_dir(ref_path):
+            return ref_path
+        raise FileNotFoundError(f"No valid session at path: {session_ref}")
+
+    # Case 2 & 3: search by session ID (full or partial)
+    exact_matches: list[Path] = []
+    prefix_matches: list[Path] = []
+
+    for _proj_name, sessions_dir in _iter_project_dirs(root, project):
+        for session_dir in sessions_dir.iterdir():
+            if not session_dir.is_dir():
+                continue
+            if not _is_valid_session_dir(session_dir):
+                continue
+
+            name = session_dir.name
+            if name == session_ref:
+                exact_matches.append(session_dir)
+            elif name.startswith(session_ref):
+                prefix_matches.append(session_dir)
+
+    # Exact match takes priority over prefix match
+    if exact_matches:
+        if len(exact_matches) == 1:
+            return exact_matches[0]
+        raise ValueError(
+            f"Ambiguous session ID '{session_ref}': "
+            f"matched {[p.name for p in exact_matches]}"
+        )
+
+    if len(prefix_matches) == 1:
+        return prefix_matches[0]
+    if len(prefix_matches) > 1:
+        raise ValueError(
+            f"Ambiguous partial session ID '{session_ref}': "
+            f"matched {[p.name for p in prefix_matches]}"
+        )
+
+    raise FileNotFoundError(f"No session found matching '{session_ref}'")
+
+
+def find_sessions(
+    *,
+    sessions_root: Path | None = None,
+    project: str | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    keyword: str | None = None,
+    status: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """List sessions with optional filtering.
+
+    Args:
+        sessions_root: Root directory containing project subdirectories.
+            Defaults to DEFAULT_SESSIONS_ROOT.
+        project: Filter by project name.
+        after: ISO date string — only include sessions created after this date.
+        before: ISO date string — only include sessions created before this date.
+        keyword: Search term — only include sessions whose transcript.jsonl
+            contains this keyword (case-insensitive). Never searches events.jsonl.
+        status: Health status filter — "healthy" or "broken". Runs
+            diagnose_transcript (expensive; opt-in only).
+        limit: Maximum number of results to return (default 50).
+
+    Returns:
+        List of dicts with keys: session_id, path, project, created, bundle,
+        model. Sorted by created (most recent first).
+    """
+    root = sessions_root if sessions_root is not None else DEFAULT_SESSIONS_ROOT
+
+    after_dt = _parse_date_filter(after) if after else None
+    before_dt = _parse_date_filter(before) if before else None
+
+    results: list[dict[str, Any]] = []
+
+    for proj_name, sessions_dir in _iter_project_dirs(root, project):
+        for session_dir in sessions_dir.iterdir():
+            if not session_dir.is_dir():
+                continue
+            if not _is_valid_session_dir(session_dir):
+                continue
+
+            try:
+                meta = load_metadata(session_dir)
+            except Exception:
+                continue
+
+            created_str = meta.get("created")
+            created_dt = _parse_created(created_str)
+
+            # Date range filters
+            if after_dt is not None and created_dt is not None:
+                if created_dt <= after_dt:
+                    continue
+            if before_dt is not None and created_dt is not None:
+                if created_dt >= before_dt:
+                    continue
+
+            # Keyword filter (transcript only, never events.jsonl)
+            if keyword is not None:
+                if not _transcript_contains_keyword(session_dir, keyword):
+                    continue
+
+            # Status filter (expensive — runs diagnosis)
+            if status is not None:
+                try:
+                    entries = load_transcript_with_lines(session_dir)
+                    diagnosis = diagnose_transcript(entries)
+                    if diagnosis["status"] != status:
+                        continue
+                except Exception:
+                    continue
+
+            results.append(
+                {
+                    "session_id": meta.get("session_id", session_dir.name),
+                    "path": session_dir,
+                    "project": proj_name,
+                    "created": created_str,
+                    "bundle": meta.get("bundle"),
+                    "model": meta.get("model"),
+                }
+            )
+
+    # Sort by created (most recent first) — None sorts last
+    results.sort(
+        key=lambda r: r["created"] or "",
+        reverse=True,
+    )
+
+    return results[:limit]
+
+
+def session_info(session_dir: Path) -> dict[str, Any]:
+    """Return metadata, turn count, and health status for a single session.
+
+    Args:
+        session_dir: Path to the session directory.
+
+    Returns:
+        Dict with keys: session_id, path, project, created, bundle, model,
+        turn_count, status, failure_modes.
+    """
+    session_dir = Path(session_dir).resolve()
+
+    meta = load_metadata(session_dir)
+
+    # Load transcript with line numbers for diagnosis
+    entries = load_transcript_with_lines(session_dir)
+    diagnosis = diagnose_transcript(entries)
+    turn_count = count_turns(entries)
+
+    # Derive project from path: sessions_root/<project>/sessions/<session_id>
+    # parent = sessions/, parent.parent = <project>/
+    project = session_dir.parent.parent.name
+
+    return {
+        "session_id": meta.get("session_id", session_dir.name),
+        "path": session_dir,
+        "project": project,
+        "created": meta.get("created"),
+        "bundle": meta.get("bundle"),
+        "model": meta.get("model"),
+        "turn_count": turn_count,
+        "status": diagnosis["status"],
+        "failure_modes": diagnosis["failure_modes"],
+    }

--- a/amplifier_foundation/session/fork.py
+++ b/amplifier_foundation/session/fork.py
@@ -456,6 +456,7 @@ def get_session_lineage(
                 parent_meta = load_metadata(parent_dir)
                 current_parent_id = parent_meta.get("parent_id")
             else:
+                # Parent dir exists but lacks metadata — stop tracing ancestors
                 break
         else:
             break

--- a/amplifier_foundation/session/fork.py
+++ b/amplifier_foundation/session/fork.py
@@ -21,7 +21,6 @@ from typing import Any
 
 from .events import slice_events_for_fork
 from .messages import (
-    add_synthetic_tool_results,
     count_turns,
     find_orphaned_tool_calls,
     get_turn_boundaries,
@@ -118,7 +117,9 @@ def fork_session(
 
     # Load parent data
     messages = load_transcript(parent_session_dir)
-    parent_metadata = load_metadata(parent_session_dir) if metadata_path.exists() else {}
+    parent_metadata = (
+        load_metadata(parent_session_dir) if metadata_path.exists() else {}
+    )
     parent_id = parent_metadata.get("session_id", parent_session_dir.name)
 
     # Determine turn
@@ -130,9 +131,7 @@ def fork_session(
         turn = max_turns
 
     if turn < 1 or turn > max_turns:
-        raise ValueError(
-            f"Turn {turn} out of range. Valid range: 1-{max_turns}"
-        )
+        raise ValueError(f"Turn {turn} out of range. Valid range: 1-{max_turns}")
 
     # Slice messages to turn
     sliced = slice_to_turn(messages, turn, handle_orphaned_tools=handle_orphaned_tools)
@@ -296,7 +295,9 @@ def get_fork_preview(
         raise FileNotFoundError(f"No transcript.jsonl in {parent_session_dir}")
 
     messages = load_transcript(parent_session_dir)
-    parent_metadata = load_metadata(parent_session_dir) if metadata_path.exists() else {}
+    parent_metadata = (
+        load_metadata(parent_session_dir) if metadata_path.exists() else {}
+    )
     parent_id = parent_metadata.get("session_id", parent_session_dir.name)
 
     max_turns = count_turns(messages)
@@ -386,13 +387,15 @@ def list_session_forks(
         try:
             child_metadata = load_metadata(child_dir)
             if child_metadata.get("parent_id") == parent_id:
-                forks.append({
-                    "session_id": child_metadata.get("session_id", child_dir.name),
-                    "session_dir": child_dir,
-                    "forked_from_turn": child_metadata.get("forked_from_turn"),
-                    "forked_at": child_metadata.get("forked_at"),
-                    "turn_count": child_metadata.get("turn_count", 0),
-                })
+                forks.append(
+                    {
+                        "session_id": child_metadata.get("session_id", child_dir.name),
+                        "session_dir": child_dir,
+                        "forked_from_turn": child_metadata.get("forked_from_turn"),
+                        "forked_at": child_metadata.get("forked_at"),
+                        "turn_count": child_metadata.get("turn_count", 0),
+                    }
+                )
         except Exception:
             # Skip sessions we can't read
             continue

--- a/amplifier_foundation/session/fork.py
+++ b/amplifier_foundation/session/fork.py
@@ -13,7 +13,6 @@ The forked session is independently resumable and addressable.
 
 from __future__ import annotations
 
-import json
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -21,12 +20,21 @@ from pathlib import Path
 from typing import Any
 
 from .events import slice_events_for_fork
-from .slice import (
+from .messages import (
     add_synthetic_tool_results,
     count_turns,
     find_orphaned_tool_calls,
     get_turn_boundaries,
     slice_to_turn,
+)
+from .store import (
+    EVENTS_FILENAME,
+    METADATA_FILENAME,
+    TRANSCRIPT_FILENAME,
+    load_metadata,
+    load_transcript,
+    write_jsonl,
+    write_metadata,
 )
 
 
@@ -98,9 +106,9 @@ def fork_session(
     parent_session_dir = Path(parent_session_dir).resolve()
 
     # Validate parent exists
-    transcript_path = parent_session_dir / "transcript.jsonl"
-    metadata_path = parent_session_dir / "metadata.json"
-    events_path = parent_session_dir / "events.jsonl"
+    transcript_path = parent_session_dir / TRANSCRIPT_FILENAME
+    metadata_path = parent_session_dir / METADATA_FILENAME
+    events_path = parent_session_dir / EVENTS_FILENAME
 
     if not transcript_path.exists():
         raise FileNotFoundError(
@@ -109,8 +117,8 @@ def fork_session(
         )
 
     # Load parent data
-    messages = _load_transcript(transcript_path)
-    parent_metadata = _load_metadata(metadata_path) if metadata_path.exists() else {}
+    messages = load_transcript(parent_session_dir)
+    parent_metadata = load_metadata(parent_session_dir) if metadata_path.exists() else {}
     parent_id = parent_metadata.get("session_id", parent_session_dir.name)
 
     # Determine turn
@@ -145,7 +153,7 @@ def fork_session(
     new_session_dir.mkdir(parents=True, exist_ok=True)
 
     # Write forked transcript
-    _write_transcript(new_session_dir / "transcript.jsonl", sliced)
+    write_jsonl(new_session_dir / TRANSCRIPT_FILENAME, sliced)
 
     # Write metadata with lineage
     now = datetime.now(timezone.utc).isoformat()
@@ -160,7 +168,7 @@ def fork_session(
         "bundle": parent_metadata.get("bundle"),
         "model": parent_metadata.get("model"),
     }
-    _write_metadata(new_session_dir / "metadata.json", new_metadata)
+    write_metadata(new_session_dir, new_metadata)
 
     # Handle events.jsonl
     events_count = 0
@@ -170,17 +178,17 @@ def fork_session(
                 events_path,
                 transcript_path,
                 turn,
-                new_session_dir / "events.jsonl",
+                new_session_dir / EVENTS_FILENAME,
                 new_session_id=session_id,
                 parent_session_id=parent_id,
             )
         except Exception:
             # Events slicing is best-effort - don't fail the fork
             # Just create empty events file
-            (new_session_dir / "events.jsonl").write_text("")
+            (new_session_dir / EVENTS_FILENAME).write_text("")
     elif include_events:
         # Create empty events file for consistency
-        (new_session_dir / "events.jsonl").write_text("")
+        (new_session_dir / EVENTS_FILENAME).write_text("")
 
     return ForkResult(
         session_id=session_id,
@@ -281,14 +289,14 @@ def get_fork_preview(
         ValueError: If turn is out of range.
     """
     parent_session_dir = Path(parent_session_dir).resolve()
-    transcript_path = parent_session_dir / "transcript.jsonl"
-    metadata_path = parent_session_dir / "metadata.json"
+    transcript_path = parent_session_dir / TRANSCRIPT_FILENAME
+    metadata_path = parent_session_dir / METADATA_FILENAME
 
     if not transcript_path.exists():
         raise FileNotFoundError(f"No transcript.jsonl in {parent_session_dir}")
 
-    messages = _load_transcript(transcript_path)
-    parent_metadata = _load_metadata(metadata_path) if metadata_path.exists() else {}
+    messages = load_transcript(parent_session_dir)
+    parent_metadata = load_metadata(parent_session_dir) if metadata_path.exists() else {}
     parent_id = parent_metadata.get("session_id", parent_session_dir.name)
 
     max_turns = count_turns(messages)
@@ -357,9 +365,9 @@ def list_session_forks(
         sessions_root = session_dir.parent
 
     # Get parent session ID
-    metadata_path = session_dir / "metadata.json"
+    metadata_path = session_dir / METADATA_FILENAME
     if metadata_path.exists():
-        parent_metadata = _load_metadata(metadata_path)
+        parent_metadata = load_metadata(session_dir)
         parent_id = parent_metadata.get("session_id", session_dir.name)
     else:
         parent_id = session_dir.name
@@ -371,12 +379,12 @@ def list_session_forks(
         if not child_dir.is_dir():
             continue
 
-        child_metadata_path = child_dir / "metadata.json"
+        child_metadata_path = child_dir / METADATA_FILENAME
         if not child_metadata_path.exists():
             continue
 
         try:
-            child_metadata = _load_metadata(child_metadata_path)
+            child_metadata = load_metadata(child_dir)
             if child_metadata.get("parent_id") == parent_id:
                 forks.append({
                     "session_id": child_metadata.get("session_id", child_dir.name),
@@ -422,9 +430,9 @@ def get_session_lineage(
         sessions_root = session_dir.parent
 
     # Load this session's metadata
-    metadata_path = session_dir / "metadata.json"
+    metadata_path = session_dir / METADATA_FILENAME
     if metadata_path.exists():
-        metadata = _load_metadata(metadata_path)
+        metadata = load_metadata(session_dir)
     else:
         metadata = {"session_id": session_dir.name}
 
@@ -440,9 +448,9 @@ def get_session_lineage(
         # Try to find parent session
         parent_dir = sessions_root / current_parent_id
         if parent_dir.exists():
-            parent_meta_path = parent_dir / "metadata.json"
+            parent_meta_path = parent_dir / METADATA_FILENAME
             if parent_meta_path.exists():
-                parent_meta = _load_metadata(parent_meta_path)
+                parent_meta = load_metadata(parent_dir)
                 current_parent_id = parent_meta.get("parent_id")
             else:
                 break
@@ -463,40 +471,6 @@ def get_session_lineage(
 
 
 # --- Private helpers ---
-
-
-def _load_transcript(path: Path) -> list[dict[str, Any]]:
-    """Load JSONL transcript file."""
-    messages = []
-    with open(path, "r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if line:
-                try:
-                    messages.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue
-    return messages
-
-
-def _write_transcript(path: Path, messages: list[dict[str, Any]]) -> None:
-    """Write JSONL transcript file."""
-    with open(path, "w", encoding="utf-8") as f:
-        for msg in messages:
-            f.write(json.dumps(msg, ensure_ascii=False) + "\n")
-
-
-def _load_metadata(path: Path) -> dict[str, Any]:
-    """Load JSON metadata file."""
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _write_metadata(path: Path, metadata: dict[str, Any]) -> None:
-    """Write JSON metadata file."""
-    path.write_text(
-        json.dumps(metadata, indent=2, ensure_ascii=False),
-        encoding="utf-8",
-    )
 
 
 def _extract_text_content(content: Any) -> str:

--- a/amplifier_foundation/session/messages.py
+++ b/amplifier_foundation/session/messages.py
@@ -177,8 +177,13 @@ def slice_to_turn(
             )
         elif handle_orphaned_tools == "remove":
             sliced = _remove_orphaned_tool_calls(sliced, orphaned)
-        else:  # "complete" is default
+        elif handle_orphaned_tools == "complete":
             sliced = add_synthetic_tool_results(sliced, orphaned)
+        else:
+            raise ValueError(
+                f"Unknown handle_orphaned_tools value: {handle_orphaned_tools!r}. "
+                "Expected 'complete', 'remove', or 'error'."
+            )
 
     return sliced
 
@@ -430,7 +435,10 @@ def get_turn_summary(
                 # Extract text from content blocks
                 for block in content:
                     if isinstance(block, dict) and block.get("type") == "text":
-                        user_content = block.get("text", "")[:max_length]
+                        text = block.get("text", "")
+                        user_content = text[:max_length]
+                        if len(text) > max_length:
+                            user_content += "..."
                         break
 
         elif role == "assistant":
@@ -443,7 +451,10 @@ def get_turn_summary(
                 for block in content:
                     if isinstance(block, dict):
                         if block.get("type") == "text" and not assistant_content:
-                            assistant_content = block.get("text", "")[:max_length]
+                            text = block.get("text", "")
+                            assistant_content = text[:max_length]
+                            if len(text) > max_length:
+                                assistant_content += "..."
                         elif block.get("type") == "tool_use":
                             tool_count += 1
 

--- a/amplifier_foundation/session/messages.py
+++ b/amplifier_foundation/session/messages.py
@@ -1,0 +1,460 @@
+"""Layer Level 1 (Message Algebra): pure list[dict] -> list[dict], zero I/O.
+
+This module provides pure functions for operating on conversation message lists.
+All functions are side-effect free and perform no file I/O.
+
+A "turn" is defined as a user message plus all subsequent non-user messages
+until the next user message. Turns are 1-indexed for user-facing operations.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_DEFAULT_SYNTHETIC_TOOL_CONTENT: str = json.dumps(
+    {
+        "error": "Tool execution interrupted by session fork",
+        "forked": True,
+        "message": (
+            "This tool call was in progress when the session was forked. "
+            "The result is not available in this forked session."
+        ),
+    }
+)
+
+_DEFAULT_SYNTHETIC_ASSISTANT_CONTENT: str = (
+    "The previous tool calls were interrupted by a session fork. "
+    "Results are not available in this forked session."
+)
+
+
+def get_turn_boundaries(messages: list[dict[str, Any]]) -> list[int]:
+    """Return indices where each turn starts (user message positions).
+
+    A turn begins with each user message. This returns the 0-indexed
+    positions of all user messages in the conversation.
+
+    Args:
+        messages: List of conversation messages with 'role' field.
+
+    Returns:
+        List of indices where user messages appear.
+
+    Example:
+        >>> messages = [
+        ...     {"role": "user", "content": "Q1"},
+        ...     {"role": "assistant", "content": "A1"},
+        ...     {"role": "user", "content": "Q2"},
+        ... ]
+        >>> get_turn_boundaries(messages)
+        [0, 2]
+    """
+    return [i for i, msg in enumerate(messages) if msg.get("role") == "user"]
+
+
+def count_turns(messages: list[dict[str, Any]]) -> int:
+    """Count the number of turns in a conversation.
+
+    Args:
+        messages: List of conversation messages.
+
+    Returns:
+        Number of turns (user messages) in the conversation.
+    """
+    return len(get_turn_boundaries(messages))
+
+
+def is_real_user_message(entry: dict[str, Any]) -> bool:
+    """Return True if entry represents a genuine human user message.
+
+    A 'real user message' is:
+    - role is 'user'
+    - no tool_call_id field
+    - content is NOT wrapped in <system-reminder> tags
+
+    Content can be a string or a list of content blocks.
+    Assistant messages and tool role messages return False.
+
+    Args:
+        entry: A message dict with at least a 'role' field.
+
+    Returns:
+        True if this is a real user-authored message, False otherwise.
+    """
+    if entry.get("role") != "user":
+        return False
+
+    if "tool_call_id" in entry:
+        return False
+
+    content = entry.get("content", "")
+
+    # Check for system-reminder tags in string content
+    if isinstance(content, str):
+        if content.strip().startswith("<system-reminder>"):
+            return False
+
+    # Check for system-reminder tags in list content
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                text = block.get("text", "")
+                if isinstance(text, str) and text.strip().startswith(
+                    "<system-reminder>"
+                ):
+                    return False
+
+    return True
+
+
+def slice_to_turn(
+    messages: list[dict[str, Any]],
+    turn: int,
+    *,
+    handle_orphaned_tools: str = "complete",
+) -> list[dict[str, Any]]:
+    """Slice messages to include only up to turn N (1-indexed).
+
+    Turn N includes the Nth user message and all responses until the
+    next user message (or end of conversation).
+
+    Args:
+        messages: Full message list from transcript.
+        turn: Turn number (1-indexed). Turn 1 = first user message + response.
+        handle_orphaned_tools: How to handle tool_use without tool_result:
+            - "complete": Add synthetic error result (default)
+            - "remove": Remove the orphaned tool_use content
+            - "error": Raise ValueError
+
+    Returns:
+        Sliced message list with orphaned tools handled.
+
+    Raises:
+        ValueError: If turn < 1 or turn > max_turns, or if handle_orphaned_tools
+            is "error" and orphaned tools are found.
+
+    Example:
+        >>> messages = [
+        ...     {"role": "user", "content": "Q1"},
+        ...     {"role": "assistant", "content": "A1"},
+        ...     {"role": "user", "content": "Q2"},
+        ...     {"role": "assistant", "content": "A2"},
+        ... ]
+        >>> sliced = slice_to_turn(messages, 1)
+        >>> len(sliced)
+        2
+    """
+    if turn < 1:
+        raise ValueError(f"Turn must be >= 1, got {turn}")
+
+    boundaries = get_turn_boundaries(messages)
+    max_turns = len(boundaries)
+
+    if max_turns == 0:
+        raise ValueError("No user messages found in conversation")
+
+    if turn > max_turns:
+        raise ValueError(
+            f"Turn {turn} exceeds max turns ({max_turns}). Valid range: 1-{max_turns}"
+        )
+
+    # Find end index: start of turn N+1, or end of messages
+    if turn < max_turns:
+        end_idx = boundaries[turn]  # Start of next turn (0-indexed)
+    else:
+        end_idx = len(messages)  # Include all messages
+
+    sliced = messages[:end_idx]
+
+    # Handle orphaned tool calls
+    orphaned = find_orphaned_tool_calls(sliced)
+    if orphaned:
+        if handle_orphaned_tools == "error":
+            raise ValueError(
+                f"Orphaned tool calls at fork boundary: {orphaned}. "
+                "These tool_use blocks have no matching tool_result."
+            )
+        elif handle_orphaned_tools == "remove":
+            sliced = _remove_orphaned_tool_calls(sliced, orphaned)
+        else:  # "complete" is default
+            sliced = add_synthetic_tool_results(sliced, orphaned)
+
+    return sliced
+
+
+def find_orphaned_tool_calls(messages: list[dict[str, Any]]) -> list[str]:
+    """Find tool_call IDs that have no corresponding tool result.
+
+    Scans messages for tool_calls in assistant messages and tool results,
+    returning IDs of calls that don't have matching results.
+
+    Args:
+        messages: List of conversation messages.
+
+    Returns:
+        List of orphaned tool_call IDs.
+    """
+    # Collect all tool_call IDs from assistant messages
+    called_ids: set[str] = set()
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            # Check tool_calls array (standard format)
+            if "tool_calls" in msg:
+                for tc in msg["tool_calls"]:
+                    if "id" in tc:
+                        called_ids.add(tc["id"])
+            # Check content blocks (Anthropic format)
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        if "id" in block:
+                            called_ids.add(block["id"])
+
+    # Collect all tool_call_ids from tool results
+    result_ids: set[str] = set()
+    for msg in messages:
+        if msg.get("role") == "tool" and "tool_call_id" in msg:
+            result_ids.add(msg["tool_call_id"])
+
+    return list(called_ids - result_ids)
+
+
+def add_synthetic_tool_results(
+    messages: list[dict[str, Any]],
+    orphaned_ids: list[str],
+    *,
+    synthetic_content: str | None = None,
+) -> list[dict[str, Any]]:
+    """Add synthetic error results for orphaned tool calls.
+
+    When forking a session mid-turn, some tool calls may not have results.
+    This adds synthetic error results inserted immediately after the assistant
+    message that made the tool calls, so the conversation remains valid.
+
+    Args:
+        messages: List of conversation messages.
+        orphaned_ids: List of tool_call IDs needing synthetic results.
+        synthetic_content: Optional custom content string for the synthetic tool
+            results. If None, uses the default fork-interruption JSON content.
+
+    Returns:
+        New message list with synthetic tool results inserted at correct positions.
+    """
+    if not orphaned_ids:
+        return messages
+
+    content_str = (
+        synthetic_content
+        if synthetic_content is not None
+        else _DEFAULT_SYNTHETIC_TOOL_CONTENT
+    )
+    orphaned_set = set(orphaned_ids)
+
+    # Build mapping of tool_call_id -> tool_name from assistant messages
+    tool_names: dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            # Handle OpenAI format: tool_calls array
+            for tc in msg.get("tool_calls", []):
+                tc_id = tc.get("id", "")
+                tc_name = tc.get("function", {}).get("name", "") or tc.get("name", "")
+                if tc_id and tc_name:
+                    tool_names[tc_id] = tc_name
+            # Handle Anthropic format: content blocks with tool_use
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        tc_id = block.get("id", "")
+                        tc_name = block.get("name", "")
+                        if tc_id and tc_name:
+                            tool_names[tc_id] = tc_name
+
+    # Walk messages and insert synthetics at correct positions
+    result: list[dict[str, Any]] = []
+    for i, msg in enumerate(messages):
+        result.append(msg)
+
+        # After each assistant message, check if any of its tool_calls are orphaned
+        if msg.get("role") == "assistant":
+            # Collect orphaned tool_call IDs from this assistant message (OpenAI format)
+            msg_orphans: list[str] = []
+            for tc in msg.get("tool_calls", []):
+                tc_id = tc.get("id", "")
+                if tc_id in orphaned_set:
+                    msg_orphans.append(tc_id)
+            # Also check Anthropic format
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        tc_id = block.get("id", "")
+                        if tc_id in orphaned_set:
+                            msg_orphans.append(tc_id)
+
+            if msg_orphans:
+                # Insert synthetic results immediately after this assistant message
+                for tc_id in msg_orphans:
+                    tool_name = tool_names.get(tc_id)
+                    synthetic: dict[str, Any] = {
+                        "role": "tool",
+                        "tool_call_id": tc_id,
+                        "content": content_str,
+                    }
+                    if tool_name:
+                        synthetic["name"] = tool_name
+                    result.append(synthetic)
+
+                # FM3 handling: if the next original message is a user message, insert
+                # a synthetic assistant response to close the interrupted turn first
+                next_idx = i + 1
+                if (
+                    next_idx < len(messages)
+                    and messages[next_idx].get("role") == "user"
+                ):
+                    result.append(
+                        {
+                            "role": "assistant",
+                            "content": _DEFAULT_SYNTHETIC_ASSISTANT_CONTENT,
+                        }
+                    )
+
+    return result
+
+
+def _remove_orphaned_tool_calls(
+    messages: list[dict[str, Any]],
+    orphaned_ids: list[str],
+) -> list[dict[str, Any]]:
+    """Remove orphaned tool_call entries from messages.
+
+    This modifies assistant messages to remove tool_calls that don't have
+    corresponding results. Use with caution as this alters conversation history.
+
+    Args:
+        messages: List of conversation messages.
+        orphaned_ids: List of tool_call IDs to remove.
+
+    Returns:
+        New message list with orphaned tool calls removed.
+    """
+    orphaned_set = set(orphaned_ids)
+    result = []
+
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            new_msg = dict(msg)
+
+            # Filter tool_calls array
+            if "tool_calls" in new_msg:
+                new_msg["tool_calls"] = [
+                    tc
+                    for tc in new_msg["tool_calls"]
+                    if tc.get("id") not in orphaned_set
+                ]
+                if not new_msg["tool_calls"]:
+                    del new_msg["tool_calls"]
+
+            # Filter content blocks (Anthropic format)
+            content = new_msg.get("content")
+            if isinstance(content, list):
+                new_content = [
+                    block
+                    for block in content
+                    if not (
+                        isinstance(block, dict)
+                        and block.get("type") == "tool_use"
+                        and block.get("id") in orphaned_set
+                    )
+                ]
+                new_msg["content"] = new_content
+
+            result.append(new_msg)
+        else:
+            result.append(msg)
+
+    return result
+
+
+def get_turn_summary(
+    messages: list[dict[str, Any]],
+    turn: int,
+    *,
+    max_length: int = 100,
+) -> dict[str, Any]:
+    """Get a summary of a specific turn for display purposes.
+
+    Args:
+        messages: List of conversation messages.
+        turn: Turn number (1-indexed).
+        max_length: Maximum length for content preview.
+
+    Returns:
+        Dictionary with turn information:
+        - turn: Turn number
+        - user_content: Truncated user message
+        - assistant_content: Truncated assistant response
+        - tool_count: Number of tool calls in turn
+        - message_count: Total messages in turn
+
+    Raises:
+        ValueError: If turn is out of range.
+    """
+    boundaries = get_turn_boundaries(messages)
+    max_turns = len(boundaries)
+
+    if turn < 1 or turn > max_turns:
+        raise ValueError(f"Turn {turn} out of range (1-{max_turns})")
+
+    start_idx = boundaries[turn - 1]  # 0-indexed
+    end_idx = boundaries[turn] if turn < max_turns else len(messages)
+
+    turn_messages = messages[start_idx:end_idx]
+
+    user_content = ""
+    assistant_content = ""
+    tool_count = 0
+
+    for msg in turn_messages:
+        role = msg.get("role")
+        content = msg.get("content", "")
+
+        if role == "user":
+            if isinstance(content, str):
+                user_content = content[:max_length]
+                if len(content) > max_length:
+                    user_content += "..."
+            elif isinstance(content, list):
+                # Extract text from content blocks
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        user_content = block.get("text", "")[:max_length]
+                        break
+
+        elif role == "assistant":
+            if isinstance(content, str):
+                if not assistant_content:  # First assistant message
+                    assistant_content = content[:max_length]
+                    if len(content) > max_length:
+                        assistant_content += "..."
+            elif isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict):
+                        if block.get("type") == "text" and not assistant_content:
+                            assistant_content = block.get("text", "")[:max_length]
+                        elif block.get("type") == "tool_use":
+                            tool_count += 1
+
+            # Count tool_calls
+            if "tool_calls" in msg:
+                tool_count += len(msg["tool_calls"])
+
+    return {
+        "turn": turn,
+        "user_content": user_content,
+        "assistant_content": assistant_content,
+        "tool_count": tool_count,
+        "message_count": len(turn_messages),
+    }

--- a/amplifier_foundation/session/slice.py
+++ b/amplifier_foundation/session/slice.py
@@ -1,402 +1,44 @@
-"""Message slicing utilities for session fork operations.
+"""Deprecated: message slicing utilities — now in messages.py.
 
-This module provides pure functions for slicing conversation messages
-at turn boundaries. A "turn" is defined as a user message plus all
-subsequent non-user messages until the next user message.
+All functions in this module have been moved to
+``amplifier_foundation.session.messages``.  This module remains as a
+thin backward-compatibility shim so existing imports continue to work,
+but it will be removed in a future release.
 
-Turns are 1-indexed for user-facing operations (turn 1 = first exchange).
+Migrate your imports::
+
+    # Old (deprecated)
+    from amplifier_foundation.session.slice import get_turn_boundaries
+
+    # New
+    from amplifier_foundation.session.messages import get_turn_boundaries
 """
 
 from __future__ import annotations
 
-import json
-from typing import Any
-
-
-def get_turn_boundaries(messages: list[dict[str, Any]]) -> list[int]:
-    """Return indices where each turn starts (user message positions).
-
-    A turn begins with each user message. This returns the 0-indexed
-    positions of all user messages in the conversation.
-
-    Args:
-        messages: List of conversation messages with 'role' field.
-
-    Returns:
-        List of indices where user messages appear.
-
-    Example:
-        >>> messages = [
-        ...     {"role": "user", "content": "Q1"},
-        ...     {"role": "assistant", "content": "A1"},
-        ...     {"role": "user", "content": "Q2"},
-        ... ]
-        >>> get_turn_boundaries(messages)
-        [0, 2]
-    """
-    return [i for i, msg in enumerate(messages) if msg.get("role") == "user"]
-
-
-def count_turns(messages: list[dict[str, Any]]) -> int:
-    """Count the number of turns in a conversation.
-
-    Args:
-        messages: List of conversation messages.
-
-    Returns:
-        Number of turns (user messages) in the conversation.
-    """
-    return len(get_turn_boundaries(messages))
-
-
-def slice_to_turn(
-    messages: list[dict[str, Any]],
-    turn: int,
-    *,
-    handle_orphaned_tools: str = "complete",
-) -> list[dict[str, Any]]:
-    """Slice messages to include only up to turn N (1-indexed).
-
-    Turn N includes the Nth user message and all responses until the
-    next user message (or end of conversation).
-
-    Args:
-        messages: Full message list from transcript.
-        turn: Turn number (1-indexed). Turn 1 = first user message + response.
-        handle_orphaned_tools: How to handle tool_use without tool_result:
-            - "complete": Add synthetic error result (default)
-            - "remove": Remove the orphaned tool_use content
-            - "error": Raise ValueError
-
-    Returns:
-        Sliced message list with orphaned tools handled.
-
-    Raises:
-        ValueError: If turn < 1 or turn > max_turns, or if handle_orphaned_tools
-            is "error" and orphaned tools are found.
-
-    Example:
-        >>> messages = [
-        ...     {"role": "user", "content": "Q1"},
-        ...     {"role": "assistant", "content": "A1"},
-        ...     {"role": "user", "content": "Q2"},
-        ...     {"role": "assistant", "content": "A2"},
-        ... ]
-        >>> sliced = slice_to_turn(messages, 1)
-        >>> len(sliced)
-        2
-    """
-    if turn < 1:
-        raise ValueError(f"Turn must be >= 1, got {turn}")
-
-    boundaries = get_turn_boundaries(messages)
-    max_turns = len(boundaries)
-
-    if max_turns == 0:
-        raise ValueError("No user messages found in conversation")
-
-    if turn > max_turns:
-        raise ValueError(
-            f"Turn {turn} exceeds max turns ({max_turns}). Valid range: 1-{max_turns}"
-        )
-
-    # Find end index: start of turn N+1, or end of messages
-    if turn < max_turns:
-        end_idx = boundaries[
-            turn
-        ]  # Start of next turn (0-indexed, so turn N+1 = boundaries[turn])
-    else:
-        end_idx = len(messages)  # Include all messages
-
-    sliced = messages[:end_idx]
-
-    # Handle orphaned tool calls
-    orphaned = find_orphaned_tool_calls(sliced)
-    if orphaned:
-        if handle_orphaned_tools == "error":
-            raise ValueError(
-                f"Orphaned tool calls at fork boundary: {orphaned}. "
-                "These tool_use blocks have no matching tool_result."
-            )
-        elif handle_orphaned_tools == "remove":
-            sliced = _remove_orphaned_tool_calls(sliced, orphaned)
-        else:  # "complete" is default
-            sliced = add_synthetic_tool_results(sliced, orphaned)
-
-    return sliced
-
-
-def find_orphaned_tool_calls(messages: list[dict[str, Any]]) -> list[str]:
-    """Find tool_call IDs that have no corresponding tool result.
-
-    Scans messages for tool_calls in assistant messages and tool results,
-    returning IDs of calls that don't have matching results.
-
-    Args:
-        messages: List of conversation messages.
-
-    Returns:
-        List of orphaned tool_call IDs.
-    """
-    # Collect all tool_call IDs from assistant messages
-    called_ids: set[str] = set()
-    for msg in messages:
-        if msg.get("role") == "assistant":
-            # Check tool_calls array (standard format)
-            if "tool_calls" in msg:
-                for tc in msg["tool_calls"]:
-                    if "id" in tc:
-                        called_ids.add(tc["id"])
-            # Check content blocks (Anthropic format)
-            content = msg.get("content")
-            if isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "tool_use":
-                        if "id" in block:
-                            called_ids.add(block["id"])
-
-    # Collect all tool_call_ids from tool results
-    result_ids: set[str] = set()
-    for msg in messages:
-        if msg.get("role") == "tool" and "tool_call_id" in msg:
-            result_ids.add(msg["tool_call_id"])
-
-    return list(called_ids - result_ids)
-
-
-def add_synthetic_tool_results(
-    messages: list[dict[str, Any]],
-    orphaned_ids: list[str],
-) -> list[dict[str, Any]]:
-    """Add synthetic error results for orphaned tool calls.
-
-    When forking a session mid-turn, some tool calls may not have results.
-    This adds synthetic error results inserted immediately after the assistant
-    message that made the tool calls, so the conversation remains valid.
-
-    Args:
-        messages: List of conversation messages.
-        orphaned_ids: List of tool_call IDs needing synthetic results.
-
-    Returns:
-        New message list with synthetic tool results inserted at correct positions.
-    """
-    if not orphaned_ids:
-        return messages
-
-    orphaned_set = set(orphaned_ids)
-
-    # Build mapping of tool_call_id -> tool_name from assistant messages
-    tool_names: dict[str, str] = {}
-    for msg in messages:
-        if msg.get("role") == "assistant":
-            # Handle OpenAI format: tool_calls array
-            for tc in msg.get("tool_calls", []):
-                tc_id = tc.get("id", "")
-                tc_name = tc.get("function", {}).get("name", "") or tc.get("name", "")
-                if tc_id and tc_name:
-                    tool_names[tc_id] = tc_name
-            # Handle Anthropic format: content blocks with tool_use
-            content = msg.get("content")
-            if isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "tool_use":
-                        tc_id = block.get("id", "")
-                        tc_name = block.get("name", "")
-                        if tc_id and tc_name:
-                            tool_names[tc_id] = tc_name
-
-    # Walk messages and insert synthetics at correct positions
-    result: list[dict[str, Any]] = []
-    for i, msg in enumerate(messages):
-        result.append(msg)
-
-        # After each assistant message, check if any of its tool_calls are orphaned
-        if msg.get("role") == "assistant":
-            # Collect orphaned tool_call IDs from this assistant message (OpenAI format)
-            msg_orphans: list[str] = []
-            for tc in msg.get("tool_calls", []):
-                tc_id = tc.get("id", "")
-                if tc_id in orphaned_set:
-                    msg_orphans.append(tc_id)
-            # Also check Anthropic format
-            content = msg.get("content")
-            if isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "tool_use":
-                        tc_id = block.get("id", "")
-                        if tc_id in orphaned_set:
-                            msg_orphans.append(tc_id)
-
-            if msg_orphans:
-                # Insert synthetic results immediately after this assistant message
-                for tc_id in msg_orphans:
-                    tool_name = tool_names.get(tc_id)
-                    synthetic: dict[str, Any] = {
-                        "role": "tool",
-                        "tool_call_id": tc_id,
-                        "content": json.dumps(
-                            {
-                                "error": "Tool execution interrupted by session fork",
-                                "forked": True,
-                                "message": "This tool call was in progress when the session was forked. "
-                                "The result is not available in this forked session.",
-                            }
-                        ),
-                    }
-                    if tool_name:
-                        synthetic["name"] = tool_name
-                    result.append(synthetic)
-
-                # FM3 handling: if the next original message is a user message, insert
-                # a synthetic assistant response to close the interrupted turn first
-                next_idx = i + 1
-                if (
-                    next_idx < len(messages)
-                    and messages[next_idx].get("role") == "user"
-                ):
-                    result.append(
-                        {
-                            "role": "assistant",
-                            "content": "The previous tool calls were interrupted by a session fork. "
-                            "Results are not available in this forked session.",
-                        }
-                    )
-
-    return result
-
-
-def _remove_orphaned_tool_calls(
-    messages: list[dict[str, Any]],
-    orphaned_ids: list[str],
-) -> list[dict[str, Any]]:
-    """Remove orphaned tool_call entries from messages.
-
-    This modifies assistant messages to remove tool_calls that don't have
-    corresponding results. Use with caution as this alters conversation history.
-
-    Args:
-        messages: List of conversation messages.
-        orphaned_ids: List of tool_call IDs to remove.
-
-    Returns:
-        New message list with orphaned tool calls removed.
-    """
-    orphaned_set = set(orphaned_ids)
-    result = []
-
-    for msg in messages:
-        if msg.get("role") == "assistant":
-            new_msg = dict(msg)
-
-            # Filter tool_calls array
-            if "tool_calls" in new_msg:
-                new_msg["tool_calls"] = [
-                    tc
-                    for tc in new_msg["tool_calls"]
-                    if tc.get("id") not in orphaned_set
-                ]
-                if not new_msg["tool_calls"]:
-                    del new_msg["tool_calls"]
-
-            # Filter content blocks (Anthropic format)
-            content = new_msg.get("content")
-            if isinstance(content, list):
-                new_content = [
-                    block
-                    for block in content
-                    if not (
-                        isinstance(block, dict)
-                        and block.get("type") == "tool_use"
-                        and block.get("id") in orphaned_set
-                    )
-                ]
-                new_msg["content"] = new_content
-
-            result.append(new_msg)
-        else:
-            result.append(msg)
-
-    return result
-
-
-def get_turn_summary(
-    messages: list[dict[str, Any]],
-    turn: int,
-    *,
-    max_length: int = 100,
-) -> dict[str, Any]:
-    """Get a summary of a specific turn for display purposes.
-
-    Args:
-        messages: List of conversation messages.
-        turn: Turn number (1-indexed).
-        max_length: Maximum length for content preview.
-
-    Returns:
-        Dictionary with turn information:
-        - turn: Turn number
-        - user_content: Truncated user message
-        - assistant_content: Truncated assistant response
-        - tool_count: Number of tool calls in turn
-        - message_count: Total messages in turn
-
-    Raises:
-        ValueError: If turn is out of range.
-    """
-    boundaries = get_turn_boundaries(messages)
-    max_turns = len(boundaries)
-
-    if turn < 1 or turn > max_turns:
-        raise ValueError(f"Turn {turn} out of range (1-{max_turns})")
-
-    start_idx = boundaries[turn - 1]  # 0-indexed
-    end_idx = boundaries[turn] if turn < max_turns else len(messages)
-
-    turn_messages = messages[start_idx:end_idx]
-
-    user_content = ""
-    assistant_content = ""
-    tool_count = 0
-
-    for msg in turn_messages:
-        role = msg.get("role")
-        content = msg.get("content", "")
-
-        if role == "user":
-            if isinstance(content, str):
-                user_content = content[:max_length]
-                if len(content) > max_length:
-                    user_content += "..."
-            elif isinstance(content, list):
-                # Extract text from content blocks
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        user_content = block.get("text", "")[:max_length]
-                        break
-
-        elif role == "assistant":
-            if isinstance(content, str):
-                if not assistant_content:  # First assistant message
-                    assistant_content = content[:max_length]
-                    if len(content) > max_length:
-                        assistant_content += "..."
-            elif isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict):
-                        if block.get("type") == "text" and not assistant_content:
-                            assistant_content = block.get("text", "")[:max_length]
-                        elif block.get("type") == "tool_use":
-                            tool_count += 1
-
-            # Count tool_calls
-            if "tool_calls" in msg:
-                tool_count += len(msg["tool_calls"])
-
-    return {
-        "turn": turn,
-        "user_content": user_content,
-        "assistant_content": assistant_content,
-        "tool_count": tool_count,
-        "message_count": len(turn_messages),
-    }
+import warnings as _warnings
+
+_warnings.warn(
+    "amplifier_foundation.session.slice is deprecated. "
+    "Import from amplifier_foundation.session.messages instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from .messages import add_synthetic_tool_results  # noqa: E402, F401
+from .messages import count_turns  # noqa: E402, F401
+from .messages import find_orphaned_tool_calls  # noqa: E402, F401
+from .messages import get_turn_boundaries  # noqa: E402, F401
+from .messages import get_turn_summary  # noqa: E402, F401
+from .messages import is_real_user_message  # noqa: E402, F401
+from .messages import slice_to_turn  # noqa: E402, F401
+
+__all__ = [
+    "add_synthetic_tool_results",
+    "count_turns",
+    "find_orphaned_tool_calls",
+    "get_turn_boundaries",
+    "get_turn_summary",
+    "is_real_user_message",
+    "slice_to_turn",
+]

--- a/amplifier_foundation/session/store.py
+++ b/amplifier_foundation/session/store.py
@@ -1,0 +1,68 @@
+"""Layer Level 2 (JSONL Store) — knows file formats, zero path-convention knowledge.
+
+This module provides:
+- Filename constants for standard session files
+- Generic JSONL read/write utilities
+
+It operates purely on Path objects and has no knowledge of where sessions live
+on disk or how directories are structured.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterator
+
+# ---------------------------------------------------------------------------
+# Filename constants
+# ---------------------------------------------------------------------------
+
+TRANSCRIPT_FILENAME = "transcript.jsonl"
+METADATA_FILENAME = "metadata.json"
+EVENTS_FILENAME = "events.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# JSONL I/O
+# ---------------------------------------------------------------------------
+
+
+def read_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    """Yield parsed JSON objects from a JSONL file.
+
+    - Opens the file with UTF-8 encoding.
+    - Skips blank lines silently.
+    - Skips lines that cannot be parsed as JSON silently.
+
+    Args:
+        path: Path to the JSONL file to read.
+
+    Yields:
+        Parsed dict objects, one per valid JSON line.
+    """
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                yield json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+
+
+def write_jsonl(path: Path, entries: list[dict[str, Any]]) -> None:
+    """Write a list of dicts to a JSONL file, one entry per line.
+
+    - Opens the file with UTF-8 encoding in write mode (overwrites if exists).
+    - Writes each entry as a JSON string followed by a newline.
+    - Uses ``ensure_ascii=False`` to preserve Unicode characters literally.
+
+    Args:
+        path: Destination path to write.
+        entries: List of dicts to serialise.
+    """
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry, ensure_ascii=False) + "\n")

--- a/amplifier_foundation/session/store.py
+++ b/amplifier_foundation/session/store.py
@@ -3,6 +3,7 @@
 This module provides:
 - Filename constants for standard session files
 - Generic JSONL read/write utilities
+- Session-specific I/O functions for transcripts, metadata, and backups
 
 It operates purely on Path objects and has no knowledge of where sessions live
 on disk or how directories are structured.
@@ -11,6 +12,8 @@ on disk or how directories are structured.
 from __future__ import annotations
 
 import json
+import shutil
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -66,3 +69,112 @@ def write_jsonl(path: Path, entries: list[dict[str, Any]]) -> None:
     with path.open("w", encoding="utf-8") as fh:
         for entry in entries:
             fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Session-specific I/O
+# ---------------------------------------------------------------------------
+
+
+def load_transcript(session_dir: Path) -> list[dict[str, Any]]:
+    """Load messages from transcript.jsonl in the given session directory.
+
+    Args:
+        session_dir: Path to the session directory containing transcript.jsonl.
+
+    Returns:
+        List of parsed message dicts.
+    """
+    return list(read_jsonl(session_dir / TRANSCRIPT_FILENAME))
+
+
+def load_transcript_with_lines(session_dir: Path) -> list[dict[str, Any]]:
+    """Load transcript entries, injecting the 1-based source line number into each.
+
+    Unlike ``load_transcript``, this function preserves original line numbers from
+    the file (blank lines are skipped but their positions are counted), and raises
+    on malformed JSON instead of silently skipping.
+
+    Args:
+        session_dir: Path to the session directory containing transcript.jsonl.
+
+    Returns:
+        List of parsed message dicts, each with an injected ``line_num`` key.
+
+    Raises:
+        ValueError: If a non-blank line cannot be parsed as JSON, with a message
+            that includes the 1-based line number.
+    """
+    entries: list[dict[str, Any]] = []
+    path = session_dir / TRANSCRIPT_FILENAME
+    with path.open(encoding="utf-8") as fh:
+        for line_num, line in enumerate(fh, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                entry = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Malformed JSON at line {line_num}: {exc}") from exc
+            entry["line_num"] = line_num
+            entries.append(entry)
+    return entries
+
+
+def write_transcript(session_dir: Path, entries: list[dict[str, Any]]) -> None:
+    """Write entries to transcript.jsonl in the given session directory.
+
+    Args:
+        session_dir: Path to the session directory.
+        entries: List of message dicts to write.
+    """
+    write_jsonl(session_dir / TRANSCRIPT_FILENAME, entries)
+
+
+def load_metadata(session_dir: Path) -> dict[str, Any]:
+    """Load metadata.json from the given session directory.
+
+    Args:
+        session_dir: Path to the session directory containing metadata.json.
+
+    Returns:
+        Parsed metadata dict.
+    """
+    return json.loads((session_dir / METADATA_FILENAME).read_text(encoding="utf-8"))
+
+
+def write_metadata(session_dir: Path, metadata: dict[str, Any]) -> None:
+    """Write metadata to metadata.json in the given session directory.
+
+    Uses ``indent=2`` for human-readable pretty-printing and ``ensure_ascii=False``
+    to preserve Unicode characters literally.
+
+    Args:
+        session_dir: Path to the session directory.
+        metadata: Metadata dict to write.
+    """
+    (session_dir / METADATA_FILENAME).write_text(
+        json.dumps(metadata, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def backup(filepath: Path, label: str) -> Path | None:
+    """Create a timestamped backup copy of a file.
+
+    The backup is placed in the same directory as the original with a name of the
+    form ``<original-name>.bak-<label>-<YYYYMMDDHHMMSS>``.
+
+    Args:
+        filepath: Path to the file to back up.
+        label: Label string inserted between ``bak-`` and the timestamp.
+
+    Returns:
+        Path to the backup file, or ``None`` if ``filepath`` does not exist.
+    """
+    if not filepath.exists():
+        return None
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
+    backup_path = filepath.parent / f"{filepath.name}.bak-{label}-{timestamp}"
+    shutil.copy2(filepath, backup_path)
+    return backup_path

--- a/context/agents/session-repair-knowledge.md
+++ b/context/agents/session-repair-knowledge.md
@@ -4,7 +4,7 @@ Reference documentation for the session repair script and the failure modes it h
 
 **Repair-first default:** ALWAYS attempt REPAIR before REWIND. Repair preserves maximum context. Rewind only when the user explicitly requests it.
 
-**Script-only rule:** ALL diagnosis, repair, and rewind operations MUST use `scripts/session-repair.py`. Never attempt manual JSONL editing.
+**Script-only rule:** ALL diagnosis, repair, and rewind operations MUST use `scripts/amplifier-session.py`. Never attempt manual JSONL editing.
 
 ---
 
@@ -51,20 +51,28 @@ Tool results are present and correctly ordered, but there is no final assistant 
 
 ## Programmatic Repair Script
 
-**Location:** `scripts/session-repair.py` (in the amplifier-foundation repo, stdlib-only Python, no dependencies)
+**Location:** `scripts/amplifier-session.py` (in the amplifier-foundation repo; `scripts/session-repair.py` is deprecated)
 
 ### Usage
 
 ```bash
 # Diagnose only (read-only, safe)
-python scripts/session-repair.py --diagnose /path/to/session/
+python scripts/amplifier-session.py diagnose <session>
 
-# Repair with COMPLETE strategy (creates timestamped backup first)
-python scripts/session-repair.py --repair /path/to/session/
+# Repair (creates timestamped backup first)
+python scripts/amplifier-session.py repair <session>
 
 # Rewind (truncate — creates timestamped backups of both transcript and events)
-python scripts/session-repair.py --rewind /path/to/session/
+python scripts/amplifier-session.py rewind <session>
+
+# Show session info
+python scripts/amplifier-session.py info <session>
+
+# Find sessions
+python scripts/amplifier-session.py find --project myproj --keyword "auth"
 ```
+
+The `<session>` argument accepts full paths, session IDs, or partial IDs.
 
 ### Exit Codes
 
@@ -97,10 +105,10 @@ Fields:
 
 ### Verification
 
-After any repair or rewind, run `--diagnose` again to confirm success:
+After any repair or rewind, run `diagnose` again to confirm success:
 
 ```bash
-python scripts/session-repair.py --diagnose /path/to/session/
+python scripts/amplifier-session.py diagnose <session>
 # Exit code 0 + {"status": "healthy"} = all checks pass
 # Exit code 1 + {"status": "broken"} = issues remain
 ```

--- a/context/agents/session-repair-knowledge.md
+++ b/context/agents/session-repair-knowledge.md
@@ -78,11 +78,11 @@ The `<session>` argument accepts full paths, session IDs, or partial IDs.
 
 | Code | Meaning |
 |------|---------|
-| 0 | Success (healthy on `--diagnose`, repaired on `--repair`, rewound on `--rewind`) |
-| 1 | Repair needed (`--diagnose`) or repair failed (`--repair`) |
+| 0 | Success (healthy on `diagnose`, repaired on `repair`, rewound on `rewind`) |
+| 1 | Repair needed (`diagnose`) or repair failed (`repair`) |
 | 2 | Invalid arguments or missing transcript file |
 
-### `--diagnose` JSON Output Format
+### `diagnose` JSON Output Format
 
 ```json
 {

--- a/context/agents/session-storage-knowledge.md
+++ b/context/agents/session-storage-knowledge.md
@@ -195,17 +195,16 @@ If the first count is higher than the second, there are orphaned tool_use blocks
 
 ### Recovery
 
-Insert a synthetic `tool_result` message after the orphaned `tool_use` in transcript.jsonl:
+**Use the session repair script — do not manually edit transcript.jsonl.**
 
-```json
-{"role":"tool","tool_call_id":"THE_ORPHANED_TOOL_ID","content":"{\"error\": \"Tool execution was interrupted by user\", \"interrupted\": true}","timestamp":"ISO_TIMESTAMP"}
+```bash
+SCRIPT="$(find / -path '*/amplifier-foundation/scripts/amplifier-session.py' -type f 2>/dev/null | head -1)"
+python "$SCRIPT" diagnose <session>
+python "$SCRIPT" repair <session>
+python "$SCRIPT" diagnose <session>   # verify
 ```
 
-**Steps:**
-1. Find the line with orphaned tool_use: `grep -n "THE_TOOL_ID" transcript.jsonl | cut -d: -f1`
-2. Back up the file: `cp transcript.jsonl transcript.jsonl.backup`
-3. Insert synthetic result after that line using `head`/`tail` or `sed`
-4. Verify the session loads correctly
+The script automatically detects orphaned tool calls, injects synthetic results, and creates timestamped backups.
 
 ## Key Principle
 

--- a/docs/plans/2026-03-18-session-utils-restructure-design.md
+++ b/docs/plans/2026-03-18-session-utils-restructure-design.md
@@ -1,0 +1,456 @@
+# Session Management Library Restructure Design
+
+## Goal
+
+Restructure `amplifier_foundation/session/` into a clean, modular library with a unified CLI script, so the session-analyst agent (a Haiku-class fast model) can perform session operations via single-command invocations instead of multi-step bash choreography — making the agent more reliable, enabling less-capable models, and consolidating scattered/duplicated code.
+
+## Background
+
+### The Problem
+
+The session-analyst agent currently performs session operations through multi-step bash choreography: locating scripts via `find /`, manually constructing file paths, chaining multiple commands, and parsing unstructured output. This is fragile on a Haiku-class model — manual JSONL editing has proven to break sessions further rather than repair them.
+
+### What Exists Today
+
+Two separate session management systems exist in amplifier-foundation, disconnected from each other:
+
+1. **`scripts/session-repair.py`** — A standalone 582-line script (not importable, not installable). The agent discovers it by searching the entire filesystem. Handles diagnose/repair/rewind.
+
+2. **`amplifier_foundation/session/`** — A proper, installable Python library with `fork.py`, `slice.py`, `events.py`, and `capabilities.py`. Contains sophisticated helpers (`find_orphaned_tool_calls()`, `add_synthetic_tool_results()`, `slice_to_turn()`, `fork_session()`, `get_session_lineage()`, streaming events manipulation). The session-analyst agent does not know this library exists.
+
+Both systems duplicate orphan-detection code with different error messages. There are zero CLI entry points in `pyproject.toml`. The behavior bundle (`behaviors/sessions.yaml`) already composes hooks-logging + hooks-session-naming + session-analyst, but the tooling underneath is fragmented.
+
+### Expert Consultation
+
+Four experts (foundation-expert, amplifier-expert, zen-architect, core-expert) independently confirmed the same layered architecture and converged on keeping everything in foundation. Key findings:
+
+- The kernel (`amplifier-core`) knows nothing about persistence — zero references to `transcript.jsonl`, `events.jsonl`, or any storage path. The kernel provides mechanisms (hooks, `get_messages()`/`set_messages()`, session IDs); everything else is policy.
+- The current storage format is a convention of amplifier-app-cli + hooks-logging, not a contract.
+- The existing `session/` package is appropriately placed — it is the reference implementation for the sessions behavior, not a generic framework.
+
+## Approach
+
+**Approach C (phased):** Full library restructure with expanded capabilities, executed in three phases so the core restructure lands first, then expanded capabilities layer on, then agent instructions are rewritten.
+
+### Why Not Simpler Approaches
+
+- **Approach A (additive)** — Adding new modules alongside existing ones leaves naming inconsistencies (`slice.py`), duplicated orphan detection, and no consolidation of I/O helpers. Technical debt compounds.
+- **Approach B (restructure only)** — Clean boundaries but misses the opportunity to add session discovery, search, and info capabilities that eliminate entire categories of agent bash choreography.
+
+### Key Architectural Decisions
+
+- **Stay in amplifier-foundation** — The session behavior is the standard policy implementation for the Amplifier ecosystem. Foundation is the right layer. No separate repo.
+- **`python <script>` invocation, not an installed CLI** — If `amplifier-session` were registered in `pyproject.toml`, it would be installed for every user of amplifier-foundation, including apps that don't use the sessions behavior. Scripts stay in `scripts/` and are invoked by the agent via bash.
+- **No premature abstractions** — No `SessionStore` protocol, no pluggable backends. Build for the concrete JSONL/file case. Extract an interface only if a second storage implementation appears.
+- **Amplifier ecosystem awareness is fine** — Core kernel concepts (`role`, `tool_calls`, coordinator protocol, `session_id`) are appropriate in foundation. App-specific config choices (directory paths) are defaults, not hardcoded logic.
+
+## Architecture
+
+### Three-Layer Model
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Level 3: Session Finder                                        │
+│  "Where are sessions?"                                          │
+│  ~/.amplifier/projects/PROJECT/sessions/SESSION_ID/             │
+│  find, resolve partial IDs, search by date/keyword/project      │
+├─────────────────────────────────────────────────────────────────┤
+│  Level 2: JSONL Store                                           │
+│  "How are sessions stored?"                                     │
+│  transcript.jsonl, metadata.json, events.jsonl                  │
+│  read/write JSONL, backup, directory-as-session-unit            │
+├─────────────────────────────────────────────────────────────────┤
+│  Level 1: Message Algebra                                       │
+│  "What can we do with message lists?"                           │
+│  Pure list[dict] → list[dict] operations, zero I/O              │
+│  Turn boundaries, orphan detection, diagnosis, repair, rewind   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Each level depends only on the level below it. Level 1 has zero I/O. Level 2 knows file formats. Level 3 knows directory conventions.
+
+### Dependency Flow
+
+```
+scripts/amplifier-session.py  (thin CLI wrapper)
+    │
+    ├── finder.py        (Level 3: resolve session references)
+    │     └── store.py   (Level 2: read metadata for search results)
+    │
+    ├── store.py         (Level 2: load/save transcripts)
+    │
+    ├── diagnosis.py     (Level 1: diagnose/repair/rewind)
+    │     └── messages.py (Level 1: orphan detection, turn ops)
+    │
+    └── fork.py          (Composite: uses messages + store)
+          ├── messages.py
+          └── store.py
+```
+
+## Components
+
+### `messages.py` — Level 1: Pure Message Operations
+
+**Renamed from `slice.py`.** Mostly a rename plus deduplication, not a rewrite. Existing functions are proven and well-tested (701-line test suite).
+
+**Functions that move unchanged:**
+
+- `get_turn_boundaries(messages) -> list[int]`
+- `count_turns(messages) -> int`
+- `slice_to_turn(messages, turn, handle_orphaned_tools="complete") -> list[dict]`
+- `find_orphaned_tool_calls(messages) -> list[str]`
+- `add_synthetic_tool_results(messages, orphaned_ids) -> list[dict]`
+- `get_turn_summary(messages, turn) -> dict`
+- `_remove_orphaned_tool_calls(messages, orphaned_ids) -> list[dict]`
+
+**Deduplication:** Today both `slice.py` and the repair script independently detect orphaned tool calls with different synthetic content (`slice.py` produces `"forked": True`, repair script produces `"unknown_error"`). After restructure, `messages.py` keeps the orphan detection logic (one implementation). The synthetic content is parameterized — `diagnosis.py` passes repair-specific content, `fork.py` passes fork-specific content.
+
+**New addition:** `is_real_user_message(entry) -> bool` moves here from the repair script. It is a pure message-level operation (checks role, tool_call_id, system-reminder tags) needed by both `diagnosis.py` and other callers.
+
+**Migration:** `slice.py` is renamed to `messages.py`. A compatibility shim in `slice.py` re-exports from `messages.py` with a deprecation warning for a migration period.
+
+### `diagnosis.py` — Level 1: Pure Repair Algorithms
+
+Extracts all pure algorithms from `scripts/session-repair.py` into importable, testable library code. Zero I/O — takes parsed entries in, returns results out.
+
+**Types:**
+
+```python
+class IncompleteTurn(TypedDict):
+    after_line: int
+    missing: str
+
+class DiagnosisResult(TypedDict):
+    status: str                         # "healthy" | "broken"
+    failure_modes: list[str]
+    orphaned_tool_ids: list[str]        # FM1: tool_use IDs with no result
+    misplaced_tool_ids: list[str]       # FM2: tool_use IDs with out-of-order results
+    incomplete_turns: list[IncompleteTurn]  # FM3: turns missing closing assistant response
+    recommended_action: str             # "none" | "repair"
+```
+
+**Core functions:**
+
+```python
+build_tool_index(entries: list[dict]) -> dict
+    # Maps tool_use IDs → {line_num, tool_name, entry_index}
+    # Maps tool_result IDs → {line_num, entry_index}
+
+is_real_user_message(entry: dict) -> bool
+    # role=="user", no tool_call_id, not <system-reminder>
+
+diagnose_transcript(entries: list[dict]) -> DiagnosisResult
+    # Detects all three failure modes, returns structured result
+
+repair_transcript(entries: list[dict], diagnosis: DiagnosisResult) -> list[dict]
+    # COMPLETE strategy: inject synthetics, remove misplaced results
+
+rewind_transcript(entries: list[dict], diagnosis: DiagnosisResult) -> list[dict]
+    # Truncate to before last real user message prior to earliest issue
+```
+
+**What changes from the repair script:**
+
+- Uses `messages.py` for orphan detection instead of reimplementing it (deduplication)
+- `diagnose()` renamed to `diagnose_transcript()` to avoid collision with file-level operations
+- Synthetic entry constants (`SYNTHETIC_TOOL_RESULT_CONTENT`, `SYNTHETIC_ASSISTANT_RESPONSE`) stay here — they are repair-specific, distinct from fork.py's fork-specific synthetics
+
+**What stays the same:** The actual repair/rewind/diagnosis algorithms. They are battle-tested (1037-line test suite) and proven in production. We are moving them, not rewriting them.
+
+### `store.py` — Level 2: Consolidated JSONL I/O
+
+Consolidates scattered/duplicated file I/O helpers into one module — the single place that knows how to read/write session files.
+
+**Functions:**
+
+```python
+# Reading
+load_transcript(session_dir: Path) -> list[dict]
+load_transcript_with_lines(session_dir: Path) -> list[dict]   # adds line_num for diagnosis
+load_metadata(session_dir: Path) -> dict
+read_jsonl(path: Path) -> Iterator[dict]                       # generic streaming reader
+
+# Writing
+write_transcript(session_dir: Path, entries: list[dict]) -> None
+write_metadata(session_dir: Path, metadata: dict) -> None
+write_jsonl(path: Path, entries: list[dict]) -> None
+
+# Safety
+backup(filepath: Path, label: str) -> Path                     # timestamped .bak file
+
+# Constants (single source of truth)
+TRANSCRIPT_FILENAME = "transcript.jsonl"
+METADATA_FILENAME = "metadata.json"
+EVENTS_FILENAME = "events.jsonl"
+```
+
+**Consolidation map:**
+
+| Today (scattered) | Tomorrow (`store.py`) |
+|----|-----|
+| Repair script's `parse_transcript()` | `load_transcript_with_lines()` |
+| Repair script's `_write_entries()` | `write_transcript()` |
+| Repair script's `_backup()` | `backup()` |
+| fork.py's `_load_transcript()` | `load_transcript()` |
+| fork.py's `_write_transcript()` | `write_transcript()` |
+| fork.py's `_load_metadata()` | `load_metadata()` |
+| events.py's `_read_jsonl()` | `read_jsonl()` |
+
+The three filename constants replace 14+ hardcoded string constructions across `fork.py`. After refactoring, `fork.py` imports from `store.py` instead of maintaining private I/O helpers.
+
+### `finder.py` — Level 3: Session Discovery
+
+The new module that eliminates the agent's multi-step bash choreography for finding sessions. Encodes the `~/.amplifier/projects/` path convention in one place.
+
+**Core functions:**
+
+```python
+resolve_session(session_ref: str, sessions_root: str | None = None) -> Path
+```
+
+Accepts full path, full session ID, or partial ID. The `sessions_root` defaults to `~/.amplifier/projects` but is overridable (for other apps or test environments). If a partial ID matches multiple sessions, raises an error listing the matches. If no match, raises an error with suggestions.
+
+```python
+find_sessions(
+    sessions_root: str | None = None,
+    project: str | None = None,
+    after: str | None = None,       # ISO date or relative ("yesterday", "last week")
+    before: str | None = None,
+    keyword: str | None = None,     # searches transcript content
+    status: str | None = None,      # "healthy" or "broken" (runs diagnosis)
+    limit: int = 50,
+) -> list[dict]
+```
+
+Returns list of `{session_id, path, project, created, bundle, model, turn_count, status}` dicts. Sorted by created (most recent first). The `keyword` search greps `transcript.jsonl` (never `events.jsonl`). The `status` filter calls `diagnosis.diagnose_transcript()` — potentially slow, so it is opt-in.
+
+```python
+session_info(session_dir: Path) -> dict
+```
+
+Returns metadata + turn count + health status + size info. Reads `metadata.json` and runs diagnosis.
+
+**Design choices:**
+
+- Default `sessions_root` of `~/.amplifier/projects` is the only place the CLI app's path convention lives — it is a default, not hardcoded logic
+- All functions accept explicit paths, so they work for any app using the same file format but different locations
+- Keyword search is deliberately limited to transcript (safe) and never touches events.jsonl (potentially 100k+ token lines that crash tools)
+
+### `scripts/amplifier-session.py` — Unified CLI Script
+
+A single script with subcommands that replaces all multi-step bash choreography. The agent goes from 4+ bash commands to 1 command per operation.
+
+**Subcommands:**
+
+```
+python scripts/amplifier-session.py diagnose <session>
+python scripts/amplifier-session.py repair <session>
+python scripts/amplifier-session.py rewind <session>
+python scripts/amplifier-session.py info <session>
+python scripts/amplifier-session.py find [--project X] [--after DATE] [--before DATE] [--keyword TEXT] [--status healthy|broken]
+python scripts/amplifier-session.py fork <session> --turn N
+```
+
+**The `<session>` argument is flexible:**
+
+- Full path: `/home/user/.amplifier/projects/myproj/sessions/abc123-def456/`
+- Session ID: `abc123-def456-...`
+- Partial ID: `abc123` (resolved via `finder.py`)
+
+Resolution logic lives in `finder.py` and is called by every subcommand. If a partial ID matches multiple sessions, it prints the matches and exits with an error (does not guess).
+
+**Output contract:** All subcommands produce structured JSON on stdout (parseable by the agent) with human-readable summaries on stderr. The agent parses JSON reliably; a human running it directly still gets useful output.
+
+**The script is thin** — each subcommand is roughly:
+1. Resolve session argument via `finder.py`
+2. Call the appropriate library function(s) from `diagnosis.py`, `store.py`, `fork.py`, etc.
+3. Format and print the result
+
+### `cli.py` — Shared Arg Parsing Helpers
+
+Shared argument parsing utilities used by the unified script. Keeps the script itself focused on orchestration rather than boilerplate.
+
+### Unchanged Components
+
+- **`events.py`** — Refined to import `read_jsonl` from `store.py` instead of maintaining a private `_read_jsonl`. Otherwise unchanged.
+- **`capabilities.py`** — Working directory helpers. Unchanged.
+- **`fork.py`** — Logic stays; I/O moves to `store.py` imports. Orphan detection delegates to `messages.py`.
+
+## Data Flow
+
+### Repair Flow (Agent Perspective)
+
+```
+Agent receives: "repair session abc123"
+  │
+  ▼
+python scripts/amplifier-session.py diagnose abc123
+  │
+  ├── finder.resolve_session("abc123") → /home/user/.amplifier/projects/myproj/sessions/abc123-.../
+  ├── store.load_transcript_with_lines(session_dir) → entries with line numbers
+  ├── diagnosis.diagnose_transcript(entries) → DiagnosisResult
+  └── stdout: JSON with status, failure modes, recommended action
+  │
+  ▼
+Agent reads JSON, reports diagnosis to user
+  │
+  ▼
+python scripts/amplifier-session.py repair abc123
+  │
+  ├── finder.resolve_session("abc123") → session_dir
+  ├── store.backup(transcript_path, "pre-repair") → .bak file
+  ├── store.load_transcript_with_lines(session_dir) → entries
+  ├── diagnosis.diagnose_transcript(entries) → diagnosis
+  ├── diagnosis.repair_transcript(entries, diagnosis) → repaired entries
+  ├── store.write_transcript(session_dir, repaired) → writes file
+  └── stdout: JSON with repair summary, backup path
+  │
+  ▼
+python scripts/amplifier-session.py diagnose abc123
+  │
+  └── stdout: JSON with status: "healthy" (verification)
+```
+
+### Session Search Flow
+
+```
+Agent receives: "find my recent sessions about authentication"
+  │
+  ▼
+python scripts/amplifier-session.py find --keyword "authentication" --after "last week"
+  │
+  ├── finder.find_sessions(keyword="authentication", after="last week")
+  │     ├── Walk ~/.amplifier/projects/*/sessions/*/
+  │     ├── Filter by date from metadata.json
+  │     ├── Grep transcript.jsonl for keyword (never events.jsonl)
+  │     └── Return sorted list with metadata
+  └── stdout: JSON array of matching sessions
+```
+
+## Error Handling
+
+### Script-Level
+
+- **Ambiguous session reference:** If a partial ID matches multiple sessions, the script prints all matches to stderr and exits with a non-zero code. The JSON on stdout contains the matches so the agent can present options to the user.
+- **Session not found:** Clear error message with the search paths tried. Suggests using `find` subcommand.
+- **Transcript parse errors:** Reported in the diagnosis result. The script never crashes on malformed JSONL — it reports what it can and flags unparseable lines.
+- **Backup failures:** If backup cannot be created (permissions, disk space), repair/rewind refuse to proceed. Safety first.
+
+### Agent-Level
+
+- **Script not found:** The agent locates the script with `find / -path '*/amplifier-foundation/scripts/amplifier-session.py'`. If not found, reports failure to user rather than attempting manual operations.
+- **Script fails:** The agent reports the error output to the user. No manual fallback — if the script fails, STOP. This is an explicit design constraint to prevent the Haiku-class model from attempting manual JSONL surgery.
+
+## Testing Strategy
+
+### Existing Tests (Preserved)
+
+- `slice.py` test suite (701 lines) → updated imports to `messages.py`
+- Repair script test suite (1037 lines) → updated to import from `diagnosis.py`
+- Fork test suite → updated to verify `store.py` integration
+
+### New Tests
+
+- **`finder.py` tests** — Session resolution with full paths, full IDs, partial IDs, ambiguous IDs, missing sessions. Search with project/date/keyword filters. Uses temp directories with synthetic session structures.
+- **`store.py` tests** — Round-trip read/write for transcript, metadata, JSONL. Backup creation and naming. Edge cases: empty files, malformed JSONL lines, missing files.
+- **`amplifier-session.py` CLI tests** — Subprocess-based (same pattern as existing `TestCLI` class). Verify each subcommand's JSON output structure, exit codes, and stderr messages.
+
+### Phase Gate
+
+Each implementation phase must leave all existing tests passing before moving to the next phase. No phase ships with broken tests.
+
+## Implementation Phasing
+
+### Phase 1 — Core Restructure
+
+| Step | Action | Risk |
+|------|--------|------|
+| 1 | Create `store.py` — consolidate all I/O helpers, introduce filename constants | Low |
+| 2 | Create `messages.py` — rename from `slice.py`, add `is_real_user_message()`, parameterize synthetic content | Low |
+| 3 | Create `diagnosis.py` — extract pure algorithms from repair script, wire to `messages.py` | Medium |
+| 4 | Refactor `fork.py` — import from `store.py` and `messages.py` | **High** (most code, most tests) |
+| 5 | Update `events.py` — import `read_jsonl` from `store.py` | Low |
+| 6 | Update `__init__.py` — export new modules, add compat shim for `slice` imports | Low |
+| 7 | Migrate existing tests — update imports, verify all 1700+ lines pass | Medium |
+
+**Risk note:** Step 4 (refactoring `fork.py`) touches the most code with the most existing tests. It is the highest-risk step but also where the biggest deduplication payoff lives.
+
+### Phase 2 — New Capabilities
+
+| Step | Action |
+|------|--------|
+| 8 | Create `finder.py` — session discovery, ID resolution, search/filter |
+| 9 | Create `scripts/amplifier-session.py` — unified script with all subcommands |
+| 10 | Write tests for finder and the script |
+| 11 | Deprecate `scripts/session-repair.py` (keep briefly for backward compat, then remove) |
+
+### Phase 3 — Agent Rewire
+
+| Step | Action |
+|------|--------|
+| 12 | Rewrite `session-analyst.md` — replace bash choreography with script invocations |
+| 13 | Update `session-repair-knowledge.md` — align with new script subcommands |
+| 14 | Clean up `session-storage-knowledge.md` — remove stale manual repair recipe (lines 196-209) |
+
+Phase 3 is documentation-only — no code tests needed.
+
+### Agent Instructions After Rewrite
+
+The repair/search/discovery sections of `session-analyst.md` collapse to:
+
+```markdown
+## Session Operations
+
+Use the `amplifier-session.py` script for all session operations.
+Find it: SCRIPT="$(find / -path '*/amplifier-foundation/scripts/amplifier-session.py' -type f 2>/dev/null | head -1)"
+
+All commands accept full paths, session IDs, or partial IDs.
+
+### Diagnose
+python "$SCRIPT" diagnose <session>
+
+### Repair (always diagnose first)
+python "$SCRIPT" diagnose <session>
+python "$SCRIPT" repair <session>
+python "$SCRIPT" diagnose <session>    # verify
+
+### Rewind (only when user explicitly requests)
+python "$SCRIPT" diagnose <session>
+python "$SCRIPT" rewind <session>
+python "$SCRIPT" diagnose <session>    # verify
+
+### Find sessions
+python "$SCRIPT" find --project myproj --after 2025-01-01
+python "$SCRIPT" find --keyword "authentication"
+
+### Session info
+python "$SCRIPT" info <session>
+```
+
+**What stays in agent instructions:** Identity notice, events.jsonl safety warnings, conversation turn model (conceptual), failure modes (conceptual awareness), parent session modification notice, search synthesis guidance, final response contract.
+
+**What gets removed/shortened:** All bash `find` patterns for session discovery, manual detection commands, storage locations section, stale manual repair recipe.
+
+**Net effect:** Agent instructions drop from ~500 lines to ~300 lines, and the actionable parts become single-command invocations.
+
+## Final Module Layout
+
+```
+amplifier_foundation/session/
+├── __init__.py          # Public API with clear exports
+├── messages.py          # Level 1: Pure message operations (renamed from slice.py)
+├── diagnosis.py         # Level 1: Pure diagnosis/repair/rewind algorithms
+├── store.py             # Level 2: JSONL file I/O (consolidated)
+├── events.py            # Level 2: Events.jsonl operations (refined)
+├── finder.py            # Level 3: Session discovery and resolution
+├── fork.py              # Composite: Fork operations (refactored)
+├── capabilities.py      # Orthogonal: Working dir helpers (unchanged)
+└── cli.py               # Shared arg parsing helpers for scripts
+
+scripts/
+└── amplifier-session.py # Unified CLI script with subcommands
+```
+
+## Open Questions
+
+None — all architectural questions were resolved through expert consultation (foundation-expert, amplifier-expert, zen-architect, core-expert).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,4 @@ testpaths = ["tests"]
 addopts = "--import-mode=importlib"
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
+

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,8 @@
+{
+  "include": [
+    "amplifier_foundation",
+    "tests"
+  ],
+  "extraPaths": ["."],
+  "typeCheckingMode": "standard"
+}

--- a/scripts/amplifier-session.py
+++ b/scripts/amplifier-session.py
@@ -35,7 +35,7 @@ _root = _here.parent
 if str(_root) not in sys.path:
     sys.path.insert(0, str(_root))
 
-from amplifier_foundation.session import (  # noqa: E402
+from amplifier_foundation.session import (  # noqa: E402  # type: ignore[attr-defined]
     EVENTS_FILENAME,
     TRANSCRIPT_FILENAME,
     backup,

--- a/scripts/amplifier-session.py
+++ b/scripts/amplifier-session.py
@@ -35,18 +35,18 @@ _root = _here.parent
 if str(_root) not in sys.path:
     sys.path.insert(0, str(_root))
 
-from amplifier_foundation.session import (  # noqa: E402  # type: ignore[attr-defined]
-    EVENTS_FILENAME,
-    TRANSCRIPT_FILENAME,
-    backup,
-    diagnose_transcript,
-    find_sessions,
-    load_transcript_with_lines,
-    repair_transcript,
-    resolve_session,
-    rewind_transcript,
-    session_info,
-    write_transcript,
+from amplifier_foundation.session import (  # noqa: E402
+    EVENTS_FILENAME,  # pyright: ignore[reportAttributeAccessIssue]
+    TRANSCRIPT_FILENAME,  # pyright: ignore[reportAttributeAccessIssue]
+    backup,  # pyright: ignore[reportAttributeAccessIssue]
+    diagnose_transcript,  # pyright: ignore[reportAttributeAccessIssue]
+    find_sessions,  # pyright: ignore[reportAttributeAccessIssue]
+    load_transcript_with_lines,  # pyright: ignore[reportAttributeAccessIssue]
+    repair_transcript,  # pyright: ignore[reportAttributeAccessIssue]
+    resolve_session,  # pyright: ignore[reportAttributeAccessIssue]
+    rewind_transcript,  # pyright: ignore[reportAttributeAccessIssue]
+    session_info,  # pyright: ignore[reportAttributeAccessIssue]
+    write_transcript,  # pyright: ignore[reportAttributeAccessIssue]
 )
 
 

--- a/scripts/amplifier-session.py
+++ b/scripts/amplifier-session.py
@@ -1,0 +1,361 @@
+"""Unified CLI for Amplifier session management.
+
+Subcommands:
+    diagnose <session>  -- Diagnose a session transcript
+    repair <session>    -- Repair a broken transcript
+    rewind <session>    -- Rewind to before the issue
+    info <session>      -- Show session metadata and status
+    find                -- Find sessions with filtering
+
+All session-accepting subcommands support:
+    --sessions-root     Root directory for sessions
+    --project           Filter by project name
+
+Human-readable messages go to stderr; structured JSON goes to stdout.
+
+Exit codes:
+    0 -- success / healthy
+    1 -- broken / error
+    2 -- invalid arguments
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# sys.path manipulation to ensure amplifier_foundation is importable
+# ---------------------------------------------------------------------------
+
+_here = Path(__file__).resolve().parent
+_root = _here.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+from amplifier_foundation.session import (  # noqa: E402
+    EVENTS_FILENAME,
+    TRANSCRIPT_FILENAME,
+    backup,
+    diagnose_transcript,
+    find_sessions,
+    load_transcript_with_lines,
+    repair_transcript,
+    resolve_session,
+    rewind_transcript,
+    session_info,
+    write_transcript,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_json_serialisable(obj):
+    """Recursively convert non-serialisable values (e.g. Path) to strings."""
+    if isinstance(obj, dict):
+        return {k: _to_json_serialisable(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_to_json_serialisable(v) for v in obj]
+    if isinstance(obj, Path):
+        return str(obj)
+    return obj
+
+
+def _resolve(args) -> Path:
+    """Resolve session reference from CLI args using resolve_session()."""
+    kwargs: dict = {}
+    if getattr(args, "sessions_root", None):
+        kwargs["sessions_root"] = Path(args.sessions_root)
+    if getattr(args, "project", None):
+        kwargs["project"] = args.project
+    return resolve_session(args.session, **kwargs)
+
+
+def _output_error(exc: Exception) -> None:
+    """Output error as JSON on stdout and message on stderr."""
+    print(json.dumps({"error": str(exc)}))
+    print(str(exc), file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
+
+
+def cmd_diagnose(args) -> int:
+    """diagnose subcommand — analyse a session transcript."""
+    try:
+        session_dir = _resolve(args)
+        entries = load_transcript_with_lines(session_dir)
+        diagnosis = diagnose_transcript(entries)
+        print(json.dumps(_to_json_serialisable(diagnosis), indent=2))
+        return 0 if diagnosis["status"] == "healthy" else 1
+    except (FileNotFoundError, ValueError) as exc:
+        _output_error(exc)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        _output_error(exc)
+        return 1
+
+
+def cmd_repair(args) -> int:
+    """repair subcommand — repair a broken transcript."""
+    try:
+        session_dir = _resolve(args)
+        entries = load_transcript_with_lines(session_dir)
+        diagnosis = diagnose_transcript(entries)
+
+        if diagnosis["status"] == "healthy":
+            print(json.dumps({"status": "no-repair-needed"}))
+            return 0
+
+        # Back up the transcript before modifying it
+        transcript_path = session_dir / TRANSCRIPT_FILENAME
+        backup_path = backup(transcript_path, "pre-repair")
+
+        # Repair
+        repaired = repair_transcript(entries, diagnosis)
+        write_transcript(session_dir, repaired)
+
+        # Verify by re-diagnosing
+        entries_after = load_transcript_with_lines(session_dir)
+        verification = diagnose_transcript(entries_after)
+
+        report = {
+            "status": "repaired" if verification["status"] == "healthy" else "failed",
+            "original_diagnosis": diagnosis,
+            "verification": verification,
+            "backup_path": str(backup_path) if backup_path else None,
+            "counts": {
+                "original_entries": len(entries),
+                "repaired_entries": len(repaired),
+            },
+        }
+        print(json.dumps(_to_json_serialisable(report), indent=2))
+        return 0 if verification["status"] == "healthy" else 1
+    except (FileNotFoundError, ValueError) as exc:
+        _output_error(exc)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        _output_error(exc)
+        return 1
+
+
+def cmd_rewind(args) -> int:
+    """rewind subcommand — rewind transcript to before the issue."""
+    try:
+        session_dir = _resolve(args)
+        entries = load_transcript_with_lines(session_dir)
+        diagnosis = diagnose_transcript(entries)
+
+        if diagnosis["status"] == "healthy":
+            print(json.dumps({"status": "no-rewind-needed"}))
+            return 0
+
+        # Back up transcript (and events.jsonl if present)
+        transcript_path = session_dir / TRANSCRIPT_FILENAME
+        backup_path = backup(transcript_path, "pre-rewind")
+
+        events_path = session_dir / EVENTS_FILENAME
+        if events_path.exists():
+            backup(events_path, "pre-rewind")
+
+        # Rewind
+        rewound = rewind_transcript(entries, diagnosis)
+        write_transcript(session_dir, rewound)
+
+        # Truncate events.jsonl proportionally if it exists
+        if events_path.exists():
+            original_count = len(entries)
+            rewound_count = len(rewound)
+            with open(events_path, encoding="utf-8") as fh:
+                event_lines = fh.readlines()
+            if original_count > 0 and event_lines:
+                ratio = rewound_count / original_count
+                keep = max(0, int(len(event_lines) * ratio))
+                with open(events_path, "w", encoding="utf-8") as fh:
+                    fh.writelines(event_lines[:keep])
+
+        report = {
+            "status": "rewound",
+            "original_entries": len(entries),
+            "rewound_entries": len(rewound),
+            "backup_path": str(backup_path) if backup_path else None,
+        }
+        print(json.dumps(_to_json_serialisable(report), indent=2))
+        return 0
+    except (FileNotFoundError, ValueError) as exc:
+        _output_error(exc)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        _output_error(exc)
+        return 1
+
+
+def cmd_info(args) -> int:
+    """info subcommand — show session metadata and status."""
+    try:
+        session_dir = _resolve(args)
+        info = session_info(session_dir)
+        print(json.dumps(_to_json_serialisable(info), indent=2))
+        return 0
+    except (FileNotFoundError, ValueError) as exc:
+        _output_error(exc)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        _output_error(exc)
+        return 1
+
+
+def cmd_find(args) -> int:
+    """find subcommand — search for sessions with optional filters."""
+    try:
+        kwargs: dict = {}
+        if args.sessions_root:
+            kwargs["sessions_root"] = Path(args.sessions_root)
+        if args.project:
+            kwargs["project"] = args.project
+        if args.after:
+            kwargs["after"] = args.after
+        if args.before:
+            kwargs["before"] = args.before
+        if args.keyword:
+            kwargs["keyword"] = args.keyword
+        if args.status:
+            kwargs["status"] = args.status
+        if args.limit is not None:
+            kwargs["limit"] = args.limit
+
+        sessions = find_sessions(**kwargs)
+        print(json.dumps(_to_json_serialisable(sessions), indent=2))
+        return 0
+    except (FileNotFoundError, ValueError) as exc:
+        _output_error(exc)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        _output_error(exc)
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def _add_session_args(sub: argparse.ArgumentParser) -> None:
+    """Add common session resolution arguments to a subparser."""
+    sub.add_argument(
+        "session",
+        help="Session path (absolute), full session ID, or partial session ID.",
+    )
+    sub.add_argument(
+        "--sessions-root",
+        metavar="DIR",
+        help="Root directory containing project subdirectories.",
+    )
+    sub.add_argument(
+        "--project",
+        metavar="NAME",
+        help="Limit session resolution to this project.",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Returns exit code: 0 = success/healthy, 1 = broken/error, 2 = invalid args.
+    """
+    parser = argparse.ArgumentParser(
+        prog="amplifier-session",
+        description="Unified CLI for Amplifier session management.",
+    )
+    subparsers = parser.add_subparsers(dest="subcommand")
+    subparsers.required = True
+
+    # diagnose
+    diag_p = subparsers.add_parser(
+        "diagnose",
+        help="Diagnose a session transcript.",
+    )
+    _add_session_args(diag_p)
+    diag_p.set_defaults(func=cmd_diagnose)
+
+    # repair
+    repair_p = subparsers.add_parser(
+        "repair",
+        help="Repair a broken transcript.",
+    )
+    _add_session_args(repair_p)
+    repair_p.set_defaults(func=cmd_repair)
+
+    # rewind
+    rewind_p = subparsers.add_parser(
+        "rewind",
+        help="Rewind transcript to before the issue.",
+    )
+    _add_session_args(rewind_p)
+    rewind_p.set_defaults(func=cmd_rewind)
+
+    # info
+    info_p = subparsers.add_parser(
+        "info",
+        help="Show session metadata and health status.",
+    )
+    _add_session_args(info_p)
+    info_p.set_defaults(func=cmd_info)
+
+    # find
+    find_p = subparsers.add_parser(
+        "find",
+        help="Find sessions with optional filters.",
+    )
+    find_p.add_argument(
+        "--sessions-root",
+        metavar="DIR",
+        help="Root directory containing project subdirectories.",
+    )
+    find_p.add_argument(
+        "--project",
+        metavar="NAME",
+        help="Filter by project name.",
+    )
+    find_p.add_argument(
+        "--after",
+        metavar="DATE",
+        help="Only include sessions created after this ISO date.",
+    )
+    find_p.add_argument(
+        "--before",
+        metavar="DATE",
+        help="Only include sessions created before this ISO date.",
+    )
+    find_p.add_argument(
+        "--keyword",
+        metavar="TERM",
+        help="Only include sessions whose transcript contains this keyword.",
+    )
+    find_p.add_argument(
+        "--status",
+        choices=["healthy", "broken"],
+        help="Filter by health status (runs diagnosis; may be slow).",
+    )
+    find_p.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        metavar="N",
+        help="Maximum number of results (default: 50).",
+    )
+    find_p.set_defaults(func=cmd_find)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/session-repair.py
+++ b/scripts/session-repair.py
@@ -36,19 +36,19 @@ _root = _here.parent
 if str(_root) not in sys.path:
     sys.path.insert(0, str(_root))
 
-from amplifier_foundation.session import (  # noqa: E402  # type: ignore[attr-defined]
-    backup,
-    build_tool_index,
-    diagnose_transcript,
-    is_real_user_message,
-    load_transcript_with_lines,
-    repair_transcript,
-    rewind_transcript,
-    write_transcript,
+from amplifier_foundation.session import (  # noqa: E402
+    backup,  # pyright: ignore[reportAttributeAccessIssue]
+    build_tool_index,  # pyright: ignore[reportAttributeAccessIssue]
+    diagnose_transcript,  # pyright: ignore[reportAttributeAccessIssue]
+    is_real_user_message,  # pyright: ignore[reportAttributeAccessIssue]
+    load_transcript_with_lines,  # pyright: ignore[reportAttributeAccessIssue]
+    repair_transcript,  # pyright: ignore[reportAttributeAccessIssue]
+    rewind_transcript,  # pyright: ignore[reportAttributeAccessIssue]
+    write_transcript,  # pyright: ignore[reportAttributeAccessIssue]
 )
 
 if TYPE_CHECKING:
-    from amplifier_foundation.session import DiagnosisResult
+    from amplifier_foundation.session import DiagnosisResult  # pyright: ignore[reportAttributeAccessIssue]
 
 # Re-export for backward compatibility (tests import these from this module)
 __all__ = [

--- a/scripts/session-repair.py
+++ b/scripts/session-repair.py
@@ -36,7 +36,7 @@ _root = _here.parent
 if str(_root) not in sys.path:
     sys.path.insert(0, str(_root))
 
-from amplifier_foundation.session import (  # noqa: E402
+from amplifier_foundation.session import (  # noqa: E402  # type: ignore[attr-defined]
     backup,
     build_tool_index,
     diagnose_transcript,

--- a/scripts/session-repair.py
+++ b/scripts/session-repair.py
@@ -11,13 +11,23 @@ Exit codes:
 
 from __future__ import annotations
 
-import argparse
-import json
-import sys
-from pathlib import Path
-from typing import TYPE_CHECKING
+import warnings
 
-from amplifier_foundation.session import (
+warnings.warn(
+    "scripts/session-repair.py is deprecated. "
+    "Use scripts/amplifier-session.py instead. "
+    "Example: python scripts/amplifier-session.py diagnose <session>",
+    DeprecationWarning,
+    stacklevel=1,
+)
+
+import argparse  # noqa: E402
+import json  # noqa: E402
+import sys  # noqa: E402
+from pathlib import Path  # noqa: E402
+from typing import TYPE_CHECKING  # noqa: E402
+
+from amplifier_foundation.session import (  # noqa: E402
     backup,
     build_tool_index,
     diagnose_transcript,

--- a/scripts/session-repair.py
+++ b/scripts/session-repair.py
@@ -27,6 +27,15 @@ import sys  # noqa: E402
 from pathlib import Path  # noqa: E402
 from typing import TYPE_CHECKING  # noqa: E402
 
+# ---------------------------------------------------------------------------
+# sys.path manipulation to ensure amplifier_foundation is importable
+# ---------------------------------------------------------------------------
+
+_here = Path(__file__).resolve().parent
+_root = _here.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
 from amplifier_foundation.session import (  # noqa: E402
     backup,
     build_tool_index,

--- a/scripts/session-repair.py
+++ b/scripts/session-repair.py
@@ -13,27 +13,38 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import TypedDict
+from typing import TYPE_CHECKING
+
+from amplifier_foundation.session import (
+    backup,
+    build_tool_index,
+    diagnose_transcript,
+    is_real_user_message,
+    load_transcript_with_lines,
+    repair_transcript,
+    rewind_transcript,
+    write_transcript,
+)
+
+if TYPE_CHECKING:
+    from amplifier_foundation.session import DiagnosisResult
+
+# Re-export for backward compatibility (tests import these from this module)
+__all__ = [
+    "parse_transcript",
+    "build_tool_index",
+    "is_real_user_message",
+    "diagnose",
+    "repair_transcript",
+    "rewind_transcript",
+]
 
 
-class IncompleteTurn(TypedDict):
-    after_line: int
-    missing: str
-
-
-class DiagnosisResult(TypedDict):
-    status: str  # "healthy" | "broken"
-    failure_modes: list[str]
-    orphaned_tool_ids: list[str]
-    misplaced_tool_ids: list[str]
-    incomplete_turns: list[IncompleteTurn]
-    recommended_action: (
-        str  # "none" | "repair" | "rewind" (rewind reserved for future use)
-    )
+# ---------------------------------------------------------------------------
+# Thin wrappers (CLI-level adapters)
+# ---------------------------------------------------------------------------
 
 
 def parse_transcript(transcript_path: Path) -> list[dict]:
@@ -41,108 +52,12 @@ def parse_transcript(transcript_path: Path) -> list[dict]:
 
     Each returned dict is the original JSON object with an added 'line_num' key
     (1-based) indicating its position in the file. Empty lines are skipped.
+
+    This is a thin adapter around ``load_transcript_with_lines``. The
+    ``transcript_path`` argument should be the path to the transcript.jsonl
+    file itself; the session directory is inferred from its parent.
     """
-    entries = []
-    with open(transcript_path, encoding="utf-8") as f:
-        for line_num, line in enumerate(f, start=1):
-            stripped = line.strip()
-            if not stripped:
-                continue
-            try:
-                entry = json.loads(stripped)
-            except json.JSONDecodeError as e:
-                raise ValueError(f"Invalid JSON at line {line_num}") from e
-            entry["line_num"] = line_num
-            entries.append(entry)
-    return entries
-
-
-def build_tool_index(entries: list[dict]) -> dict:
-    """Build an index of tool_use IDs and tool_result IDs from parsed entries.
-
-    Returns:
-        {
-            'tool_uses': {'<id>': {'line_num': N, 'tool_name': '...', 'entry_index': M}},
-            'tool_results': {'<id>': {'line_num': N, 'entry_index': M}},
-        }
-    """
-    tool_uses = {}
-    tool_results = {}
-
-    for idx, entry in enumerate(entries):
-        # Extract tool_use IDs from assistant messages with tool_calls
-        if entry.get("role") == "assistant" and "tool_calls" in entry:
-            for tool_call in entry["tool_calls"]:
-                call_id = tool_call.get("id", "")
-                tool_name = tool_call.get("function", {}).get("name", "")
-                tool_uses[call_id] = {
-                    "line_num": entry["line_num"],
-                    "tool_name": tool_name,
-                    "entry_index": idx,
-                }
-
-        # Extract tool_result IDs from tool role messages
-        elif entry.get("role") == "tool" and "tool_call_id" in entry:
-            tool_results[entry["tool_call_id"]] = {
-                "line_num": entry["line_num"],
-                "entry_index": idx,
-            }
-
-    return {"tool_uses": tool_uses, "tool_results": tool_results}
-
-
-def is_real_user_message(entry: dict) -> bool:
-    """Return True if entry represents a genuine human user message.
-
-    A 'real user message' is:
-    - role is 'user'
-    - no tool_call_id field
-    - content is NOT wrapped in <system-reminder> tags
-
-    Content can be a string or a list of content blocks.
-    Assistant messages and tool role messages return False.
-    """
-    if entry.get("role") != "user":
-        return False
-
-    if "tool_call_id" in entry:
-        return False
-
-    content = entry.get("content", "")
-
-    # Check for system-reminder tags in string content
-    if isinstance(content, str):
-        stripped = content.strip()
-        if stripped.startswith("<system-reminder>"):
-            return False
-
-    # Check for system-reminder tags in list content
-    elif isinstance(content, list):
-        for block in content:
-            text = block.get("text", "")
-            if isinstance(text, str) and text.strip().startswith("<system-reminder>"):
-                return False
-
-    return True
-
-
-# ---------------------------------------------------------------------------
-# Diagnostic engine
-# ---------------------------------------------------------------------------
-
-
-def _has_intervening_disruption(
-    entries: list[dict], use_idx: int, result_idx: int
-) -> bool:
-    """Return True if a real user message or unrelated assistant turn appears
-    between entry indices *use_idx* and *result_idx*."""
-    for between_idx in range(use_idx + 1, result_idx):
-        between = entries[between_idx]
-        if is_real_user_message(between):
-            return True
-        if between.get("role") == "assistant" and "tool_calls" not in between:
-            return True
-    return False
+    return load_transcript_with_lines(transcript_path.parent)
 
 
 def diagnose(session_dir: Path | str) -> DiagnosisResult:
@@ -157,320 +72,8 @@ def diagnose(session_dir: Path | str) -> DiagnosisResult:
         recommended_action: "none" | "repair" ("rewind" reserved for future use)
     """
     session_dir = Path(session_dir)
-    transcript_path = session_dir / "transcript.jsonl"
-    entries = parse_transcript(transcript_path)
-    index = build_tool_index(entries)
-
-    failure_modes: list[str] = []
-    orphaned_tool_ids: list[str] = []
-    misplaced_tool_ids: list[str] = []
-    incomplete_turns: list[IncompleteTurn] = []
-
-    # --- Failure mode 1: missing tool results ---
-    for tc_id in index["tool_uses"]:
-        if tc_id not in index["tool_results"]:
-            orphaned_tool_ids.append(tc_id)
-    if orphaned_tool_ids:
-        failure_modes.append("missing_tool_results")
-
-    # --- Failure mode 2: ordering violations ---
-    # A tool_result is misplaced if a real user message or a different assistant
-    # turn appears between the tool_use and its result.
-    for tc_id, use_info in index["tool_uses"].items():
-        if tc_id not in index["tool_results"]:
-            continue  # already caught as orphan
-        result_info = index["tool_results"][tc_id]
-        use_idx = use_info["entry_index"]
-        result_idx = result_info["entry_index"]
-
-        if _has_intervening_disruption(entries, use_idx, result_idx):
-            misplaced_tool_ids.append(tc_id)
-    if misplaced_tool_ids:
-        failure_modes.append("ordering_violation")
-
-    # --- Failure mode 3: incomplete assistant turns ---
-    # Walk through entries looking for assistant messages with tool_calls.
-    # For each, verify that after all its tool_results there is a final
-    # assistant text response before the next real user message.
-    orphaned_set = set(orphaned_tool_ids)
-    misplaced_set = set(misplaced_tool_ids)
-    for tc_id, use_info in index["tool_uses"].items():
-        # Only check with the first tool_call in each assistant message
-        # to avoid duplicate detection for multi-tool calls.
-        assistant_idx = use_info["entry_index"]
-        assistant_entry = entries[assistant_idx]
-        first_tc_id = assistant_entry.get("tool_calls", [{}])[0].get("id")
-        if tc_id != first_tc_id:
-            continue
-
-        # Skip if any tool_call from this assistant message is orphaned/misplaced
-        all_tc_ids = [tc["id"] for tc in assistant_entry.get("tool_calls", [])]
-        if any(tid in orphaned_set or tid in misplaced_set for tid in all_tc_ids):
-            continue
-
-        # Find the last tool_result for this assistant message's tool_calls
-        last_result_idx = assistant_idx
-        for tid in all_tc_ids:
-            if tid in index["tool_results"]:
-                res_idx = index["tool_results"][tid]["entry_index"]
-                if res_idx > last_result_idx:
-                    last_result_idx = res_idx
-
-        if last_result_idx == assistant_idx:
-            continue  # No results found (shouldn't happen if we skipped orphans)
-
-        # Check what comes after the last tool result
-        next_idx = last_result_idx + 1
-        if next_idx >= len(entries):
-            # End of transcript — incomplete if we're missing the closing response
-            incomplete_turns.append(
-                {
-                    "after_line": entries[last_result_idx]["line_num"],
-                    "missing": "assistant_response",
-                }
-            )
-            continue
-
-        next_entry = entries[next_idx]
-        if is_real_user_message(next_entry):
-            # Real user message immediately after tool results = incomplete turn
-            incomplete_turns.append(
-                {
-                    "after_line": entries[last_result_idx]["line_num"],
-                    "missing": "assistant_response",
-                }
-            )
-
-    if incomplete_turns:
-        failure_modes.append("incomplete_assistant_turn")
-
-    status = "broken" if failure_modes else "healthy"
-    recommended = "repair" if failure_modes else "none"
-
-    return {
-        "status": status,
-        "failure_modes": failure_modes,
-        "orphaned_tool_ids": orphaned_tool_ids,
-        "misplaced_tool_ids": misplaced_tool_ids,
-        "incomplete_turns": incomplete_turns,
-        "recommended_action": recommended,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Repair engine
-# ---------------------------------------------------------------------------
-
-
-SYNTHETIC_TOOL_RESULT_CONTENT = json.dumps(
-    {
-        "error": "unknown_error",
-        "message": "Tool execution was interrupted and no result was captured.",
-    }
-)
-
-SYNTHETIC_ASSISTANT_RESPONSE: dict = {
-    "role": "assistant",
-    "content": [
-        {
-            "type": "text",
-            "text": (
-                "The previous tool calls were interrupted. "
-                "This response was automatically repaired."
-            ),
-        }
-    ],
-}
-
-
-def _make_synthetic_tool_result(tool_call_id: str, tool_name: str) -> dict:
-    """Create a synthetic tool result for an orphaned or misplaced tool call."""
-    return {
-        "role": "tool",
-        "tool_call_id": tool_call_id,
-        "name": tool_name,
-        "content": SYNTHETIC_TOOL_RESULT_CONTENT,
-    }
-
-
-def _make_synthetic_assistant_response() -> dict:
-    """Create a fresh synthetic assistant response for an incomplete turn.
-
-    Returns a fresh copy to avoid shared mutable state between injected entries.
-    """
-    return {
-        "role": SYNTHETIC_ASSISTANT_RESPONSE["role"],
-        "content": [dict(block) for block in SYNTHETIC_ASSISTANT_RESPONSE["content"]],
-    }
-
-
-def _strip_line_num(entry: dict) -> dict:
-    """Return a copy of *entry* without the internal ``line_num`` key."""
-    d = entry.copy()
-    d.pop("line_num", None)
-    return d
-
-
-def repair_transcript(entries: list[dict], diagnosis: DiagnosisResult) -> list[dict]:
-    """Apply the COMPLETE repair strategy to a parsed transcript.
-
-    Returns a new list of entries (without ``line_num`` keys) with:
-    - synthetic tool results injected for orphaned/misplaced tool calls
-    - synthetic assistant responses where needed
-    - misplaced tool results removed
-    """
-    # 1. Healthy transcripts are returned unchanged (minus line_num).
-    if diagnosis["status"] == "healthy":
-        return [_strip_line_num(e) for e in entries]
-
-    orphaned_set = set(diagnosis["orphaned_tool_ids"])
-    misplaced_set = set(diagnosis["misplaced_tool_ids"])
-    broken_set = orphaned_set | misplaced_set
-    incomplete_after_lines = {t["after_line"] for t in diagnosis["incomplete_turns"]}
-
-    # 2. Build skip_indices — entry indices of misplaced tool results.
-    skip_indices: set[int] = set()
-    for idx, entry in enumerate(entries):
-        if entry.get("role") == "tool" and entry.get("tool_call_id") in misplaced_set:
-            skip_indices.add(idx)
-
-    # 3–6. Walk entries, applying repairs.
-    result: list[dict] = []
-    for idx, entry in enumerate(entries):
-        # 3. Skip misplaced tool results.
-        if idx in skip_indices:
-            continue
-
-        result.append(_strip_line_num(entry))
-
-        # 4. After assistant messages with tool_calls: inject synthetic
-        #    results for orphaned / misplaced tool_call IDs.
-        if entry.get("role") == "assistant" and "tool_calls" in entry:
-            tool_calls = entry["tool_calls"]
-            all_tc_ids = [tc["id"] for tc in tool_calls]
-            broken_in_msg = [tc for tc in tool_calls if tc["id"] in broken_set]
-
-            for tc in broken_in_msg:
-                tc_id = tc["id"]
-                tc_name = tc.get("function", {}).get("name", "")
-                result.append(_make_synthetic_tool_result(tc_id, tc_name))
-
-            # 5. If ALL tool_calls from this message were broken AND
-            #    the next non-skipped entry is a real user message (or end
-            #    of transcript): inject a synthetic assistant response.
-            if len(broken_in_msg) == len(all_tc_ids) and all_tc_ids:
-                next_entry = None
-                for future_idx in range(idx + 1, len(entries)):
-                    if future_idx not in skip_indices:
-                        next_entry = entries[future_idx]
-                        break
-                if next_entry is None or is_real_user_message(next_entry):
-                    result.append(_make_synthetic_assistant_response())
-
-        # 6. After tool results at incomplete_after_lines: inject synthetic
-        #    assistant response.  (entry still has line_num; only the
-        #    appended copy is stripped.)
-        elif (
-            entry.get("role") == "tool"
-            and entry.get("line_num") in incomplete_after_lines
-        ):
-            result.append(_make_synthetic_assistant_response())
-
-    return result
-
-
-# ---------------------------------------------------------------------------
-# Rewind engine
-# ---------------------------------------------------------------------------
-
-
-def rewind_transcript(entries: list[dict], diagnosis: DiagnosisResult) -> list[dict]:
-    """Truncate transcript to before the last real user message prior to issues.
-
-    If the transcript is healthy, return all entries stripped of ``line_num``.
-    Otherwise, find the earliest issue, walk backwards to find the last real
-    user message before it, and return ``entries[:rewind_to_idx]`` stripped.
-
-    Returns an empty list if the first turn itself is broken
-    (``rewind_to_idx`` is ``None`` or ``0``).
-    """
-    if diagnosis["status"] == "healthy":
-        return [_strip_line_num(e) for e in entries]
-
-    # 1. Find earliest_issue_idx from orphaned, misplaced, and incomplete turns.
-    index = build_tool_index(entries)
-    issue_indices: list[int] = []
-
-    # Orphaned tool_ids → entry_index of the tool_use (assistant message)
-    for tc_id in diagnosis["orphaned_tool_ids"]:
-        if tc_id in index["tool_uses"]:
-            issue_indices.append(index["tool_uses"][tc_id]["entry_index"])
-
-    # Misplaced tool_ids → entry_index of the tool_use (assistant message)
-    for tc_id in diagnosis["misplaced_tool_ids"]:
-        if tc_id in index["tool_uses"]:
-            issue_indices.append(index["tool_uses"][tc_id]["entry_index"])
-
-    # Incomplete turns → walk back from after_line to find assistant with tool_calls
-    for turn in diagnosis["incomplete_turns"]:
-        after_line = turn["after_line"]
-        # Find the entry with this line_num, then walk backwards
-        for idx in range(len(entries) - 1, -1, -1):
-            if entries[idx].get("line_num") == after_line:
-                # Walk backwards from here to find the assistant with tool_calls
-                for back_idx in range(idx, -1, -1):
-                    e = entries[back_idx]
-                    if e.get("role") == "assistant" and "tool_calls" in e:
-                        issue_indices.append(back_idx)
-                        break
-                break
-
-    if not issue_indices:
-        # Diagnosis says broken but referenced IDs weren't found in entries;
-        # safest fallback is to return the full transcript unchanged.
-        return [_strip_line_num(e) for e in entries]
-
-    earliest_issue_idx = min(issue_indices)
-
-    # 2. Walk backwards from earliest_issue_idx to find the last real user message.
-    rewind_to_idx: int | None = None
-    for idx in range(earliest_issue_idx - 1, -1, -1):
-        if is_real_user_message(entries[idx]):
-            rewind_to_idx = idx
-            break
-
-    # 3. If rewind_to_idx is None or 0, return [] (first turn is broken).
-    if rewind_to_idx is None or rewind_to_idx == 0:
-        return []
-
-    # 4. Return entries[:rewind_to_idx] stripped of line_num.
-    return [_strip_line_num(e) for e in entries[:rewind_to_idx]]
-
-
-# ---------------------------------------------------------------------------
-# CLI helpers
-# ---------------------------------------------------------------------------
-
-
-def _backup(filepath: Path, label: str) -> Path | None:
-    """Create a timestamped backup of *filepath*.
-
-    Returns the backup path, or ``None`` if *filepath* does not exist.
-    The backup is named ``<filepath>.bak-<label>-<YYYYMMDDHHMMSS>``.
-    """
-    if not filepath.exists():
-        return None
-    ts = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-    dest = filepath.with_name(f"{filepath.name}.bak-{label}-{ts}")
-    shutil.copy2(filepath, dest)
-    return dest
-
-
-def _write_entries(filepath: Path, entries: list[dict]) -> None:
-    """Write a list of dicts as JSONL to *filepath*."""
-    with open(filepath, "w", encoding="utf-8") as f:
-        for entry in entries:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    entries = load_transcript_with_lines(session_dir)
+    return diagnose_transcript(entries)
 
 
 # ---------------------------------------------------------------------------
@@ -520,10 +123,10 @@ def main(argv: list[str] | None = None) -> int:
             print("no-repair-needed")
             return 0
 
-        _backup(transcript_path, "pre-repair")
-        entries = parse_transcript(transcript_path)
+        backup(transcript_path, "pre-repair")
+        entries = load_transcript_with_lines(session_dir)
         repaired = repair_transcript(entries, diag)
-        _write_entries(transcript_path, repaired)
+        write_transcript(session_dir, repaired)
 
         # Verify by re-diagnosing
         verification = diagnose(session_dir)
@@ -546,14 +149,14 @@ def main(argv: list[str] | None = None) -> int:
             print("no-rewind-needed")
             return 0
 
-        _backup(transcript_path, "pre-rewind")
+        backup(transcript_path, "pre-rewind")
         events_path = session_dir / "events.jsonl"
         if events_path.exists():
-            _backup(events_path, "pre-rewind")
+            backup(events_path, "pre-rewind")
 
-        entries = parse_transcript(transcript_path)
+        entries = load_transcript_with_lines(session_dir)
         rewound = rewind_transcript(entries, diag)
-        _write_entries(transcript_path, rewound)
+        write_transcript(session_dir, rewound)
 
         # Truncate events.jsonl proportionally if it exists
         if events_path.exists():

--- a/tests/test_amplifier_session_cli.py
+++ b/tests/test_amplifier_session_cli.py
@@ -1,0 +1,337 @@
+"""Tests for scripts/amplifier-session.py unified CLI.
+
+Uses subprocess invocation to test each subcommand end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_script_path = (
+    Path(__file__).resolve().parent.parent / "scripts" / "amplifier-session.py"
+)
+_project_root = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    """Run the amplifier-session.py CLI with the given arguments."""
+    env = {**os.environ, "PYTHONPATH": str(_project_root)}
+    return subprocess.run(
+        [sys.executable, str(_script_path), *args],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+
+
+def _make_session(
+    tmp_path: Path,
+    entries: list[dict],
+    metadata: dict | None = None,
+) -> Path:
+    """Create a session at tmp_path/proj1/sessions/test-session-001/.
+
+    Returns the session directory path.
+    """
+    session_dir = tmp_path / "proj1" / "sessions" / "test-session-001"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write transcript.jsonl
+    with open(session_dir / "transcript.jsonl", "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    # Write metadata.json
+    meta = dict(metadata) if metadata is not None else {}
+    meta.setdefault("session_id", "test-session-001")
+    meta.setdefault("created", "2024-06-01T10:00:00+00:00")
+    meta.setdefault("bundle", "test-bundle")
+    meta.setdefault("model", "test-model")
+    with open(session_dir / "metadata.json", "w", encoding="utf-8") as f:
+        json.dump(meta, f, indent=2)
+
+    return session_dir
+
+
+_HEALTHY_ENTRIES = [
+    {"role": "user", "content": "Hello"},
+    {"role": "assistant", "content": "Hi there"},
+]
+
+# Broken: assistant has tool_call with no matching tool result (orphaned)
+_BROKEN_ENTRIES = [
+    {"role": "user", "content": "Hello"},
+    {"role": "assistant", "content": "Hi"},
+    {"role": "user", "content": "Please use a tool"},
+    {
+        "role": "assistant",
+        "content": "Using tool",
+        "tool_calls": [
+            {
+                "id": "tc_broken_001",
+                "function": {"name": "some_tool", "arguments": "{}"},
+            }
+        ],
+    },
+    {"role": "user", "content": "Next message"},
+]
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseSubcommand (4 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseSubcommand:
+    """Tests for the `diagnose` subcommand."""
+
+    def test_diagnose_healthy_exits_0(self, tmp_path: Path) -> None:
+        """Healthy session: exit 0 and JSON status=healthy."""
+        session_dir = _make_session(tmp_path, _HEALTHY_ENTRIES)
+        result = _run("diagnose", str(session_dir))
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "healthy"
+        assert data["failure_modes"] == []
+
+    def test_diagnose_broken_exits_1_with_failure_modes(self, tmp_path: Path) -> None:
+        """Broken session: exit 1 and failure_modes non-empty."""
+        session_dir = _make_session(tmp_path, _BROKEN_ENTRIES)
+        result = _run("diagnose", str(session_dir))
+        assert result.returncode == 1
+        data = json.loads(result.stdout)
+        assert data["status"] == "broken"
+        assert len(data["failure_modes"]) > 0
+
+    def test_diagnose_by_session_id_with_sessions_root(self, tmp_path: Path) -> None:
+        """Can resolve session by full session ID with --sessions-root."""
+        _make_session(tmp_path, _HEALTHY_ENTRIES)
+        result = _run(
+            "diagnose",
+            "test-session-001",
+            "--sessions-root",
+            str(tmp_path),
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "healthy"
+
+    def test_diagnose_by_partial_id(self, tmp_path: Path) -> None:
+        """Can resolve session by partial session ID with --sessions-root."""
+        _make_session(tmp_path, _HEALTHY_ENTRIES)
+        result = _run(
+            "diagnose",
+            "test-session",  # partial prefix
+            "--sessions-root",
+            str(tmp_path),
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "healthy"
+
+
+# ---------------------------------------------------------------------------
+# TestRepairSubcommand (4 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestRepairSubcommand:
+    """Tests for the `repair` subcommand."""
+
+    def test_repair_healthy_is_noop(self, tmp_path: Path) -> None:
+        """Healthy session: exit 0 and status=no-repair-needed."""
+        session_dir = _make_session(tmp_path, _HEALTHY_ENTRIES)
+        result = _run("repair", str(session_dir))
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "no-repair-needed"
+
+    def test_repair_broken_succeeds_with_repaired(self, tmp_path: Path) -> None:
+        """Broken session: exit 0 and status=repaired."""
+        session_dir = _make_session(tmp_path, _BROKEN_ENTRIES)
+        result = _run("repair", str(session_dir))
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "repaired"
+
+    def test_repair_creates_backup_file(self, tmp_path: Path) -> None:
+        """Repair creates a .bak-pre-repair backup file in the session dir."""
+        session_dir = _make_session(tmp_path, _BROKEN_ENTRIES)
+        _run("repair", str(session_dir))
+        backup_files = list(session_dir.glob("transcript.jsonl.bak-pre-repair-*"))
+        assert len(backup_files) == 1
+
+    def test_repair_then_diagnose_returns_healthy(self, tmp_path: Path) -> None:
+        """After repair, re-diagnosing returns healthy (exit 0)."""
+        session_dir = _make_session(tmp_path, _BROKEN_ENTRIES)
+        repair_result = _run("repair", str(session_dir))
+        assert repair_result.returncode == 0
+
+        diag_result = _run("diagnose", str(session_dir))
+        assert diag_result.returncode == 0
+        data = json.loads(diag_result.stdout)
+        assert data["status"] == "healthy"
+
+
+# ---------------------------------------------------------------------------
+# TestRewindSubcommand (3 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestRewindSubcommand:
+    """Tests for the `rewind` subcommand."""
+
+    def test_rewind_healthy_is_noop(self, tmp_path: Path) -> None:
+        """Healthy session: exit 0 and status=no-rewind-needed."""
+        session_dir = _make_session(tmp_path, _HEALTHY_ENTRIES)
+        result = _run("rewind", str(session_dir))
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["status"] == "no-rewind-needed"
+
+    def test_rewind_broken_succeeds_with_rewound_entries_less_than_original(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Broken session: rewound_entries < original_entries."""
+        session_dir = _make_session(tmp_path, _BROKEN_ENTRIES)
+        result = _run("rewind", str(session_dir))
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["rewound_entries"] < data["original_entries"]
+
+    def test_rewind_creates_backup(self, tmp_path: Path) -> None:
+        """Rewind creates a .bak-pre-rewind backup file in the session dir."""
+        session_dir = _make_session(tmp_path, _BROKEN_ENTRIES)
+        _run("rewind", str(session_dir))
+        backup_files = list(session_dir.glob("transcript.jsonl.bak-pre-rewind-*"))
+        assert len(backup_files) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestInfoSubcommand (1 test)
+# ---------------------------------------------------------------------------
+
+
+class TestInfoSubcommand:
+    """Tests for the `info` subcommand."""
+
+    def test_info_returns_metadata_with_required_fields(self, tmp_path: Path) -> None:
+        """Returns JSON with session_id, turn_count, and status."""
+        session_dir = _make_session(tmp_path, _HEALTHY_ENTRIES)
+        result = _run("info", str(session_dir))
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "session_id" in data
+        assert "turn_count" in data
+        assert "status" in data
+        assert data["session_id"] == "test-session-001"
+        assert data["turn_count"] == 1  # one user message in _HEALTHY_ENTRIES
+        assert data["status"] == "healthy"
+
+
+# ---------------------------------------------------------------------------
+# TestFindSubcommand (3 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestFindSubcommand:
+    """Tests for the `find` subcommand."""
+
+    def test_find_all_with_sessions_root(self, tmp_path: Path) -> None:
+        """find --sessions-root returns all sessions as a JSON array."""
+        _make_session(tmp_path, _HEALTHY_ENTRIES)
+        result = _run("find", "--sessions-root", str(tmp_path))
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        # Verify expected fields present
+        assert "session_id" in data[0]
+        assert "project" in data[0]
+
+    def test_find_with_project_filter(self, tmp_path: Path) -> None:
+        """find --project filters to sessions in that project."""
+        # Create sessions in two projects
+        _make_session(tmp_path, _HEALTHY_ENTRIES)
+        # Create second session in proj2
+        proj2_dir = tmp_path / "proj2" / "sessions" / "test-session-002"
+        proj2_dir.mkdir(parents=True, exist_ok=True)
+        with open(proj2_dir / "transcript.jsonl", "w", encoding="utf-8") as f:
+            for entry in _HEALTHY_ENTRIES:
+                f.write(json.dumps(entry) + "\n")
+        with open(proj2_dir / "metadata.json", "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "session_id": "test-session-002",
+                    "created": "2024-06-01T10:00:00+00:00",
+                },
+                f,
+            )
+
+        result = _run(
+            "find",
+            "--sessions-root",
+            str(tmp_path),
+            "--project",
+            "proj1",
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        session_ids = [s["session_id"] for s in data]
+        assert "test-session-001" in session_ids
+        assert "test-session-002" not in session_ids
+
+    def test_find_with_status_filter(self, tmp_path: Path) -> None:
+        """find --status healthy returns only healthy sessions."""
+        _make_session(tmp_path, _HEALTHY_ENTRIES)
+
+        result = _run(
+            "find",
+            "--sessions-root",
+            str(tmp_path),
+            "--status",
+            "healthy",
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        assert data[0]["session_id"] == "test-session-001"
+
+
+# ---------------------------------------------------------------------------
+# TestCLIEdgeCases (2 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestCLIEdgeCases:
+    """Edge case tests for the amplifier-session.py CLI."""
+
+    def test_no_subcommand_exits_2(self) -> None:
+        """Running with no subcommand exits with code 2."""
+        result = _run()
+        assert result.returncode == 2
+
+    def test_nonexistent_session_exits_1_with_error(self, tmp_path: Path) -> None:
+        """Attempting to diagnose a nonexistent session exits 1 with error JSON."""
+        result = _run(
+            "diagnose",
+            "nonexistent-session-xyz-12345",
+            "--sessions-root",
+            str(tmp_path),
+        )
+        assert result.returncode == 1
+        data = json.loads(result.stdout)
+        assert "error" in data

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -19,6 +19,7 @@ from amplifier_foundation.session import (
     get_session_lineage,
     get_turn_boundaries,
     get_turn_summary,
+    is_real_user_message,
     list_session_forks,
     slice_events_for_fork,
     slice_events_to_timestamp,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -700,3 +700,49 @@ class TestGetEventSummary:
         assert "prompt:submit" in summary["event_types"]
         assert summary["first_timestamp"] is not None
         assert summary["last_timestamp"] is not None
+
+
+class TestIsRealUserMessage:
+    def test_user_message_is_real(self):
+        assert is_real_user_message({"role": "user", "content": "Hello"}) is True
+
+    def test_assistant_message_is_not_real(self):
+        assert is_real_user_message({"role": "assistant", "content": "Hi"}) is False
+
+    def test_tool_role_is_not_real(self):
+        assert is_real_user_message({"role": "tool", "content": "result"}) is False
+
+    def test_tool_call_id_is_not_real(self):
+        assert (
+            is_real_user_message(
+                {"role": "user", "content": "result", "tool_call_id": "abc123"}
+            )
+            is False
+        )
+
+    def test_system_reminder_string_is_not_real(self):
+        assert (
+            is_real_user_message(
+                {
+                    "role": "user",
+                    "content": "<system-reminder>some context</system-reminder>",
+                }
+            )
+            is False
+        )
+
+    def test_system_reminder_in_list_content_is_not_real(self):
+        assert (
+            is_real_user_message(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "<system-reminder>ctx</system-reminder>",
+                        }
+                    ],
+                }
+            )
+            is False
+        )

--- a/tests/test_session_analyst_md.py
+++ b/tests/test_session_analyst_md.py
@@ -1,0 +1,326 @@
+"""Tests for session-analyst.md documentation rewrite.
+
+Verifies that the session-analyst agent documentation has been updated to:
+1. Use the unified amplifier-session.py script instead of bash choreography
+2. Contain concise section replacements for Storage Locations, Search Workflow,
+   Search Strategies, Session Repair, and Example Queries
+3. Be shorter than the original (~400 lines vs ~507)
+4. Have no references to the old session-repair.py in workflow sections
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+AGENT_FILE = Path(__file__).parent.parent / "agents" / "session-analyst.md"
+
+# The unified script path that should appear in the file
+SCRIPT_DISCOVERY_LINE = (
+    "SCRIPT=\"$(find / -path '*/amplifier-foundation/scripts/amplifier-session.py' "
+    '-type f 2>/dev/null | head -1)"'
+)
+
+# Old script reference that should NOT appear in workflow sections
+OLD_SCRIPT_REFERENCE = "session-repair.py"
+
+# Maximum line count after rewrite (target ~400, must be < 507)
+MAX_LINE_COUNT = 490
+
+
+@pytest.fixture
+def content() -> str:
+    """Read the session-analyst.md file."""
+    assert AGENT_FILE.exists(), f"Agent file not found: {AGENT_FILE}"
+    return AGENT_FILE.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def lines(content: str) -> list[str]:
+    """Return lines of the file."""
+    return content.splitlines()
+
+
+# ── Test 1: Script discovery line is present ──────────────────────────────────
+
+
+class TestScriptDiscovery:
+    """The unified script discovery line must be present."""
+
+    def test_script_discovery_line_present(self, content: str) -> None:
+        """The amplifier-session.py discovery line must be in the file."""
+        assert "amplifier-session.py" in content, (
+            "Script discovery line for amplifier-session.py not found"
+        )
+
+    def test_script_discovery_uses_find(self, content: str) -> None:
+        """Discovery must use find command with correct path pattern."""
+        assert (
+            "find / -path '*/amplifier-foundation/scripts/amplifier-session.py'"
+            in content
+        ), "Script discovery 'find' pattern not found in file"
+
+    def test_script_variable_assigned(self, content: str) -> None:
+        """SCRIPT variable must be assigned from the find command."""
+        assert 'SCRIPT="$(find' in content or "SCRIPT=$(find" in content, (
+            "SCRIPT variable assignment not found"
+        )
+
+
+# ── Test 2: Old session-repair.py removed from workflow sections ──────────────
+
+
+class TestNoOldScriptInWorkflow:
+    """session-repair.py must not appear in the workflow/repair sections."""
+
+    def test_session_repair_py_not_in_repair_section(self, content: str) -> None:
+        """session-repair.py should not appear in the Session Repair workflow."""
+        # Find the repair section
+        repair_section_start = content.find("## Session Repair")
+        if repair_section_start == -1:
+            pytest.skip("Session Repair section not found")
+
+        # Get content after repair section
+        repair_content = content[repair_section_start:]
+        assert OLD_SCRIPT_REFERENCE not in repair_content, (
+            f"Old script reference '{OLD_SCRIPT_REFERENCE}' found in Session Repair section"
+        )
+
+    def test_script_in_repair_section_is_new(self, content: str) -> None:
+        """The repair section should reference amplifier-session.py, not session-repair.py."""
+        repair_section_start = content.find("## Session Repair")
+        if repair_section_start == -1:
+            pytest.skip("Session Repair section not found")
+
+        repair_content = content[repair_section_start:]
+        assert "amplifier-session.py" in repair_content, (
+            "amplifier-session.py not found in Session Repair section"
+        )
+
+
+# ── Test 3: python "$SCRIPT" invocations present ──────────────────────────────
+
+
+class TestScriptInvocations:
+    """Workflow sections must use python \"$SCRIPT\" invocations."""
+
+    def test_python_script_invocation_present(self, content: str) -> None:
+        """The file must contain python \"$SCRIPT\" invocations."""
+        assert 'python "$SCRIPT"' in content, (
+            'python "$SCRIPT" invocations not found in file'
+        )
+
+    def test_repair_command_uses_script(self, content: str) -> None:
+        """Repair step must use python \"$SCRIPT\" not raw python session-repair.py."""
+        assert (
+            'python "$SCRIPT" --repair' in content
+            or 'python "$SCRIPT" repair' in content
+        ), "Repair command via $SCRIPT not found"
+
+    def test_diagnose_command_uses_script(self, content: str) -> None:
+        """Diagnose step must use python \"$SCRIPT\" not raw python session-repair.py."""
+        assert (
+            'python "$SCRIPT" --diagnose' in content
+            or 'python "$SCRIPT" diagnose' in content
+        ), "Diagnose command via $SCRIPT not found"
+
+
+# ── Test 4: File is shorter than original ────────────────────────────────────
+
+
+class TestFileLength:
+    """File must be shorter after the rewrite."""
+
+    def test_file_shorter_than_original(self, lines: list[str]) -> None:
+        """File must be shorter than the 507-line original."""
+        line_count = len(lines)
+        assert line_count < MAX_LINE_COUNT, (
+            f"File has {line_count} lines, expected < {MAX_LINE_COUNT} "
+            f"(original was 507 lines)"
+        )
+
+    def test_file_not_empty(self, lines: list[str]) -> None:
+        """File must have content."""
+        assert len(lines) > 100, "File appears to be too short (less than 100 lines)"
+
+
+# ── Test 5: Storage Locations section is concise ─────────────────────────────
+
+
+class TestStorageLocationsSection:
+    """Storage Locations section must be condensed."""
+
+    def test_storage_locations_section_exists(self, content: str) -> None:
+        """Storage Locations section must still exist."""
+        assert "## Storage Locations" in content, "Storage Locations section not found"
+
+    def test_storage_locations_mentions_metadata_json(self, content: str) -> None:
+        """metadata.json must be mentioned in Storage Locations."""
+        assert "metadata.json" in content, (
+            "metadata.json not found in Storage Locations"
+        )
+
+    def test_storage_locations_mentions_events_jsonl(self, content: str) -> None:
+        """events.jsonl must be mentioned with DANGER warning."""
+        assert "events.jsonl" in content, "events.jsonl not found"
+        # Should have danger/warning about events.jsonl
+        assert "DANGER" in content or "100k" in content, (
+            "DANGER warning for events.jsonl not found"
+        )
+
+    def test_storage_locations_mentions_transcript_jsonl(self, content: str) -> None:
+        """transcript.jsonl must be mentioned."""
+        assert "transcript.jsonl" in content, "transcript.jsonl not found"
+
+
+# ── Test 6: Search Workflow section uses script ───────────────────────────────
+
+
+class TestSearchWorkflowSection:
+    """Search Workflow section must use script-based examples."""
+
+    def test_search_section_exists(self, content: str) -> None:
+        """Search Workflow or Search section must exist."""
+        assert "## Search Workflow" in content or "## Searching Sessions" in content, (
+            "Search Workflow section not found"
+        )
+
+    def test_synthesis_guidance_preserved(self, content: str) -> None:
+        """Synthesis guidance must be preserved (overview, per-session summary)."""
+        assert "Overview" in content or "overview" in content, (
+            "Overview synthesis guidance not found"
+        )
+
+    def test_cross_session_insights_preserved(self, content: str) -> None:
+        """Cross-session insights guidance must be preserved."""
+        assert "cross-session" in content.lower() or "Cross-Session" in content, (
+            "Cross-session insights guidance not found"
+        )
+
+
+# ── Test 7: Search Strategies section uses one-liners ────────────────────────
+
+
+class TestSearchStrategiesSection:
+    """Search Strategies section must have one-liner examples with $SCRIPT."""
+
+    def test_search_strategies_section_exists(self, content: str) -> None:
+        """Search Strategies section must exist."""
+        assert "## Search Strategies" in content, "Search Strategies section not found"
+
+    def test_deep_event_analysis_preserved(self, content: str) -> None:
+        """Deep Event Analysis section must be preserved with NEVER warning."""
+        assert "Deep Event Analysis" in content, "Deep Event Analysis section not found"
+        assert "NEVER" in content, "NEVER warning not found in Deep Event Analysis"
+
+
+# ── Test 8: Session Repair section uses script ───────────────────────────────
+
+
+class TestSessionRepairSection:
+    """Session Repair section must use the unified script workflow."""
+
+    def test_session_repair_section_exists(self, content: str) -> None:
+        """Session Repair section must exist."""
+        assert "## Session Repair" in content, "Session Repair section not found"
+
+    def test_failure_modes_table_present(self, content: str) -> None:
+        """Failure modes table (FM1, FM2, FM3) must be present."""
+        assert "FM1" in content, "FM1 failure mode not found"
+        assert "FM2" in content, "FM2 failure mode not found"
+        assert "FM3" in content, "FM3 failure mode not found"
+
+    def test_mandatory_script_mandate(self, content: str) -> None:
+        """Mandatory script-only mandate must be present."""
+        assert "MANDATORY" in content or "mandatory" in content.lower(), (
+            "Mandatory script mandate not found"
+        )
+
+    def test_three_step_workflow_present(self, content: str) -> None:
+        """Three-step workflow (diagnose -> repair/rewind -> verify) must be present."""
+        assert "diagnose" in content.lower(), "Diagnose step not found"
+        assert "verify" in content.lower(), "Verify step not found"
+
+    def test_script_failure_guidance_present(self, content: str) -> None:
+        """Script failure guidance (STOP and report) must be present."""
+        assert (
+            "script fails" in content.lower()
+            or "If the script fails" in content
+            or "Script Fails" in content
+        ), "Script failure guidance not found"
+
+    def test_parent_session_note_present(self, content: str) -> None:
+        """Parent session modification note must be present."""
+        assert "parent" in content.lower() and "session" in content.lower(), (
+            "Parent session note not found"
+        )
+
+
+# ── Test 9: Example Queries section uses script ──────────────────────────────
+
+
+class TestExampleQueriesSection:
+    """Example Queries section must use script-based examples."""
+
+    def test_example_queries_section_exists(self, content: str) -> None:
+        """Example Queries section must exist."""
+        assert "## Example Queries" in content, "Example Queries section not found"
+
+    def test_session_resume_query_present(self, content: str) -> None:
+        """\"Why won't session X resume\" example must be present."""
+        assert "resume" in content.lower(), "Session resume query not found"
+
+    def test_find_session_query_present(self, content: str) -> None:
+        """Find session example must be present."""
+        assert "c3843177" in content or "Find session" in content, (
+            "Find session example not found"
+        )
+
+    def test_rewind_example_present(self, content: str) -> None:
+        """Rewind example must be present."""
+        assert "Rewind" in content or "rewind" in content, "Rewind example not found"
+
+    def test_example_queries_use_script(self, content: str) -> None:
+        """Example Queries should reference the script approach."""
+        # Find the example queries section
+        eq_start = content.find("## Example Queries")
+        if eq_start == -1:
+            pytest.skip("Example Queries section not found")
+        eq_content = content[eq_start : eq_start + 2000]
+        # Should have script invocations in examples
+        assert "$SCRIPT" in eq_content or "amplifier-session.py" in eq_content, (
+            "Script invocations not found in Example Queries section"
+        )
+
+
+# ── Test 10: Valid markdown structure ────────────────────────────────────────
+
+
+class TestMarkdownValidity:
+    """File must be valid markdown with proper frontmatter."""
+
+    def test_frontmatter_present(self, content: str) -> None:
+        """File must start with YAML frontmatter."""
+        assert content.startswith("---"), "File must start with YAML frontmatter"
+
+    def test_frontmatter_closes(self, content: str) -> None:
+        """Frontmatter must be closed with ---."""
+        # Find second --- after start
+        second_dashes = content.find("---", 3)
+        assert second_dashes > 0, "Frontmatter closing --- not found"
+
+    def test_agent_name_in_frontmatter(self, content: str) -> None:
+        """Agent name must be in frontmatter."""
+        assert "session-analyst" in content[:500], (
+            "session-analyst name not in frontmatter"
+        )
+
+    def test_attribution_rule_preserved(self, content: str) -> None:
+        """Attribution rule (parent_id / sub-session) must be preserved."""
+        assert (
+            "parent_id" in content
+            or "parent chain" in content
+            or "Attribution" in content
+        ), "Attribution rule not preserved"

--- a/tests/test_session_analyst_md.py
+++ b/tests/test_session_analyst_md.py
@@ -113,18 +113,16 @@ class TestScriptInvocations:
         )
 
     def test_repair_command_uses_script(self, content: str) -> None:
-        """Repair step must use python \"$SCRIPT\" not raw python session-repair.py."""
-        assert (
-            'python "$SCRIPT" --repair' in content
-            or 'python "$SCRIPT" repair' in content
-        ), "Repair command via $SCRIPT not found"
+        """Repair step must use python \"$SCRIPT\" subcommand syntax."""
+        assert 'python "$SCRIPT" repair' in content, (
+            "Repair command via $SCRIPT not found (must use subcommand syntax: repair, not --repair)"
+        )
 
     def test_diagnose_command_uses_script(self, content: str) -> None:
-        """Diagnose step must use python \"$SCRIPT\" not raw python session-repair.py."""
-        assert (
-            'python "$SCRIPT" --diagnose' in content
-            or 'python "$SCRIPT" diagnose' in content
-        ), "Diagnose command via $SCRIPT not found"
+        """Diagnose step must use python \"$SCRIPT\" subcommand syntax."""
+        assert 'python "$SCRIPT" diagnose' in content, (
+            "Diagnose command via $SCRIPT not found (must use subcommand syntax: diagnose, not --diagnose)"
+        )
 
 
 # ── Test 4: File is shorter than original ────────────────────────────────────

--- a/tests/test_session_analyst_md.py
+++ b/tests/test_session_analyst_md.py
@@ -27,7 +27,7 @@ SCRIPT_DISCOVERY_LINE = (
 OLD_SCRIPT_REFERENCE = "session-repair.py"
 
 # Maximum line count after rewrite (target ~400, must be < 507)
-MAX_LINE_COUNT = 490
+MAX_LINE_COUNT = 420
 
 
 @pytest.fixture

--- a/tests/test_session_diagnosis.py
+++ b/tests/test_session_diagnosis.py
@@ -1,0 +1,373 @@
+"""Tests for amplifier_foundation.session.diagnosis module.
+
+Layer Level 1 (Diagnosis Algebra): pure list[dict] -> list[dict], zero I/O.
+"""
+
+from __future__ import annotations
+
+from amplifier_foundation.session.diagnosis import (
+    DiagnosisResult,
+    build_tool_index,
+    diagnose_transcript,
+    repair_transcript,
+    rewind_transcript,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_entries_with_lines(messages: list[dict]) -> list[dict]:
+    """Add 1-based line_num to each message."""
+    return [{**m, "line_num": i + 1} for i, m in enumerate(messages)]
+
+
+def _tc(tc_id: str, name: str) -> dict:
+    """Build a tool_call dict."""
+    return {"id": tc_id, "function": {"name": name}}
+
+
+def _tool_result(tc_id: str, name: str, content: str) -> dict:
+    """Build a tool result dict."""
+    return {"role": "tool", "tool_call_id": tc_id, "name": name, "content": content}
+
+
+# ---------------------------------------------------------------------------
+# TestBuildToolIndex
+# ---------------------------------------------------------------------------
+
+
+class TestBuildToolIndex:
+    def test_finds_tool_use_ids(self):
+        """build_tool_index finds tool_use IDs with line_num, tool_name, entry_index."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc("call_abc", "my_tool")],
+                },
+            ]
+        )
+        index = build_tool_index(entries)
+        assert "call_abc" in index["tool_uses"]
+        info = index["tool_uses"]["call_abc"]
+        assert info["line_num"] == 2
+        assert info["tool_name"] == "my_tool"
+        assert info["entry_index"] == 1
+
+    def test_finds_tool_result_ids(self):
+        """build_tool_index finds tool_result IDs with entry_index."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc("call_abc", "my_tool")],
+                },
+                _tool_result("call_abc", "my_tool", "result"),
+            ]
+        )
+        index = build_tool_index(entries)
+        assert "call_abc" in index["tool_results"]
+        info = index["tool_results"]["call_abc"]
+        assert info["entry_index"] == 2
+
+
+# ---------------------------------------------------------------------------
+# TestDiagnoseTranscript
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseTranscript:
+    def test_healthy_transcript(self):
+        """A complete turn with no issues is healthy."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc("call_1", "do_thing")],
+                },
+                _tool_result("call_1", "do_thing", "ok"),
+                {"role": "assistant", "content": "Done"},
+            ]
+        )
+        result = diagnose_transcript(entries)
+        assert result["status"] == "healthy"
+        assert result["failure_modes"] == []
+        assert result["orphaned_tool_ids"] == []
+        assert result["misplaced_tool_ids"] == []
+        assert result["incomplete_turns"] == []
+
+    def test_detects_missing_tool_results(self):
+        """Orphaned tool_calls (no result) produce missing_tool_results failure mode."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc("call_1", "tool_a"), _tc("call_2", "tool_b")],
+                },
+            ]
+        )
+        result = diagnose_transcript(entries)
+        assert result["status"] == "broken"
+        assert "missing_tool_results" in result["failure_modes"]
+        assert set(result["orphaned_tool_ids"]) == {"call_1", "call_2"}
+
+    def test_detects_ordering_violation(self):
+        """Tool result after a user message produces ordering_violation."""
+        tc_id = "call_1"
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Turn 1"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc(tc_id, "my_tool")],
+                },
+                {"role": "user", "content": "Turn 2"},  # intervening user message
+                _tool_result(tc_id, "my_tool", "result"),
+            ]
+        )
+        result = diagnose_transcript(entries)
+        assert "ordering_violation" in result["failure_modes"]
+        assert tc_id in result["misplaced_tool_ids"]
+
+    def test_detects_incomplete_assistant_turn(self):
+        """Tool results followed immediately by user message = incomplete turn."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Turn 1"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc("call_1", "my_tool")],
+                },
+                _tool_result("call_1", "my_tool", "result"),
+                {"role": "user", "content": "Turn 2"},  # no closing assistant response
+            ]
+        )
+        result = diagnose_transcript(entries)
+        assert "incomplete_assistant_turn" in result["failure_modes"]
+        assert len(result["incomplete_turns"]) == 1
+        assert result["incomplete_turns"][0]["missing"] == "assistant_response"
+
+    def test_no_tool_calls_is_healthy(self):
+        """A transcript with no tool calls is healthy."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+                {"role": "user", "content": "How are you?"},
+                {"role": "assistant", "content": "Great"},
+            ]
+        )
+        result = diagnose_transcript(entries)
+        assert result["status"] == "healthy"
+
+    def test_recommended_action(self):
+        """recommended_action is 'none' for healthy and 'repair' for broken."""
+        healthy_entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+            ]
+        )
+        broken_entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc("call_1", "my_tool")],
+                },
+            ]
+        )
+        healthy = diagnose_transcript(healthy_entries)
+        broken = diagnose_transcript(broken_entries)
+        assert healthy["recommended_action"] == "none"
+        assert broken["recommended_action"] == "repair"
+
+
+# ---------------------------------------------------------------------------
+# TestRepairTranscript
+# ---------------------------------------------------------------------------
+
+
+class TestRepairTranscript:
+    def test_healthy_transcript_unchanged(self):
+        """Healthy transcript is returned unchanged (minus line_num)."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+            ]
+        )
+        diagnosis: DiagnosisResult = {
+            "status": "healthy",
+            "failure_modes": [],
+            "orphaned_tool_ids": [],
+            "misplaced_tool_ids": [],
+            "incomplete_turns": [],
+            "recommended_action": "none",
+        }
+        result = repair_transcript(entries, diagnosis)
+        assert len(result) == 2
+        assert all("line_num" not in e for e in result)
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+
+    def test_injects_synthetics_for_orphans(self):
+        """Orphaned tool calls get synthetic tool results injected."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc("call_1", "tool_a"), _tc("call_2", "tool_b")],
+                },
+                {"role": "user", "content": "Next turn"},
+            ]
+        )
+        diagnosis = diagnose_transcript(entries)
+        result = repair_transcript(entries, diagnosis)
+        tool_results = [e for e in result if e.get("role") == "tool"]
+        assert len(tool_results) == 2
+        for tr in tool_results:
+            assert "error" in tr["content"]
+
+    def test_removes_misplaced_and_injects_synthetic(self):
+        """Misplaced tool result is removed; synthetic result is injected in order."""
+        tc_id = "call_1"
+        original_result = _tool_result(tc_id, "my_tool", "original_content")
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Turn 1"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc(tc_id, "my_tool")],
+                },
+                {"role": "user", "content": "Turn 2 (disruption)"},
+                original_result,
+            ]
+        )
+        diagnosis = diagnose_transcript(entries)
+        result = repair_transcript(entries, diagnosis)
+        # Original misplaced result should NOT be in output
+        assert not any(e.get("content") == "original_content" for e in result)
+        # Exactly 1 synthetic tool result should be present
+        tool_results = [e for e in result if e.get("role") == "tool"]
+        assert len(tool_results) == 1
+
+
+# ---------------------------------------------------------------------------
+# TestRewindTranscript
+# ---------------------------------------------------------------------------
+
+
+class TestRewindTranscript:
+    def test_rewinds_before_first_issue(self):
+        """Rewind returns 2 entries from the first healthy turn."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Turn 1"},  # index 0
+                {"role": "assistant", "content": "Response"},  # index 1
+                {"role": "user", "content": "Turn 2"},  # index 2
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc("call_1", "my_tool")],  # orphan
+                },  # index 3
+            ]
+        )
+        diagnosis = diagnose_transcript(entries)
+        result = rewind_transcript(entries, diagnosis)
+        assert len(result) == 2
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+
+    def test_healthy_returns_all(self):
+        """Healthy transcript rewind returns all entries stripped of line_num."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+            ]
+        )
+        diagnosis: DiagnosisResult = {
+            "status": "healthy",
+            "failure_modes": [],
+            "orphaned_tool_ids": [],
+            "misplaced_tool_ids": [],
+            "incomplete_turns": [],
+            "recommended_action": "none",
+        }
+        result = rewind_transcript(entries, diagnosis)
+        assert len(result) == 2
+        assert all("line_num" not in e for e in result)
+
+    def test_first_turn_broken_returns_empty(self):
+        """Rewind with first turn broken returns empty list."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Turn 1"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc("call_1", "my_tool")],  # orphan
+                },
+            ]
+        )
+        diagnosis = diagnose_transcript(entries)
+        result = rewind_transcript(entries, diagnosis)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# TestIntegrationRoundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestIntegrationRoundtrip:
+    def test_orphans_roundtrip(self):
+        """diagnose -> repair -> re-diagnose for orphans produces healthy."""
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [_tc("call_1", "my_tool")],
+                },
+                {"role": "user", "content": "Follow up"},
+            ]
+        )
+        diagnosis = diagnose_transcript(entries)
+        repaired = repair_transcript(entries, diagnosis)
+        # Re-diagnose: add line_nums back for the re-diagnosis
+        re_entries = _make_entries_with_lines(repaired)
+        re_diagnosis = diagnose_transcript(re_entries)
+        assert re_diagnosis["status"] == "healthy"
+
+    def test_combined_failures_roundtrip(self):
+        """diagnose -> repair -> re-diagnose for ordering+orphans produces healthy."""
+        tc_orphan = "call_orphan"
+        tc_misplaced = "call_misplaced"
+        original_result = _tool_result(tc_misplaced, "tool_b", "original")
+        entries = _make_entries_with_lines(
+            [
+                {"role": "user", "content": "Turn 1"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        _tc(tc_orphan, "tool_a"),
+                        _tc(tc_misplaced, "tool_b"),
+                    ],
+                },
+                {"role": "user", "content": "Turn 2"},  # disruption
+                original_result,  # misplaced result
+            ]
+        )
+        diagnosis = diagnose_transcript(entries)
+        repaired = repair_transcript(entries, diagnosis)
+        re_entries = _make_entries_with_lines(repaired)
+        re_diagnosis = diagnose_transcript(re_entries)
+        assert re_diagnosis["status"] == "healthy"

--- a/tests/test_session_finder.py
+++ b/tests/test_session_finder.py
@@ -1,0 +1,274 @@
+"""Tests for amplifier_foundation.session.finder — session discovery and resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amplifier_foundation.session.store import write_metadata, write_transcript
+from amplifier_foundation.session.finder import (
+    find_sessions,
+    resolve_session,
+    session_info,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session(
+    sessions_root: Path,
+    project: str,
+    session_id: str,
+    *,
+    messages: list[dict] | None = None,
+    metadata: dict | None = None,
+) -> Path:
+    """Create a minimal session directory for testing.
+
+    Creates the session at sessions_root/<project>/sessions/<session_id>/
+    with a transcript.jsonl and metadata.json.
+    """
+    session_dir = sessions_root / project / "sessions" / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    msgs = (
+        messages
+        if messages is not None
+        else [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+    )
+    write_transcript(session_dir, msgs)
+
+    meta = dict(metadata) if metadata is not None else {}
+    meta.setdefault("session_id", session_id)
+    meta.setdefault("created", "2024-06-01T10:00:00+00:00")
+    meta.setdefault("bundle", "test-bundle")
+    meta.setdefault("model", "test-model")
+    write_metadata(session_dir, meta)
+
+    return session_dir
+
+
+# ---------------------------------------------------------------------------
+# TestResolveSession (6 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSession:
+    """Tests for resolve_session — accepts full path, full ID, or partial ID."""
+
+    def test_resolve_full_path(self, tmp_path: Path):
+        """Passing an absolute path to a valid session dir returns that path."""
+        session_dir = _make_session(tmp_path, "proj-a", "session-abc123")
+        result = resolve_session(str(session_dir), sessions_root=tmp_path)
+        assert result == session_dir
+
+    def test_resolve_full_id(self, tmp_path: Path):
+        """Passing an exact session ID finds the session dir across projects."""
+        session_dir = _make_session(tmp_path, "proj-a", "session-abc123")
+        result = resolve_session("session-abc123", sessions_root=tmp_path)
+        assert result == session_dir
+
+    def test_resolve_partial_id(self, tmp_path: Path):
+        """Passing a prefix of a session ID resolves to that session."""
+        session_dir = _make_session(tmp_path, "proj-a", "session-abc123fullname")
+        result = resolve_session("session-abc", sessions_root=tmp_path)
+        assert result == session_dir
+
+    def test_ambiguous_partial_raises_value_error(self, tmp_path: Path):
+        """Partial ID that matches multiple sessions raises ValueError."""
+        _make_session(tmp_path, "proj-a", "session-abc-first")
+        _make_session(tmp_path, "proj-b", "session-abc-second")
+        with pytest.raises(ValueError, match="[Aa]mbiguous"):
+            resolve_session("session-abc", sessions_root=tmp_path)
+
+    def test_no_match_raises_file_not_found(self, tmp_path: Path):
+        """Non-existent session ID raises FileNotFoundError."""
+        _make_session(tmp_path, "proj-a", "session-abc123")
+        with pytest.raises(FileNotFoundError):
+            resolve_session("nonexistent-id", sessions_root=tmp_path)
+
+    def test_project_filter_disambiguation(self, tmp_path: Path):
+        """Project filter resolves ambiguous partial ID by restricting scope."""
+        session_a = _make_session(tmp_path, "proj-a", "session-xyz-one")
+        _make_session(tmp_path, "proj-b", "session-xyz-two")
+        # Without filter: ambiguous
+        with pytest.raises(ValueError):
+            resolve_session("session-xyz", sessions_root=tmp_path)
+        # With filter: unambiguous
+        result = resolve_session(
+            "session-xyz", sessions_root=tmp_path, project="proj-a"
+        )
+        assert result == session_a
+
+
+# ---------------------------------------------------------------------------
+# TestFindSessions (7 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestFindSessions:
+    """Tests for find_sessions — list and filter sessions."""
+
+    def test_find_all(self, tmp_path: Path):
+        """find_sessions with no filters returns all sessions."""
+        _make_session(tmp_path, "proj-a", "sess-001")
+        _make_session(tmp_path, "proj-a", "sess-002")
+        _make_session(tmp_path, "proj-b", "sess-003")
+        results = find_sessions(sessions_root=tmp_path)
+        assert len(results) == 3
+
+    def test_filter_by_project(self, tmp_path: Path):
+        """project filter restricts results to a single project."""
+        _make_session(tmp_path, "proj-a", "sess-001")
+        _make_session(tmp_path, "proj-a", "sess-002")
+        _make_session(tmp_path, "proj-b", "sess-003")
+        results = find_sessions(sessions_root=tmp_path, project="proj-a")
+        assert len(results) == 2
+        assert all(r["project"] == "proj-a" for r in results)
+
+    def test_filter_by_after_date(self, tmp_path: Path):
+        """after filter excludes sessions created before the given date."""
+        _make_session(
+            tmp_path,
+            "proj-a",
+            "old-sess",
+            metadata={"created": "2023-01-01T00:00:00+00:00"},
+        )
+        _make_session(
+            tmp_path,
+            "proj-a",
+            "new-sess",
+            metadata={"created": "2025-01-01T00:00:00+00:00"},
+        )
+        results = find_sessions(sessions_root=tmp_path, after="2024-01-01")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "new-sess"
+
+    def test_filter_by_keyword(self, tmp_path: Path):
+        """keyword filter only returns sessions with keyword in transcript."""
+        _make_session(
+            tmp_path,
+            "proj-a",
+            "match-sess",
+            messages=[
+                {"role": "user", "content": "Tell me about elephants"},
+                {"role": "assistant", "content": "Elephants are large mammals"},
+            ],
+        )
+        _make_session(
+            tmp_path,
+            "proj-a",
+            "no-match-sess",
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+            ],
+        )
+        results = find_sessions(sessions_root=tmp_path, keyword="elephant")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "match-sess"
+
+    def test_respects_limit(self, tmp_path: Path):
+        """limit parameter caps the number of returned results."""
+        for i in range(10):
+            _make_session(tmp_path, "proj-a", f"sess-{i:03d}")
+        results = find_sessions(sessions_root=tmp_path, limit=3)
+        assert len(results) == 3
+
+    def test_returns_expected_fields(self, tmp_path: Path):
+        """Each result dict has session_id, path, project, created, bundle, model."""
+        _make_session(
+            tmp_path,
+            "proj-a",
+            "sess-full",
+            metadata={
+                "session_id": "sess-full",
+                "created": "2024-06-01T10:00:00+00:00",
+                "bundle": "my-bundle",
+                "model": "my-model",
+            },
+        )
+        results = find_sessions(sessions_root=tmp_path)
+        assert len(results) == 1
+        r = results[0]
+        assert r["session_id"] == "sess-full"
+        assert isinstance(r["path"], Path)
+        assert r["project"] == "proj-a"
+        assert r["created"] == "2024-06-01T10:00:00+00:00"
+        assert r["bundle"] == "my-bundle"
+        assert r["model"] == "my-model"
+
+    def test_empty_root_returns_empty(self, tmp_path: Path):
+        """sessions_root with no project dirs returns empty list."""
+        empty_root = tmp_path / "empty"
+        empty_root.mkdir()
+        results = find_sessions(sessions_root=empty_root)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# TestSessionInfo (2 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionInfo:
+    """Tests for session_info — metadata + turn_count + health status."""
+
+    def test_basic_info_with_turn_count_and_healthy_status(self, tmp_path: Path):
+        """session_info returns correct fields for a healthy session."""
+        session_dir = _make_session(
+            tmp_path,
+            "proj-a",
+            "healthy-sess",
+            messages=[
+                {"role": "user", "content": "Turn 1"},
+                {"role": "assistant", "content": "Response 1"},
+                {"role": "user", "content": "Turn 2"},
+                {"role": "assistant", "content": "Response 2"},
+            ],
+            metadata={
+                "session_id": "healthy-sess",
+                "created": "2024-06-01T10:00:00+00:00",
+                "bundle": "test-bundle",
+                "model": "gpt-4",
+            },
+        )
+        info = session_info(session_dir)
+        assert info["session_id"] == "healthy-sess"
+        assert info["path"] == session_dir
+        assert info["project"] == "proj-a"
+        assert info["created"] == "2024-06-01T10:00:00+00:00"
+        assert info["bundle"] == "test-bundle"
+        assert info["model"] == "gpt-4"
+        assert info["turn_count"] == 2
+        assert info["status"] == "healthy"
+        assert info["failure_modes"] == []
+
+    def test_broken_session_with_failure_modes(self, tmp_path: Path):
+        """session_info returns failure_modes for a session with orphaned tool calls."""
+        session_dir = _make_session(
+            tmp_path,
+            "proj-a",
+            "broken-sess",
+            messages=[
+                {"role": "user", "content": "Do something"},
+                {
+                    "role": "assistant",
+                    "content": "Using a tool",
+                    "tool_calls": [
+                        {"id": "call_xyz", "function": {"name": "my_tool"}},
+                    ],
+                },
+                # Missing tool result — orphaned tool call
+            ],
+        )
+        info = session_info(session_dir)
+        assert info["status"] == "broken"
+        assert "missing_tool_results" in info["failure_modes"]

--- a/tests/test_session_finder.py
+++ b/tests/test_session_finder.py
@@ -151,6 +151,24 @@ class TestFindSessions:
         assert len(results) == 1
         assert results[0]["session_id"] == "new-sess"
 
+    def test_filter_by_before_date(self, tmp_path: Path):
+        """before filter excludes sessions created after the given date."""
+        _make_session(
+            tmp_path,
+            "proj-a",
+            "old-sess",
+            metadata={"created": "2023-01-01T00:00:00+00:00"},
+        )
+        _make_session(
+            tmp_path,
+            "proj-a",
+            "new-sess",
+            metadata={"created": "2025-01-01T00:00:00+00:00"},
+        )
+        results = find_sessions(sessions_root=tmp_path, before="2024-01-01")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "old-sess"
+
     def test_filter_by_keyword(self, tmp_path: Path):
         """keyword filter only returns sessions with keyword in transcript."""
         _make_session(

--- a/tests/test_session_init_exports.py
+++ b/tests/test_session_init_exports.py
@@ -17,6 +17,7 @@ class TestExistingExports:
     """Verify pre-existing symbols still export correctly."""
 
     def test_fork_exports(self):
+        """These symbols come from the .fork module (session branching/lineage)."""
         from amplifier_foundation.session import (  # noqa: F401
             ForkResult,
             fork_session,
@@ -27,6 +28,7 @@ class TestExistingExports:
         )
 
     def test_events_exports(self):
+        """These symbols come from the .events module (event log utilities)."""
         from amplifier_foundation.session import (  # noqa: F401
             count_events,
             get_event_summary,
@@ -47,6 +49,7 @@ class TestExistingExports:
         )
 
     def test_capabilities_exports(self):
+        """These symbols come from the .capabilities module (working directory helpers)."""
         from amplifier_foundation.session import (  # noqa: F401
             WORKING_DIR_CAPABILITY,
             get_working_dir,

--- a/tests/test_session_init_exports.py
+++ b/tests/test_session_init_exports.py
@@ -1,0 +1,142 @@
+"""Tests for amplifier_foundation.session __init__.py exports.
+
+Verifies that all 38 public symbols are importable directly from the
+top-level session package after the __init__.py update.
+"""
+
+from __future__ import annotations
+
+
+# =============================================================================
+# RED: These imports should fail before the __init__.py is updated,
+# and pass after the update.
+# =============================================================================
+
+
+class TestExistingExports:
+    """Verify pre-existing symbols still export correctly."""
+
+    def test_fork_exports(self):
+        from amplifier_foundation.session import (  # noqa: F401
+            ForkResult,
+            fork_session,
+            fork_session_in_memory,
+            get_fork_preview,
+            get_session_lineage,
+            list_session_forks,
+        )
+
+    def test_events_exports(self):
+        from amplifier_foundation.session import (  # noqa: F401
+            count_events,
+            get_event_summary,
+            get_last_timestamp_for_turn,
+            slice_events_for_fork,
+            slice_events_to_timestamp,
+        )
+
+    def test_messages_exports(self):
+        """These were previously imported from .slice, now from .messages."""
+        from amplifier_foundation.session import (  # noqa: F401
+            add_synthetic_tool_results,
+            count_turns,
+            find_orphaned_tool_calls,
+            get_turn_boundaries,
+            get_turn_summary,
+            slice_to_turn,
+        )
+
+    def test_capabilities_exports(self):
+        from amplifier_foundation.session import (  # noqa: F401
+            WORKING_DIR_CAPABILITY,
+            get_working_dir,
+            set_working_dir,
+        )
+
+
+class TestNewExports:
+    """Verify newly added symbols are exported from the session package."""
+
+    def test_is_real_user_message_export(self):
+        from amplifier_foundation.session import is_real_user_message  # noqa: F401
+
+    def test_store_constants_export(self):
+        from amplifier_foundation.session import (  # noqa: F401
+            EVENTS_FILENAME,
+            METADATA_FILENAME,
+            TRANSCRIPT_FILENAME,
+        )
+
+    def test_store_functions_export(self):
+        from amplifier_foundation.session import (  # noqa: F401
+            backup,
+            load_metadata,
+            load_transcript,
+            load_transcript_with_lines,
+            read_jsonl,
+            write_jsonl,
+            write_metadata,
+            write_transcript,
+        )
+
+    def test_diagnosis_types_export(self):
+        from amplifier_foundation.session import (  # noqa: F401
+            DiagnosisResult,
+            IncompleteTurn,
+        )
+
+    def test_diagnosis_functions_export(self):
+        from amplifier_foundation.session import (  # noqa: F401
+            build_tool_index,
+            diagnose_transcript,
+            repair_transcript,
+            rewind_transcript,
+        )
+
+
+class TestDunderAll:
+    """Verify __all__ contains all 38 expected names."""
+
+    def test_all_contains_38_names(self):
+        import amplifier_foundation.session as session
+
+        assert hasattr(session, "__all__"), "__all__ must be defined"
+        assert len(session.__all__) == 38, (
+            f"Expected 38 names in __all__, got {len(session.__all__)}: "
+            f"{sorted(session.__all__)}"
+        )
+
+    def test_all_includes_new_names(self):
+        import amplifier_foundation.session as session
+
+        expected_new = {
+            "is_real_user_message",
+            "TRANSCRIPT_FILENAME",
+            "METADATA_FILENAME",
+            "EVENTS_FILENAME",
+            "read_jsonl",
+            "write_jsonl",
+            "load_transcript",
+            "load_transcript_with_lines",
+            "write_transcript",
+            "load_metadata",
+            "write_metadata",
+            "backup",
+            "diagnose_transcript",
+            "repair_transcript",
+            "rewind_transcript",
+            "build_tool_index",
+            "DiagnosisResult",
+            "IncompleteTurn",
+        }
+        for name in expected_new:
+            assert name in session.__all__, f"{name!r} missing from __all__"
+
+    def test_all_symbols_are_importable(self):
+        """Every name in __all__ must be accessible as an attribute."""
+        import amplifier_foundation.session as session
+
+        for name in session.__all__:
+            assert hasattr(session, name), (
+                f"Name {name!r} is in __all__ but not importable from the package"
+            )

--- a/tests/test_session_init_exports.py
+++ b/tests/test_session_init_exports.py
@@ -97,15 +97,28 @@ class TestNewExports:
         )
 
 
-class TestDunderAll:
-    """Verify __all__ contains all 38 expected names."""
+class TestFinderExports:
+    """Verify finder symbols are exported from the session package."""
 
-    def test_all_contains_38_names(self):
+    def test_find_sessions_export(self):
+        from amplifier_foundation.session import find_sessions  # noqa: F401
+
+    def test_resolve_session_export(self):
+        from amplifier_foundation.session import resolve_session  # noqa: F401
+
+    def test_session_info_export(self):
+        from amplifier_foundation.session import session_info  # noqa: F401
+
+
+class TestDunderAll:
+    """Verify __all__ contains all 41 expected names."""
+
+    def test_all_contains_41_names(self):
         import amplifier_foundation.session as session
 
         assert hasattr(session, "__all__"), "__all__ must be defined"
-        assert len(session.__all__) == 38, (
-            f"Expected 38 names in __all__, got {len(session.__all__)}: "
+        assert len(session.__all__) == 41, (
+            f"Expected 41 names in __all__, got {len(session.__all__)}: "
             f"{sorted(session.__all__)}"
         )
 
@@ -131,6 +144,10 @@ class TestDunderAll:
             "build_tool_index",
             "DiagnosisResult",
             "IncompleteTurn",
+            # Finder operations
+            "find_sessions",
+            "resolve_session",
+            "session_info",
         }
         for name in expected_new:
             assert name in session.__all__, f"{name!r} missing from __all__"

--- a/tests/test_session_messages.py
+++ b/tests/test_session_messages.py
@@ -1,0 +1,219 @@
+"""Tests for amplifier_foundation.session.messages module.
+
+Layer Level 1 (Message Algebra): pure list[dict] -> list[dict], zero I/O.
+"""
+
+from __future__ import annotations
+
+import json
+
+from amplifier_foundation.session.messages import (
+    add_synthetic_tool_results,
+    count_turns,
+    find_orphaned_tool_calls,
+    get_turn_boundaries,
+    get_turn_summary,
+    is_real_user_message,
+    slice_to_turn,
+)
+
+
+# =============================================================================
+# TestIsRealUserMessage
+# =============================================================================
+
+
+class TestIsRealUserMessage:
+    def test_plain_user_message_returns_true(self):
+        """A plain user message with string content is real."""
+        entry = {"role": "user", "content": "Hello, world!"}
+        assert is_real_user_message(entry) is True
+
+    def test_tool_call_id_present_returns_false(self):
+        """A user-role message with tool_call_id is not real."""
+        entry = {"role": "user", "tool_call_id": "call_abc123", "content": "result data"}
+        assert is_real_user_message(entry) is False
+
+    def test_role_tool_returns_false(self):
+        """A message with role='tool' is not a real user message."""
+        entry = {"role": "tool", "tool_call_id": "call_abc123", "content": "result data"}
+        assert is_real_user_message(entry) is False
+
+    def test_string_content_starting_with_system_reminder_returns_false(self):
+        """A user message with string content starting with <system-reminder> is not real."""
+        entry = {
+            "role": "user",
+            "content": "<system-reminder>You are helpful</system-reminder>",
+        }
+        assert is_real_user_message(entry) is False
+
+    def test_list_content_with_system_reminder_text_returns_false(self):
+        """A user message with list content containing <system-reminder> is not real."""
+        entry = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "<system-reminder>injected context</system-reminder>",
+                }
+            ],
+        }
+        assert is_real_user_message(entry) is False
+
+    def test_assistant_role_returns_false(self):
+        """An assistant message is not a real user message."""
+        entry = {"role": "assistant", "content": "I can help with that."}
+        assert is_real_user_message(entry) is False
+
+    def test_empty_content_user_message_returns_true(self):
+        """A user message with empty string content is still real."""
+        entry = {"role": "user", "content": ""}
+        assert is_real_user_message(entry) is True
+
+    def test_list_content_without_system_reminder_returns_true(self):
+        """A user message with list content that has no system-reminder is real."""
+        entry = {
+            "role": "user",
+            "content": [{"type": "text", "text": "regular user text"}],
+        }
+        assert is_real_user_message(entry) is True
+
+
+# =============================================================================
+# TestParameterizedSyntheticContent
+# =============================================================================
+
+
+class TestParameterizedSyntheticContent:
+    """Tests for the synthetic_content parameter in add_synthetic_tool_results."""
+
+    def _make_messages_with_orphan(self, tool_id: str = "tc_a") -> list[dict]:
+        """Helper: assistant message with an orphaned tool call."""
+        return [
+            {"role": "user", "content": "Do something"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": tool_id,
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+
+    def test_default_content_contains_forked_key(self):
+        """Default synthetic content is fork-style JSON with a 'forked' key."""
+        messages = self._make_messages_with_orphan("tc_a")
+        result = add_synthetic_tool_results(messages, ["tc_a"])
+        tool_results = [m for m in result if m.get("role") == "tool"]
+        assert len(tool_results) == 1
+        content = json.loads(tool_results[0]["content"])
+        assert "forked" in content
+
+    def test_custom_synthetic_content_string_used_when_provided(self):
+        """When synthetic_content is given, it is used as the tool result content."""
+        messages = self._make_messages_with_orphan("tc_b")
+        custom = '{"error": "custom error message"}'
+        result = add_synthetic_tool_results(messages, ["tc_b"], synthetic_content=custom)
+        tool_results = [m for m in result if m.get("role") == "tool"]
+        assert len(tool_results) == 1
+        assert tool_results[0]["content"] == custom
+
+    def test_custom_content_applied_to_all_results_for_multiple_orphans(self):
+        """Custom synthetic_content is applied to every orphaned tool call."""
+        messages = [
+            {"role": "user", "content": "Do two things"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc_x",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": "{}"},
+                    },
+                    {
+                        "id": "tc_y",
+                        "type": "function",
+                        "function": {"name": "grep", "arguments": "{}"},
+                    },
+                ],
+            },
+        ]
+        custom = '{"error": "all interrupted"}'
+        result = add_synthetic_tool_results(
+            messages, ["tc_x", "tc_y"], synthetic_content=custom
+        )
+        tool_results = [m for m in result if m.get("role") == "tool"]
+        assert len(tool_results) == 2
+        for tr in tool_results:
+            assert tr["content"] == custom
+
+
+# =============================================================================
+# TestExistingFunctionsAvailable
+# =============================================================================
+
+
+class TestExistingFunctionsAvailable:
+    """Verify all functions from slice.py are available via messages.py."""
+
+    def test_get_turn_boundaries_returns_user_indices(self):
+        """get_turn_boundaries returns [0, 2] for 3-message conversation."""
+        messages = [
+            {"role": "user", "content": "Q1"},
+            {"role": "assistant", "content": "A1"},
+            {"role": "user", "content": "Q2"},
+        ]
+        assert get_turn_boundaries(messages) == [0, 2]
+
+    def test_count_turns_returns_1_for_user_plus_assistant(self):
+        """count_turns returns 1 for a user + assistant message pair."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        assert count_turns(messages) == 1
+
+    def test_slice_to_turn_returns_2_messages(self):
+        """slice_to_turn(messages, 1) returns 2 messages for a 2-turn conversation."""
+        messages = [
+            {"role": "user", "content": "Q1"},
+            {"role": "assistant", "content": "A1"},
+            {"role": "user", "content": "Q2"},
+            {"role": "assistant", "content": "A2"},
+        ]
+        sliced = slice_to_turn(messages, 1)
+        assert len(sliced) == 2
+
+    def test_find_orphaned_tool_calls_finds_orphan(self):
+        """find_orphaned_tool_calls correctly identifies orphaned tool call 'tc_a'."""
+        messages = [
+            {"role": "user", "content": "Do something"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc_a",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+        orphans = find_orphaned_tool_calls(messages)
+        assert "tc_a" in orphans
+
+    def test_get_turn_summary_returns_dict_with_turn(self):
+        """get_turn_summary returns a dict with the correct turn number."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        summary = get_turn_summary(messages, 1)
+        assert isinstance(summary, dict)
+        assert summary["turn"] == 1

--- a/tests/test_session_messages.py
+++ b/tests/test_session_messages.py
@@ -31,12 +31,20 @@ class TestIsRealUserMessage:
 
     def test_tool_call_id_present_returns_false(self):
         """A user-role message with tool_call_id is not real."""
-        entry = {"role": "user", "tool_call_id": "call_abc123", "content": "result data"}
+        entry = {
+            "role": "user",
+            "tool_call_id": "call_abc123",
+            "content": "result data",
+        }
         assert is_real_user_message(entry) is False
 
     def test_role_tool_returns_false(self):
         """A message with role='tool' is not a real user message."""
-        entry = {"role": "tool", "tool_call_id": "call_abc123", "content": "result data"}
+        entry = {
+            "role": "tool",
+            "tool_call_id": "call_abc123",
+            "content": "result data",
+        }
         assert is_real_user_message(entry) is False
 
     def test_string_content_starting_with_system_reminder_returns_false(self):
@@ -117,7 +125,9 @@ class TestParameterizedSyntheticContent:
         """When synthetic_content is given, it is used as the tool result content."""
         messages = self._make_messages_with_orphan("tc_b")
         custom = '{"error": "custom error message"}'
-        result = add_synthetic_tool_results(messages, ["tc_b"], synthetic_content=custom)
+        result = add_synthetic_tool_results(
+            messages, ["tc_b"], synthetic_content=custom
+        )
         tool_results = [m for m in result if m.get("role") == "tool"]
         assert len(tool_results) == 1
         assert tool_results[0]["content"] == custom
@@ -217,3 +227,69 @@ class TestExistingFunctionsAvailable:
         summary = get_turn_summary(messages, 1)
         assert isinstance(summary, dict)
         assert summary["turn"] == 1
+
+
+# =============================================================================
+# TestSliceToTurnUnknownHandle
+# =============================================================================
+
+
+class TestSliceToTurnUnknownHandle:
+    """Tests that unknown handle_orphaned_tools values raise ValueError."""
+
+    def test_unknown_handle_value_raises_value_error(self):
+        """An unrecognized handle_orphaned_tools value raises ValueError."""
+        messages = [
+            {"role": "user", "content": "Do something"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc_a",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+        import pytest
+
+        with pytest.raises(ValueError, match="Unknown handle_orphaned_tools"):
+            slice_to_turn(messages, 1, handle_orphaned_tools="ignore")
+
+
+# =============================================================================
+# TestGetTurnSummaryEllipsis
+# =============================================================================
+
+
+class TestGetTurnSummaryEllipsis:
+    """Tests for consistent ellipsis truncation in get_turn_summary."""
+
+    def test_list_content_appends_ellipsis_when_truncated(self):
+        """get_turn_summary appends '...' when list content text exceeds max_length."""
+        long_text = "x" * 200
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": long_text}],
+            },
+            {"role": "assistant", "content": "response"},
+        ]
+        summary = get_turn_summary(messages, 1, max_length=50)
+        assert summary["user_content"].endswith("...")
+
+    def test_list_content_no_ellipsis_when_not_truncated(self):
+        """get_turn_summary does NOT append '...' when list content fits in max_length."""
+        short_text = "short"
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": short_text}],
+            },
+            {"role": "assistant", "content": "response"},
+        ]
+        summary = get_turn_summary(messages, 1, max_length=50)
+        assert summary["user_content"] == short_text
+        assert not summary["user_content"].endswith("...")

--- a/tests/test_session_repair.py
+++ b/tests/test_session_repair.py
@@ -805,6 +805,27 @@ class TestCLI:
         result = _run_cli(str(tmp_path))
         assert result.returncode == 2
 
+    def test_deprecation_warning_emitted(self):
+        """Running with -W all emits DeprecationWarning directing to new script."""
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = (
+            f"{_project_root}:{existing}" if existing else str(_project_root)
+        )
+        result = subprocess.run(
+            [sys.executable, "-W", "all", str(_script_path), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        assert "DeprecationWarning" in result.stderr, (
+            f"Expected DeprecationWarning in stderr, got: {result.stderr!r}"
+        )
+        assert "amplifier-session.py" in result.stderr, (
+            f"Expected 'amplifier-session.py' in stderr, got: {result.stderr!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # TestIntegrationRealisticFailures

--- a/tests/test_session_repair.py
+++ b/tests/test_session_repair.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -10,6 +11,7 @@ import pytest
 
 # Load session-repair.py as a module (it's a script, not a package)
 _script_path = Path(__file__).resolve().parent.parent / "scripts" / "session-repair.py"
+_project_root = Path(__file__).resolve().parent.parent
 _spec = importlib.util.spec_from_file_location("session_repair", _script_path)
 if _spec is None or _spec.loader is None:
     raise ImportError(f"Could not load {_script_path}")
@@ -675,12 +677,22 @@ class TestRewindTranscript:
 
 
 def _run_cli(*args: str) -> subprocess.CompletedProcess:
-    """Run session-repair.py as a subprocess with the given arguments."""
+    """Run session-repair.py as a subprocess with the given arguments.
+
+    Sets PYTHONPATH to ensure the subprocess finds the local amplifier_foundation
+    package rather than any other installed version.
+    """
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{_project_root}:{existing}" if existing else str(_project_root)
+    )
     return subprocess.run(
         [sys.executable, str(_script_path), *args],
         capture_output=True,
         text=True,
         timeout=10,
+        env=env,
     )
 
 

--- a/tests/test_session_repair_knowledge_md.py
+++ b/tests/test_session_repair_knowledge_md.py
@@ -1,0 +1,171 @@
+"""Tests for session-repair-knowledge.md documentation update.
+
+Verifies that the session-repair-knowledge.md file has been updated to:
+1. Use the new script path (amplifier-session.py) with deprecation note
+2. Use subcommand-style CLI examples (not old flag-style)
+3. Have no stale --diagnose / --repair / --rewind flag references anywhere
+4. Show new commands: info and find
+5. Include the <session> argument note
+6. Update the Verification section to use the new script
+"""
+
+from pathlib import Path
+
+import pytest
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+KNOWLEDGE_FILE = (
+    Path(__file__).parent.parent / "context" / "agents" / "session-repair-knowledge.md"
+)
+
+
+@pytest.fixture
+def content() -> str:
+    """Read the session-repair-knowledge.md file."""
+    assert KNOWLEDGE_FILE.exists(), f"Knowledge file not found: {KNOWLEDGE_FILE}"
+    return KNOWLEDGE_FILE.read_text(encoding="utf-8")
+
+
+# ── Test 1: File exists and has reasonable length ────────────────────────────
+
+
+class TestFileExists:
+    """File must exist and have reasonable content."""
+
+    def test_file_exists(self) -> None:
+        """session-repair-knowledge.md must exist."""
+        assert KNOWLEDGE_FILE.exists(), "session-repair-knowledge.md not found"
+
+    def test_file_has_reasonable_length(self, content: str) -> None:
+        """File must have roughly similar length to the original."""
+        lines = content.splitlines()
+        assert 80 <= len(lines) <= 200, (
+            f"File has {len(lines)} lines — expected between 80 and 200"
+        )
+
+
+# ── Test 2: Location line updated ───────────────────────────────────────────
+
+
+class TestLocationLine:
+    """Location line must reference amplifier-session.py and deprecate old script."""
+
+    def test_location_references_new_script(self, content: str) -> None:
+        """Location line must reference scripts/amplifier-session.py."""
+        assert "scripts/amplifier-session.py" in content, (
+            "Location line must reference scripts/amplifier-session.py"
+        )
+
+    def test_location_mentions_deprecation(self, content: str) -> None:
+        """Location line must mention deprecation of session-repair.py."""
+        assert "deprecated" in content, (
+            "Location line must mention that scripts/session-repair.py is deprecated"
+        )
+
+
+# ── Test 3: Usage section uses subcommand style ──────────────────────────────
+
+
+class TestUsageSection:
+    """Usage section must use subcommand-style examples."""
+
+    def test_usage_has_diagnose_subcommand(self, content: str) -> None:
+        """Usage section must show 'diagnose <session>' subcommand."""
+        assert "amplifier-session.py diagnose" in content, (
+            "Usage section must show subcommand: amplifier-session.py diagnose <session>"
+        )
+
+    def test_usage_has_repair_subcommand(self, content: str) -> None:
+        """Usage section must show 'repair <session>' subcommand."""
+        assert "amplifier-session.py repair" in content, (
+            "Usage section must show subcommand: amplifier-session.py repair <session>"
+        )
+
+    def test_usage_has_rewind_subcommand(self, content: str) -> None:
+        """Usage section must show 'rewind <session>' subcommand."""
+        assert "amplifier-session.py rewind" in content, (
+            "Usage section must show subcommand: amplifier-session.py rewind <session>"
+        )
+
+    def test_usage_has_info_command(self, content: str) -> None:
+        """Usage section must show new 'info <session>' command."""
+        assert "amplifier-session.py info" in content, (
+            "Usage section must show new command: amplifier-session.py info <session>"
+        )
+
+    def test_usage_has_find_command(self, content: str) -> None:
+        """Usage section must show new 'find' command."""
+        assert "amplifier-session.py find" in content, (
+            "Usage section must show new command: amplifier-session.py find --project ..."
+        )
+
+    def test_usage_has_session_arg_note(self, content: str) -> None:
+        """Usage section must note that <session> accepts full paths, IDs, or partial IDs."""
+        assert "partial IDs" in content or "partial ID" in content, (
+            "Usage section must note that <session> accepts full paths, session IDs, or partial IDs"
+        )
+
+    def test_usage_section_no_old_flag_style(self, content: str) -> None:
+        """Usage section must not use old 'session-repair.py --diagnose' style."""
+        assert "session-repair.py --diagnose" not in content, (
+            "Usage section still uses old flag style: session-repair.py --diagnose"
+        )
+        assert "session-repair.py --repair" not in content, (
+            "Usage section still uses old flag style: session-repair.py --repair"
+        )
+        assert "session-repair.py --rewind" not in content, (
+            "Usage section still uses old flag style: session-repair.py --rewind"
+        )
+
+
+# ── Test 4: No stale flag references anywhere in the document ────────────────
+
+
+class TestNoStaleFlags:
+    """The document must not contain old --diagnose / --repair / --rewind flag references."""
+
+    def test_no_stale_diagnose_flag(self, content: str) -> None:
+        """No standalone --diagnose flag reference anywhere in the document."""
+        assert "`--diagnose`" not in content, (
+            "Stale --diagnose flag reference remains (found in Exit Codes table or section heading). "
+            "Replace with `diagnose` (subcommand style without --)."
+        )
+
+    def test_no_stale_repair_flag(self, content: str) -> None:
+        """No standalone --repair flag reference anywhere in the document."""
+        assert "`--repair`" not in content, (
+            "Stale --repair flag reference remains (found in Exit Codes table). "
+            "Replace with `repair` (subcommand style without --)."
+        )
+
+    def test_no_stale_rewind_flag(self, content: str) -> None:
+        """No standalone --rewind flag reference anywhere in the document."""
+        assert "`--rewind`" not in content, (
+            "Stale --rewind flag reference remains (found in Exit Codes table). "
+            "Replace with `rewind` (subcommand style without --)."
+        )
+
+    def test_diagnose_section_heading_no_flag(self, content: str) -> None:
+        """The diagnose JSON Output Format section heading must not use --diagnose."""
+        assert "### `--diagnose`" not in content, (
+            "Section heading still uses old flag style: ### `--diagnose` JSON Output Format. "
+            "Replace with ### `diagnose` JSON Output Format"
+        )
+
+
+# ── Test 5: Verification section uses new script ─────────────────────────────
+
+
+class TestVerificationSection:
+    """Verification section must use amplifier-session.py with subcommand style."""
+
+    def test_verification_uses_new_script(self, content: str) -> None:
+        """Verification section must use amplifier-session.py diagnose."""
+        # Check section exists and uses the new script
+        verification_start = content.find("### Verification")
+        assert verification_start != -1, "Verification section not found"
+        verification_content = content[verification_start:]
+        assert "amplifier-session.py diagnose" in verification_content, (
+            "Verification section must use: python scripts/amplifier-session.py diagnose <session>"
+        )

--- a/tests/test_session_storage_knowledge_md.py
+++ b/tests/test_session_storage_knowledge_md.py
@@ -1,0 +1,129 @@
+"""Tests for session-storage-knowledge.md documentation update.
+
+Verifies that the session-storage-knowledge.md file has been updated to:
+1. Remove manual repair recipe (grep/sed/head/tail instructions)
+2. Replace with script-based recovery using amplifier-session.py diagnose/repair
+3. No manual transcript.jsonl editing instructions remain in Recovery section
+"""
+
+from pathlib import Path
+
+import pytest
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+KNOWLEDGE_FILE = (
+    Path(__file__).parent.parent / "context" / "agents" / "session-storage-knowledge.md"
+)
+
+
+@pytest.fixture
+def content() -> str:
+    """Read the session-storage-knowledge.md file."""
+    assert KNOWLEDGE_FILE.exists(), f"Knowledge file not found: {KNOWLEDGE_FILE}"
+    return KNOWLEDGE_FILE.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def recovery_section(content: str) -> str:
+    """Extract the Recovery subsection from the content."""
+    start = content.find("### Recovery")
+    assert start != -1, "Recovery section not found in session-storage-knowledge.md"
+    # Find the next heading after Recovery
+    next_heading = content.find("\n## ", start + 1)
+    if next_heading == -1:
+        next_heading = content.find("\n### ", start + len("### Recovery") + 1)
+    if next_heading == -1:
+        return content[start:]
+    return content[start:next_heading]
+
+
+# ── Test 1: File exists ─────────────────────────────────────────────────────
+
+
+class TestFileExists:
+    """File must exist."""
+
+    def test_file_exists(self) -> None:
+        """session-storage-knowledge.md must exist."""
+        assert KNOWLEDGE_FILE.exists(), "session-storage-knowledge.md not found"
+
+
+# ── Test 2: No manual repair instructions in Recovery section ───────────────
+
+
+class TestNoManualRepairInstructions:
+    """Recovery section must not contain manual repair instructions."""
+
+    def test_no_grep_for_orphaned_tool(self, recovery_section: str) -> None:
+        """Recovery section must not instruct using grep to find orphaned tool_use lines."""
+        assert "THE_TOOL_ID" not in recovery_section, (
+            "Recovery section still contains manual grep instructions for THE_TOOL_ID. "
+            "Replace with script-based recovery."
+        )
+
+    def test_no_manual_insert_instructions(self, recovery_section: str) -> None:
+        """Recovery section must not instruct manually inserting tool_result JSON."""
+        assert "Insert a synthetic" not in recovery_section, (
+            "Recovery section still contains manual insert instructions. "
+            "Replace with script-based recovery."
+        )
+
+    def test_no_head_tail_sed_instructions(self, recovery_section: str) -> None:
+        """Recovery section must not instruct using head/tail or sed to edit transcript.jsonl."""
+        assert (
+            "head`/`tail`" not in recovery_section
+            and "head/tail" not in recovery_section
+        ), (
+            "Recovery section still contains head/tail instructions for manual editing. "
+            "Replace with script-based recovery."
+        )
+
+    def test_no_backup_cp_instructions(self, recovery_section: str) -> None:
+        """Recovery section must not instruct using cp to back up transcript.jsonl."""
+        assert "cp transcript.jsonl transcript.jsonl.backup" not in recovery_section, (
+            "Recovery section still contains manual cp backup instructions. "
+            "Replace with script-based recovery."
+        )
+
+    def test_no_manual_transcript_editing(self, recovery_section: str) -> None:
+        """Recovery section must not contain manual transcript.jsonl editing instructions."""
+        assert "transcript.jsonl.backup" not in recovery_section, (
+            "Recovery section still references manual backup of transcript.jsonl. "
+            "Replace with script-based recovery."
+        )
+
+
+# ── Test 3: Script-based recovery is present ────────────────────────────────
+
+
+class TestScriptBasedRecovery:
+    """Recovery section must contain script-based recovery using amplifier-session.py."""
+
+    def test_recovery_uses_diagnose_command(self, recovery_section: str) -> None:
+        """Recovery section must show 'amplifier-session.py diagnose' command."""
+        assert (
+            "amplifier-session.py diagnose" in recovery_section
+            or ('amplifier-session.py" diagnose' in recovery_section)
+            or ('"$SCRIPT" diagnose' in recovery_section)
+        ), 'Recovery section must show: python "$SCRIPT" diagnose <session>'
+
+    def test_recovery_uses_repair_command(self, recovery_section: str) -> None:
+        """Recovery section must show 'amplifier-session.py repair' command."""
+        assert "amplifier-session.py repair" in recovery_section or (
+            '"$SCRIPT" repair' in recovery_section
+        ), 'Recovery section must show: python "$SCRIPT" repair <session>'
+
+    def test_recovery_warns_against_manual_editing(self, recovery_section: str) -> None:
+        """Recovery section must warn against manually editing transcript.jsonl."""
+        assert "do not manually edit" in recovery_section or (
+            "not manually edit" in recovery_section
+        ), "Recovery section must warn: do not manually edit transcript.jsonl"
+
+    def test_recovery_mentions_script_find(self, recovery_section: str) -> None:
+        """Recovery section must show how to find the script via find command."""
+        assert (
+            "amplifier-foundation/scripts/amplifier-session.py" in recovery_section
+        ), (
+            "Recovery section must show how to locate amplifier-session.py via find command"
+        )

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -1,0 +1,119 @@
+"""Tests for amplifier_foundation.session.store — filename constants and JSONL I/O."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from amplifier_foundation.session.store import (
+    EVENTS_FILENAME,
+    METADATA_FILENAME,
+    TRANSCRIPT_FILENAME,
+    read_jsonl,
+    write_jsonl,
+)
+
+
+# =============================================================================
+# TestConstants
+# =============================================================================
+
+
+class TestConstants:
+    """Verify module-level filename constants have the correct values."""
+
+    def test_transcript_filename(self):
+        assert TRANSCRIPT_FILENAME == "transcript.jsonl"
+
+    def test_metadata_filename(self):
+        assert METADATA_FILENAME == "metadata.json"
+
+    def test_events_filename(self):
+        assert EVENTS_FILENAME == "events.jsonl"
+
+
+# =============================================================================
+# TestReadJsonl
+# =============================================================================
+
+
+class TestReadJsonl:
+    """Verify read_jsonl behaviour across valid data, edge cases, and errors."""
+
+    def test_reads_valid_jsonl(self, tmp_path: Path):
+        """Reads a file with 3 valid JSON lines and returns all 3 entries."""
+        p = tmp_path / "data.jsonl"
+        p.write_text(
+            '{"a": 1}\n{"b": 2}\n{"c": 3}\n',
+            encoding="utf-8",
+        )
+        result = list(read_jsonl(p))
+        assert result == [{"a": 1}, {"b": 2}, {"c": 3}]
+
+    def test_skips_blank_lines(self, tmp_path: Path):
+        """Blank lines in a JSONL file are silently skipped."""
+        p = tmp_path / "blanks.jsonl"
+        p.write_text(
+            '{"x": 1}\n\n{"y": 2}\n\n',
+            encoding="utf-8",
+        )
+        result = list(read_jsonl(p))
+        assert result == [{"x": 1}, {"y": 2}]
+
+    def test_skips_malformed_lines(self, tmp_path: Path):
+        """Lines that are not valid JSON are silently skipped."""
+        p = tmp_path / "malformed.jsonl"
+        p.write_text(
+            '{"good": true}\nNOT JSON\n{"also": "good"}\n',
+            encoding="utf-8",
+        )
+        result = list(read_jsonl(p))
+        assert result == [{"good": True}, {"also": "good"}]
+
+    def test_handles_empty_file(self, tmp_path: Path):
+        """An empty file produces an empty iterator without raising."""
+        p = tmp_path / "empty.jsonl"
+        p.write_text("", encoding="utf-8")
+        result = list(read_jsonl(p))
+        assert result == []
+
+    def test_returns_iterator(self, tmp_path: Path):
+        """read_jsonl returns an iterator (has __next__)."""
+        p = tmp_path / "iter.jsonl"
+        p.write_text('{"z": 0}\n', encoding="utf-8")
+        it = read_jsonl(p)
+        assert hasattr(it, "__next__")
+
+
+# =============================================================================
+# TestWriteJsonl
+# =============================================================================
+
+
+class TestWriteJsonl:
+    """Verify write_jsonl produces correct JSONL output."""
+
+    def test_writes_and_roundtrips(self, tmp_path: Path):
+        """Entries written by write_jsonl can be read back by read_jsonl."""
+        p = tmp_path / "roundtrip.jsonl"
+        entries = [{"id": 1, "val": "a"}, {"id": 2, "val": "b"}, {"id": 3, "val": "c"}]
+        write_jsonl(p, entries)
+        result = list(read_jsonl(p))
+        assert result == entries
+
+    def test_writes_empty_list(self, tmp_path: Path):
+        """Writing an empty list produces an empty file."""
+        p = tmp_path / "empty_out.jsonl"
+        write_jsonl(p, [])
+        assert p.read_text(encoding="utf-8") == ""
+
+    def test_preserves_unicode(self, tmp_path: Path):
+        """Unicode characters (including non-ASCII) are preserved without escaping."""
+        p = tmp_path / "unicode.jsonl"
+        entries = [{"msg": "héllo wörld 日本語"}]
+        write_jsonl(p, entries)
+        raw = p.read_text(encoding="utf-8")
+        # ensure_ascii=False means the chars appear literally, not as \uXXXX
+        assert "héllo wörld 日本語" in raw
+        # and round-trip is faithful
+        result = list(read_jsonl(p))
+        assert result == entries

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from amplifier_foundation.session.store import (
     EVENTS_FILENAME,
     METADATA_FILENAME,
     TRANSCRIPT_FILENAME,
+    backup,
+    load_metadata,
+    load_transcript,
+    load_transcript_with_lines,
     read_jsonl,
     write_jsonl,
+    write_metadata,
+    write_transcript,
 )
 
 
@@ -117,3 +124,187 @@ class TestWriteJsonl:
         # and round-trip is faithful
         result = list(read_jsonl(p))
         assert result == entries
+
+
+# =============================================================================
+# TestLoadTranscript
+# =============================================================================
+
+
+class TestLoadTranscript:
+    """Verify load_transcript reads messages from transcript.jsonl."""
+
+    def test_loads_messages(self, tmp_path: Path):
+        """Loads 2 messages from transcript.jsonl into a list of dicts."""
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        transcript = session_dir / "transcript.jsonl"
+        transcript.write_text(
+            '{"role": "user", "content": "hello"}\n{"role": "assistant", "content": "hi"}\n',
+            encoding="utf-8",
+        )
+        result = load_transcript(session_dir)
+        assert result == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+
+    def test_loads_empty_transcript(self, tmp_path: Path):
+        """Loads an empty transcript.jsonl and returns an empty list."""
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        transcript = session_dir / "transcript.jsonl"
+        transcript.write_text("", encoding="utf-8")
+        result = load_transcript(session_dir)
+        assert result == []
+
+
+# =============================================================================
+# TestLoadTranscriptWithLines
+# =============================================================================
+
+
+class TestLoadTranscriptWithLines:
+    """Verify load_transcript_with_lines injects 1-based line numbers."""
+
+    def test_adds_line_num_to_each_entry(self, tmp_path: Path):
+        """Each entry gets a line_num key matching its 1-based line position."""
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        transcript = session_dir / "transcript.jsonl"
+        transcript.write_text(
+            '{"role": "user", "content": "hello"}\n{"role": "assistant", "content": "hi"}\n',
+            encoding="utf-8",
+        )
+        result = load_transcript_with_lines(session_dir)
+        assert result[0]["line_num"] == 1
+        assert result[1]["line_num"] == 2
+
+    def test_blank_lines_preserve_original_line_numbers(self, tmp_path: Path):
+        """Blank lines are skipped; entries get the line numbers of their actual lines."""
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        transcript = session_dir / "transcript.jsonl"
+        # Line 1: entry, Line 2: blank, Line 3: entry
+        transcript.write_text(
+            '{"role": "user", "content": "hello"}\n\n{"role": "assistant", "content": "hi"}\n',
+            encoding="utf-8",
+        )
+        result = load_transcript_with_lines(session_dir)
+        assert len(result) == 2
+        assert result[0]["line_num"] == 1
+        assert result[1]["line_num"] == 3
+
+    def test_malformed_json_raises_value_error_with_line_number(self, tmp_path: Path):
+        """Malformed JSON on line 2 raises ValueError mentioning 'line 2'."""
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        transcript = session_dir / "transcript.jsonl"
+        transcript.write_text(
+            '{"role": "user", "content": "hello"}\nNOT JSON\n{"role": "assistant", "content": "hi"}\n',
+            encoding="utf-8",
+        )
+        import pytest
+
+        with pytest.raises(ValueError, match="line 2"):
+            load_transcript_with_lines(session_dir)
+
+
+# =============================================================================
+# TestLoadMetadata
+# =============================================================================
+
+
+class TestLoadMetadata:
+    """Verify load_metadata reads metadata.json into a dict."""
+
+    def test_loads_metadata_fields(self, tmp_path: Path):
+        """Loads metadata.json with session_id, bundle, and model fields."""
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        metadata = session_dir / "metadata.json"
+        metadata.write_text(
+            '{"session_id": "abc123", "bundle": "my-bundle", "model": "gpt-4"}',
+            encoding="utf-8",
+        )
+        result = load_metadata(session_dir)
+        assert result == {"session_id": "abc123", "bundle": "my-bundle", "model": "gpt-4"}
+
+
+# =============================================================================
+# TestWriteTranscript
+# =============================================================================
+
+
+class TestWriteTranscript:
+    """Verify write_transcript persists entries to transcript.jsonl."""
+
+    def test_roundtrips_write_then_load(self, tmp_path: Path):
+        """Entries written by write_transcript can be loaded back by load_transcript."""
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        entries = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+        write_transcript(session_dir, entries)
+        result = load_transcript(session_dir)
+        assert result == entries
+
+
+# =============================================================================
+# TestWriteMetadata
+# =============================================================================
+
+
+class TestWriteMetadata:
+    """Verify write_metadata persists metadata to metadata.json."""
+
+    def test_roundtrips_write_then_load(self, tmp_path: Path):
+        """Metadata written by write_metadata can be loaded back by load_metadata."""
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        metadata = {"session_id": "xyz789", "bundle": "test-bundle", "model": "claude-3"}
+        write_metadata(session_dir, metadata)
+        result = load_metadata(session_dir)
+        assert result == metadata
+
+    def test_output_is_pretty_printed(self, tmp_path: Path):
+        """write_metadata uses indent=2 so the output contains newlines."""
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        metadata = {"session_id": "xyz789", "bundle": "test-bundle"}
+        write_metadata(session_dir, metadata)
+        raw = (session_dir / "metadata.json").read_text(encoding="utf-8")
+        assert "\n" in raw
+
+
+# =============================================================================
+# TestBackup
+# =============================================================================
+
+
+class TestBackup:
+    """Verify backup creates a timestamped copy of a file."""
+
+    def test_creates_backup_with_label_and_original_content(self, tmp_path: Path):
+        """backup() creates a file with 'bak-pre-repair-' in the name and the original content."""
+        original = tmp_path / "transcript.jsonl"
+        original.write_text('{"role": "user", "content": "hello"}\n', encoding="utf-8")
+        result = backup(original, "pre-repair")
+        assert result is not None
+        assert "bak-pre-repair-" in result.name
+        assert result.read_text(encoding="utf-8") == '{"role": "user", "content": "hello"}\n'
+
+    def test_returns_none_for_missing_file(self, tmp_path: Path):
+        """backup() returns None when the target file does not exist."""
+        missing = tmp_path / "nonexistent.jsonl"
+        result = backup(missing, "pre-repair")
+        assert result is None
+
+    def test_backup_name_format(self, tmp_path: Path):
+        """Backup file is named '<original>.bak-pre-rewind-YYYYMMDDHHMMSS' (14-digit timestamp)."""
+        original = tmp_path / "transcript.jsonl"
+        original.write_text('{"role": "user"}\n', encoding="utf-8")
+        result = backup(original, "pre-rewind")
+        assert result is not None
+        # Name should match: transcript.jsonl.bak-pre-rewind-YYYYMMDDHHMMSS
+        pattern = r"^transcript\.jsonl\.bak-pre-rewind-\d{14}$"
+        assert re.match(pattern, result.name), f"Unexpected backup name: {result.name}"

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -77,11 +77,11 @@ class TestReadJsonl:
         assert result == []
 
     def test_returns_iterator(self, tmp_path: Path):
-        """read_jsonl returns an iterator (has __next__)."""
+        """read_jsonl returns an iterator (has both __iter__ and __next__)."""
         p = tmp_path / "iter.jsonl"
         p.write_text('{"z": 0}\n', encoding="utf-8")
         it = read_jsonl(p)
-        assert hasattr(it, "__next__")
+        assert hasattr(it, "__iter__") and hasattr(it, "__next__")
 
 
 # =============================================================================

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 from amplifier_foundation.session.store import (
     EVENTS_FILENAME,
     METADATA_FILENAME,
@@ -204,8 +206,6 @@ class TestLoadTranscriptWithLines:
             '{"role": "user", "content": "hello"}\nNOT JSON\n{"role": "assistant", "content": "hi"}\n',
             encoding="utf-8",
         )
-        import pytest
-
         with pytest.raises(ValueError, match="line 2"):
             load_transcript_with_lines(session_dir)
 
@@ -228,7 +228,11 @@ class TestLoadMetadata:
             encoding="utf-8",
         )
         result = load_metadata(session_dir)
-        assert result == {"session_id": "abc123", "bundle": "my-bundle", "model": "gpt-4"}
+        assert result == {
+            "session_id": "abc123",
+            "bundle": "my-bundle",
+            "model": "gpt-4",
+        }
 
 
 # =============================================================================
@@ -243,7 +247,10 @@ class TestWriteTranscript:
         """Entries written by write_transcript can be loaded back by load_transcript."""
         session_dir = tmp_path / "session"
         session_dir.mkdir()
-        entries = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+        entries = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
         write_transcript(session_dir, entries)
         result = load_transcript(session_dir)
         assert result == entries
@@ -261,7 +268,11 @@ class TestWriteMetadata:
         """Metadata written by write_metadata can be loaded back by load_metadata."""
         session_dir = tmp_path / "session"
         session_dir.mkdir()
-        metadata = {"session_id": "xyz789", "bundle": "test-bundle", "model": "claude-3"}
+        metadata = {
+            "session_id": "xyz789",
+            "bundle": "test-bundle",
+            "model": "claude-3",
+        }
         write_metadata(session_dir, metadata)
         result = load_metadata(session_dir)
         assert result == metadata
@@ -291,7 +302,10 @@ class TestBackup:
         result = backup(original, "pre-repair")
         assert result is not None
         assert "bak-pre-repair-" in result.name
-        assert result.read_text(encoding="utf-8") == '{"role": "user", "content": "hello"}\n'
+        assert (
+            result.read_text(encoding="utf-8")
+            == '{"role": "user", "content": "hello"}\n'
+        )
 
     def test_returns_none_for_missing_file(self, tmp_path: Path):
         """backup() returns None when the target file does not exist."""

--- a/tests/test_slice_shim.py
+++ b/tests/test_slice_shim.py
@@ -1,0 +1,167 @@
+"""Tests for backward-compatibility shim in amplifier_foundation.session.slice.
+
+Verifies that:
+1. Importing from slice.py issues a DeprecationWarning
+2. All 7 functions re-exported from messages.py work correctly via the shim
+3. __all__ exposes all expected names
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+
+
+class TestSliceDeprecationWarning:
+    """slice.py must fire a DeprecationWarning on import."""
+
+    def test_import_fires_deprecation_warning(self):
+        """Importing from slice module raises DeprecationWarning."""
+        # Remove any cached module so re-import fires the warning
+        for key in list(sys.modules.keys()):
+            if "amplifier_foundation.session.slice" in key:
+                del sys.modules[key]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            importlib.import_module("amplifier_foundation.session.slice")
+
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert len(deprecation_warnings) >= 1, (
+            "Expected at least one DeprecationWarning when importing "
+            "amplifier_foundation.session.slice, got none."
+        )
+
+    def test_deprecation_message_mentions_messages_module(self):
+        """The DeprecationWarning message must point to messages.py."""
+        for key in list(sys.modules.keys()):
+            if "amplifier_foundation.session.slice" in key:
+                del sys.modules[key]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            importlib.import_module("amplifier_foundation.session.slice")
+
+        deprecation_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert deprecation_warnings, "No DeprecationWarning was raised."
+        msg = str(deprecation_warnings[0].message)
+        assert "messages" in msg, (
+            f"DeprecationWarning message should mention 'messages', got: {msg!r}"
+        )
+
+
+class TestSliceShimExports:
+    """slice.py shim must re-export all 7 functions from messages.py."""
+
+    def _get_slice_module(self):
+        """Import slice module, ignoring deprecation warnings."""
+        for key in list(sys.modules.keys()):
+            if "amplifier_foundation.session.slice" in key:
+                del sys.modules[key]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return importlib.import_module("amplifier_foundation.session.slice")
+
+    def test_all_contains_expected_functions(self):
+        """__all__ must list all 7 function names."""
+        mod = self._get_slice_module()
+        expected = {
+            "add_synthetic_tool_results",
+            "count_turns",
+            "find_orphaned_tool_calls",
+            "get_turn_boundaries",
+            "get_turn_summary",
+            "is_real_user_message",
+            "slice_to_turn",
+        }
+        assert hasattr(mod, "__all__"), "slice module must define __all__"
+        assert set(mod.__all__) == expected, (
+            f"__all__ mismatch.\n  Expected: {sorted(expected)}\n  Got: {sorted(mod.__all__)}"
+        )
+
+    def test_get_turn_boundaries_works(self):
+        """get_turn_boundaries imported from slice shim works correctly."""
+        mod = self._get_slice_module()
+        msgs = [
+            {"role": "user", "content": "Q1"},
+            {"role": "assistant", "content": "A1"},
+            {"role": "user", "content": "Q2"},
+        ]
+        assert mod.get_turn_boundaries(msgs) == [0, 2]
+
+    def test_count_turns_works(self):
+        """count_turns imported from slice shim works correctly."""
+        mod = self._get_slice_module()
+        msgs = [
+            {"role": "user", "content": "Q1"},
+            {"role": "assistant", "content": "A1"},
+        ]
+        assert mod.count_turns(msgs) == 1
+
+    def test_is_real_user_message_works(self):
+        """is_real_user_message imported from slice shim works correctly."""
+        mod = self._get_slice_module()
+        assert mod.is_real_user_message({"role": "user", "content": "hi"}) is True
+        assert mod.is_real_user_message({"role": "assistant", "content": "hi"}) is False
+
+    def test_slice_to_turn_works(self):
+        """slice_to_turn imported from slice shim works correctly."""
+        mod = self._get_slice_module()
+        msgs = [
+            {"role": "user", "content": "Q1"},
+            {"role": "assistant", "content": "A1"},
+            {"role": "user", "content": "Q2"},
+            {"role": "assistant", "content": "A2"},
+        ]
+        sliced = mod.slice_to_turn(msgs, 1)
+        assert len(sliced) == 2
+        assert sliced[0]["content"] == "Q1"
+
+    def test_find_orphaned_tool_calls_works(self):
+        """find_orphaned_tool_calls imported from slice shim works correctly."""
+        mod = self._get_slice_module()
+        msgs = [
+            {"role": "user", "content": "use tool"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "call_x", "function": {"name": "f", "arguments": "{}"}}
+                ],
+            },
+            # No tool result — call_x is orphaned
+        ]
+        orphaned = mod.find_orphaned_tool_calls(msgs)
+        assert "call_x" in orphaned
+
+    def test_add_synthetic_tool_results_works(self):
+        """add_synthetic_tool_results imported from slice shim works correctly."""
+        mod = self._get_slice_module()
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "call_y", "function": {"name": "g", "arguments": "{}"}}
+                ],
+            }
+        ]
+        result = mod.add_synthetic_tool_results(msgs, ["call_y"])
+        assert len(result) == 2  # original + synthetic
+        assert result[1]["role"] == "tool"
+
+    def test_get_turn_summary_works(self):
+        """get_turn_summary imported from slice shim works correctly."""
+        mod = self._get_slice_module()
+        msgs = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "World"},
+        ]
+        summary = mod.get_turn_summary(msgs, 1)
+        assert summary["turn"] == 1
+        assert summary["user_content"] == "Hello"


### PR DESCRIPTION
## Summary

Restructures `amplifier_foundation/session/` into a clean, modular library with a unified CLI script, making the session-analyst agent dramatically more reliable by eliminating manual JSONL editing in favor of deterministic script invocations.

### Part 1: Script-Only Repair Mandate (merged earlier as PR #129, included in this branch)
- Removed all manual repair/rewind procedures from session-analyst agent instructions
- Added mandatory script-only workflow with explicit prohibition on manual JSONL editing
- Simplified session-repair-knowledge.md from 231 to 106 lines

### Part 2: Library Restructure (Phase 1 — Core)
- **`store.py`** — Consolidated JSONL I/O (read/write transcript, metadata, events, backup) with filename constants as single source of truth
- **`messages.py`** — Renamed from `slice.py` with `is_real_user_message()` and parameterized synthetic content for deduplication
- **`diagnosis.py`** — Extracted pure repair/rewind/diagnosis algorithms from the standalone script into importable library code
- **Refactored `fork.py`** — Uses `store.py` and `messages.py`, removed 14+ hardcoded filename strings
- **Refactored `events.py`** — Uses `store.py`'s `read_jsonl`
- **`slice.py` compat shim** — Re-exports from `messages.py` with deprecation warning
- **Updated `__init__.py`** — Exports all new modules (strict superset: 19 → 37 symbols, zero removals)

### Part 3: New Capabilities (Phase 2) + Agent Rewire (Phase 3)
- **`finder.py`** — Session discovery by partial ID, full ID, or path; search by project/date/keyword/status
- **`scripts/amplifier-session.py`** — Unified CLI with subcommands: `diagnose`, `repair`, `rewind`, `info`, `find`
- **Deprecated `scripts/session-repair.py`** — Emits warning, delegates to library
- **Rewrote `session-analyst.md`** — From ~500 to ~400 lines; bash choreography replaced with single-command invocations
- **Updated `session-repair-knowledge.md`** and **`session-storage-knowledge.md`** — Removed stale manual recipes

### Backward Compatibility

Verified against amplifier-app-cli, amplifier-bundle-recipes, and internal foundation consumers by 4 independent reviewers:
- `__init__.py` is a strict superset (zero symbol removals)
- `slice.py` compat shim preserves all old import paths with deprecation warning
- `fork_session` / `fork_session_in_memory` signatures byte-for-byte identical
- Delegate tool has zero imports from `amplifier_foundation.session`
- Recipe execution has zero imports from `amplifier_foundation.session`
- All private helpers that were removed (`_load_transcript`, `_write_transcript`, etc.) have zero external consumers

### Test Results
- 850 tests passing, 0 failures
- 1 intentional deprecation warning (old script)
- 7 new test files, ~88 new tests

### Files Changed
- 28 files changed, +5,233 / -1,143 lines