### PR TITLE
fix: strip markdown body from lean bundle entry points

### DIFF
--- a/experiments/exp-lean/README.md
+++ b/experiments/exp-lean/README.md
@@ -1,29 +1,66 @@
 # Experimental Lean Bundles
 
-Stripped-down Amplifier bundles for cost-effective sessions. Two tiers available:
+Stripped-down Amplifier bundles for cost-effective sessions. Two tiers available.
 
-## exp-lean-foundation
-
-Minimal infrastructure — 84% token reduction vs standard Foundation (8.6K vs 54.6K tokens).
-
-Includes core tools, delegate, skills, UX hooks. No modes, no expert consultants, no heavy context docs.
+## Install
 
 ```bash
+# Lean Foundation (84% token reduction: 54,568 -> 8,614 tokens)
 amplifier bundle add foundation:experiments/exp-lean/exp-lean-foundation --name exp-lean-foundation
 amplifier bundle use exp-lean-foundation
-```
 
-## exp-lean-amplifier-dev
-
-Dev tooling on top of lean-foundation — 71% token reduction vs standard amplifier-dev (17.8K vs 60.5K tokens).
-
-Adds dev agents (explorer, git-ops, bug-hunter, zen-architect, modular-builder, file-ops, post-task-cleanup), Python tooling (ruff, pyright, LSP), and apply_patch.
-
-```bash
+# Lean Amplifier Dev (71% token reduction: 60,539 -> 17,790 tokens)
 amplifier bundle add foundation:experiments/exp-lean/exp-lean-amplifier-dev --name exp-lean-amplifier-dev
 amplifier bundle use exp-lean-amplifier-dev
 ```
 
+## exp-lean-foundation
+
+Minimal infrastructure -- core tools, delegate, skills, UX hooks. No modes, no expert consultants, no heavy context docs.
+
+| Component | Included |
+|-----------|----------|
+| Session config (orchestrator, context) | Yes |
+| Core tools (filesystem, bash, web, search, todo) | Yes |
+| Delegate tool (agent orchestration) | Yes |
+| Skills tool (on-demand context loading) | Yes |
+| UX hooks (streaming, status, redaction, logging) | Yes |
+| Todo hooks (reminder, display, session naming) | Yes |
+| Modes (brainstorm, debug, verify, etc.) | No |
+| Expert consultants (amplifier, core, foundation) | No |
+| Heavy context docs (delegation-instructions, multi-agent-patterns) | No |
+| Design intelligence, browser-tester, terminal-tester | No |
+| Recipes, superpowers, routing-matrix | No |
+
+## exp-lean-amplifier-dev
+
+Dev tooling on top of lean-foundation -- dev agents, Python tooling, LSP, apply_patch.
+
+| Component | Included |
+|-----------|----------|
+| Everything in exp-lean-foundation | Yes |
+| Dev agents (explorer, git-ops, bug-hunter, zen-architect, modular-builder, file-ops, post-task-cleanup) | Yes |
+| Python tooling (ruff, pyright, auto-check hook) | Yes |
+| LSP / code intelligence (pyright) | Yes |
+| apply_patch (V4A diff editing) | Yes |
+| Browser testing, terminal testing | No |
+| Design intelligence | No |
+| Stories, dot-graph, superpowers | No |
+| Recipes, shadow environments | No |
+| Expert consultants (amplifier, core, foundation) | No |
+| Routing matrix, MCP | No |
+
+## Measured Token Cost
+
+All numbers measured in a clean shadow environment (zero host contamination) with `amplifier run --mode single "hello"`.
+
+| Bundle | Input Tokens |
+|--------|-------------|
+| Foundation (standard) | 54,568 |
+| **exp-lean-foundation** | **8,614** |
+| amplifier-dev (standard) | 60,539 |
+| **exp-lean-amplifier-dev** | **17,790** |
+
 ## Feedback
 
-These are experiments. If sessions feel degraded compared to the standard bundles, report what's missing.
+These are experiments in token cost reduction. Please report whether sessions feel degraded, about the same, or better than standard bundles.

--- a/experiments/exp-lean/exp-lean-amplifier-dev.md
+++ b/experiments/exp-lean/exp-lean-amplifier-dev.md
@@ -5,7 +5,7 @@ bundle:
   description: |
     EXPERIMENTAL lean amplifier-dev bundle -- minimal token footprint with dev tooling.
     
-    Stripped amplifier-dev for cost-effective dev sessions: 71% reduction (60K → 17.8K tokens).
+    Stripped amplifier-dev for cost-effective dev sessions: 71% reduction (60K -> 17.8K tokens).
     Includes lean-foundation base plus dev agents, Python tooling, and LSP.
     
     To use this bundle:
