### PR TITLE
fix(hooks-session-naming): make provider timeout configurable

### DIFF
--- a/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
+++ b/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
@@ -35,6 +35,7 @@ class SessionNamingConfig:
     max_description_length: int = 200
     max_retries: int = 3
     model_role: str | None = "fast"
+    provider_timeout: float = 10.0
 
 
 INITIAL_NAMING_PROMPT = """You generate names and descriptions for conversation sessions.
@@ -248,11 +249,12 @@ class SessionNamingHook:
             # Call the provider — hard timeout caps stalled providers
             try:
                 response = await asyncio.wait_for(
-                    self._call_provider(prompt), timeout=10.0
+                    self._call_provider(prompt), timeout=self.config.provider_timeout
                 )
             except asyncio.TimeoutError:
                 logger.warning(
-                    "Session naming provider call timed out (10 s) for session %s",
+                    "Session naming provider call timed out (%d s) for session %s",
+                    int(self.config.provider_timeout),
                     session_id[:8],
                 )
                 await self.coordinator.hooks.emit(
@@ -575,6 +577,8 @@ async def mount(
             Defaults to "fast" so naming uses a cheap model automatically.
             Set to None to use the priority provider explicitly.
             Falls back to priority provider silently when hooks-routing is not installed.
+        provider_timeout: float (default: 10.0) - Timeout in seconds for the provider call.
+            Increase for slow local models (e.g., Ollama on external storage).
     """
     config = config or {}
 
@@ -585,6 +589,7 @@ async def mount(
         max_description_length=config.get("max_description_length", 200),
         max_retries=config.get("max_retries", 3),
         model_role=config.get("model_role"),
+        provider_timeout=float(config.get("provider_timeout", 10.0)),
     )
 
     hook = SessionNamingHook(coordinator, hook_config)


### PR DESCRIPTION
## Summary

The session naming hook had a **hardcoded 10-second timeout** that caused session initialization to fail when using local Ollama models requiring longer cold-load times from external storage.

## Problem

On the Mac Studio running Ollama with a 234GB model directory on external storage (ai-storage), cold-loading large models (e.g., gemma4:31b at 19GB) takes >10 seconds. This caused every session to fail with:
```
Session naming provider call timed out (10 s) for session X
```

The timeout was hardcoded in the module with no override mechanism.

## Solution

Made the provider timeout configurable:
- Added `provider_timeout: float = 10.0` to SessionNamingConfig dataclass
- Changed hardcoded `timeout=10.0` to `timeout=self.config.provider_timeout` in asyncio.wait_for call
- Updated logger output to show the actual configured timeout
- Maintains backward compatibility (10s default preserved)

## Configuration

Users can now override the timeout in `~/.amplifier/settings.yaml`:

```yaml
overrides:
  hooks-session-naming:
    config:
      provider_timeout: 60  # 60 seconds for local models on external storage
```

## Testing

Verified on Mac Studio:
- Before fix: Session naming timed out on every cold-load
- After fix: Sessions complete successfully with 60s provider timeout
- Model used: Ollama (gemma4:31b from external ai-storage)

## Backward Compatibility

✅ Default timeout remains 10 seconds
✅ No breaking changes to the module interface
✅ Configuration is optional