### PR TITLE
fix(tool-delegate): add observability for model_role routing failures

### DIFF
--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -748,13 +748,21 @@ Agent usage notes:
                             )
                             for r in resolved
                         ]
+                    else:
+                        logger.warning(
+                            "model_role '%s' resolved to no candidates "
+                            "(available roles: %s, installed providers: %s)",
+                            raw_model_role,
+                            list(matrix.keys()),
+                            list(providers.keys()),
+                        )
                 except ImportError:
                     logger.warning(
                         "model_role '%s' specified but amplifier_module_hooks_routing not available",
                         raw_model_role,
                     )
             else:
-                logger.debug(
+                logger.warning(
                     "model_role '%s' specified but no routing_matrix in session state",
                     raw_model_role,
                 )
@@ -875,6 +883,12 @@ Agent usage notes:
                         "context_scope": context_scope,
                         "tool_call_id": tool_call_id,
                         "parallel_group_id": parallel_group_id,
+                        "model_role": raw_model_role or None,
+                        "provider_preferences": (
+                            [p.to_dict() for p in provider_preferences]
+                            if provider_preferences
+                            else None
+                        ),
                     },
                 )
 
@@ -987,6 +1001,20 @@ Agent usage notes:
                     },
                 )
 
+            # Build provider routing summary (only when routing was requested)
+            # Always include both keys for a stable dict shape — consumers
+            # can safely read provider_routing["model_role"] without KeyError.
+            provider_routing = None
+            if raw_model_role or provider_preferences:
+                provider_routing = {
+                    "model_role": raw_model_role or None,
+                    "resolved": (
+                        [p.to_dict() for p in provider_preferences]
+                        if provider_preferences
+                        else None
+                    ),
+                }
+
             # Return output with session_id for multi-turn capability
             session_id_result = result["session_id"]
             return ToolResult(
@@ -998,6 +1026,11 @@ Agent usage notes:
                     "turn_count": result.get("turn_count", 1),
                     "status": result.get("status", "success"),
                     "metadata": result.get("metadata", {}),
+                    **(
+                        {"provider_routing": provider_routing}
+                        if provider_routing
+                        else {}
+                    ),
                 },
             )
 

--- a/modules/tool-delegate/tests/test_delegate_model_role.py
+++ b/modules/tool-delegate/tests/test_delegate_model_role.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
 from unittest.mock import AsyncMock, MagicMock
@@ -358,3 +359,388 @@ class TestDelegateModelRole:
         _, kwargs = spawn_fn.call_args
         # No matrix means no resolution — provider_preferences stays None
         assert kwargs["provider_preferences"] is None
