### PR TITLE
fix: cross-check importability before trusting install-state cache

### DIFF
--- a/amplifier_foundation/modules/activator.py
+++ b/amplifier_foundation/modules/activator.py
@@ -408,8 +408,36 @@ class ModuleActivator:
 
         # Check if already installed with matching fingerprint
         if not force and self._install_state.is_installed(module_path):
-            logger.debug(f"Skipping install for {module_path.name} (already installed)")
-            return
+            # Cross-check: verify the package is still actually importable.
+            # `uv tool upgrade` runs `uv sync` which can remove editable installs
+            # without changing the Python symlink mtime, leaving a stale cache
+            # entry that causes _install_dependencies() to skip reinstallation.
+            _stale = False
+            _pyproject = module_path / "pyproject.toml"
+            if _pyproject.exists():
+                try:
+                    import tomllib
+
+                    with open(_pyproject, "rb") as f:
+                        _data = tomllib.load(f)
+                    _pkg_name = _data.get("project", {}).get("name", "")
+                    if _pkg_name:
+                        _normalized = _pkg_name.replace("-", "_")
+                        if find_spec(_normalized) is None:
+                            logger.debug(
+                                f"Package '{_pkg_name}' no longer importable "
+                                f"(removed by uv sync?), invalidating cache "
+                                f"for {module_path.name}"
+                            )
+                            self._install_state.invalidate(module_path)
+                            _stale = True
+                except Exception:
+                    pass
+            if not _stale:
+                logger.debug(
+                    f"Skipping install for {module_path.name} (already installed)"
+                )
+                return
 
         if progress_callback and module_name:
             progress_callback("installing", module_name)


### PR DESCRIPTION
## Summary

Fixes a stale install-state cache bug that causes recurring failures when users run `amplifier update`. Bundle-root packages (like `amplifier-env-common`) are incorrectly skipped during reinstall, leaving downstream modules unable to resolve their dependencies.

## Root Cause

The `InstallStateManager` cache becomes stale when `uv sync` removes editable-installed bundle packages from the venv **without changing the Python symlink mtime**. This is distinct from full venv recreation (`uv tool install --force`), where the mtime does change and the staleness is detected.

### Sequence:
1. `amplifier-env-common` is defined at bundle root (pyproject.toml) and installed before modules
2. After `amplifier update` / `uv tool upgrade`, uv syncs the venv and removes `amplifier-env-common` (not in amplifier's own lockfile)
3. install-state.json still records it as installed (python symlink mtime unchanged)
4. On next startup, `_install_dependencies()` trusts the stale cache at Guard 2 (`is_installed()`) and skips reinstall
5. Module install fails: "No solution found when resolving dependencies: amplifier-env-common"

## Impact

Recurring failures for users of amplifier-bundle-execution-environments and other bundles with shared root dependencies. Symptoms include:
- tools-env-all installation fails
- hooks-env-all installation fails  
- Any module depending on bundle-root packages fails

## The Fix

Added a cross-check in the install-state cache guard (Guard 2, line ~418). When `is_installed()` returns True, we now verify the package is still actually importable via `find_spec()`. If `find_spec()` returns None (package was removed from venv by uv sync), we invalidate the stale cache entry and fall through to reinstall.

This mirrors the existing pattern of Guard 1 (the wheel guard) which already does a `find_spec` check before trusting the cache.

### Code pattern:
```python
# Old: Trust cache blindly
if is_installed():
    return

# New: Verify package still exists in venv
if is_installed():
    if find_spec(normalized) is None:  # Invalidate stale cache
        delete_from_cache(module_hash)
    else:
        return
```

## Testing

- All 23 existing unit tests pass
- Lint and format verified clean
- Ready for integration testing with amplifier-bundle-execution-environments

Generated with [Amplifier](https://github.com/microsoft/amplifier)