@@ -16,39 +16,5 @@ includes:
   - bundle: foundation:experiments/exp-lean/behaviors/lean-foundation
   - bundle: foundation:experiments/exp-lean/behaviors/lean-amplifier-dev
 ---
-
-# Experimental Lean Amplifier Dev Bundle
-
-Development bundle with **71% token reduction** vs standard amplifier-dev.
-
-## What's Included
-
-| Component | Included |
-|-----------|----------|
-| Everything in exp-lean-foundation | Yes |
-| Dev agents (explorer, git-ops, bug-hunter, zen-architect, modular-builder, file-ops, post-task-cleanup) | Yes |
-| Python tooling (ruff, pyright, auto-check hook) | Yes |
-| LSP / code intelligence (pyright) | Yes |
-| apply_patch (V4A diff editing) | Yes |
-| Browser testing, terminal testing | No |
-| Design intelligence | No |
-| Stories, dot-graph, superpowers | No |
-| Recipes, shadow environments | No |
-| Expert consultants (amplifier, core, foundation) | No |
-| Routing matrix, MCP | No |
-
-## Measured Token Cost
-
-| Bundle | Input Tokens |
-|--------|-------------|
-| amplifier-dev (standard) | 60,539 |
-| **exp-lean-amplifier-dev** | **17,790** |
-
-Measured in a clean shadow environment with `amplifier run --mode single "hello"`.
-
-## Feedback
-
-This is an experiment in token cost reduction. Please report whether sessions feel
-degraded, about the same, or better than standard amplifier-dev.
 
 @foundation:experiments/exp-lean/context/system-base.md

--- a/experiments/exp-lean/exp-lean-foundation.md
+++ b/experiments/exp-lean/exp-lean-foundation.md
@@ -5,7 +5,7 @@ bundle:
   description: |
     EXPERIMENTAL lean foundation bundle -- minimal token footprint.
     
-    Stripped Foundation for cost-effective sessions: 84% reduction (54K → 8.6K tokens).
+    Stripped Foundation for cost-effective sessions: 84% reduction (54K -> 8.6K tokens).
     Core tools, essential UX hooks, delegate tool, skills. No modes, no expert
     consultants, no heavy context docs.
     
@@ -16,39 +16,5 @@ bundle:
 includes:
   - bundle: foundation:experiments/exp-lean/behaviors/lean-foundation
 ---
-
-# Experimental Lean Foundation Bundle
-
-Minimal Amplifier infrastructure with **84% token reduction** vs standard Foundation.
-
-## What's Included
-
-| Component | Included |
-|-----------|----------|
-| Session config (orchestrator, context) | Yes |
-| Core tools (filesystem, bash, web, search, todo) | Yes |
-| Delegate tool (agent orchestration) | Yes |
-| Skills tool (on-demand context loading) | Yes |
-| UX hooks (streaming, status, redaction, logging) | Yes |
-| Todo hooks (reminder, display, session naming) | Yes |
-| Modes (brainstorm, debug, verify, etc.) | No |
-| Expert consultants (amplifier, core, foundation) | No |
-| Heavy context docs (delegation-instructions, multi-agent-patterns) | No |
-| Design intelligence, browser-tester, terminal-tester | No |
-| Recipes, superpowers, routing-matrix | No |
-
-## Measured Token Cost
-
-| Bundle | Input Tokens |
-|--------|-------------|
-| Foundation (standard) | 54,568 |
-| **exp-lean-foundation** | **8,614** |
-
-Measured in a clean shadow environment with `amplifier run --mode single "hello"`.
-
-## Feedback
-
-This is an experiment in token cost reduction. Please report whether sessions feel
-degraded, about the same, or better than standard Foundation.
 
 @foundation:experiments/exp-lean/context/system-base.md


### PR DESCRIPTION
## Problem

The markdown body in `exp-lean-foundation.md` and `exp-lean-amplifier-dev.md` was being injected as LLM instruction context. The "What's Included" tables, token cost tables, and feedback paragraphs are useful for humans browsing GitHub but waste tokens in sessions.

## Fix

- Stripped markdown body from both entry point files — they now contain only frontmatter + the `@context` include
- Moved all human-readable documentation to `README.md` (not loaded into sessions)

## Before/After

**Before** (`exp-lean-foundation.md`):
```
---
frontmatter...
---
# Experimental Lean Foundation Bundle     <-- loaded as instruction
| Component | Included |                  <-- loaded as instruction
...30 lines of tables and text...         <-- loaded as instruction
@foundation:.../context/system-base.md
```

**After:**
```
---
frontmatter...
---
@foundation:.../context/system-base.md
```

The `description:` field in frontmatter is metadata (shows in `amplifier bundle list`, not in session context), so it stays as-is.