+
+
+# =============================================================================
+# Tests: Fix 1 — observability warnings for model_role failures
+# =============================================================================
+
+
+class TestModelRoleObservabilityWarnings:
+    """Tests that silent model_role failures now emit WARNING-level log messages."""
+
+    @pytest.mark.asyncio
+    async def test_model_role_empty_resolution_logs_warning(self, caplog):
+        """resolve_model_role returning [] logs a WARNING with diagnostic context."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+
+        # Resolver returns empty list — role exists in matrix but no provider matched
+        mock_resolve = AsyncMock(return_value=[])
+        cleanup = _install_mock_resolver(mock_resolve)
+
+        try:
+            tool = _make_delegate_tool(
+                spawn_fn=spawn_fn,
+                agents={"test-agent": {"description": "A test agent"}},
+                session_state={
+                    "routing_matrix": {
+                        "roles": {
+                            "coding": {
+                                "candidates": [
+                                    {
+                                        "provider": "anthropic",
+                                        "model": "claude-sonnet-4-6",
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+            )
+            tool.coordinator.get = MagicMock(
+                side_effect=lambda key: (
+                    {"provider-openai": MagicMock()} if key == "providers" else None
+                )
+            )
+
+            with caplog.at_level(
+                logging.WARNING, logger="amplifier_module_tool_delegate"
+            ):
+                result = await tool.execute(
+                    {
+                        "agent": "test-agent",
+                        "instruction": "Write some code",
+                        "context_depth": "none",
+                        "model_role": "coding",
+                    }
+                )
+
+            # Should still succeed — fall-through is graceful
+            assert result.success is True
+
+            # Resolver was called but returned empty
+            mock_resolve.assert_called_once()
+
+            # spawn received provider_preferences=None (resolution failed)
+            spawn_fn.assert_called_once()
+            _, kwargs = spawn_fn.call_args
+            assert kwargs["provider_preferences"] is None, (
+                "Empty resolution should leave provider_preferences as None"
+            )
+
+            # Warning was emitted — must mention the role, available roles, and providers
+            warning_messages = [
+                r.message for r in caplog.records if r.levelno == logging.WARNING
+            ]
+            assert any("coding" in str(m) for m in warning_messages), (
+                f"Expected WARNING mentioning 'coding' role; got: {warning_messages}"
+            )
+        finally:
+            cleanup()
+
+    @pytest.mark.asyncio
+    async def test_model_role_without_matrix_logs_warning(self, caplog):
+        """model_role with no routing_matrix logs WARNING (not just DEBUG)."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={"test-agent": {"description": "A test agent"}},
+            session_state={},  # No routing_matrix
+        )
+
+        with caplog.at_level(logging.WARNING, logger="amplifier_module_tool_delegate"):
+            result = await tool.execute(
+                {
+                    "agent": "test-agent",
+                    "instruction": "Do something",
+                    "context_depth": "none",
+                    "model_role": "fast",
+                }
+            )
+
+        assert result.success is True
+
+        # At least one WARNING mentioning the role
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("fast" in str(m) for m in warning_messages), (
+            f"Expected WARNING mentioning 'fast' role; got: {warning_messages}"
+        )
+
+        # No DEBUG-only records for the missing-matrix case (it should be WARNING)
+        debug_only = [
+            r.message
+            for r in caplog.records
+            if r.levelno == logging.DEBUG and "fast" in str(r.message)
+        ]
+        assert not debug_only, (
+            f"Expected WARNING (not DEBUG) for missing routing_matrix; "
+            f"found DEBUG: {debug_only}"
+        )
+
+
+# =============================================================================
+# Tests: Fix 3 — provider_routing in ToolResult output
+# =============================================================================
+
+
+class TestProviderRoutingInResult:
+    """Tests that ToolResult output includes provider_routing when routing was requested."""
+
+    @pytest.mark.asyncio
+    async def test_provider_routing_in_result_on_success(self):
+        """Successful model_role resolution returns provider_routing in output."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+
+        mock_resolve = AsyncMock(
+            return_value=[
+                {"provider": "anthropic", "model": "claude-sonnet-4-6", "config": {}}
+            ]
+        )
+        cleanup = _install_mock_resolver(mock_resolve)
+
+        try:
+            tool = _make_delegate_tool(
+                spawn_fn=spawn_fn,
+                agents={"test-agent": {"description": "A test agent"}},
+                session_state={
+                    "routing_matrix": {
+                        "roles": {
+                            "coding": {
+                                "candidates": [
+                                    {
+                                        "provider": "anthropic",
+                                        "model": "claude-sonnet-4-6",
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+            )
+            tool.coordinator.get = MagicMock(
+                side_effect=lambda key: (
+                    {"provider-anthropic": MagicMock()} if key == "providers" else None
+                )
+            )
+
+            result = await tool.execute(
+                {
+                    "agent": "test-agent",
+                    "instruction": "Write code",
+                    "context_depth": "none",
+                    "model_role": "coding",
+                }
+            )
+
+            assert result.success is True
+            assert result.output is not None
+            assert "provider_routing" in result.output, (
+                f"Expected 'provider_routing' key in output; got keys: {list(result.output.keys())}"
+            )
+
+            routing = result.output["provider_routing"]
+            assert routing["model_role"] == "coding"
+            assert routing["resolved"] is not None, (
+                "Successful resolution should produce non-null 'resolved'"
+            )
+            assert len(routing["resolved"]) >= 1
+            assert routing["resolved"][0]["provider"] == "anthropic"
+        finally:
+            cleanup()
+
+    @pytest.mark.asyncio
+    async def test_provider_routing_in_result_on_failure(self):
+        """Failed model_role resolution returns provider_routing with resolved=None."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+
+        # Resolver returns empty — no candidates matched installed providers
+        mock_resolve = AsyncMock(return_value=[])
+        cleanup = _install_mock_resolver(mock_resolve)
+
+        try:
+            tool = _make_delegate_tool(
+                spawn_fn=spawn_fn,
+                agents={"test-agent": {"description": "A test agent"}},
+                session_state={
+                    "routing_matrix": {
+                        "roles": {
+                            "coding": {
+                                "candidates": [
+                                    {
+                                        "provider": "anthropic",
+                                        "model": "claude-sonnet-4-6",
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+            )
+            tool.coordinator.get = MagicMock(
+                side_effect=lambda key: (
+                    {"provider-openai": MagicMock()} if key == "providers" else None
+                )
+            )
+
+            result = await tool.execute(
+                {
+                    "agent": "test-agent",
+                    "instruction": "Write code",
+                    "context_depth": "none",
+                    "model_role": "coding",
+                }
+            )
+
+            assert result.success is True
+            assert result.output is not None
+            assert "provider_routing" in result.output, (
+                "provider_routing should be present even on resolution failure"
+            )
+
+            routing = result.output["provider_routing"]
+            assert routing["model_role"] == "coding"
+            assert routing["resolved"] is None, (
+                "Empty resolution should produce resolved=None"
+            )
+        finally:
+            cleanup()
+
+
+# =============================================================================
+# Tests: Fix 2 — delegate:agent_spawned event includes routing intent
+# =============================================================================
+
+
+class TestAgentSpawnedEventIncludesRouting:
+    """Tests that delegate:agent_spawned event payload includes routing fields."""
+
+    @pytest.mark.asyncio
+    async def test_agent_spawned_event_includes_routing(self):
+        """delegate:agent_spawned event includes model_role and provider_preferences."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+
+        mock_resolve = AsyncMock(
+            return_value=[
+                {"provider": "anthropic", "model": "claude-haiku-3.5", "config": {}}
+            ]
+        )
+        cleanup = _install_mock_resolver(mock_resolve)
+
+        try:
+            tool = _make_delegate_tool(
+                spawn_fn=spawn_fn,
+                agents={"test-agent": {"description": "A test agent"}},
+                session_state={
+                    "routing_matrix": {
+                        "roles": {
+                            "fast": {
+                                "candidates": [
+                                    {"provider": "anthropic", "model": "claude-haiku-*"}
+                                ]
+                            }
+                        }
+                    }
+                },
+            )
+            tool.coordinator.get = MagicMock(
+                side_effect=lambda key: (
+                    {"provider-anthropic": MagicMock()} if key == "providers" else None
+                )
+            )
+
+            # Set up a mock hooks object so events are emitted
+            mock_hooks = MagicMock()
+            mock_hooks.emit = AsyncMock()
+            tool.coordinator.get = MagicMock(
+                side_effect=lambda key: (
+                    mock_hooks
+                    if key == "hooks"
+                    else (
+                        {"provider-anthropic": MagicMock()}
+                        if key == "providers"
+                        else None
+                    )
+                )
+            )
+
+            await tool.execute(
+                {
+                    "agent": "test-agent",
+                    "instruction": "Do something fast",
+                    "context_depth": "none",
+                    "model_role": "fast",
+                }
+            )
+
+            # Find the agent_spawned event call
+            spawned_calls = [
+                call
+                for call in mock_hooks.emit.call_args_list
+                if call.args[0] == "delegate:agent_spawned"
+            ]
+            assert len(spawned_calls) == 1, (
+                f"Expected exactly one delegate:agent_spawned event; got {len(spawned_calls)}"
+            )
+
+            payload = spawned_calls[0].args[1]
+
+            # model_role must be present
+            assert "model_role" in payload, (
+                f"Expected 'model_role' in event payload; got keys: {list(payload.keys())}"
+            )
+            assert payload["model_role"] == "fast"
+
+            # provider_preferences must be present — non-null because resolution succeeded
+            assert "provider_preferences" in payload, (
+                f"Expected 'provider_preferences' in event payload; got keys: {list(payload.keys())}"
+            )
+            assert payload["provider_preferences"] is not None, (
+                "provider_preferences should be non-null after successful resolution"
+            )
+            assert len(payload["provider_preferences"]) >= 1
+            assert payload["provider_preferences"][0]["provider"] == "anthropic"
+        finally:
+            cleanup()


### PR DESCRIPTION
## Summary

Fixes silent-failure modes in the delegate tool's model routing integration with the routing-matrix bundle. Investigated via systematic 4-phase debugging across 5 repos.

### Problem

When `model_role` resolution fails (no routing matrix, resolver not importable, no candidates match), the delegate tool silently falls through with zero feedback. The `delegate:agent_spawned` event and `ToolResult` output contained no routing information, making it impossible to diagnose whether routing actually affected provider selection.

### Changes

**Observability fixes** (all in `tool-delegate/__init__.py`):
- **Fix 1:** WARNING when `resolve_model_role()` returns `[]` — logs role name, available roles, installed providers
- **Fix 2:** Promote "no routing_matrix" from `logger.debug` → `logger.warning`
- **Fix 3:** Enrich `delegate:agent_spawned` event with `model_role` and `provider_preferences` fields
- **Fix 4:** Add `provider_routing` dict to `ToolResult` output (stable shape: always includes `model_role` and `resolved` keys)

### Tests

5 new tests in `test_delegate_model_role.py`:
- `test_model_role_empty_resolution_logs_warning`
- `test_model_role_without_matrix_logs_warning`
- `test_provider_routing_in_result_on_success`
- `test_provider_routing_in_result_on_failure`
- `test_agent_spawned_event_includes_routing`

### Companion PR

Structural routing fixes in amplifier-app-cli (separate PR) — deep-copy agents isolation, spawn_sub_session routing fallback, capability propagation.

### Verification

- All 9/9 model role tests pass
- E2E Docker smoke test passed with `--local-source` override
- Security review: no credentials exposed, no attack vectors
- Architecture review: all changes are mechanism (observability), not policy