### PR TITLE
feat: add bundle-configurator experiment

### DIFF
--- a/experiments/bundle-configurator/README.md
+++ b/experiments/bundle-configurator/README.md
@@ -1,0 +1,175 @@
+# Bundle Configurator (Experiment)
+
+An offline bundle editor that loads any Foundation bundle, shows the token cost breakdown by behavior, and lets you add or remove behaviors with full dependency tracking. Saves the result as a valid `.md` file that Foundation can load directly.
+
+This is an experiment co-located in the Foundation repo. It does not ship in the Foundation wheel. The merge path, if Brian approves the API, is to move `amplifier_configurator/` into `amplifier_foundation/configurator/` — same pattern as `amplifier_foundation/session/`.
+
+## Install
+
+```bash
+pip install "git+https://github.com/microsoft/amplifier-foundation@feat/bundle-configurator-experiment#subdirectory=experiments/bundle-configurator"
+```
+
+After this branch is merged to main:
+
+```bash
+pip install "git+https://github.com/microsoft/amplifier-foundation#subdirectory=experiments/bundle-configurator"
+```
+
+## Quick Start
+
+```python
+from amplifier_configurator import BundleConfigurator
+
+# Load any bundle Foundation knows about
+cfg = BundleConfigurator.load_sync("foundation")
+
+# See token cost by behavior, sorted descending
+for behavior, tokens in cfg.tokens_by_behavior().items():
+    print(f"  {behavior:30s} {tokens:5d} tokens")
+
+# Total
+print(f"\nTotal: {cfg.total_tokens()} tokens")
+
+# Remove a behavior (returns a new instance — original unchanged)
+lean = cfg.remove_behavior("code-intel")
+
+# See what changed
+diff = cfg.diff(lean)
+print(f"\nRemoved: {diff.token_delta} tokens")
+for part in diff.removed_parts:
+    print(f"  - {part.kind.value} {part.name}")
+
+# Save the result as a valid .md bundle file
+lean.save("/tmp/lean-foundation/bundle.md")
+```
+
+## API
+
+### BundleConfigurator
+
+The main class. Constructed via class methods; do not instantiate directly.
+
+**Loading:**
+
+```python
+# Async (preferred in async contexts)
+cfg = await BundleConfigurator.load("foundation")
+
+# Synchronous wrapper
+cfg = BundleConfigurator.load_sync("foundation")
+```
+
+`source` accepts any Foundation-supported identifier: bundle name, git URI, or file path.
+
+**Querying:**
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `list_behaviors()` | `list[BehaviorInfo]` | All included behaviors, leaves first |
+| `list_parts(kind=None)` | `list[TrackedPart]` | All tracked parts; optional `PartKind` filter |
+| `tokens_by_behavior()` | `dict[str, int]` | Token cost per behavior, sorted descending |
+| `total_tokens()` | `int` | Sum of all part tokens + root instruction |
+| `get_behavior(name)` | `BehaviorInfo` | Behavior by short name; raises `KeyError` if not found |
+| `get_part(kind, name)` | `TrackedPart` | Part by `(PartKind, name)`; raises `KeyError` if not found |
+
+**Mutation (immutable — each method returns a new instance):**
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `remove_behavior(name)` | `BundleConfigurator` | Remove behavior and all parts it exclusively contributed; cascades to orphaned children |
+| `remove_part(kind, name)` | `BundleConfigurator` | Remove a single part; raises `DependencyError` if part is required |
+| `await add_behavior(uri)` | `BundleConfigurator` | Load and merge a new behavior by URI |
+
+**Analysis and output:**
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `diff(other)` | `BundleDiff` | Parts and behaviors added/removed, token delta |
+| `validate()` | `(list[str], list[str])` | `(errors, warnings)` from dependency analysis |
+| `save(path)` | `Path` | Write `.md` bundle file; raises `ConfiguratorError` on validation errors |
+
+### Data Models
+
+**`BehaviorInfo`** — what a behavior contributes:
+- `name: str` — short name (e.g. `"code-intel"`)
+- `uri: str` — full Foundation URI
+- `parts: tuple[TrackedPart, ...]` — de-duplicated parts this behavior won
+- `total_tokens: int` — context token cost (context files + instructions only)
+- `depth: int` — 0 = direct include of root, 1 = transitive, etc.
+- `include_chain: tuple[str, ...]` — path from root to this behavior
+
+**`TrackedPart`** — a single element with its origin:
+- `kind: PartKind` — `TOOL | HOOK | AGENT | PROVIDER | CONTEXT`
+- `name: str` — module name or context key
+- `source_behavior: str | None` — which behavior contributed it (`None` = root)
+- `tokens: int` — estimated token cost (non-zero only for `CONTEXT` parts)
+- `config: dict` — the raw dict from the bundle YAML
+
+**`BundleDiff`**:
+- `added_parts / removed_parts: tuple[TrackedPart, ...]`
+- `added_behaviors / removed_behaviors: tuple[str, ...]`
+- `before_tokens / after_tokens / token_delta: int`
+
+**`PartKind`** (enum): `TOOL`, `HOOK`, `AGENT`, `PROVIDER`, `CONTEXT`
+
+### Errors
+
+- `ConfiguratorError` — base error class
+- `LoadError` — Foundation failed to load the bundle
+- `DependencyError` — attempted to remove a required part (e.g. `tool-bash`, `tool-filesystem`, `tool-search`)
+
+## What It Counts
+
+The library measures **context files and instruction text** — the portions of a bundle that are part of the bundle definition and loaded at session start. This is the controllable portion.
+
+It does not measure tool schemas. Tool schemas are injected by Foundation at runtime based on installed module versions; they are not present in the `.md` bundle file and cannot be measured offline.
+
+For most optimization work, context files and instructions are the dominant cost. Tool schemas are relatively stable across sessions.
+
+## How It Works
+
+1. The library calls Foundation's `BundleRegistry` to load each included behavior separately, building a complete include tree.
+2. Each behavior's contributions (tools, hooks, agents, context files) are attributed to that behavior using a last-write-wins, bottom-up rule: deeper (leaf) behaviors win over shallower ones on conflicts.
+3. The resulting `ProvenanceMap` tracks every part with its source behavior, token cost, and original config dict.
+4. All mutation methods (`remove_behavior`, `remove_part`, `add_behavior`) work on the `ProvenanceMap` directly and return a new `BundleConfigurator` without reloading from disk.
+5. `save()` serializes the current state to YAML frontmatter + markdown body using the include-reference pattern (behaviors referenced by URI, not flattened).
+
+## Relationship to Runtime Configurator
+
+This library is the **offline** bundle editor. It produces `.md` bundle files.
+
+Brian's runtime configurator (in Foundation's session layer) is the **online** toggle — it switches behaviors on and off within a running session without touching the bundle file on disk.
+
+They are complementary: this library produces the files that the runtime configurator operates on. A workflow might be: use this library to produce a lean bundle variant, then use the runtime configurator to dynamically adjust it mid-session.
+
+## Status
+
+Experiment. Not production-ready. API may change based on Brian's feedback.
+
+Test coverage:
+- 129 unit tests (no Foundation required)
+- 6 integration tests (require Foundation to be installed and reachable)
+- 1 end-to-end round-trip test (`e2e_shadow_test.py`)
+
+## Run Tests
+
+```bash
+# Install dependencies
+pip install -e ".[dev]"
+
+# Unit tests only (fast, no Foundation network calls)
+pytest tests/ -k "not integration"
+
+# Integration tests (loads real bundles via Foundation)
+pytest tests/test_real_bundles.py -m integration -v
+
+# End-to-end round trip
+pytest tests/e2e_shadow_test.py -v
+```
+
+Or, using the Amplifier-managed Python:
+
+```bash
+~/.local/share/uv/tools/amplifier/bin/python -m pytest tests/ -k "not integration"
+```

--- a/experiments/bundle-configurator/amplifier_configurator/__init__.py
+++ b/experiments/bundle-configurator/amplifier_configurator/__init__.py
@@ -1,0 +1,46 @@
+"""amplifier_configurator — provenance-aware bundle editing for Amplifier.
+
+Built on Foundation's real Bundle API. Not a reimplementation.
+"""
+
+from __future__ import annotations
+
+from .configurator import BundleConfigurator
+from .dependencies import PART_DEPENDENCIES, REQUIRED_PARTS, validate_provenance
+from .models import (
+    BehaviorInfo,
+    BundleDiff,
+    ConfiguratorError,
+    ConfiguratorWarning,
+    DependencyError,
+    LoadError,
+    PartKind,
+    ProvenanceMap,
+    TrackedPart,
+)
+from .serialize import serialize_bundle
+from .tokens import estimate_tokens_for_file, estimate_tokens_for_text
+
+__all__ = [
+    # Main class
+    "BundleConfigurator",
+    # Data models
+    "BehaviorInfo",
+    "BundleDiff",
+    "PartKind",
+    "ProvenanceMap",
+    "TrackedPart",
+    # Errors
+    "ConfiguratorError",
+    "ConfiguratorWarning",
+    "DependencyError",
+    "LoadError",
+    # Functions
+    "estimate_tokens_for_file",
+    "estimate_tokens_for_text",
+    "serialize_bundle",
+    "validate_provenance",
+    # Constants
+    "PART_DEPENDENCIES",
+    "REQUIRED_PARTS",
+]

--- a/experiments/bundle-configurator/amplifier_configurator/configurator.py
+++ b/experiments/bundle-configurator/amplifier_configurator/configurator.py
@@ -1,0 +1,567 @@
+"""Main BundleConfigurator class — wraps a ProvenanceMap for introspection and customization.
+
+Provides an immutable-mutation API: all mutation methods return a NEW
+BundleConfigurator instance rather than modifying the existing one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from pathlib import Path
+
+from amplifier_foundation.bundle import Bundle
+
+from .models import (
+    BehaviorInfo,
+    BundleDiff,
+    ConfiguratorError,
+    DependencyError,
+    PartKind,
+    ProvenanceMap,
+    TrackedPart,
+)
+
+
+class BundleConfigurator:
+    """Wraps a ProvenanceMap with query and immutable-mutation API.
+
+    All mutation methods (``remove_behavior``, ``remove_part``, ``add_behavior``)
+    return a **new** ``BundleConfigurator`` instance — the original is never
+    modified.
+    """
+
+    def __init__(self, provenance: ProvenanceMap) -> None:
+        self._provenance = provenance
+
+    # -------------------------------------------------------------------------
+    # Properties
+    # -------------------------------------------------------------------------
+
+    @property
+    def provenance(self) -> ProvenanceMap:
+        """The underlying ProvenanceMap."""
+        return self._provenance
+
+    @property
+    def bundle(self) -> Bundle:
+        """The composed Foundation Bundle as loaded by Foundation.
+
+        .. warning::
+            This reflects the **original** Foundation-loaded state and is **not**
+            updated when parts or behaviors are removed via mutation methods
+            (``remove_behavior``, ``remove_part``, ``add_behavior``).
+
+            Use :meth:`list_parts` / :meth:`list_behaviors` to inspect current
+            state, and :meth:`save` to serialize the current mutated state.
+        """
+        return self._provenance.composed_bundle
+
+    # -------------------------------------------------------------------------
+    # Factory methods
+    # -------------------------------------------------------------------------
+
+    @classmethod
+    async def load(cls, source: str) -> "BundleConfigurator":
+        """Load a bundle source and build a full ProvenanceMap.
+
+        Parameters
+        ----------
+        source:
+            Any Foundation-supported source: bundle name, git URI, or file path.
+
+        Returns
+        -------
+        BundleConfigurator
+            Wraps the built ProvenanceMap.
+        """
+        from .provenance import build_provenance_map
+
+        pmap = await build_provenance_map(source)
+        return cls(pmap)
+
+    @classmethod
+    def load_sync(cls, source: str) -> "BundleConfigurator":
+        """Synchronous wrapper around :meth:`load` using ``asyncio.run``."""
+        return asyncio.run(cls.load(source))
+
+    # -------------------------------------------------------------------------
+    # Query methods
+    # -------------------------------------------------------------------------
+
+    def list_behaviors(self) -> list[BehaviorInfo]:
+        """Return all behaviors sorted by include_order (leaves first).
+
+        The include_order recorded in the ProvenanceMap is bottom-up (deepest
+        leaves first, shallowest last), so this order reflects dependency
+        depth.
+
+        Returns
+        -------
+        list[BehaviorInfo]
+            Behaviors in include_order sequence.
+        """
+        return [
+            self._provenance.behaviors[uri]
+            for uri in self._provenance.include_order
+            if uri in self._provenance.behaviors
+        ]
+
+    def list_parts(self, kind: PartKind | None = None) -> list[TrackedPart]:
+        """Return all tracked parts, optionally filtered by kind.
+
+        Parameters
+        ----------
+        kind:
+            If given, only parts of this ``PartKind`` are returned.
+
+        Returns
+        -------
+        list[TrackedPart]
+            All (or filtered) parts from ``ProvenanceMap.all_parts``.
+        """
+        parts: list[TrackedPart] = list(self._provenance.all_parts)
+        if kind is not None:
+            parts = [p for p in parts if p.kind == kind]
+        return parts
+
+    def total_tokens(self) -> int:
+        """Total estimated token cost.
+
+        Returns
+        -------
+        int
+            Sum of all part tokens across ``all_parts`` **plus**
+            ``root_instruction_tokens``.
+        """
+        return (
+            sum(p.tokens for p in self._provenance.all_parts)
+            + self._provenance.root_instruction_tokens
+        )
+
+    def tokens_by_behavior(self) -> dict[str, int]:
+        """Token cost breakdown sorted descending.
+
+        The returned dict maps behavior **name** → token count.  A special
+        ``"<root>"`` key holds the root instruction token count.
+
+        Returns
+        -------
+        dict[str, int]
+            Mapping sorted in descending order of token count.
+        """
+        costs: dict[str, int] = {}
+        for beh in self._provenance.behaviors.values():
+            costs[beh.name] = beh.total_tokens
+        # Root cost = instruction tokens + root-won parts in all_parts.
+        # Root's _pending_context is an aggregate of all sub-behavior context;
+        # those files are attributed to the sub-behaviors that declared them
+        # (via setdefault in _deduplicate_parts). Only parts that no sub-behavior
+        # claimed appear in all_parts with source_behavior=None.
+        root_won_tokens = sum(
+            p.tokens for p in self._provenance.all_parts if p.source_behavior is None
+        )
+        costs["<root>"] = self._provenance.root_instruction_tokens + root_won_tokens
+        # Return sorted by value descending; Python 3.7+ dicts preserve insertion order.
+        return dict(sorted(costs.items(), key=lambda item: item[1], reverse=True))
+
+    def get_behavior(self, name: str) -> BehaviorInfo:
+        """Return the BehaviorInfo with the given short name.
+
+        Parameters
+        ----------
+        name:
+            Short behavior name (e.g. ``"bug-hunter"``), **not** its URI.
+
+        Returns
+        -------
+        BehaviorInfo
+
+        Raises
+        ------
+        KeyError
+            If no behavior with that name exists in this configurator.
+        """
+        for beh in self._provenance.behaviors.values():
+            if beh.name == name:
+                return beh
+        raise KeyError(name)
+
+    def get_part(self, kind: PartKind, name: str) -> TrackedPart:
+        """Return the TrackedPart identified by (kind, name).
+
+        Parameters
+        ----------
+        kind:
+            The :class:`PartKind` of the part.
+        name:
+            The part name (e.g. ``"tool-bash"`` or
+            ``"leaf-behavior:lsp-config"``).
+
+        Returns
+        -------
+        TrackedPart
+
+        Raises
+        ------
+        KeyError
+            If no matching part exists.
+        """
+        for part in self._provenance.all_parts:
+            if part.kind == kind and part.name == name:
+                return part
+        raise KeyError((kind, name))
+
+    # -------------------------------------------------------------------------
+    # Mutation methods (immutable — return NEW instance)
+    # -------------------------------------------------------------------------
+
+    def remove_behavior(self, name: str) -> "BundleConfigurator":
+        """Remove a behavior by short name.
+
+        Returns a new ``BundleConfigurator`` with the behavior and all parts
+        exclusively contributed by it removed.  Any behaviors that become
+        orphaned (their direct parent in the include chain was removed) are
+        also removed recursively.
+
+        Parameters
+        ----------
+        name:
+            Short behavior name to remove.
+
+        Raises
+        ------
+        KeyError
+            If no behavior with that name exists.
+        """
+        # Find the URI of the behavior to remove.
+        uri_to_remove: str | None = None
+        for uri, beh in self._provenance.behaviors.items():
+            if beh.name == name:
+                uri_to_remove = uri
+                break
+        if uri_to_remove is None:
+            raise KeyError(name)
+
+        behavior_name = self._provenance.behaviors[uri_to_remove].name
+
+        # Collect all behavior names to remove, including orphaned ones.
+        # A behavior is orphaned when its direct parent in include_chain
+        # (include_chain[-2]) is among the removed names.
+        names_removed: set[str] = {behavior_name}
+        changed = True
+        while changed:
+            changed = False
+            for beh in self._provenance.behaviors.values():
+                if beh.name in names_removed:
+                    continue
+                # Direct parent = element immediately before this behavior.
+                if (
+                    len(beh.include_chain) >= 2
+                    and beh.include_chain[-2] in names_removed
+                ):
+                    names_removed.add(beh.name)
+                    changed = True
+
+        # Build updated data structures.
+        new_behaviors = {
+            k: v
+            for k, v in self._provenance.behaviors.items()
+            if v.name not in names_removed
+        }
+        uris_to_remove = {
+            uri
+            for uri, beh in self._provenance.behaviors.items()
+            if beh.name in names_removed
+        }
+        new_include_order = tuple(
+            u for u in self._provenance.include_order if u not in uris_to_remove
+        )
+        # Remove parts exclusively from removed behaviors.
+        new_all_parts = tuple(
+            p
+            for p in self._provenance.all_parts
+            if p.source_behavior not in names_removed
+        )
+        return self._recompose(
+            behaviors=new_behaviors,
+            include_order=new_include_order,
+            all_parts=new_all_parts,
+        )
+
+    def remove_part(self, kind: PartKind, name: str) -> "BundleConfigurator":
+        """Remove a part by (kind, name) from all parts and behavior records.
+
+        Returns a new ``BundleConfigurator``.
+
+        Parameters
+        ----------
+        kind:
+            The :class:`PartKind` of the part to remove.
+        name:
+            The part name (e.g. ``\"tool-lsp\"``).
+
+        Raises
+        ------
+        KeyError
+            If no matching part exists.
+        DependencyError
+            If the part is in the set of required parts that must always be
+            present (e.g. ``tool-bash``, ``tool-filesystem``, ``tool-search``).
+        """
+        from .dependencies import REQUIRED
+
+        # Guard: part must exist.
+        found = any(
+            p.kind == kind and p.name == name for p in self._provenance.all_parts
+        )
+        if not found:
+            raise KeyError((kind, name))
+
+        # Guard: required parts cannot be removed.
+        if name in REQUIRED:
+            raise DependencyError([name])
+
+        new_all_parts = tuple(
+            p
+            for p in self._provenance.all_parts
+            if not (p.kind == kind and p.name == name)
+        )
+        new_root_parts = tuple(
+            p
+            for p in self._provenance.root_parts
+            if not (p.kind == kind and p.name == name)
+        )
+        new_behaviors: dict[str, BehaviorInfo] = {}
+        for uri, beh in self._provenance.behaviors.items():
+            new_parts = tuple(
+                p for p in beh.parts if not (p.kind == kind and p.name == name)
+            )
+            new_raw = tuple(
+                p for p in beh.raw_parts if not (p.kind == kind and p.name == name)
+            )
+            new_behaviors[uri] = dataclasses.replace(
+                beh,
+                parts=new_parts,
+                raw_parts=new_raw,
+                total_tokens=sum(p.tokens for p in new_parts),
+            )
+        return self._recompose(
+            behaviors=new_behaviors,
+            all_parts=new_all_parts,
+            root_parts=new_root_parts,
+        )
+
+    async def add_behavior(self, uri: str) -> "BundleConfigurator":
+        """Add a new behavior by URI.
+
+        Loads the behavior tree rooted at ``uri``, merges it into the current
+        provenance map using the same bottom-up, last-write-wins rules as
+        :func:`build_provenance_map`, and returns a new
+        ``BundleConfigurator``.
+
+        Parameters
+        ----------
+        uri:
+            Foundation-supported URI for the behavior bundle.
+        """
+        from .provenance import _load_behavior_tree, _deduplicate_parts
+        from amplifier_foundation.registry import BundleRegistry
+
+        registry = BundleRegistry()
+        new_behavior_infos, new_raw_bundles = await _load_behavior_tree(
+            uri=uri,
+            depth=0,
+            chain=(self._provenance.root_name,),
+            registry=registry,
+            seen=set(),
+        )
+
+        # Merge new behaviors (de-duplicate URIs; new wins).
+        merged_behaviors = dict(self._provenance.behaviors)
+        merged_include_order = list(self._provenance.include_order)
+        for beh in new_behavior_infos:
+            if beh.uri not in merged_behaviors:
+                merged_behaviors[beh.uri] = beh
+                merged_include_order.append(beh.uri)
+            else:
+                merged_behaviors[beh.uri] = beh  # new wins
+
+        new_include_order = tuple(merged_include_order)
+
+        # Re-deduplicate all parts with the updated behaviors.
+        all_parts, updated_behaviors = _deduplicate_parts(
+            merged_behaviors,
+            self._provenance.root_parts,
+            new_include_order,
+        )
+
+        merged_raw_bundles = dict(self._provenance._raw_bundles)
+        merged_raw_bundles.update(new_raw_bundles)
+
+        return self._recompose(
+            behaviors=updated_behaviors,
+            include_order=new_include_order,
+            all_parts=all_parts,
+            _raw_bundles=merged_raw_bundles,
+        )
+
+    # -------------------------------------------------------------------------
+    # Diff, validate, compose, save
+    # -------------------------------------------------------------------------
+
+    def diff(self, other: "BundleConfigurator") -> BundleDiff:
+        """Compute the diff between this configurator (before) and *other* (after).
+
+        Parameters
+        ----------
+        other:
+            The "after" configurator to compare against.
+
+        Returns
+        -------
+        BundleDiff
+        """
+        self_keys = {(p.kind, p.name) for p in self._provenance.all_parts}
+        other_keys = {(p.kind, p.name) for p in other._provenance.all_parts}
+
+        added_keys = other_keys - self_keys
+        removed_keys = self_keys - other_keys
+
+        added_parts = tuple(
+            p for p in other._provenance.all_parts if (p.kind, p.name) in added_keys
+        )
+        removed_parts = tuple(
+            p for p in self._provenance.all_parts if (p.kind, p.name) in removed_keys
+        )
+
+        self_uris = set(self._provenance.behaviors.keys())
+        other_uris = set(other._provenance.behaviors.keys())
+
+        added_behaviors = tuple(other_uris - self_uris)
+        removed_behaviors = tuple(self_uris - other_uris)
+
+        before_tokens = self.total_tokens()
+        after_tokens = other.total_tokens()
+
+        return BundleDiff(
+            added_parts=added_parts,
+            removed_parts=removed_parts,
+            added_behaviors=added_behaviors,
+            removed_behaviors=removed_behaviors,
+            token_delta=after_tokens - before_tokens,
+            before_tokens=before_tokens,
+            after_tokens=after_tokens,
+        )
+
+    def validate(self) -> tuple[list[str], list[str]]:
+        """Run bundle validation and return ``(errors, warnings)``.
+
+        Uses provenance-aware validation via
+        :func:`~amplifier_configurator.dependencies.validate_provenance`.
+
+        Returns
+        -------
+        tuple[list[str], list[str]]
+            ``(errors, warnings)`` where *errors* are hard failures (e.g.
+            missing required parts) and *warnings* are soft issues (e.g.
+            missing optional dependencies or agents without tool-delegate).
+        """
+        from .dependencies import validate_provenance
+
+        return validate_provenance(self._provenance)
+
+    def compose(self) -> Bundle:
+        """Return the composed Foundation Bundle.
+
+        This is the same object accessible via :attr:`bundle`.
+
+        .. warning::
+            Like :attr:`bundle`, this reflects the **original** Foundation-loaded
+            state and is **not** updated by mutation methods.  Use
+            :meth:`list_parts` / :meth:`list_behaviors` to inspect current state,
+            and :meth:`save` to serialize the current mutated state.
+        """
+        return self.bundle
+
+    def save(self, path: str | Path) -> Path:
+        """Save the current composed bundle as a .md file.
+
+        Calls :meth:`validate` first; raises :class:`~amplifier_configurator.models.ConfiguratorError`
+        if any validation errors are found.  Uses :func:`~amplifier_configurator.serialize.serialize_bundle`
+        to generate the YAML frontmatter + markdown body content.
+
+        Parameters
+        ----------
+        path:
+            Destination file path (parent directories are created if needed).
+
+        Returns
+        -------
+        Path
+            The path to the written file.
+
+        Raises
+        ------
+        ConfiguratorError
+            If validation finds hard errors (e.g. missing required parts).
+        """
+        from .serialize import serialize_bundle
+
+        errors, warnings = self.validate()
+        if errors:
+            raise ConfiguratorError(f"Bundle has validation errors: {errors!r}")
+
+        dest = Path(path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        content = serialize_bundle(
+            self._provenance, warnings=warnings if warnings else None
+        )
+        dest.write_text(content)
+        return dest
+
+    # -------------------------------------------------------------------------
+    # Private helpers
+    # -------------------------------------------------------------------------
+
+    def _recompose(
+        self,
+        *,
+        behaviors: dict[str, BehaviorInfo] | None = None,
+        include_order: tuple[str, ...] | None = None,
+        all_parts: tuple[TrackedPart, ...] | None = None,
+        root_parts: tuple[TrackedPart, ...] | None = None,
+        _raw_bundles: dict[str, Bundle] | None = None,
+    ) -> "BundleConfigurator":
+        """Create a new BundleConfigurator with selectively replaced provenance fields.
+
+        Parameters
+        ----------
+        behaviors:
+            Replacement behaviors dict.  Uses existing value if ``None``.
+        include_order:
+            Replacement include_order tuple.  Uses existing value if ``None``.
+        all_parts:
+            Replacement all_parts tuple.  Uses existing value if ``None``.
+        root_parts:
+            Replacement root_parts tuple.  Uses existing value if ``None``.
+        _raw_bundles:
+            Replacement raw bundles mapping.  Uses existing value if ``None``.
+
+        Returns
+        -------
+        BundleConfigurator
+            New instance wrapping the updated ProvenanceMap.
+        """
+        p = self._provenance
+        new_pmap = dataclasses.replace(
+            p,
+            behaviors=behaviors if behaviors is not None else p.behaviors,
+            include_order=include_order
+            if include_order is not None
+            else p.include_order,
+            all_parts=all_parts if all_parts is not None else p.all_parts,
+            root_parts=root_parts if root_parts is not None else p.root_parts,
+            _raw_bundles=_raw_bundles if _raw_bundles is not None else p._raw_bundles,
+        )
+        return BundleConfigurator(new_pmap)

--- a/experiments/bundle-configurator/amplifier_configurator/dependencies.py
+++ b/experiments/bundle-configurator/amplifier_configurator/dependencies.py
@@ -1,0 +1,193 @@
+"""Dependency map and validation for bundle parts (provenance-aware).
+
+New API (provenance-aware):
+  - PART_DEPENDENCIES, AGENT_REQUIRES_DELEGATE, REQUIRED_PARTS, INFRASTRUCTURE
+  - _get_all_part_names(pmap: ProvenanceMap) -> set[str]
+  - validate_provenance(pmap: ProvenanceMap) -> tuple[list[str], list[str]]
+
+Legacy API (Bundle-based, kept for backward compatibility):
+  - DEPENDENCIES (alias for PART_DEPENDENCIES)
+  - REQUIRED (alias for REQUIRED_PARTS)
+  - get_all_part_names(bundle: Bundle) -> set[str]
+  - check_dependencies(bundle: Bundle) -> list[str]
+  - check_required(bundle: Bundle) -> list[str]
+  - validate(bundle: Bundle) -> tuple[list[str], list[str]]
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from amplifier_foundation.bundle import Bundle
+
+if TYPE_CHECKING:
+    from .models import ProvenanceMap
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Known dependency relationships: part name -> [deps it needs]
+PART_DEPENDENCIES: dict[str, list[str]] = {
+    # hooks -> tools they need
+    "hooks-todo-reminder": ["tool-todo"],
+    "hooks-todo-display": ["tool-todo"],
+    # tools -> context files they need
+    "tool-lsp": ["context:python-lsp", "context:lsp-general"],
+    "tool-skills": ["context:skills-instructions"],
+    "tool-recipes": ["context:recipe-awareness"],
+    "tool-modes": ["context:modes-instructions"],
+    # python check -> context
+    "python_check": ["context:python-dev-instructions"],
+}
+
+# Whether agents always require tool-delegate
+AGENT_REQUIRES_DELEGATE: bool = True
+
+# Parts that must always be present in every bundle
+REQUIRED_PARTS: set[str] = {
+    "tool-bash",
+    "tool-filesystem",
+    "tool-search",
+}
+
+# Infrastructure parts (not subject to standard validation rules)
+INFRASTRUCTURE: set[str] = {"session"}
+
+# ---------------------------------------------------------------------------
+# Backward-compat aliases (legacy names)
+# ---------------------------------------------------------------------------
+
+DEPENDENCIES = PART_DEPENDENCIES
+REQUIRED = REQUIRED_PARTS
+
+
+# ---------------------------------------------------------------------------
+# Provenance-aware API (new)
+# ---------------------------------------------------------------------------
+
+
+def _get_all_part_names(pmap: ProvenanceMap) -> set[str]:
+    """Return a set of all part identifiers from a ProvenanceMap.
+
+    Context parts use ``'context:{short_name}'`` format where *short_name*
+    is the last segment after splitting the TrackedPart name on ``':'``.
+    All other part kinds use their name as-is.
+
+    This normalisation lets callers compare against ``PART_DEPENDENCIES``
+    values which also use the ``'context:X'`` format.
+    """
+    from .models import PartKind
+
+    names: set[str] = set()
+    for part in pmap.all_parts:
+        if part.kind == PartKind.CONTEXT:
+            short_name = part.name.split(":")[-1]
+            names.add(f"context:{short_name}")
+        else:
+            names.add(part.name)
+    return names
+
+
+def validate_provenance(pmap: ProvenanceMap) -> tuple[list[str], list[str]]:
+    """Full provenance-aware validation.
+
+    Parameters
+    ----------
+    pmap:
+        The :class:`ProvenanceMap` to validate.
+
+    Returns
+    -------
+    tuple[list[str], list[str]]
+        ``(errors, warnings)`` where:
+
+        * **errors** — missing required parts (hard failures).
+        * **warnings** — missing declared dependencies or agents without
+          ``tool-delegate`` (soft failures).
+    """
+    from .models import PartKind
+
+    names = _get_all_part_names(pmap)
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # --- Required parts (errors) -------------------------------------------
+    for req in REQUIRED_PARTS:
+        if req not in names:
+            errors.append(f"Required part missing: {req}")
+
+    # --- Part dependencies (warnings) --------------------------------------
+    for part_name, deps in PART_DEPENDENCIES.items():
+        if part_name in names:
+            for dep in deps:
+                if dep not in names:
+                    warnings.append(f"{part_name} requires {dep} but it's missing")
+
+    # --- Agents need tool-delegate (warning) --------------------------------
+    if AGENT_REQUIRES_DELEGATE:
+        has_agents = any(part.kind == PartKind.AGENT for part in pmap.all_parts)
+        if has_agents and "tool-delegate" not in names:
+            warnings.append("Agents require tool-delegate but it's not in the bundle")
+
+    return errors, warnings
+
+
+# ---------------------------------------------------------------------------
+# Bundle-based API (legacy — kept for backward compatibility)
+# ---------------------------------------------------------------------------
+
+
+def get_all_part_names(bundle: Bundle) -> set[str]:
+    """Return a set of all part identifiers present in a ``Bundle``.
+
+    .. deprecated::
+        Use :func:`_get_all_part_names` with a :class:`ProvenanceMap` instead.
+    """
+    names: set[str] = set()
+    for t in bundle.tools:
+        names.add(t.get("module", t.get("id", "")))
+    for h in bundle.hooks:
+        names.add(h.get("module", h.get("id", "")))
+    for name in bundle.agents:
+        names.add(f"agent:{name}")
+    for name in bundle.context:
+        names.add(f"context:{name}")
+    for p in bundle.providers:
+        names.add(p.get("module", p.get("id", "")))
+    return names
+
+
+def check_dependencies(bundle: Bundle) -> list[str]:
+    """Check for missing declared dependencies.  Returns warning strings."""
+    names = get_all_part_names(bundle)
+    warnings: list[str] = []
+
+    for part_name, deps in PART_DEPENDENCIES.items():
+        if part_name in names:
+            for dep in deps:
+                if dep not in names:
+                    warnings.append(f"{part_name} requires {dep} but it's missing")
+
+    # Agents need tool-delegate to be spawned
+    if bundle.agents and not any(
+        t.get("module") == "tool-delegate" for t in bundle.tools
+    ):
+        warnings.append("Agents require tool-delegate but it's not in the bundle")
+
+    return warnings
+
+
+def check_required(bundle: Bundle) -> list[str]:
+    """Check that required parts are present.  Returns error strings."""
+    names = get_all_part_names(bundle)
+    errors: list[str] = []
+    for req in REQUIRED_PARTS:
+        if req not in names:
+            errors.append(f"Required part missing: {req}")
+    return errors
+
+
+def validate(bundle: Bundle) -> tuple[list[str], list[str]]:
+    """Full Bundle-based validation.  Returns ``(errors, warnings)``."""
+    return check_required(bundle), check_dependencies(bundle)

--- a/experiments/bundle-configurator/amplifier_configurator/models.py
+++ b/experiments/bundle-configurator/amplifier_configurator/models.py
@@ -1,0 +1,249 @@
+"""Domain models for amplifier_configurator — error hierarchy and part kind enum."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from amplifier_foundation.bundle import Bundle
+
+
+class PartKind(str, Enum):
+    """Kind of bundle part.
+
+    Values are plain strings so they serialize cleanly to JSON without a
+    custom encoder.  ``isinstance(PartKind.TOOL, str)`` is True.
+    """
+
+    TOOL = "tool"
+    HOOK = "hook"
+    PROVIDER = "provider"
+    AGENT = "agent"
+    CONTEXT = "context"
+
+
+# ---------------------------------------------------------------------------
+# Error hierarchy
+# ---------------------------------------------------------------------------
+
+
+class ConfiguratorError(Exception):
+    """Base exception for all amplifier_configurator errors."""
+
+
+class DependencyError(ConfiguratorError):
+    """Raised when a bundle has unresolvable dependency relationships.
+
+    Parameters
+    ----------
+    parts:
+        List of part identifiers involved in the dependency problem.
+    """
+
+    def __init__(self, parts: list[str]) -> None:
+        self.parts = parts
+        super().__init__(f"Dependency error involving parts: {parts!r}")
+
+
+class LoadError(ConfiguratorError):
+    """Raised when a bundle cannot be loaded from a source.
+
+    Parameters
+    ----------
+    source:
+        Human-readable description of where the load was attempted (e.g. a
+        file path or URL).
+    cause:
+        The underlying exception that triggered the failure, if any.
+    """
+
+    def __init__(self, source: str, cause: Exception | None = None) -> None:
+        self.source = source
+        self.cause = cause
+        msg = f"Failed to load bundle from {source!r}"
+        if cause is not None:
+            msg += f": {cause}"
+        super().__init__(msg)
+
+
+class ConfiguratorWarning(UserWarning):
+    """Warning category for non-fatal configurator issues."""
+
+
+# ---------------------------------------------------------------------------
+# Tracked-part and behavior dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TrackedPart:
+    """A single part tracked within a behavior's composition.
+
+    Attributes
+    ----------
+    kind:
+        The type of part (tool, hook, provider, agent, or context).
+    name:
+        Module name of the part (e.g. ``"tool-bash"``).
+    source_behavior:
+        The behavior (agent URI) that directly contributed this part, or
+        ``None`` for parts present at the root bundle level.
+    tokens:
+        Estimated token cost for this part.
+    config:
+        Raw configuration dict from the bundle definition.
+    namespace_path:
+        For ``CONTEXT`` parts loaded via a namespace (e.g.
+        ``"foundation:instructions"``); ``None`` for non-namespaced parts.
+    """
+
+    kind: PartKind
+    name: str
+    source_behavior: str | None
+    tokens: int
+    config: dict[str, Any]
+    namespace_path: str | None
+
+    def __hash__(self) -> int:
+        # ``config`` is a plain dict and therefore not hashable.  We hash only
+        # the remaining scalar fields.  Two instances are equal (via the
+        # dataclass-generated __eq__ which includes *all* fields) only when
+        # every field matches, so excluding ``config`` from the hash is safe —
+        # it may increase collisions but never produces incorrect equality.
+        return hash(
+            (
+                self.kind,
+                self.name,
+                self.source_behavior,
+                self.tokens,
+                self.namespace_path,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class BehaviorInfo:
+    """Aggregated information about a resolved agent behavior.
+
+    Attributes
+    ----------
+    name:
+        Short name of the agent (e.g. ``"bug-hunter"``).
+    uri:
+        Fully-qualified agent URI (e.g. ``"foundation:bug-hunter"``).
+    parts:
+        De-duplicated tuple of ``TrackedPart`` instances contributing to this
+        behavior (i.e. parts visible after de-duplication across the include
+        chain).
+    raw_parts:
+        All ``TrackedPart`` instances before de-duplication, preserving the
+        order and multiplicity in which they appear in the include chain.
+    total_tokens:
+        Sum of ``tokens`` across ``parts`` (the de-duplicated set).
+    depth:
+        Nesting depth in the include chain (0 for root-level agents).
+    include_chain:
+        Ordered sequence of behavior URIs from the root to this behavior,
+        capturing how it was reached.
+    instruction:
+        Agent instruction string, or ``None`` if not specified.
+    """
+
+    name: str
+    uri: str
+    parts: tuple[TrackedPart, ...]
+    raw_parts: tuple[TrackedPart, ...]
+    total_tokens: int
+    depth: int
+    include_chain: tuple[str, ...]
+    instruction: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# ProvenanceMap and BundleDiff dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProvenanceMap:
+    """Full provenance record for a composed bundle.
+
+    This dataclass is intentionally *mutable* — mutation methods rebuild it
+    internally.  Do **not** freeze it.
+
+    Attributes
+    ----------
+    root_name:
+        Short name of the root bundle.
+    root_uri:
+        Fully-qualified URI of the root bundle.
+    root_instruction:
+        Root-level agent instruction string, or ``None`` if absent.
+    root_instruction_tokens:
+        Estimated token cost of ``root_instruction``.
+    behaviors:
+        Mapping from behavior URI to ``BehaviorInfo`` for each agent included
+        in the composition.
+    root_parts:
+        Parts present at the root bundle level (before any behavior includes).
+    all_parts:
+        Union of ``root_parts`` and all parts contributed by every behavior in
+        the composition (de-duplicated, ordered).
+    composed_bundle:
+        The final ``Bundle`` produced by the composition.
+    include_order:
+        Ordered tuple of behavior URIs reflecting the inclusion sequence.
+    session_config:
+        Session-level configuration dict.
+    spawn_config:
+        Spawn-level configuration dict, or ``None`` when not present.
+    _raw_bundles:
+        Internal mapping from bundle name to the raw ``Bundle`` object used
+        during composition.
+    """
+
+    root_name: str
+    root_uri: str
+    root_instruction: str | None
+    root_instruction_tokens: int
+    behaviors: dict[str, BehaviorInfo]
+    root_parts: tuple[TrackedPart, ...]
+    all_parts: tuple[TrackedPart, ...]
+    composed_bundle: Bundle
+    include_order: tuple[str, ...]
+    session_config: dict[str, Any]
+    spawn_config: dict[str, Any] | None
+    _raw_bundles: dict[str, Bundle]
+
+
+@dataclass(frozen=True)
+class BundleDiff:
+    """Immutable record of the delta between two bundle compositions.
+
+    Attributes
+    ----------
+    added_parts:
+        Parts present in the *after* bundle that are absent from *before*.
+    removed_parts:
+        Parts present in the *before* bundle that are absent from *after*.
+    added_behaviors:
+        Behavior URIs introduced in the *after* bundle.
+    removed_behaviors:
+        Behavior URIs removed in the *after* bundle.
+    token_delta:
+        Net change in token count (positive = more tokens, negative = fewer).
+    before_tokens:
+        Total token count of the *before* bundle composition.
+    after_tokens:
+        Total token count of the *after* bundle composition.
+    """
+
+    added_parts: tuple[TrackedPart, ...]
+    removed_parts: tuple[TrackedPart, ...]
+    added_behaviors: tuple[str, ...]
+    removed_behaviors: tuple[str, ...]
+    token_delta: int
+    before_tokens: int
+    after_tokens: int

--- a/experiments/bundle-configurator/amplifier_configurator/provenance.py
+++ b/experiments/bundle-configurator/amplifier_configurator/provenance.py
@@ -1,0 +1,618 @@
+"""Provenance-aware bundle loading for amplifier_configurator.
+
+The core function is ``build_provenance_map(source)`` which loads a bundle and
+all its includes, tracking which behavior contributed each part (tool, hook,
+agent, context, provider).  The result is a :class:`ProvenanceMap` that lets
+callers see exactly where every token comes from.
+
+Algorithm overview (see design doc §4 for full details):
+
+  Step 1 — Load root bundle with ``auto_include=False`` to get raw parts and
+            the include list without following them.
+  Step 2 — Recursively load each include with ``_load_behavior_tree()``,
+            bottom-up (leaves first, parent last).
+  Step 5 — Deduplicate parts with last-write-wins (parent overrides child).
+  Step 7 — Load the fully-composed bundle with ``auto_include=True`` and
+            resolve pending context paths.
+  Step 8 — Back-fill context parts that still have 0 tokens from the composed
+            bundle's resolved paths.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import Any
+
+from amplifier_foundation import load_bundle
+from amplifier_foundation.bundle import Bundle
+from amplifier_foundation.registry import BundleRegistry
+
+from .models import BehaviorInfo, LoadError, PartKind, ProvenanceMap, TrackedPart
+from .tokens import estimate_tokens_for_file, estimate_tokens_for_text
+
+# Maximum recursion depth for include trees (safety limit).
+MAX_INCLUDE_DEPTH: int = 10
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_include_uri(entry: Any) -> str | None:
+    """Extract a URI string from a bundle include entry.
+
+    Foundation's ``includes`` list accepts two formats:
+
+    * ``{"bundle": "<uri>"}`` — dict with a ``"bundle"`` key
+    * ``"<uri>"`` — plain string
+
+    Returns the URI string, or ``None`` for unknown formats.
+    """
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, dict) and "bundle" in entry:
+        return entry["bundle"]
+    return None
+
+
+def _extract_parts_from_bundle(
+    bundle: Bundle,
+    source_behavior: str | None,
+) -> list[TrackedPart]:
+    """Extract all parts from a raw (uncomposed) Bundle into TrackedPart objects.
+
+    Parameters
+    ----------
+    bundle:
+        The raw bundle to extract parts from.
+    source_behavior:
+        The name of the behavior that owns this bundle, or ``None`` for the
+        root bundle's own parts.
+
+    Returns
+    -------
+    list[TrackedPart]
+        Parts in declaration order: tools, hooks, providers, agents, context.
+    """
+    parts: list[TrackedPart] = []
+
+    # --- Tools (tokens = 0; descriptions are generated at runtime) -----------
+    for tool in bundle.tools:
+        name: str = tool.get("module") or tool.get("id", "?")
+        parts.append(
+            TrackedPart(
+                kind=PartKind.TOOL,
+                name=name,
+                source_behavior=source_behavior,
+                tokens=0,
+                config=tool,
+                namespace_path=None,
+            )
+        )
+
+    # --- Hooks (tokens = 0; injections are dynamic and per-turn) -------------
+    for hook in bundle.hooks:
+        name = hook.get("module") or hook.get("id", "?")
+        parts.append(
+            TrackedPart(
+                kind=PartKind.HOOK,
+                name=name,
+                source_behavior=source_behavior,
+                tokens=0,
+                config=hook,
+                namespace_path=None,
+            )
+        )
+
+    # --- Providers (tokens = 0; they contribute no context tokens) -----------
+    for provider in bundle.providers:
+        name = provider.get("module") or provider.get("id", "?")
+        parts.append(
+            TrackedPart(
+                kind=PartKind.PROVIDER,
+                name=name,
+                source_behavior=source_behavior,
+                tokens=0,
+                config=provider,
+                namespace_path=None,
+            )
+        )
+
+    # --- Agents (tokens = description + instruction) -------------------------
+    for agent_name, agent_config in bundle.agents.items():
+        description: str | None = agent_config.get("description")
+        instruction: str | None = agent_config.get("instruction")
+        tokens = estimate_tokens_for_text(description) + estimate_tokens_for_text(
+            instruction
+        )
+        parts.append(
+            TrackedPart(
+                kind=PartKind.AGENT,
+                name=agent_name,
+                source_behavior=source_behavior,
+                tokens=tokens,
+                config=agent_config,
+                namespace_path=None,
+            )
+        )
+
+    # --- Context (tokens from file content if path is resolvable) ------------
+    for ctx_name, ctx_path in bundle.context.items():
+        namespaced_name = f"{bundle.name}:{ctx_name}"
+        if isinstance(ctx_path, Path):
+            tokens = estimate_tokens_for_file(ctx_path)
+        else:
+            tokens = 0
+        config: dict[str, Any] = {"path": str(ctx_path)} if ctx_path else {}
+        parts.append(
+            TrackedPart(
+                kind=PartKind.CONTEXT,
+                name=namespaced_name,
+                source_behavior=source_behavior,
+                tokens=tokens,
+                config=config,
+                namespace_path=None,
+            )
+        )
+
+    # --- Pending context (namespace-URI refs not yet resolved to file paths) --
+    # Foundation stores namespace-referenced context entries in _pending_context
+    # as {"namespace:path": "namespace:path"} when a bundle is loaded with
+    # auto_include=False.  They only migrate to bundle.context after the fully-
+    # composed bundle calls resolve_pending_context() (Step 7 of the algorithm).
+    # We emit 0-token TrackedParts here so _backfill_context_tokens() can fill
+    # them in from the composed bundle once resolve_pending_context() has run.
+    # The part name is the full reference string (e.g. "amplifier:context/foo.md")
+    # because that is the key used in composed.context after resolution, which
+    # ensures the backfill lookup succeeds and deduplication across behaviors
+    # with the same context file works correctly.
+    for _ctx_key, ctx_ref in bundle._pending_context.items():
+        parts.append(
+            TrackedPart(
+                kind=PartKind.CONTEXT,
+                name=ctx_ref,
+                source_behavior=source_behavior,
+                tokens=0,
+                config={"ref": ctx_ref},
+                namespace_path=ctx_ref,
+            )
+        )
+
+    return parts
+
+
+async def _load_behavior_tree(
+    uri: str,
+    depth: int,
+    chain: tuple[str, ...],
+    registry: BundleRegistry,
+    seen: set[str],
+) -> tuple[list[BehaviorInfo], dict[str, Bundle]]:
+    """Recursively load a behavior and all its sub-includes.
+
+    Returns results in **bottom-up** order (deepest leaves first, this
+    behavior last) so that the caller can build ``include_order`` by simply
+    appending the returned list.
+
+    Parameters
+    ----------
+    uri:
+        The URI of the behavior to load.
+    depth:
+        Current nesting depth (0 for direct includes of root).
+    chain:
+        Tuple of ancestor bundle names leading to this behavior.
+    registry:
+        Shared BundleRegistry for caching across all loads.
+    seen:
+        URIs already in the current call chain (for circular-include detection).
+
+    Returns
+    -------
+    tuple[list[BehaviorInfo], dict[str, Bundle]]
+        Ordered list of BehaviorInfo (bottom-up) plus a mapping of
+        behavior-name → raw Bundle (for ``ProvenanceMap._raw_bundles``).
+
+    Raises
+    ------
+    LoadError
+        If the depth limit is exceeded, a circular include is detected, or
+        Foundation raises an exception while loading the bundle.
+    """
+    if depth > MAX_INCLUDE_DEPTH:
+        raise LoadError(
+            source=uri,
+            cause=ValueError(
+                f"Include tree exceeds maximum depth ({MAX_INCLUDE_DEPTH}) at {uri!r}. "
+                "Possible circular reference."
+            ),
+        )
+
+    if uri in seen:
+        raise LoadError(
+            source=uri,
+            cause=ValueError(f"Circular include detected: {(*chain, uri)!r}"),
+        )
+
+    # Load the behavior bundle without following its own includes.
+    # Resolve namespace URIs (e.g. "lean:behaviors/lean-foundation") to real file
+    # or git URIs before calling Foundation's load_bundle, which uses a plain
+    # SimpleSourceResolver that cannot handle namespace:path syntax.  The
+    # registry already knows about the root bundle at this point (it was
+    # registered in build_provenance_map's Step 1), so _resolve_include_source
+    # can look up the namespace and return a file:// URI.
+    try:
+        effective_uri = registry._resolve_include_source(uri) or uri
+        behavior_raw = await load_bundle(
+            effective_uri, auto_include=False, registry=registry
+        )
+    except Exception as exc:
+        raise LoadError(source=uri, cause=exc) from exc
+
+    raw_parts = tuple(
+        _extract_parts_from_bundle(behavior_raw, source_behavior=behavior_raw.name)
+    )
+
+    # Recurse into sub-includes before adding this behavior (bottom-up order).
+    new_seen = seen | {uri}
+    sub_behavior_infos: list[BehaviorInfo] = []
+    sub_raw_bundles: dict[str, Bundle] = {}
+
+    for include_entry in behavior_raw.includes:
+        sub_uri = _extract_include_uri(include_entry)
+        if sub_uri is None:
+            continue
+        sub_list, sub_bundles = await _load_behavior_tree(
+            sub_uri,
+            depth + 1,
+            chain + (behavior_raw.name,),
+            registry,
+            new_seen,
+        )
+        sub_behavior_infos.extend(sub_list)
+        sub_raw_bundles.update(sub_bundles)
+
+    # Use effective_uri (the fully-resolved git/file URI) rather than the
+    # original namespace URI.  Storing the resolved URI ensures that when
+    # serialize_bundle() writes the includes list it emits standalone git URIs
+    # (e.g. "git+https://…#subdirectory=behaviors/foo.yaml") rather than
+    # namespace-relative URIs (e.g. "foundation:behaviors/foo").
+    #
+    # Namespace URIs are only resolvable within Foundation's bundle registry; a
+    # saved .md file that contains them breaks round-trip loading because
+    # Foundation re-registers the bundle's name as a namespace pointing to the
+    # saved file's location, then fails to find the sub-behaviors there.
+    behavior_info = BehaviorInfo(
+        name=behavior_raw.name,
+        uri=effective_uri,
+        parts=raw_parts,
+        raw_parts=raw_parts,
+        total_tokens=sum(p.tokens for p in raw_parts),
+        depth=depth,
+        include_chain=chain + (behavior_raw.name,),
+        instruction=behavior_raw.instruction,
+    )
+
+    raw_bundles: dict[str, Bundle] = {behavior_raw.name: behavior_raw}
+    raw_bundles.update(sub_raw_bundles)
+
+    # Return: sub-behaviors first (bottom-up), then this behavior.
+    return sub_behavior_infos + [behavior_info], raw_bundles
+
+
+def _deduplicate_parts(
+    behaviors: dict[str, BehaviorInfo],
+    root_parts: tuple[TrackedPart, ...],
+    include_order: tuple[str, ...],
+) -> tuple[tuple[TrackedPart, ...], dict[str, BehaviorInfo]]:
+    """Apply last-write-wins deduplication across all behaviors.
+
+    Walk ``include_order`` (bottom-up, so parent behaviors come later and
+    therefore *win* over children with the same part).  Root parts win over
+    everything — with one exception: context files.
+
+    Foundation aggregates every sub-behavior's ``_pending_context`` into the
+    root bundle's ``_pending_context``.  If the root's context parts
+    unconditionally override sub-behavior context, every context file ends up
+    attributed to ``<root>`` (``source_behavior=None``) and removing any
+    behavior produces zero token savings.
+
+    Correct attribution rule: root context wins *only* for files that no
+    sub-behavior claimed.  Sub-behavior attribution wins for all files that
+    appear in at least one behavior's ``raw_parts``.
+
+    Returns
+    -------
+    tuple[tuple[TrackedPart, ...], dict[str, BehaviorInfo]]
+        ``(all_parts, updated_behaviors)`` where each behavior's ``parts``
+        field contains only the parts it *won* after deduplication.
+    """
+    # last-write-wins accumulator: (kind, name) → winning TrackedPart
+    winner: dict[tuple[PartKind, str], TrackedPart] = {}
+
+    # Walk behaviors in include_order (leaf first → parent last).
+    for uri in include_order:
+        behavior = behaviors.get(uri)
+        if behavior is None:
+            continue
+        for part in behavior.raw_parts:
+            winner[(part.kind, part.name)] = part
+
+    # Root parts override everything (parent composes last in Foundation).
+    # Exception: CONTEXT parts — root's _pending_context is an *aggregate* of
+    # all sub-behavior context, so sub-behavior attribution should win.  Root
+    # context only fills slots that no sub-behavior claimed (e.g. context
+    # declared directly on the root bundle, not via an include).
+    for part in root_parts:
+        if part.kind == PartKind.CONTEXT:
+            winner.setdefault((part.kind, part.name), part)
+        else:
+            winner[(part.kind, part.name)] = part
+
+    # Rebuild each BehaviorInfo with only its winning parts.
+    updated_behaviors: dict[str, BehaviorInfo] = {}
+    for uri, behavior in behaviors.items():
+        winning_parts = tuple(
+            part
+            for part in behavior.raw_parts
+            if winner.get((part.kind, part.name)) is part
+        )
+        updated_behaviors[uri] = dataclasses.replace(
+            behavior,
+            parts=winning_parts,
+            total_tokens=sum(p.tokens for p in winning_parts),
+        )
+
+    all_parts = tuple(winner.values())
+    return all_parts, updated_behaviors
+
+
+def _backfill_context_tokens(
+    behaviors: dict[str, BehaviorInfo],
+    root_parts: tuple[TrackedPart, ...],
+    include_order: tuple[str, ...],
+    composed: Bundle,
+) -> tuple[dict[str, BehaviorInfo], tuple[TrackedPart, ...], tuple[TrackedPart, ...]]:
+    """Back-fill 0-token context parts using the fully-composed bundle's paths.
+
+    After loading individual behaviors with ``auto_include=False``, context
+    paths may still be unresolved (pending).  The fully-composed bundle has
+    resolved all paths via ``resolve_pending_context()``.  This function
+    patches any context part whose ``tokens == 0`` with the real file token
+    count derived from the composed bundle.
+
+    Context files extracted from the root bundle's ``_pending_context`` land in
+    ``root_parts`` (not in any behavior's parts), because Foundation's
+    last-write-wins deduplication in ``_deduplicate_parts`` lets root_parts
+    override every behavior.  ``root_parts`` must therefore be patched here
+    alongside ``behaviors``; otherwise context token counts remain zero.
+
+    Returns
+    -------
+    tuple[dict[str, BehaviorInfo], tuple[TrackedPart, ...], tuple[TrackedPart, ...]]
+        ``(updated_behaviors, updated_root_parts, all_parts)`` with refreshed
+        token counts in both the behavior map and the root parts tuple.
+    """
+    # Build a {context_name: tokens} lookup from the composed bundle.
+    resolved_tokens: dict[str, int] = {}
+    for ctx_name, ctx_path in composed.context.items():
+        if isinstance(ctx_path, Path) and ctx_path.exists():
+            resolved_tokens[ctx_name] = estimate_tokens_for_file(ctx_path)
+
+    if not resolved_tokens:
+        # Nothing to back-fill — skip the rebuild.
+        all_parts = _recompute_all_parts(behaviors, root_parts, include_order)
+        return behaviors, root_parts, all_parts
+
+    # Patch root_parts that have 0-token context entries.
+    #
+    # When the root bundle is loaded with auto_include=False, Foundation still
+    # propagates the full _pending_context from all sub-behaviors up to the
+    # root level.  _extract_parts_from_bundle() then places every context
+    # reference into root_parts (source_behavior=None).  After
+    # _deduplicate_parts() the root wins every (CONTEXT, name) slot, so
+    # behaviors end up with zero context parts.  Without patching root_parts,
+    # all context files would remain at 0 tokens even though the composed
+    # bundle has resolved their paths.
+    new_root = list(root_parts)
+    for i, part in enumerate(new_root):
+        if part.kind == PartKind.CONTEXT and part.tokens == 0:
+            tokens = resolved_tokens.get(part.name, 0)
+            if tokens > 0:
+                new_root[i] = dataclasses.replace(part, tokens=tokens)
+    updated_root_parts = tuple(new_root)
+
+    # Patch behaviors that have 0-token context parts (handles bundles where
+    # context is NOT fully propagated to the root, e.g. deeply nested includes).
+    updated: dict[str, BehaviorInfo] = {}
+    for uri, behavior in behaviors.items():
+        new_parts = list(behavior.parts)
+        new_raw = list(behavior.raw_parts)
+        changed = False
+
+        for i, part in enumerate(new_parts):
+            if part.kind == PartKind.CONTEXT and part.tokens == 0:
+                tokens = resolved_tokens.get(part.name, 0)
+                if tokens > 0:
+                    new_parts[i] = dataclasses.replace(part, tokens=tokens)
+                    changed = True
+
+        for i, part in enumerate(new_raw):
+            if part.kind == PartKind.CONTEXT and part.tokens == 0:
+                tokens = resolved_tokens.get(part.name, 0)
+                if tokens > 0:
+                    new_raw[i] = dataclasses.replace(part, tokens=tokens)
+
+        if changed:
+            updated[uri] = dataclasses.replace(
+                behavior,
+                parts=tuple(new_parts),
+                raw_parts=tuple(new_raw),
+                total_tokens=sum(p.tokens for p in new_parts),
+            )
+        else:
+            updated[uri] = behavior
+
+    all_parts = _recompute_all_parts(updated, updated_root_parts, include_order)
+    return updated, updated_root_parts, all_parts
+
+
+def _recompute_all_parts(
+    behaviors: dict[str, BehaviorInfo],
+    root_parts: tuple[TrackedPart, ...],
+    include_order: tuple[str, ...],
+) -> tuple[TrackedPart, ...]:
+    """Recompute ``all_parts`` after patching behavior parts.
+
+    Applies the same last-write-wins rule as ``_deduplicate_parts``, including
+    the CONTEXT exception: root context only fills unclaimed slots.
+    """
+    winner: dict[tuple[PartKind, str], TrackedPart] = {}
+    for uri in include_order:
+        behavior = behaviors.get(uri)
+        if behavior is None:
+            continue
+        for part in behavior.raw_parts:
+            winner[(part.kind, part.name)] = part
+    for part in root_parts:
+        if part.kind == PartKind.CONTEXT:
+            winner.setdefault((part.kind, part.name), part)
+        else:
+            winner[(part.kind, part.name)] = part
+    return tuple(winner.values())
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def build_provenance_map(source: str) -> ProvenanceMap:
+    """Build a full provenance map for a bundle and all its includes.
+
+    This is the primary entry point for this module.  It:
+
+    1. Loads the root bundle without following includes (Step 1).
+    2. Recursively loads all includes, bottom-up (Steps 2–3).
+    3. Deduplicates parts across behaviors (Step 5).
+    4. Loads the fully-composed bundle (Step 7).
+    5. Back-fills 0-token context parts (Step 8).
+
+    Parameters
+    ----------
+    source:
+        Any Foundation-supported source: bundle name, git URI, or file path.
+
+    Returns
+    -------
+    ProvenanceMap
+        Complete provenance record with per-behavior token attribution.
+
+    Raises
+    ------
+    LoadError
+        Wraps any Foundation exception that occurs during loading.
+    """
+    registry = BundleRegistry()
+
+    # -------------------------------------------------------------------------
+    # Step 1: Load the root bundle WITHOUT following includes.
+    # -------------------------------------------------------------------------
+    try:
+        root_raw = await load_bundle(source, auto_include=False, registry=registry)
+    except Exception as exc:
+        raise LoadError(source=source, cause=exc) from exc
+
+    root_name = root_raw.name
+    root_instruction = root_raw.instruction
+    root_instruction_tokens = estimate_tokens_for_text(root_instruction)
+    session_config: dict[str, Any] = dict(root_raw.session) if root_raw.session else {}
+    spawn_config: dict[str, Any] | None = (
+        dict(root_raw.spawn) if root_raw.spawn else None
+    )
+
+    # Collect root-level parts — source_behavior=None.
+    root_parts = tuple(_extract_parts_from_bundle(root_raw, source_behavior=None))
+
+    # -------------------------------------------------------------------------
+    # Steps 2–3: Recursively load all includes (depth-first, bottom-up).
+    # -------------------------------------------------------------------------
+    all_behavior_infos: list[BehaviorInfo] = []
+    accumulated_raw_bundles: dict[str, Bundle] = {root_name: root_raw}
+
+    for include_entry in root_raw.includes:
+        uri = _extract_include_uri(include_entry)
+        if uri is None:
+            continue
+        sub_list, sub_raw = await _load_behavior_tree(
+            uri=uri,
+            depth=0,
+            chain=(root_name,),
+            registry=registry,
+            seen=set(),
+        )
+        all_behavior_infos.extend(sub_list)
+        accumulated_raw_bundles.update(sub_raw)
+
+    # Build behaviors dict (keyed by URI) and include_order (insertion order).
+    behaviors: dict[str, BehaviorInfo] = {}
+    include_order_list: list[str] = []
+    for beh_info in all_behavior_infos:
+        if beh_info.uri not in behaviors:
+            behaviors[beh_info.uri] = beh_info
+            include_order_list.append(beh_info.uri)
+
+    include_order = tuple(include_order_list)
+
+    # -------------------------------------------------------------------------
+    # Step 5: Deduplicate parts (last-write-wins; root overrides all).
+    # -------------------------------------------------------------------------
+    all_parts, behaviors = _deduplicate_parts(behaviors, root_parts, include_order)
+
+    # -------------------------------------------------------------------------
+    # Step 7: Load the fully-composed bundle.
+    #
+    # IMPORTANT: use a fresh registry (no registry= parameter) rather than the
+    # shared one from Steps 1-2.  The shared registry caches per-behavior bundles
+    # from their auto_include=False loads; passing it here causes Foundation to
+    # return those cached raw bundles instead of performing a full composition.
+    # A fresh load lets Foundation accumulate source_base_paths and _pending_context
+    # from all included bundles, which _backfill_context_tokens() needs.
+    # -------------------------------------------------------------------------
+    try:
+        composed = await load_bundle(source, auto_include=True)
+        composed.resolve_pending_context()
+    except Exception as exc:
+        raise LoadError(source=source, cause=exc) from exc
+
+    # -------------------------------------------------------------------------
+    # Step 8: Back-fill context parts that still have 0 tokens.
+    #
+    # _backfill_context_tokens returns 3 values: (updated_behaviors,
+    # updated_root_parts, all_parts).  root_parts must be updated because
+    # Foundation propagates every _pending_context entry from sub-behaviors up
+    # to the root bundle when loaded with auto_include=False, so the context
+    # TrackedParts land in root_parts rather than in any behavior's parts.
+    # The old 2-value signature silently left root_parts unpatched; now we
+    # assign the updated root_parts so total_tokens() reflects context files.
+    # -------------------------------------------------------------------------
+    behaviors, root_parts, all_parts = _backfill_context_tokens(
+        behaviors, root_parts, include_order, composed
+    )
+
+    return ProvenanceMap(
+        root_name=root_name,
+        root_uri=source,
+        root_instruction=root_instruction,
+        root_instruction_tokens=root_instruction_tokens,
+        behaviors=behaviors,
+        root_parts=root_parts,
+        all_parts=all_parts,
+        composed_bundle=composed,
+        include_order=include_order,
+        session_config=session_config,
+        spawn_config=spawn_config,
+        _raw_bundles=accumulated_raw_bundles,
+    )

--- a/experiments/bundle-configurator/amplifier_configurator/serialize.py
+++ b/experiments/bundle-configurator/amplifier_configurator/serialize.py
@@ -1,0 +1,127 @@
+"""Bundle serialization — save to .md format with YAML frontmatter.
+
+Uses the include-reference pattern: behaviors are referenced by URI,
+not dumped flat. Context paths use namespace syntax, not absolute paths.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from .models import PartKind, ProvenanceMap
+
+
+def serialize_bundle(
+    pmap: ProvenanceMap,
+    *,
+    warnings: list[str] | None = None,
+) -> str:
+    """Serialize a ProvenanceMap to .md bundle format.
+
+    Returns a string with YAML frontmatter + markdown instruction body.
+
+    Parameters
+    ----------
+    pmap:
+        The ProvenanceMap containing all bundle composition data.
+    warnings:
+        Optional list of warning strings to include as YAML comments
+        prefixed with '# WARNING:'.
+
+    Returns
+    -------
+    str
+        Output format: '---\\n{warning_lines}{yaml}---\\n{body}'
+        The YAML frontmatter contains bundle metadata, includes, session,
+        spawn, tools, hooks, providers, agents, and context (namespace syntax).
+        The markdown body contains the root instruction (if any).
+    """
+    data: dict = {}
+
+    # Bundle metadata
+    data["bundle"] = {"name": pmap.root_name, "version": "1.0.0"}
+
+    # Includes — reference behaviors by URI (depth-0 only; sub-behaviors
+    # are pulled in transitively when Foundation loads the bundle).
+    includes: list[dict[str, str]] = []
+    for beh_key in pmap.include_order:
+        if beh_key in pmap.behaviors:
+            beh = pmap.behaviors[beh_key]
+            # Only include top-level behaviors (depth 0).
+            # Sub-behaviors (depth >= 1) are pulled in transitively.
+            if beh.depth == 0:
+                includes.append({"bundle": beh.uri})
+    if includes:
+        data["includes"] = includes
+
+    # Session config (infrastructure — always in root)
+    if pmap.session_config:
+        data["session"] = pmap.session_config
+
+    # Spawn config (omit if None)
+    if pmap.spawn_config:
+        data["spawn"] = pmap.spawn_config
+
+    # Root-level tools
+    root_tools = [
+        dict(p.config)
+        for p in pmap.root_parts
+        if p.kind == PartKind.TOOL and p.config.get("module")
+    ]
+    if root_tools:
+        data["tools"] = root_tools
+
+    # Root-level hooks
+    root_hooks = [
+        dict(p.config)
+        for p in pmap.root_parts
+        if p.kind == PartKind.HOOK and p.config.get("module")
+    ]
+    if root_hooks:
+        data["hooks"] = root_hooks
+
+    # Root-level providers
+    root_providers = [
+        dict(p.config)
+        for p in pmap.root_parts
+        if p.kind == PartKind.PROVIDER and p.config.get("module")
+    ]
+    if root_providers:
+        data["providers"] = root_providers
+
+    # Root-level agents
+    root_agents = {
+        p.name: dict(p.config) for p in pmap.root_parts if p.kind == PartKind.AGENT
+    }
+    if root_agents:
+        data["agents"] = root_agents
+
+    # Context — use namespace syntax (never absolute paths).
+    # Uses namespace_path when available, falls back to the part name.
+    # Absolute paths are never written to the output.
+    context_refs: list[str] = []
+    for part in pmap.all_parts:
+        if part.kind == PartKind.CONTEXT:
+            if part.namespace_path:
+                context_refs.append(part.namespace_path)
+            elif part.name:
+                context_refs.append(part.name)
+    if context_refs:
+        data["context"] = {"include": context_refs}
+
+    # Build YAML frontmatter
+    yaml_str = yaml.dump(
+        data, default_flow_style=False, sort_keys=False, allow_unicode=True
+    )
+
+    # Build warning comments (prefixed with '# WARNING:')
+    warning_lines = ""
+    if warnings:
+        warning_lines = "\n".join(f"# WARNING: {w}" for w in warnings) + "\n"
+
+    # Build markdown body — instruction goes AFTER the closing '---'
+    body = ""
+    if pmap.root_instruction:
+        body = f"\n{pmap.root_instruction}\n"
+
+    return f"---\n{warning_lines}{yaml_str}---\n{body}"

--- a/experiments/bundle-configurator/amplifier_configurator/tokens.py
+++ b/experiments/bundle-configurator/amplifier_configurator/tokens.py
@@ -1,0 +1,39 @@
+"""Token estimation utilities.
+
+Uses Foundation's formula: len(content) // 4.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def estimate_tokens_for_text(text: str | None) -> int:
+    """Estimate token count for a text string.
+
+    Args:
+        text: The text to estimate. None or empty returns 0.
+
+    Returns:
+        Estimated token count using len(text) // 4.
+    """
+    if not text:
+        return 0
+    return len(text) // 4
+
+
+def estimate_tokens_for_file(path: Path) -> int:
+    """Estimate token count for a file on disk.
+
+    Args:
+        path: Path to the file to read.
+
+    Returns:
+        Estimated token count using len(content) // 4, or 0 if the file
+        cannot be read (OSError) or decoded (UnicodeDecodeError).
+    """
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return 0
+    return len(content) // 4

--- a/experiments/bundle-configurator/pyproject.toml
+++ b/experiments/bundle-configurator/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "amplifier-configurator"
+version = "0.3.0"
+description = "Offline bundle editor with provenance tracking for Amplifier"
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "MIT" }
+authors = [{ name = "Microsoft", email = "amplifier@microsoft.com" }]
+dependencies = [
+    "amplifier-foundation>=1.0.0",
+    "pyyaml>=6.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["amplifier_configurator"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v"
+asyncio_mode = "auto"
+markers = [
+    "integration: marks tests as real-Foundation integration tests (run with: pytest -m integration)",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.23",
+    "pytest-mock>=3.15.1",
+]

--- a/experiments/bundle-configurator/tests/conftest.py
+++ b/experiments/bundle-configurator/tests/conftest.py
@@ -1,0 +1,285 @@
+"""Shared fixtures for all tests.
+
+All fixtures use Foundation's Bundle directly — no YAML parsing, no file loading.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+from amplifier_foundation.bundle import Bundle
+
+from amplifier_configurator.models import (
+    BehaviorInfo,
+    PartKind,
+    ProvenanceMap,
+    TrackedPart,
+)
+
+
+# ---------------------------------------------------------------------------
+# Integration test gating
+# ---------------------------------------------------------------------------
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Skip integration-marked tests unless ``-m integration`` is specified."""
+    markexpr: str = config.option.markexpr or ""
+    if "integration" not in markexpr:
+        skip_marker = pytest.mark.skip(
+            reason="integration test — run with: pytest -m integration"
+        )
+        for item in items:
+            if "integration" in item.keywords:
+                item.add_marker(skip_marker)
+
+
+# ---------------------------------------------------------------------------
+# Helper function (not a fixture)
+# ---------------------------------------------------------------------------
+
+
+def _make_tracked_part(
+    name: str,
+    kind: PartKind = PartKind.TOOL,
+    source_behavior: str | None = None,
+    tokens: int = 0,
+    config: dict | None = None,
+    namespace_path: str | None = None,
+) -> TrackedPart:
+    """Create a TrackedPart with sensible defaults for testing."""
+    return TrackedPart(
+        kind=kind,
+        name=name,
+        source_behavior=source_behavior,
+        tokens=tokens,
+        config=config or {},
+        namespace_path=namespace_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bundle fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def simple_bundle() -> Bundle:
+    """A minimal bundle with tools, a hook, an agent, and context."""
+    return Bundle(
+        name="test-bundle",
+        version="1.0.0",
+        description="Test bundle",
+        tools=[
+            {"module": "tool-bash", "source": "git+https://example.com/tool-bash"},
+            {"module": "tool-filesystem", "source": "git+https://example.com/tool-fs"},
+            {"module": "tool-search", "source": "git+https://example.com/tool-search"},
+            {
+                "module": "tool-delegate",
+                "source": "git+https://example.com/tool-delegate",
+            },
+        ],
+        hooks=[
+            {"module": "hooks-todo-reminder", "source": "git+https://example.com/hook"},
+        ],
+        providers=[
+            {"module": "provider-openai", "source": "git+https://example.com/provider"},
+        ],
+        agents={
+            "bug-hunter": {
+                "description": "Finds bugs",
+                "instruction": "Hunt down bugs relentlessly.",
+            }
+        },
+        context={},
+    )
+
+
+@pytest.fixture()
+def bundle_with_context(tmp_path: Path) -> Bundle:
+    """A bundle that has real context files on disk."""
+    ctx_file = tmp_path / "instructions.md"
+    ctx_file.write_text("# Instructions\n" + "A" * 400)  # ~100 tokens
+    return Bundle(
+        name="ctx-bundle",
+        tools=[
+            {"module": "tool-bash", "source": "git+https://example.com/tool-bash"},
+            {"module": "tool-filesystem", "source": "git+https://example.com/tool-fs"},
+            {"module": "tool-search", "source": "git+https://example.com/tool-search"},
+        ],
+        context={"instructions": ctx_file},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provenance / behavior-tree fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_behavior_tree(tmp_path: Path) -> dict[str, Bundle]:
+    """Three-level include tree for provenance testing.
+
+    Structure: root → mid (depth 0) → leaf (depth 1)
+
+    - root: 4 tools (bash, filesystem, search, delegate), instruction set
+    - mid:  1 tool (python_check), includes leaf
+    - leaf: 1 tool (tool-lsp), 1 context (lsp-config, 103 tokens)
+    """
+    # Create a real context file so token estimation works (103 tokens = 412 chars)
+    lsp_file = tmp_path / "lsp.md"
+    lsp_file.write_text("A" * 412)
+
+    leaf = Bundle(
+        name="leaf-behavior",
+        tools=[
+            {"module": "tool-lsp", "source": "git+https://example.com/tool-lsp@main"}
+        ],
+        context={"lsp-config": lsp_file},
+    )
+
+    mid = Bundle(
+        name="mid-behavior",
+        tools=[
+            {
+                "module": "python_check",
+                "source": "git+https://example.com/python-check@main",
+            }
+        ],
+        includes=[{"bundle": "leaf-behavior-uri"}],  # type: ignore[arg-type]
+    )
+
+    root = Bundle(
+        name="root-bundle",
+        tools=[
+            {"module": "tool-bash", "source": "git+https://example.com/tool-bash@main"},
+            {
+                "module": "tool-filesystem",
+                "source": "git+https://example.com/tool-fs@main",
+            },
+            {
+                "module": "tool-search",
+                "source": "git+https://example.com/tool-search@main",
+            },
+            {
+                "module": "tool-delegate",
+                "source": "git+https://example.com/tool-delegate@main",
+            },
+        ],
+        includes=[{"bundle": "mid-behavior-uri"}],  # type: ignore[arg-type]
+        instruction="You are a helpful assistant.",
+    )
+
+    return {"root": root, "mid": mid, "leaf": leaf}
+
+
+@pytest.fixture()
+def simple_provenance_map(mock_behavior_tree: dict[str, Bundle]) -> ProvenanceMap:
+    """Pre-built ProvenanceMap for configurator tests.
+
+    Mirrors the mock_behavior_tree structure:
+    - root: tool-bash, tool-filesystem, tool-search, tool-delegate (source_behavior=None)
+    - mid:  python_check (source_behavior="mid-behavior")
+    - leaf: tool-lsp, context:lsp-config at 103 tokens (source_behavior="leaf-behavior")
+    - root instruction: 'You are a helpful assistant.' → 7 tokens
+    """
+    # Root parts — source_behavior=None
+    root_parts = (
+        _make_tracked_part("tool-bash", PartKind.TOOL, source_behavior=None),
+        _make_tracked_part("tool-filesystem", PartKind.TOOL, source_behavior=None),
+        _make_tracked_part("tool-search", PartKind.TOOL, source_behavior=None),
+        _make_tracked_part("tool-delegate", PartKind.TOOL, source_behavior=None),
+    )
+
+    # Leaf parts
+    leaf_lsp_tool = _make_tracked_part(
+        "tool-lsp", PartKind.TOOL, source_behavior="leaf-behavior"
+    )
+    leaf_lsp_ctx = _make_tracked_part(
+        "leaf-behavior:lsp-config",
+        PartKind.CONTEXT,
+        source_behavior="leaf-behavior",
+        tokens=103,
+    )
+    leaf_parts = (leaf_lsp_tool, leaf_lsp_ctx)
+
+    # Mid parts
+    mid_python_check = _make_tracked_part(
+        "python_check", PartKind.TOOL, source_behavior="mid-behavior"
+    )
+    mid_parts = (mid_python_check,)
+
+    # BehaviorInfo for leaf (depth=1, include_chain includes mid)
+    leaf_info = BehaviorInfo(
+        name="leaf-behavior",
+        uri="leaf-behavior-uri",
+        parts=leaf_parts,
+        raw_parts=leaf_parts,
+        total_tokens=103,  # context dominates; tool contributes 0
+        depth=1,
+        include_chain=("root-bundle", "mid-behavior", "leaf-behavior"),
+    )
+
+    # BehaviorInfo for mid (depth=0, direct include of root)
+    mid_info = BehaviorInfo(
+        name="mid-behavior",
+        uri="mid-behavior-uri",
+        parts=mid_parts,
+        raw_parts=mid_parts,
+        total_tokens=0,  # tool-only, 0 tokens
+        depth=0,
+        include_chain=("root-bundle", "mid-behavior"),
+    )
+
+    behaviors: dict[str, BehaviorInfo] = {
+        "leaf-behavior-uri": leaf_info,
+        "mid-behavior-uri": mid_info,
+    }
+    include_order = ("leaf-behavior-uri", "mid-behavior-uri")
+
+    # all_parts = root + leaf + mid (no deduplication needed — all unique names)
+    all_parts = root_parts + leaf_parts + mid_parts
+
+    # root instruction "You are a helpful assistant." → len=28 // 4 = 7 tokens
+    root_instruction = "You are a helpful assistant."
+    root_instruction_tokens = len(root_instruction) // 4  # = 7
+
+    return ProvenanceMap(
+        root_name="root-bundle",
+        root_uri="root-uri",
+        root_instruction=root_instruction,
+        root_instruction_tokens=root_instruction_tokens,
+        behaviors=behaviors,
+        root_parts=root_parts,
+        all_parts=all_parts,
+        composed_bundle=mock_behavior_tree["root"],
+        include_order=include_order,
+        session_config={},
+        spawn_config=None,
+        _raw_bundles={
+            "root-bundle": mock_behavior_tree["root"],
+            "mid-behavior": mock_behavior_tree["mid"],
+            "leaf-behavior": mock_behavior_tree["leaf"],
+        },
+    )
+
+
+@pytest.fixture(scope="session")
+def lean_bundle_path() -> Path:
+    """Path to the lean bundle. Skips the test if not found."""
+    possible_paths = [
+        Path(__file__).parent.parent.parent
+        / "stripped-bundles"
+        / "lean-bundle"
+        / "bundle.md",
+        Path.home() / ".amplifier" / "bundles" / "lean-bundle" / "bundle.md",
+    ]
+    for p in possible_paths:
+        if p.exists():
+            return p
+    pytest.skip("Lean bundle not found; skipping integration test")

--- a/experiments/bundle-configurator/tests/e2e_shadow_test.py
+++ b/experiments/bundle-configurator/tests/e2e_shadow_test.py
@@ -1,0 +1,432 @@
+"""End-to-end shadow environment test: load real bundle, edit, save, verify with Foundation.
+
+This script is designed to be run directly with the Amplifier Python interpreter
+(which has both amplifier_configurator and amplifier_foundation installed).
+
+Usage:
+    ~/.local/share/uv/tools/amplifier/bin/python tests/e2e_shadow_test.py
+
+Exit codes:
+    0 — all checks passed
+    1 — one or more checks failed
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+from pathlib import Path
+
+
+def section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}")
+
+
+def ok(msg: str) -> None:
+    print(f"  ✓  {msg}")
+
+
+def fail(msg: str) -> None:
+    print(f"  ✗  {msg}", file=sys.stderr)
+
+
+def info(msg: str) -> None:
+    print(f"     {msg}")
+
+
+# ---------------------------------------------------------------------------
+# Results accumulator
+# ---------------------------------------------------------------------------
+
+_failures: list[str] = []
+
+
+def check(label: str, condition: bool, detail: str = "") -> bool:
+    if condition:
+        ok(label)
+        return True
+    else:
+        msg = label + (f": {detail}" if detail else "")
+        fail(msg)
+        _failures.append(msg)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Main test body
+# ---------------------------------------------------------------------------
+
+
+async def run_e2e() -> int:
+    from amplifier_configurator import BundleConfigurator, PartKind
+    from amplifier_foundation import load_bundle
+
+    # -----------------------------------------------------------------------
+    # Step 1: Load foundation bundle
+    # -----------------------------------------------------------------------
+    section("Step 1: Load 'foundation' bundle with full provenance")
+
+    c = await BundleConfigurator.load("foundation")
+
+    check("Bundle loaded without exception", c is not None)
+    check(
+        "root_name is 'foundation'",
+        c.provenance.root_name == "foundation",
+        f"got {c.provenance.root_name!r}",
+    )
+
+    behaviors = c.list_behaviors()
+    check("Has behaviors (>0)", len(behaviors) > 0, f"got {len(behaviors)}")
+    info(f"Behavior count: {len(behaviors)}")
+
+    total_tok = c.total_tokens()
+    check(
+        "total_tokens() > 5,000 (context files are being counted)",
+        total_tok > 5_000,
+        f"got {total_tok} — if this fails, _pending_context backfill is broken",
+    )
+    info(f"Total tokens: {total_tok:,}")
+
+    all_parts = c.list_parts()
+    check("Has parts (>0)", len(all_parts) > 0, f"got {len(all_parts)}")
+    info(f"Total parts: {len(all_parts)}")
+
+    ctx_parts = c.list_parts(kind=PartKind.CONTEXT)
+    check(
+        "Has CONTEXT parts (>0)",
+        len(ctx_parts) > 0,
+        "0 context parts — _pending_context extraction may be broken",
+    )
+    info(f"Context parts: {len(ctx_parts)}")
+
+    zero_tok_ctx = [p.name for p in ctx_parts if p.tokens == 0]
+    check(
+        "All CONTEXT parts have non-zero token counts",
+        len(zero_tok_ctx) == 0,
+        f"zero-token context parts: {zero_tok_ctx}",
+    )
+
+    tool_names = {p.name for p in c.list_parts(kind=PartKind.TOOL)}
+    check(
+        "'tool-bash' present",
+        "tool-bash" in tool_names,
+        f"tools found: {sorted(tool_names)}",
+    )
+    check("'tool-filesystem' present", "tool-filesystem" in tool_names)
+
+    behavior_names = {b.name for b in behaviors}
+    # Check structural presence: ≥5 named behaviors (not hardcoded names, since
+    # the live foundation bundle changes as upstream repositories update).
+    check(
+        "at least 5 named behaviors loaded",
+        sum(1 for n in behavior_names if n) >= 5,
+        f"named behaviors: {sorted(n for n in behavior_names if n)}",
+    )
+
+    # -----------------------------------------------------------------------
+    # Step 2: Token breakdown
+    # -----------------------------------------------------------------------
+    section("Step 2: Token breakdown by behavior")
+
+    by_beh = c.tokens_by_behavior()
+    check("tokens_by_behavior() returns non-empty dict", len(by_beh) > 0)
+    check("'<root>' key present in breakdown", "<root>" in by_beh)
+
+    total_from_breakdown = sum(by_beh.values())
+    check(
+        "tokens_by_behavior() sum roughly matches total_tokens()",
+        abs(total_from_breakdown - total_tok) <= 50,
+        f"breakdown sum={total_from_breakdown:,}  total_tokens={total_tok:,}",
+    )
+
+    info("Top 8 behaviors by token cost:")
+    for name, tokens in list(by_beh.items())[:8]:
+        info(f"  {name}: {tokens:,}")
+
+    # -----------------------------------------------------------------------
+    # Step 3: Remove behaviors
+    # -----------------------------------------------------------------------
+    section("Step 3: Remove behaviors (immutable mutation)")
+
+    original_tokens = c.total_tokens()
+    original_behavior_count = len(c.list_behaviors())
+
+    removable_candidates = [
+        b.name
+        for b in behaviors
+        if not any(x in b.name for x in ["foundation", "core", "base"])
+    ]
+    info(
+        f"Removable candidates ({len(removable_candidates)}): {removable_candidates[:5]}..."
+    )
+
+    edited = c
+    removed: list[str] = []
+
+    for bname in removable_candidates[:3]:
+        try:
+            candidate = edited.remove_behavior(bname)
+            # verify it actually reduced behaviors
+            if len(candidate.list_behaviors()) < len(edited.list_behaviors()):
+                edited = candidate
+                removed.append(bname)
+                info(f"  Removed: {bname}")
+        except Exception as exc:
+            info(f"  Skipped {bname!r}: {exc}")
+
+    check(
+        "At least one behavior was successfully removed",
+        len(removed) > 0,
+        f"no behaviors removed from candidates: {removable_candidates[:3]}",
+    )
+
+    new_tokens = edited.total_tokens()
+    new_behavior_count = len(edited.list_behaviors())
+    token_saving = original_tokens - new_tokens
+    saving_pct = (token_saving / original_tokens * 100) if original_tokens else 0
+
+    check(
+        "Token count did not increase after removal",
+        new_tokens <= original_tokens,
+        f"{original_tokens:,} → {new_tokens:,}",
+    )
+    check(
+        "Behavior count decreased",
+        new_behavior_count < original_behavior_count,
+        f"{original_behavior_count} → {new_behavior_count}",
+    )
+
+    info(f"Before: {original_tokens:,} tokens  |  {original_behavior_count} behaviors")
+    info(f"After:  {new_tokens:,} tokens  |  {new_behavior_count} behaviors")
+    info(f"Saved:  {token_saving:,} tokens ({saving_pct:.1f}%)")
+
+    # -----------------------------------------------------------------------
+    # Step 4: Diff
+    # -----------------------------------------------------------------------
+    section("Step 4: Diff (original vs. edited)")
+
+    diff = c.diff(edited)
+
+    check("diff.removed_behaviors is non-empty", len(diff.removed_behaviors) > 0)
+    check(
+        "diff.added_behaviors is empty",
+        len(diff.added_behaviors) == 0,
+        f"unexpected additions: {diff.added_behaviors}",
+    )
+    check(
+        "diff.token_delta <= 0 (removing only reduces tokens)",
+        diff.token_delta <= 0,
+        f"token_delta={diff.token_delta}",
+    )
+    check(
+        "diff.before_tokens matches original total_tokens()",
+        diff.before_tokens == original_tokens,
+        f"before={diff.before_tokens}  expected={original_tokens}",
+    )
+    check(
+        "diff.after_tokens matches edited total_tokens()",
+        diff.after_tokens == new_tokens,
+        f"after={diff.after_tokens}  expected={new_tokens}",
+    )
+
+    info(f"Removed behaviors: {diff.removed_behaviors}")
+    info(f"Removed parts:     {len(diff.removed_parts)}")
+    info(f"Token delta:       {diff.token_delta:,}")
+
+    # -----------------------------------------------------------------------
+    # Step 5: Validate
+    # -----------------------------------------------------------------------
+    section("Step 5: Validate edited bundle")
+
+    errors, warnings = edited.validate()
+
+    check("validate() returns no hard errors", len(errors) == 0, f"errors: {errors}")
+    info(f"Warnings ({len(warnings)}): {warnings[:3]}")
+
+    # -----------------------------------------------------------------------
+    # Step 6: Save to file
+    # -----------------------------------------------------------------------
+    section("Step 6: Save edited bundle to .md file")
+
+    output_dir = Path(tempfile.mkdtemp(prefix="configurator_e2e_"))
+    output_path = output_dir / "edited-foundation.md"
+
+    try:
+        saved_path = edited.save(str(output_path))
+    except Exception as exc:
+        fail(f"save() raised: {exc}")
+        _failures.append(f"save() raised: {exc}")
+        # Can't continue without the file
+        _print_summary()
+        return 1
+
+    check("save() returned a Path", isinstance(saved_path, Path))
+    check("Output file exists", output_path.exists())
+    file_size = output_path.stat().st_size
+    check("Output file is non-empty (>100 bytes)", file_size > 100, f"size={file_size}")
+    info(f"Saved to: {output_path}")
+    info(f"File size: {file_size:,} bytes")
+
+    # -----------------------------------------------------------------------
+    # Step 7: Verify saved file structure
+    # -----------------------------------------------------------------------
+    section("Step 7: Verify saved file structure")
+
+    content = output_path.read_text()
+
+    check("File starts with YAML frontmatter '---'", content.startswith("---"))
+    check("File has closing frontmatter delimiter", content.count("---") >= 2)
+    check("File contains 'includes:' section", "includes:" in content)
+
+    check("No absolute '/Users/' paths leaked into file", "/Users/" not in content)
+    check("No absolute '/home/' paths leaked into file", "/home/" not in content)
+    check("No '/tmp/' paths leaked into file", "/tmp/" not in content)
+
+    # Parse the YAML frontmatter
+    import yaml as _yaml
+
+    parts = content.split("---", 2)
+    yaml_ok = len(parts) >= 3
+    check(
+        "File has at least 3 '---' split sections (header/yaml/body)",
+        yaml_ok,
+        f"got {len(parts)} sections",
+    )
+
+    if yaml_ok:
+        try:
+            parsed = _yaml.safe_load(parts[1])
+            check(
+                "YAML frontmatter parses without error",
+                isinstance(parsed, dict),
+                f"got {type(parsed)}",
+            )
+            if isinstance(parsed, dict):
+                check("YAML has 'bundle' key", "bundle" in parsed)
+                bundle_meta = parsed.get("bundle", {})
+                check(
+                    "Bundle has 'name' field",
+                    "name" in bundle_meta,
+                    f"keys: {list(bundle_meta)}",
+                )
+                check(
+                    "Bundle name is 'foundation'",
+                    bundle_meta.get("name") == "foundation",
+                    f"got {bundle_meta.get('name')!r}",
+                )
+
+                has_includes = (
+                    "includes" in parsed.get("bundle", {}) or "includes" in parsed
+                )
+                check("Saved bundle has 'includes' section", has_includes)
+
+                # Check the removed behaviors are absent
+                file_includes_raw = str(parsed)
+                for rname in removed:
+                    check(
+                        f"Removed behavior '{rname}' not referenced in saved YAML",
+                        rname not in file_includes_raw,
+                        f"found in: {file_includes_raw[:200]}",
+                    )
+
+        except _yaml.YAMLError as exc:
+            fail(f"YAML parse error: {exc}")
+            _failures.append(f"YAML parse error: {exc}")
+
+    info("Saved file preview (first 30 lines):")
+    for i, line in enumerate(content.splitlines()[:30], 1):
+        info(f"  {i:2d}: {line}")
+
+    # -----------------------------------------------------------------------
+    # Step 8: Verify saved file loads back with Foundation's load_bundle
+    # -----------------------------------------------------------------------
+    section("Step 8: Verify Foundation can load the saved file")
+
+    try:
+        foundation_bundle = await load_bundle(str(output_path), auto_include=True)
+        check("Foundation load_bundle() succeeded on saved file", True)
+        info(f"Bundle name:     {foundation_bundle.name!r}")
+        info(f"Tools:           {len(foundation_bundle.tools)}")
+        info(f"Hooks:           {len(foundation_bundle.hooks)}")
+        info(f"Agents:          {len(foundation_bundle.agents)}")
+        info(f"_pending_context:{len(foundation_bundle._pending_context)}")
+        info(
+            f"Instruction len: {len(foundation_bundle.instruction) if foundation_bundle.instruction else 0}"
+        )
+
+        check(
+            "Loaded bundle has tools",
+            len(foundation_bundle.tools) > 0,
+            "empty tools list",
+        )
+        check(
+            "Loaded bundle name matches",
+            foundation_bundle.name == "foundation",
+            f"got {foundation_bundle.name!r}",
+        )
+
+        # Verify removed behaviors are gone from the loaded bundle tools
+        loaded_tool_names = {
+            t.get("module") or t.get("id") for t in foundation_bundle.tools
+        }
+        info(f"Tool count in loaded bundle: {len(loaded_tool_names)}")
+
+        check("ROUND-TRIP SUCCESS: Foundation loaded the saved file", True)
+
+    except Exception as exc:
+        # This can legitimately fail if the saved bundle references sub-behavior
+        # URIs that Foundation can't resolve without a registry. But we still
+        # want to surface the error clearly.
+        info(f"Foundation load error: {exc}")
+        info(
+            "NOTE: This may be expected if sub-behavior URIs need Foundation's bundle registry."
+        )
+        check("ROUND-TRIP: Foundation accepted the saved file format", False, str(exc))
+
+    # -----------------------------------------------------------------------
+    # Step 9: Round-trip through BundleConfigurator.load (file path)
+    # -----------------------------------------------------------------------
+    section("Step 9: Round-trip — load saved file back with BundleConfigurator")
+
+    try:
+        c2 = await BundleConfigurator.load(str(output_path))
+        check("BundleConfigurator.load() succeeded on saved file", True)
+        info(f"  root_name: {c2.provenance.root_name!r}")
+        info(f"  behaviors: {len(c2.list_behaviors())}")
+        info(f"  tokens:    {c2.total_tokens():,}")
+        check(
+            "Round-trip behavior count <= original",
+            len(c2.list_behaviors()) <= original_behavior_count,
+        )
+        check(
+            "Round-trip token count <= original",
+            c2.total_tokens() <= original_tokens + 50,
+        )
+    except Exception as exc:
+        info(f"BundleConfigurator round-trip error: {exc}")
+        check("BundleConfigurator round-trip succeeded", False, str(exc))
+
+    # -----------------------------------------------------------------------
+    # Print summary and return
+    # -----------------------------------------------------------------------
+    _print_summary()
+    info(f"Output file preserved at: {output_path}")
+    return 0 if not _failures else 1
+
+
+def _print_summary() -> None:
+    section("SUMMARY")
+    if not _failures:
+        print("\n  ALL CHECKS PASSED ✓\n")
+    else:
+        print(f"\n  {len(_failures)} CHECK(S) FAILED:\n")
+        for f in _failures:
+            print(f"    ✗ {f}")
+        print()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(run_e2e()))

--- a/experiments/bundle-configurator/tests/test_configurator.py
+++ b/experiments/bundle-configurator/tests/test_configurator.py
@@ -1,0 +1,576 @@
+"""Tests for BundleConfigurator — wraps ProvenanceMap with query API.
+
+41 tests covering:
+  - constructor / properties (2)
+  - list_behaviors (3)
+  - list_parts (3)
+  - total_tokens (2)
+  - tokens_by_behavior (2)
+  - get_behavior (2)
+  - get_part (2)
+  - remove_behavior (7)
+  - remove_part (5)
+  - add_behavior (4)
+  - diff (4)
+  - validate (2)
+  - save (3)
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from amplifier_foundation.bundle import Bundle
+
+from amplifier_configurator import BundleConfigurator, DependencyError
+from amplifier_configurator.models import (
+    BehaviorInfo,
+    BundleDiff,
+    LoadError,
+    PartKind,
+    ProvenanceMap,
+    TrackedPart,
+)
+
+
+# ---------------------------------------------------------------------------
+# constructor / properties
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_takes_provenance_map(simple_provenance_map: ProvenanceMap) -> None:
+    """BundleConfigurator accepts a ProvenanceMap and exposes it via .provenance."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    assert cfg.provenance is simple_provenance_map
+
+
+def test_bundle_property_returns_composed_bundle(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """cfg.bundle returns the composed_bundle from the ProvenanceMap."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    assert cfg.bundle is simple_provenance_map.composed_bundle
+
+
+# ---------------------------------------------------------------------------
+# list_behaviors
+# ---------------------------------------------------------------------------
+
+
+def test_list_behaviors_returns_all(simple_provenance_map: ProvenanceMap) -> None:
+    """list_behaviors() returns all behaviors (leaf + mid = 2)."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    behaviors = cfg.list_behaviors()
+    assert len(behaviors) == 2
+    names = {b.name for b in behaviors}
+    assert names == {"leaf-behavior", "mid-behavior"}
+
+
+def test_list_behaviors_sorted_by_include_order(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """list_behaviors() is sorted by include_order: leaf first (depth=1), mid second (depth=0)."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    behaviors = cfg.list_behaviors()
+    # include_order = ("leaf-behavior-uri", "mid-behavior-uri") — leaf is first
+    assert behaviors[0].name == "leaf-behavior"
+    assert behaviors[1].name == "mid-behavior"
+
+
+def test_list_behaviors_returns_behavior_info(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """Every item returned by list_behaviors() is a BehaviorInfo instance."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    behaviors = cfg.list_behaviors()
+    for b in behaviors:
+        assert isinstance(b, BehaviorInfo)
+
+
+# ---------------------------------------------------------------------------
+# list_parts
+# ---------------------------------------------------------------------------
+
+
+def test_list_parts_all(simple_provenance_map: ProvenanceMap) -> None:
+    """list_parts() with no filter returns all parts from all_parts."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    parts = cfg.list_parts()
+    assert len(parts) == len(simple_provenance_map.all_parts)
+
+
+def test_list_parts_filter_by_kind(simple_provenance_map: ProvenanceMap) -> None:
+    """list_parts(PartKind.TOOL) returns only TOOL parts."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    tool_parts = cfg.list_parts(PartKind.TOOL)
+    assert len(tool_parts) > 0
+    assert all(p.kind == PartKind.TOOL for p in tool_parts)
+
+
+def test_list_parts_filter_context(simple_provenance_map: ProvenanceMap) -> None:
+    """list_parts(PartKind.CONTEXT) returns only the single context part."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    ctx_parts = cfg.list_parts(PartKind.CONTEXT)
+    assert len(ctx_parts) == 1
+    assert ctx_parts[0].kind == PartKind.CONTEXT
+    assert ctx_parts[0].name == "leaf-behavior:lsp-config"
+
+
+# ---------------------------------------------------------------------------
+# total_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_total_tokens_sum_103_plus_7(simple_provenance_map: ProvenanceMap) -> None:
+    """total_tokens() = sum of all part tokens (103) + root_instruction_tokens (7) = 110."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    assert cfg.total_tokens() == 110
+
+
+def test_total_tokens_includes_root_instruction(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """total_tokens() decreases by exactly 7 when root_instruction_tokens is zeroed."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    full = cfg.total_tokens()
+
+    pmap_no_instr = dataclasses.replace(
+        simple_provenance_map, root_instruction_tokens=0
+    )
+    cfg_no_instr = BundleConfigurator(pmap_no_instr)
+    assert cfg_no_instr.total_tokens() == full - 7
+
+
+# ---------------------------------------------------------------------------
+# tokens_by_behavior
+# ---------------------------------------------------------------------------
+
+
+def test_tokens_by_behavior_values(simple_provenance_map: ProvenanceMap) -> None:
+    """tokens_by_behavior() has correct per-behavior and <root> values."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    tbb = cfg.tokens_by_behavior()
+    assert tbb["leaf-behavior"] == 103
+    assert tbb["<root>"] == 7
+
+
+def test_tokens_by_behavior_sorted_descending(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """tokens_by_behavior() is sorted in descending order of token count."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    tbb = cfg.tokens_by_behavior()
+    values = list(tbb.values())
+    assert values == sorted(values, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# get_behavior
+# ---------------------------------------------------------------------------
+
+
+def test_get_behavior(simple_provenance_map: ProvenanceMap) -> None:
+    """get_behavior(name) returns the matching BehaviorInfo."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    beh = cfg.get_behavior("leaf-behavior")
+    assert isinstance(beh, BehaviorInfo)
+    assert beh.name == "leaf-behavior"
+
+
+def test_get_behavior_not_found(simple_provenance_map: ProvenanceMap) -> None:
+    """get_behavior(name) raises KeyError when behavior is not present."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    with pytest.raises(KeyError):
+        cfg.get_behavior("nonexistent-behavior")
+
+
+# ---------------------------------------------------------------------------
+# get_part
+# ---------------------------------------------------------------------------
+
+
+def test_get_part(simple_provenance_map: ProvenanceMap) -> None:
+    """get_part(kind, name) returns the matching TrackedPart."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    part = cfg.get_part(PartKind.CONTEXT, "leaf-behavior:lsp-config")
+    assert isinstance(part, TrackedPart)
+    assert part.kind == PartKind.CONTEXT
+    assert part.name == "leaf-behavior:lsp-config"
+
+
+def test_get_part_not_found(simple_provenance_map: ProvenanceMap) -> None:
+    """get_part(kind, name) raises KeyError when part is not present."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    with pytest.raises(KeyError):
+        cfg.get_part(PartKind.TOOL, "nonexistent-tool")
+
+
+# ---------------------------------------------------------------------------
+# remove_behavior
+# ---------------------------------------------------------------------------
+
+
+def test_remove_behavior_returns_new_instance(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """remove_behavior returns a new BundleConfigurator, not the same instance."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    new_cfg = cfg.remove_behavior("leaf-behavior")
+    assert new_cfg is not cfg
+
+
+def test_remove_behavior_original_unchanged(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """Original configurator is not modified after remove_behavior."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    original_count = len(cfg.list_behaviors())
+    cfg.remove_behavior("leaf-behavior")
+    assert len(cfg.list_behaviors()) == original_count
+
+
+def test_remove_behavior_removes_parts(simple_provenance_map: ProvenanceMap) -> None:
+    """remove_behavior removes all parts contributed by the removed behavior."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    new_cfg = cfg.remove_behavior("leaf-behavior")
+    part_names = {p.name for p in new_cfg.list_parts()}
+    assert "tool-lsp" not in part_names
+    assert "leaf-behavior:lsp-config" not in part_names
+
+
+def test_remove_behavior_raises_key_error_nonexistent(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """remove_behavior raises KeyError when the behavior name is not found."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    with pytest.raises(KeyError):
+        cfg.remove_behavior("nonexistent-behavior")
+
+
+def test_remove_behavior_preserves_other_behaviors(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """remove_behavior preserves behaviors that were not removed."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    new_cfg = cfg.remove_behavior("leaf-behavior")
+    names = {b.name for b in new_cfg.list_behaviors()}
+    assert "mid-behavior" in names
+    assert "leaf-behavior" not in names
+
+
+def test_remove_behavior_reduces_tokens(simple_provenance_map: ProvenanceMap) -> None:
+    """remove_behavior reduces total_tokens by the removed behavior's token contribution."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    original_tokens = cfg.total_tokens()
+    new_cfg = cfg.remove_behavior("leaf-behavior")
+    # leaf-behavior contributes 103 tokens (the lsp-config context part)
+    assert new_cfg.total_tokens() == original_tokens - 103
+
+
+def test_remove_behavior_mid_orphans_leaf(simple_provenance_map: ProvenanceMap) -> None:
+    """Removing mid-behavior also removes leaf-behavior (orphan detection).
+
+    leaf-behavior's include_chain is ('root-bundle', 'mid-behavior', 'leaf-behavior').
+    mid-behavior is the only non-root includer of leaf-behavior, so removing
+    mid-behavior leaves leaf-behavior without an active parent: it is orphaned
+    and must also be removed.
+    """
+    cfg = BundleConfigurator(simple_provenance_map)
+    new_cfg = cfg.remove_behavior("mid-behavior")
+    names = {b.name for b in new_cfg.list_behaviors()}
+    assert "mid-behavior" not in names
+    assert "leaf-behavior" not in names
+
+
+# ---------------------------------------------------------------------------
+# remove_part
+# ---------------------------------------------------------------------------
+
+
+def test_remove_part_removes_specific_tool(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """remove_part removes the specified tool from all parts."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    new_cfg = cfg.remove_part(PartKind.TOOL, "tool-lsp")
+    tool_names = {p.name for p in new_cfg.list_parts(PartKind.TOOL)}
+    assert "tool-lsp" not in tool_names
+
+
+def test_remove_part_original_unchanged(simple_provenance_map: ProvenanceMap) -> None:
+    """Original configurator is not modified after remove_part."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    original_count = len(cfg.list_parts())
+    cfg.remove_part(PartKind.TOOL, "tool-lsp")
+    assert len(cfg.list_parts()) == original_count
+
+
+def test_remove_part_raises_key_error_nonexistent(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """remove_part raises KeyError when the (kind, name) pair is not present."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    with pytest.raises(KeyError):
+        cfg.remove_part(PartKind.TOOL, "nonexistent-tool")
+
+
+def test_remove_part_raises_dependency_error_for_required(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """remove_part raises DependencyError when trying to remove a required part (tool-bash)."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    with pytest.raises(DependencyError):
+        cfg.remove_part(PartKind.TOOL, "tool-bash")
+
+
+def test_remove_part_removes_context_part(simple_provenance_map: ProvenanceMap) -> None:
+    """remove_part removes a context part correctly."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    new_cfg = cfg.remove_part(PartKind.CONTEXT, "leaf-behavior:lsp-config")
+    ctx_parts = new_cfg.list_parts(PartKind.CONTEXT)
+    assert not any(p.name == "leaf-behavior:lsp-config" for p in ctx_parts)
+
+
+# ---------------------------------------------------------------------------
+# add_behavior
+# ---------------------------------------------------------------------------
+
+
+async def test_add_behavior_new_parts_appear_in_all_parts(
+    simple_provenance_map: ProvenanceMap,
+    mocker: MockerFixture,
+) -> None:
+    """add_behavior: new behavior's parts appear in all_parts after merge."""
+    new_part = TrackedPart(
+        kind=PartKind.TOOL,
+        name="tool-new",
+        source_behavior="new-behavior",
+        tokens=0,
+        config={},
+        namespace_path=None,
+    )
+    new_beh = BehaviorInfo(
+        name="new-behavior",
+        uri="new-behavior-uri",
+        parts=(new_part,),
+        raw_parts=(new_part,),
+        total_tokens=0,
+        depth=0,
+        include_chain=("root-bundle", "new-behavior"),
+    )
+    mocker.patch(
+        "amplifier_configurator.provenance._load_behavior_tree",
+        new=AsyncMock(
+            return_value=([new_beh], {"new-behavior": Bundle(name="new-behavior")})
+        ),
+    )
+
+    cfg = BundleConfigurator(simple_provenance_map)
+    new_cfg = await cfg.add_behavior("new-behavior-uri")
+
+    part_names = {p.name for p in new_cfg.list_parts()}
+    assert "tool-new" in part_names
+
+
+async def test_add_behavior_duplicate_uri_new_wins(
+    simple_provenance_map: ProvenanceMap,
+    mocker: MockerFixture,
+) -> None:
+    """add_behavior: when a known URI is re-added, the new version replaces the old."""
+    updated_part = TrackedPart(
+        kind=PartKind.TOOL,
+        name="tool-lsp-v2",
+        source_behavior="leaf-behavior",
+        tokens=0,
+        config={},
+        namespace_path=None,
+    )
+    updated_leaf = BehaviorInfo(
+        name="leaf-behavior",
+        uri="leaf-behavior-uri",
+        parts=(updated_part,),
+        raw_parts=(updated_part,),
+        total_tokens=0,
+        depth=1,
+        include_chain=("root-bundle", "mid-behavior", "leaf-behavior"),
+    )
+    mocker.patch(
+        "amplifier_configurator.provenance._load_behavior_tree",
+        new=AsyncMock(return_value=([updated_leaf], {})),
+    )
+
+    cfg = BundleConfigurator(simple_provenance_map)
+    new_cfg = await cfg.add_behavior("leaf-behavior-uri")
+
+    part_names = {p.name for p in new_cfg.list_parts()}
+    # New part from updated behavior appears; old exclusive part is gone
+    assert "tool-lsp-v2" in part_names
+    assert "tool-lsp" not in part_names
+
+
+async def test_add_behavior_extends_include_order(
+    simple_provenance_map: ProvenanceMap,
+    mocker: MockerFixture,
+) -> None:
+    """add_behavior: new behavior URI is appended to include_order."""
+    new_beh = BehaviorInfo(
+        name="extra-behavior",
+        uri="extra-behavior-uri",
+        parts=(),
+        raw_parts=(),
+        total_tokens=0,
+        depth=0,
+        include_chain=("root-bundle", "extra-behavior"),
+    )
+    mocker.patch(
+        "amplifier_configurator.provenance._load_behavior_tree",
+        new=AsyncMock(return_value=([new_beh], {})),
+    )
+
+    cfg = BundleConfigurator(simple_provenance_map)
+    new_cfg = await cfg.add_behavior("extra-behavior-uri")
+
+    assert "extra-behavior-uri" in new_cfg.provenance.include_order
+
+
+async def test_add_behavior_propagates_load_error(
+    simple_provenance_map: ProvenanceMap,
+    mocker: MockerFixture,
+) -> None:
+    """add_behavior: LoadError raised by _load_behavior_tree propagates to caller."""
+    mocker.patch(
+        "amplifier_configurator.provenance._load_behavior_tree",
+        new=AsyncMock(side_effect=LoadError("not found")),
+    )
+
+    cfg = BundleConfigurator(simple_provenance_map)
+    with pytest.raises(LoadError):
+        await cfg.add_behavior("bad-uri")
+
+
+# ---------------------------------------------------------------------------
+# diff
+# ---------------------------------------------------------------------------
+
+
+def test_diff_with_self_is_empty(simple_provenance_map: ProvenanceMap) -> None:
+    """diff(self) returns a BundleDiff with no added/removed parts or behaviors and zero token_delta."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    d = cfg.diff(cfg)
+    assert d.added_parts == ()
+    assert d.removed_parts == ()
+    assert d.added_behaviors == ()
+    assert d.removed_behaviors == ()
+    assert d.token_delta == 0
+
+
+def test_diff_after_remove_behavior_shows_removed(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """diff after remove_behavior shows removed_parts, removed behavior URI, and negative token_delta."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    new_cfg = cfg.remove_behavior("leaf-behavior")
+    d = cfg.diff(new_cfg)
+
+    # leaf-behavior contributed tool-lsp and the lsp-config context part
+    removed_names = {p.name for p in d.removed_parts}
+    assert "tool-lsp" in removed_names
+    assert "leaf-behavior:lsp-config" in removed_names
+
+    # behavior URI should appear in removed_behaviors
+    assert "leaf-behavior-uri" in d.removed_behaviors
+
+    # removing a behavior with tokens must decrease the total
+    assert d.token_delta < 0
+
+
+def test_diff_after_remove_part_shows_removed_name(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """diff after remove_part includes the removed part name in removed_parts."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    new_cfg = cfg.remove_part(PartKind.CONTEXT, "leaf-behavior:lsp-config")
+    d = cfg.diff(new_cfg)
+
+    removed_names = {p.name for p in d.removed_parts}
+    assert "leaf-behavior:lsp-config" in removed_names
+
+
+def test_diff_returns_bundle_diff_type(simple_provenance_map: ProvenanceMap) -> None:
+    """diff() returns a BundleDiff instance."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    d = cfg.diff(cfg)
+    assert isinstance(d, BundleDiff)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+def test_validate_clean_bundle_returns_empty_errors(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """validate() on a clean bundle (all required parts present) returns empty errors."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    errors, _ = cfg.validate()
+    assert errors == []
+
+
+def test_validate_returns_tuple_of_length_2(
+    simple_provenance_map: ProvenanceMap,
+) -> None:
+    """validate() returns a 2-tuple of (errors, warnings)."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    result = cfg.validate()
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# save
+# ---------------------------------------------------------------------------
+
+
+def test_save_writes_md_file(
+    simple_provenance_map: ProvenanceMap, tmp_path: Path
+) -> None:
+    """save() writes a .md file and returns the output path.
+
+    Verifies that result path equals output path, file exists, and content
+    contains '---' (YAML frontmatter delimiter) and 'root-bundle' (bundle name).
+    """
+    cfg = BundleConfigurator(simple_provenance_map)
+    output_path = tmp_path / "bundle.md"
+    result = cfg.save(output_path)
+    assert result == output_path
+    assert output_path.exists()
+    content = output_path.read_text()
+    assert "---" in content
+    assert "root-bundle" in content
+
+
+def test_save_creates_parent_directories(
+    simple_provenance_map: ProvenanceMap, tmp_path: Path
+) -> None:
+    """save() creates parent directories automatically when they don't exist."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    nested_path = tmp_path / "deep" / "nested" / "bundle.md"
+    cfg.save(nested_path)
+    assert nested_path.exists()
+
+
+def test_save_instruction_in_body(
+    simple_provenance_map: ProvenanceMap, tmp_path: Path
+) -> None:
+    """save() writes the root instruction into the file body."""
+    cfg = BundleConfigurator(simple_provenance_map)
+    output_path = tmp_path / "bundle.md"
+    cfg.save(output_path)
+    content = output_path.read_text()
+    assert "You are a helpful assistant." in content

--- a/experiments/bundle-configurator/tests/test_dependencies.py
+++ b/experiments/bundle-configurator/tests/test_dependencies.py
@@ -1,0 +1,228 @@
+"""Tests for dependencies.py — provenance-aware dependency validation.
+
+13 tests covering:
+  - REQUIRED_PARTS contents (3)
+  - validate_provenance errors (3)
+  - validate_provenance warnings (4)
+  - validate_provenance return type (1)
+  - legacy Bundle-based API smoke tests (2)
+"""
+
+from __future__ import annotations
+
+from amplifier_foundation.bundle import Bundle
+
+from amplifier_configurator.dependencies import (
+    REQUIRED_PARTS,
+    validate_provenance,
+)
+from amplifier_configurator.models import (
+    PartKind,
+    ProvenanceMap,
+    TrackedPart,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_part(name: str, kind: PartKind = PartKind.TOOL) -> TrackedPart:
+    """Create a minimal TrackedPart for testing."""
+    return TrackedPart(
+        kind=kind,
+        name=name,
+        source_behavior=None,
+        tokens=0,
+        config={},
+        namespace_path=None,
+    )
+
+
+def _pmap(parts: list[TrackedPart]) -> ProvenanceMap:
+    """Create a minimal ProvenanceMap wrapping the given parts."""
+    return ProvenanceMap(
+        root_name="test",
+        root_uri="test",
+        root_instruction=None,
+        root_instruction_tokens=0,
+        behaviors={},
+        root_parts=tuple(parts),
+        all_parts=tuple(parts),
+        composed_bundle=Bundle(name="test"),
+        include_order=(),
+        session_config={},
+        spawn_config=None,
+        _raw_bundles={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# REQUIRED_PARTS contents
+# ---------------------------------------------------------------------------
+
+
+def test_required_parts_contains_tool_bash() -> None:
+    """REQUIRED_PARTS must include tool-bash."""
+    assert "tool-bash" in REQUIRED_PARTS
+
+
+def test_required_parts_contains_tool_filesystem() -> None:
+    """REQUIRED_PARTS must include tool-filesystem."""
+    assert "tool-filesystem" in REQUIRED_PARTS
+
+
+def test_required_parts_contains_tool_search() -> None:
+    """REQUIRED_PARTS must include tool-search."""
+    assert "tool-search" in REQUIRED_PARTS
+
+
+# ---------------------------------------------------------------------------
+# validate_provenance — errors (required parts)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_all_required_present_no_errors() -> None:
+    """validate_provenance returns no errors when all required parts present."""
+    pmap = _pmap(
+        [
+            _make_part("tool-bash"),
+            _make_part("tool-filesystem"),
+            _make_part("tool-search"),
+        ]
+    )
+    errors, _ = validate_provenance(pmap)
+    assert errors == []
+
+
+def test_validate_missing_tool_bash_produces_error() -> None:
+    """validate_provenance returns an error when tool-bash is absent."""
+    pmap = _pmap(
+        [
+            _make_part("tool-filesystem"),
+            _make_part("tool-search"),
+        ]
+    )
+    errors, _ = validate_provenance(pmap)
+    assert any("tool-bash" in e for e in errors)
+
+
+def test_validate_empty_bundle_errors_count_equals_required_parts() -> None:
+    """validate_provenance on an empty bundle produces one error per REQUIRED_PARTS entry."""
+    pmap = _pmap([])
+    errors, _ = validate_provenance(pmap)
+    assert len(errors) == len(REQUIRED_PARTS)
+
+
+# ---------------------------------------------------------------------------
+# validate_provenance — warnings (dependencies)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_hooks_todo_reminder_without_tool_todo_produces_warning() -> None:
+    """hooks-todo-reminder without tool-todo produces a warning."""
+    pmap = _pmap(
+        [
+            _make_part("tool-bash"),
+            _make_part("tool-filesystem"),
+            _make_part("tool-search"),
+            _make_part("hooks-todo-reminder", PartKind.HOOK),
+        ]
+    )
+    _, warnings = validate_provenance(pmap)
+    assert any("hooks-todo-reminder" in w and "tool-todo" in w for w in warnings)
+
+
+def test_validate_agents_without_delegate_produces_warning() -> None:
+    """An agent without tool-delegate present produces a warning."""
+    pmap = _pmap(
+        [
+            _make_part("tool-bash"),
+            _make_part("tool-filesystem"),
+            _make_part("tool-search"),
+            _make_part("my-agent", PartKind.AGENT),
+        ]
+    )
+    _, warnings = validate_provenance(pmap)
+    assert any("tool-delegate" in w for w in warnings)
+
+
+def test_validate_agents_with_delegate_no_warning() -> None:
+    """Agents with tool-delegate present produce no tool-delegate warning."""
+    pmap = _pmap(
+        [
+            _make_part("tool-bash"),
+            _make_part("tool-filesystem"),
+            _make_part("tool-search"),
+            _make_part("tool-delegate"),
+            _make_part("my-agent", PartKind.AGENT),
+        ]
+    )
+    _, warnings = validate_provenance(pmap)
+    assert not any("Agents require tool-delegate" in w for w in warnings)
+
+
+def test_validate_clean_bundle_no_warnings() -> None:
+    """A bundle with only the three required tools produces no warnings."""
+    pmap = _pmap(
+        [
+            _make_part("tool-bash"),
+            _make_part("tool-filesystem"),
+            _make_part("tool-search"),
+        ]
+    )
+    _, warnings = validate_provenance(pmap)
+    assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# validate_provenance — return type
+# ---------------------------------------------------------------------------
+
+
+def test_validate_returns_tuple_of_length_2() -> None:
+    """validate_provenance returns a 2-tuple (errors, warnings)."""
+    pmap = _pmap([])
+    result = validate_provenance(pmap)
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Legacy Bundle-based API (smoke tests)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_get_all_part_names_returns_set() -> None:
+    """get_all_part_names(bundle) returns a set containing tool names."""
+    from amplifier_configurator.dependencies import get_all_part_names
+
+    bundle = Bundle(
+        name="legacy-test",
+        tools=[{"module": "tool-bash"}, {"module": "tool-filesystem"}],
+    )
+    result = get_all_part_names(bundle)
+    assert isinstance(result, set)
+    assert "tool-bash" in result
+    assert "tool-filesystem" in result
+
+
+def test_legacy_validate_returns_two_tuple() -> None:
+    """validate(bundle) returns a 2-tuple of (errors, warnings)."""
+    from amplifier_configurator.dependencies import validate
+
+    bundle = Bundle(
+        name="legacy-test",
+        tools=[
+            {"module": "tool-bash"},
+            {"module": "tool-filesystem"},
+            {"module": "tool-search"},
+        ],
+    )
+    result = validate(bundle)
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    errors, warnings = result
+    # All required parts present — no errors expected
+    assert errors == []

--- a/experiments/bundle-configurator/tests/test_integration.py
+++ b/experiments/bundle-configurator/tests/test_integration.py
@@ -1,0 +1,128 @@
+"""Integration tests for BundleConfigurator with real Foundation bundles.
+
+All tests are marked with ``pytestmark = pytest.mark.integration`` and skip by
+default in normal ``pytest`` runs.  Run them explicitly with::
+
+    pytest -m integration
+
+The lean bundle path comes from the ``lean_bundle_path`` session fixture in
+``conftest.py``; individual tests are skipped automatically when the bundle is
+absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amplifier_configurator import BundleConfigurator
+from amplifier_configurator.dependencies import REQUIRED_PARTS
+from amplifier_configurator.models import PartKind
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# 1. Load
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_lean_bundle(lean_bundle_path: Path) -> None:
+    """Loading the lean bundle produces a configurator with root_name 'lean' and behaviors."""
+    cfg = await BundleConfigurator.load(str(lean_bundle_path))
+
+    assert cfg.provenance.root_name == "lean"
+    assert len(cfg.provenance.behaviors) > 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Tool names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lean_bundle_has_tools(lean_bundle_path: Path) -> None:
+    """tool-bash is present in the lean bundle's tool parts."""
+    cfg = await BundleConfigurator.load(str(lean_bundle_path))
+
+    tool_names = [p.name for p in cfg.list_parts(kind=PartKind.TOOL)]
+    assert "tool-bash" in tool_names
+
+
+# ---------------------------------------------------------------------------
+# 3. Token count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lean_bundle_token_count(lean_bundle_path: Path) -> None:
+    """Total token count for the lean bundle is positive."""
+    cfg = await BundleConfigurator.load(str(lean_bundle_path))
+
+    assert cfg.total_tokens() > 0
+
+
+# ---------------------------------------------------------------------------
+# 4. Tokens by behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lean_bundle_tokens_by_behavior(lean_bundle_path: Path) -> None:
+    """tokens_by_behavior returns a non-empty mapping."""
+    cfg = await BundleConfigurator.load(str(lean_bundle_path))
+
+    breakdown = cfg.tokens_by_behavior()
+    assert len(breakdown) > 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Save round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lean_bundle_save_roundtrip(
+    lean_bundle_path: Path, tmp_path: Path
+) -> None:
+    """Load → save → verify file on disk contains expected markers."""
+    cfg = await BundleConfigurator.load(str(lean_bundle_path))
+    dest = tmp_path / "saved_bundle.md"
+
+    cfg.save(dest)
+
+    assert dest.exists()
+    content = dest.read_text()
+    assert "---" in content
+    assert "lean" in content
+
+
+# ---------------------------------------------------------------------------
+# 6. Remove behavior and diff
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lean_bundle_remove_and_diff(lean_bundle_path: Path) -> None:
+    """Remove a non-critical behavior and verify it appears in the diff."""
+    cfg = await BundleConfigurator.load(str(lean_bundle_path))
+
+    # Find a behavior whose parts don't include any required parts.
+    removable_name: str | None = None
+    removable_uri: str | None = None
+    for uri, beh in cfg.provenance.behaviors.items():
+        part_names = {p.name for p in beh.parts}
+        if not (part_names & REQUIRED_PARTS):
+            removable_name = beh.name
+            removable_uri = uri
+            break
+
+    if removable_name is None:
+        pytest.skip("No safely removable behavior found in the lean bundle")
+
+    new_cfg = cfg.remove_behavior(removable_name)
+    diff = cfg.diff(new_cfg)
+
+    assert removable_uri in diff.removed_behaviors

--- a/experiments/bundle-configurator/tests/test_models.py
+++ b/experiments/bundle-configurator/tests/test_models.py
@@ -1,0 +1,433 @@
+"""Tests for amplifier_configurator.models — error hierarchy and PartKind enum."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError
+
+from amplifier_foundation.bundle import Bundle
+
+from amplifier_configurator.models import (
+    BehaviorInfo,
+    BundleDiff,
+    ConfiguratorError,
+    ConfiguratorWarning,
+    DependencyError,
+    LoadError,
+    PartKind,
+    ProvenanceMap,
+    TrackedPart,
+)
+
+
+# ---------------------------------------------------------------------------
+# PartKind tests
+# ---------------------------------------------------------------------------
+
+
+def test_partkind_values() -> None:
+    """PartKind members have the expected string values."""
+    assert PartKind.TOOL == "tool"
+    assert PartKind.HOOK == "hook"
+    assert PartKind.PROVIDER == "provider"
+    assert PartKind.AGENT == "agent"
+    assert PartKind.CONTEXT == "context"
+
+
+def test_partkind_is_str() -> None:
+    """PartKind members are plain str instances (isinstance check)."""
+    for member in PartKind:
+        assert isinstance(member, str), f"{member!r} is not a str"
+
+
+def test_partkind_serializes_to_json() -> None:
+    """PartKind values serialize cleanly to JSON without a custom encoder."""
+    serialized = json.dumps({"kind": PartKind.TOOL})
+    assert serialized == '{"kind": "tool"}'
+
+
+def test_partkind_has_five_members() -> None:
+    """PartKind has exactly 5 members."""
+    assert len(PartKind) == 5
+
+
+# ---------------------------------------------------------------------------
+# ConfiguratorError tests
+# ---------------------------------------------------------------------------
+
+
+def test_configurator_error_is_exception() -> None:
+    """ConfiguratorError is a subclass of Exception."""
+    assert issubclass(ConfiguratorError, Exception)
+    err = ConfiguratorError("boom")
+    assert isinstance(err, Exception)
+
+
+# ---------------------------------------------------------------------------
+# DependencyError tests
+# ---------------------------------------------------------------------------
+
+
+def test_dependency_error_is_configurator_error() -> None:
+    """DependencyError is a ConfiguratorError with a parts attribute."""
+    err = DependencyError(parts=["tool:foo", "hook:bar"])
+    assert isinstance(err, ConfiguratorError)
+    assert err.parts == ["tool:foo", "hook:bar"]
+
+
+# ---------------------------------------------------------------------------
+# LoadError tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_error_is_configurator_error() -> None:
+    """LoadError is a ConfiguratorError with source and cause attributes."""
+    cause = ValueError("underlying")
+    err = LoadError(source="bundle.yaml", cause=cause)
+    assert isinstance(err, ConfiguratorError)
+    assert err.source == "bundle.yaml"
+    assert err.cause is cause
+
+
+def test_load_error_cause_defaults_to_none() -> None:
+    """LoadError.cause defaults to None when not supplied."""
+    err = LoadError(source="bundle.yaml")
+    assert err.source == "bundle.yaml"
+    assert err.cause is None
+
+
+# ---------------------------------------------------------------------------
+# ConfiguratorWarning tests
+# ---------------------------------------------------------------------------
+
+
+def test_configurator_warning_is_user_warning() -> None:
+    """ConfiguratorWarning is a subclass of UserWarning."""
+    assert issubclass(ConfiguratorWarning, UserWarning)
+    w = ConfiguratorWarning("heads up")
+    assert isinstance(w, UserWarning)
+
+
+# ---------------------------------------------------------------------------
+# TrackedPart tests
+# ---------------------------------------------------------------------------
+
+
+def test_tracked_part_construction() -> None:
+    """TrackedPart can be constructed with all required fields."""
+    part = TrackedPart(
+        kind=PartKind.TOOL,
+        name="tool-bash",
+        source_behavior="my-behavior",
+        tokens=42,
+        config={"module": "tool-bash"},
+        namespace_path=None,
+    )
+    assert part.kind == PartKind.TOOL
+    assert part.name == "tool-bash"
+    assert part.source_behavior == "my-behavior"
+    assert part.tokens == 42
+    assert part.config == {"module": "tool-bash"}
+    assert part.namespace_path is None
+
+
+def test_tracked_part_is_frozen() -> None:
+    """TrackedPart is a frozen dataclass — mutation raises FrozenInstanceError."""
+    part = TrackedPart(
+        kind=PartKind.HOOK,
+        name="hook-example",
+        source_behavior=None,
+        tokens=10,
+        config={},
+        namespace_path=None,
+    )
+    try:
+        part.name = "changed"  # type: ignore[misc]
+        raise AssertionError("Expected FrozenInstanceError was not raised")
+    except FrozenInstanceError:
+        pass
+
+
+def test_tracked_part_source_behavior_none_means_root() -> None:
+    """source_behavior=None indicates a root-level (non-included) part."""
+    part = TrackedPart(
+        kind=PartKind.PROVIDER,
+        name="provider-openai",
+        source_behavior=None,
+        tokens=5,
+        config={"module": "provider-openai"},
+        namespace_path=None,
+    )
+    assert part.source_behavior is None
+
+
+def test_tracked_part_context_has_namespace_path() -> None:
+    """A context TrackedPart can carry a namespace_path."""
+    part = TrackedPart(
+        kind=PartKind.CONTEXT,
+        name="instructions",
+        source_behavior="foundation",
+        tokens=200,
+        config={"file": "instructions.md"},
+        namespace_path="foundation:instructions",
+    )
+    assert part.namespace_path == "foundation:instructions"
+
+
+def test_tracked_part_hashable() -> None:
+    """TrackedPart instances are hashable and can be stored in sets."""
+    part_a = TrackedPart(
+        kind=PartKind.TOOL,
+        name="tool-bash",
+        source_behavior=None,
+        tokens=42,
+        config={"module": "tool-bash"},
+        namespace_path=None,
+    )
+    part_b = TrackedPart(
+        kind=PartKind.TOOL,
+        name="tool-bash",
+        source_behavior=None,
+        tokens=42,
+        config={"module": "tool-bash"},
+        namespace_path=None,
+    )
+    # Both should hash identically and be usable in set operations
+    s = {part_a, part_b}
+    assert len(s) == 1
+
+
+# ---------------------------------------------------------------------------
+# BehaviorInfo tests
+# ---------------------------------------------------------------------------
+
+
+def test_behavior_info_construction() -> None:
+    """BehaviorInfo can be constructed with all required fields."""
+    part = TrackedPart(
+        kind=PartKind.TOOL,
+        name="tool-bash",
+        source_behavior=None,
+        tokens=42,
+        config={},
+        namespace_path=None,
+    )
+    info = BehaviorInfo(
+        name="my-agent",
+        uri="foundation:my-agent",
+        parts=(part,),
+        raw_parts=(part,),
+        total_tokens=42,
+        depth=0,
+        include_chain=("root",),
+    )
+    assert info.name == "my-agent"
+    assert info.uri == "foundation:my-agent"
+    assert info.parts == (part,)
+    assert info.raw_parts == (part,)
+    assert info.total_tokens == 42
+    assert info.depth == 0
+    assert info.include_chain == ("root",)
+    assert info.instruction is None
+
+
+def test_behavior_info_is_frozen() -> None:
+    """BehaviorInfo is a frozen dataclass — mutation raises FrozenInstanceError."""
+    info = BehaviorInfo(
+        name="my-agent",
+        uri="foundation:my-agent",
+        parts=(),
+        raw_parts=(),
+        total_tokens=0,
+        depth=0,
+        include_chain=(),
+    )
+    try:
+        info.name = "changed"  # type: ignore[misc]
+        raise AssertionError("Expected FrozenInstanceError was not raised")
+    except FrozenInstanceError:
+        pass
+
+
+def test_behavior_info_with_instruction() -> None:
+    """BehaviorInfo instruction field stores the agent instruction string when provided."""
+    info = BehaviorInfo(
+        name="bug-hunter",
+        uri="foundation:bug-hunter",
+        parts=(),
+        raw_parts=(),
+        total_tokens=0,
+        depth=1,
+        include_chain=("root", "foundation"),
+        instruction="Hunt down bugs relentlessly.",
+    )
+    assert info.instruction == "Hunt down bugs relentlessly."
+
+
+# ---------------------------------------------------------------------------
+# ProvenanceMap tests
+# ---------------------------------------------------------------------------
+
+
+def _make_part(name: str, source_behavior: str | None = None) -> TrackedPart:
+    """Helper to create a TrackedPart for testing."""
+    return TrackedPart(
+        kind=PartKind.TOOL,
+        name=name,
+        source_behavior=source_behavior,
+        tokens=10,
+        config={},
+        namespace_path=None,
+    )
+
+
+def _make_behavior(uri: str, parts: tuple[TrackedPart, ...] = ()) -> BehaviorInfo:
+    """Helper to create a BehaviorInfo for testing."""
+    return BehaviorInfo(
+        name=uri.split(":")[-1],
+        uri=uri,
+        parts=parts,
+        raw_parts=parts,
+        total_tokens=sum(p.tokens for p in parts),
+        depth=0,
+        include_chain=(uri,),
+    )
+
+
+def test_provenance_map_construction(simple_bundle: Bundle) -> None:
+    """ProvenanceMap can be constructed with all required fields."""
+    root_part = _make_part("tool-bash")
+    behavior_part = _make_part("tool-search", source_behavior="foundation:bug-hunter")
+    behavior = _make_behavior("foundation:bug-hunter", parts=(behavior_part,))
+
+    pmap = ProvenanceMap(
+        root_name="test-bundle",
+        root_uri="foundation:test-bundle",
+        root_instruction="You are a test agent.",
+        root_instruction_tokens=10,
+        behaviors={"foundation:bug-hunter": behavior},
+        root_parts=(root_part,),
+        all_parts=(root_part, behavior_part),
+        composed_bundle=simple_bundle,
+        include_order=("foundation:bug-hunter",),
+        session_config={"model": "gpt-4"},
+        spawn_config=None,
+        _raw_bundles={"test-bundle": simple_bundle},
+    )
+
+    assert pmap.root_name == "test-bundle"
+    assert pmap.root_uri == "foundation:test-bundle"
+    assert pmap.root_instruction == "You are a test agent."
+    assert pmap.root_instruction_tokens == 10
+    assert "foundation:bug-hunter" in pmap.behaviors
+    assert pmap.root_parts == (root_part,)
+    assert pmap.all_parts == (root_part, behavior_part)
+    assert pmap.composed_bundle is simple_bundle
+    assert pmap.include_order == ("foundation:bug-hunter",)
+    assert pmap.session_config == {"model": "gpt-4"}
+    assert pmap.spawn_config is None
+    assert "test-bundle" in pmap._raw_bundles
+
+
+def test_provenance_map_is_mutable(simple_bundle: Bundle) -> None:
+    """ProvenanceMap is NOT frozen — field mutation must succeed."""
+    root_part = _make_part("tool-bash")
+    pmap = ProvenanceMap(
+        root_name="original",
+        root_uri="foundation:original",
+        root_instruction=None,
+        root_instruction_tokens=0,
+        behaviors={},
+        root_parts=(root_part,),
+        all_parts=(root_part,),
+        composed_bundle=simple_bundle,
+        include_order=(),
+        session_config={},
+        spawn_config=None,
+        _raw_bundles={},
+    )
+    # Mutating a field should not raise
+    pmap.root_name = "mutated"
+    assert pmap.root_name == "mutated"
+
+
+def test_provenance_map_all_parts_is_union(simple_bundle: Bundle) -> None:
+    """all_parts contains both root_parts and parts from all behaviors."""
+    root_part = _make_part("tool-bash")
+    b_part_1 = _make_part("tool-search", source_behavior="foundation:agent-a")
+    b_part_2 = _make_part("tool-filesystem", source_behavior="foundation:agent-b")
+    behavior_a = _make_behavior("foundation:agent-a", parts=(b_part_1,))
+    behavior_b = _make_behavior("foundation:agent-b", parts=(b_part_2,))
+
+    all_p = (root_part, b_part_1, b_part_2)
+    pmap = ProvenanceMap(
+        root_name="union-test",
+        root_uri="foundation:union-test",
+        root_instruction=None,
+        root_instruction_tokens=0,
+        behaviors={
+            "foundation:agent-a": behavior_a,
+            "foundation:agent-b": behavior_b,
+        },
+        root_parts=(root_part,),
+        all_parts=all_p,
+        composed_bundle=simple_bundle,
+        include_order=("foundation:agent-a", "foundation:agent-b"),
+        session_config={},
+        spawn_config=None,
+        _raw_bundles={},
+    )
+
+    # all_parts should contain root_parts entries
+    assert root_part in pmap.all_parts
+    # all_parts should contain behavior parts
+    assert b_part_1 in pmap.all_parts
+    assert b_part_2 in pmap.all_parts
+    # all_parts length equals root + all behavior parts
+    assert len(pmap.all_parts) == 3
+
+
+# ---------------------------------------------------------------------------
+# BundleDiff tests
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_diff_construction() -> None:
+    """BundleDiff can be constructed with all required fields."""
+    added = _make_part("tool-new")
+    removed = _make_part("tool-old")
+    diff = BundleDiff(
+        added_parts=(added,),
+        removed_parts=(removed,),
+        added_behaviors=("foundation:new-agent",),
+        removed_behaviors=("foundation:old-agent",),
+        token_delta=50,
+        before_tokens=100,
+        after_tokens=150,
+    )
+
+    assert diff.added_parts == (added,)
+    assert diff.removed_parts == (removed,)
+    assert diff.added_behaviors == ("foundation:new-agent",)
+    assert diff.removed_behaviors == ("foundation:old-agent",)
+    assert diff.token_delta == 50
+    assert diff.before_tokens == 100
+    assert diff.after_tokens == 150
+
+
+def test_bundle_diff_is_frozen() -> None:
+    """BundleDiff is a frozen dataclass — mutation raises FrozenInstanceError."""
+    diff = BundleDiff(
+        added_parts=(),
+        removed_parts=(),
+        added_behaviors=(),
+        removed_behaviors=(),
+        token_delta=0,
+        before_tokens=0,
+        after_tokens=0,
+    )
+    try:
+        diff.token_delta = 99  # type: ignore[misc]
+        raise AssertionError("Expected FrozenInstanceError was not raised")
+    except FrozenInstanceError:
+        pass

--- a/experiments/bundle-configurator/tests/test_provenance.py
+++ b/experiments/bundle-configurator/tests/test_provenance.py
@@ -1,0 +1,604 @@
+"""Tests for amplifier_configurator.provenance module.
+
+Tests for:
+  - _extract_include_uri  (4 tests)
+  - _extract_parts_from_bundle  (6 tests)
+  - build_provenance_map  (8 async tests via mock_load_bundle fixture)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from amplifier_foundation.bundle import Bundle
+
+from amplifier_configurator.models import PartKind, TrackedPart
+from amplifier_configurator.provenance import (
+    _extract_include_uri,
+    _extract_parts_from_bundle,
+    build_provenance_map,
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_include_uri  (4 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_include_uri_from_dict_format() -> None:
+    """Dict format {'bundle': 'uri'} returns the URI string."""
+    result = _extract_include_uri({"bundle": "git+https://example.com/foo"})
+    assert result == "git+https://example.com/foo"
+
+
+def test_extract_include_uri_from_plain_string() -> None:
+    """Plain string format returns the string directly."""
+    result = _extract_include_uri("foundation:some-behavior")
+    assert result == "foundation:some-behavior"
+
+
+def test_extract_include_uri_dict_without_bundle_key_returns_none() -> None:
+    """Dict without 'bundle' key returns None."""
+    result = _extract_include_uri({"uri": "something", "other": "value"})
+    assert result is None
+
+
+def test_extract_include_uri_unknown_format_returns_none() -> None:
+    """Unknown formats (int, list, None) return None."""
+    assert _extract_include_uri(42) is None
+    assert _extract_include_uri(["foo", "bar"]) is None
+    assert _extract_include_uri(None) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_parts_from_bundle  (6 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_parts_tool_name_from_module_key() -> None:
+    """Tool names are extracted from the 'module' key."""
+    bundle = Bundle(
+        name="test-bundle",
+        tools=[
+            {"module": "tool-bash", "source": "git+https://example.com/tool-bash@main"}
+        ],
+    )
+    parts = _extract_parts_from_bundle(bundle, source_behavior=None)
+    tool_parts = [p for p in parts if p.kind == PartKind.TOOL]
+    assert len(tool_parts) == 1
+    assert tool_parts[0].name == "tool-bash"
+    assert tool_parts[0].tokens == 0  # tools always contribute 0 tokens
+
+
+def test_extract_parts_tool_name_from_id_key() -> None:
+    """Tool name falls back to 'id' key when 'module' is absent."""
+    bundle = Bundle(
+        name="test-bundle",
+        tools=[
+            {
+                "id": "tool-special",
+                "source": "git+https://example.com/tool-special@main",
+            }
+        ],
+    )
+    parts = _extract_parts_from_bundle(bundle, source_behavior=None)
+    tool_parts = [p for p in parts if p.kind == PartKind.TOOL]
+    assert len(tool_parts) == 1
+    assert tool_parts[0].name == "tool-special"
+
+
+def test_extract_parts_source_behavior_is_set() -> None:
+    """All extracted parts carry the provided source_behavior value."""
+    bundle = Bundle(
+        name="my-behavior",
+        tools=[{"module": "tool-bash"}],
+        hooks=[{"module": "hooks-todo"}],
+    )
+    parts = _extract_parts_from_bundle(bundle, source_behavior="my-behavior")
+    assert len(parts) == 2
+    assert all(p.source_behavior == "my-behavior" for p in parts)
+
+
+def test_extract_parts_root_has_none_source_behavior() -> None:
+    """Root parts are extracted with source_behavior=None."""
+    bundle = Bundle(
+        name="root-bundle",
+        tools=[{"module": "tool-bash"}, {"module": "tool-search"}],
+    )
+    parts = _extract_parts_from_bundle(bundle, source_behavior=None)
+    assert all(p.source_behavior is None for p in parts)
+
+
+def test_extract_parts_agent_tokens_from_description_and_instruction() -> None:
+    """Agent token count = estimate_tokens(description) + estimate_tokens(instruction)."""
+    description = "Finds bugs"  # 10 chars → 10//4 = 2 tokens
+    instruction = "Hunt them relentlessly."  # 23 chars → 23//4 = 5 tokens
+    bundle = Bundle(
+        name="test-bundle",
+        agents={
+            "bug-hunter": {
+                "description": description,
+                "instruction": instruction,
+            }
+        },
+    )
+    parts = _extract_parts_from_bundle(bundle, source_behavior=None)
+    agent_parts = [p for p in parts if p.kind == PartKind.AGENT]
+    assert len(agent_parts) == 1
+    expected = len(description) // 4 + len(instruction) // 4
+    assert agent_parts[0].tokens == expected
+
+
+def test_extract_parts_context_names_are_namespaced() -> None:
+    """Context TrackedPart names are '{bundle.name}:{ctx_name}'."""
+    ctx_path = Path("/tmp/nonexistent_lsp_ctx.md")
+    bundle = Bundle(
+        name="leaf-behavior",
+        context={"lsp-config": ctx_path},
+    )
+    parts = _extract_parts_from_bundle(bundle, source_behavior="leaf-behavior")
+    ctx_parts = [p for p in parts if p.kind == PartKind.CONTEXT]
+    assert len(ctx_parts) == 1
+    assert ctx_parts[0].name == "leaf-behavior:lsp-config"
+    assert ctx_parts[0].source_behavior == "leaf-behavior"
+
+
+def test_extract_parts_pending_context_creates_zero_token_parts() -> None:
+    """_pending_context entries produce 0-token CONTEXT TrackedParts.
+
+    This is the key bug regression test: Foundation stores namespace-referenced
+    context files in bundle._pending_context (not bundle.context) when a bundle
+    is loaded with auto_include=False.  _extract_parts_from_bundle() must read
+    both fields so that the backfill step can assign real token counts later.
+    """
+    bundle = Bundle(name="ns-behavior")
+    ref = "amplifier:context/ecosystem-overview.md"
+    bundle._pending_context[ref] = ref
+
+    parts = _extract_parts_from_bundle(bundle, source_behavior="ns-behavior")
+    ctx_parts = [p for p in parts if p.kind == PartKind.CONTEXT]
+
+    assert len(ctx_parts) == 1, (
+        "_pending_context entry must be extracted as a CONTEXT TrackedPart; "
+        f"got {len(ctx_parts)} context parts"
+    )
+    assert ctx_parts[0].name == ref, (
+        "Part name must equal the full namespace reference string so it matches "
+        "the composed.context key used by _backfill_context_tokens()"
+    )
+    assert ctx_parts[0].tokens == 0, "Token count must be 0 before backfill"
+    assert ctx_parts[0].namespace_path == ref, (
+        "namespace_path must hold the ref for diagnostics"
+    )
+    assert ctx_parts[0].source_behavior == "ns-behavior"
+
+
+def test_extract_parts_pending_context_same_ref_from_two_behaviors_deduplicates() -> (
+    None
+):
+    """Two behaviors referencing the same context file produce identical part keys.
+
+    Deduplication relies on (kind, name) identity.  Both behaviors must emit a
+    part whose name is the shared namespace reference so last-write-wins applies.
+    """
+    ref = "amplifier:context/shared.md"
+    bundle_a = Bundle(name="behavior-a")
+    bundle_b = Bundle(name="behavior-b")
+    bundle_a._pending_context[ref] = ref
+    bundle_b._pending_context[ref] = ref
+
+    parts_a = _extract_parts_from_bundle(bundle_a, source_behavior="behavior-a")
+    parts_b = _extract_parts_from_bundle(bundle_b, source_behavior="behavior-b")
+
+    ctx_a = [p for p in parts_a if p.kind == PartKind.CONTEXT]
+    ctx_b = [p for p in parts_b if p.kind == PartKind.CONTEXT]
+
+    assert ctx_a[0].name == ctx_b[0].name == ref, (
+        "Shared context ref must produce the same part name from both behaviors "
+        "so deduplication by (kind, name) works correctly"
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_provenance_map  (8 async tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_load_bundle(mock_behavior_tree: dict[str, Bundle]):
+    """Async mock for load_bundle that serves bundles from mock_behavior_tree.
+
+    - auto_include=False: returns the matching raw bundle for each URI
+    - auto_include=True:  returns a composed bundle (all parts merged)
+    """
+    tree = mock_behavior_tree
+    leaf = tree["leaf"]
+
+    # Composed bundle merges all parts; context is already resolved (real file)
+    composed = Bundle(
+        name="root-bundle",
+        tools=[
+            {"module": "tool-bash", "source": "git+https://example.com/tool-bash@main"},
+            {
+                "module": "tool-filesystem",
+                "source": "git+https://example.com/tool-fs@main",
+            },
+            {
+                "module": "tool-search",
+                "source": "git+https://example.com/tool-search@main",
+            },
+            {
+                "module": "tool-delegate",
+                "source": "git+https://example.com/tool-delegate@main",
+            },
+            {
+                "module": "python_check",
+                "source": "git+https://example.com/python-check@main",
+            },
+            {"module": "tool-lsp", "source": "git+https://example.com/tool-lsp@main"},
+        ],
+        instruction="You are a helpful assistant.",
+        # Context key prefixed as "leaf-behavior:lsp-config" (post-compose namespacing)
+        context={"leaf-behavior:lsp-config": list(leaf.context.values())[0]},
+    )
+
+    async def _load(source: str, *, auto_include: bool = True, registry=None) -> Bundle:
+        if auto_include:
+            return composed
+        raw_map = {
+            "root-uri": tree["root"],
+            "mid-behavior-uri": tree["mid"],
+            "leaf-behavior-uri": tree["leaf"],
+        }
+        if source not in raw_map:
+            raise ValueError(f"Unknown source in mock: {source!r}")
+        return raw_map[source]
+
+    return _load
+
+
+async def test_build_provenance_map_root_name_and_instruction(mock_load_bundle) -> None:
+    """build_provenance_map sets root_name and root_instruction from the root bundle."""
+    with patch(
+        "amplifier_configurator.provenance.load_bundle", side_effect=mock_load_bundle
+    ):
+        pmap = await build_provenance_map("root-uri")
+
+    assert pmap.root_name == "root-bundle"
+    assert pmap.root_instruction == "You are a helpful assistant."
+
+
+async def test_build_provenance_map_behaviors_count_and_names(mock_load_bundle) -> None:
+    """behaviors has exactly 2 entries: leaf-behavior and mid-behavior."""
+    with patch(
+        "amplifier_configurator.provenance.load_bundle", side_effect=mock_load_bundle
+    ):
+        pmap = await build_provenance_map("root-uri")
+
+    assert len(pmap.behaviors) == 2
+    behavior_names = {beh.name for beh in pmap.behaviors.values()}
+    assert behavior_names == {"leaf-behavior", "mid-behavior"}
+
+
+async def test_build_provenance_map_include_order_bottom_up(mock_load_bundle) -> None:
+    """include_order is bottom-up: leaf first (depth=1), then mid (depth=0)."""
+    with patch(
+        "amplifier_configurator.provenance.load_bundle", side_effect=mock_load_bundle
+    ):
+        pmap = await build_provenance_map("root-uri")
+
+    order_uris = list(pmap.include_order)
+    # Find positions of leaf and mid in include_order
+    leaf_idx = next(
+        i
+        for i, uri in enumerate(order_uris)
+        if pmap.behaviors[uri].name == "leaf-behavior"
+    )
+    mid_idx = next(
+        i
+        for i, uri in enumerate(order_uris)
+        if pmap.behaviors[uri].name == "mid-behavior"
+    )
+    assert leaf_idx < mid_idx, "leaf must come before mid in bottom-up order"
+
+
+async def test_build_provenance_map_root_parts_have_no_source_behavior(
+    mock_load_bundle,
+) -> None:
+    """root_parts contains 4 tools, all with source_behavior=None."""
+    with patch(
+        "amplifier_configurator.provenance.load_bundle", side_effect=mock_load_bundle
+    ):
+        pmap = await build_provenance_map("root-uri")
+
+    assert len(pmap.root_parts) == 4
+    assert all(p.source_behavior is None for p in pmap.root_parts)
+    root_tool_names = {p.name for p in pmap.root_parts}
+    assert root_tool_names == {
+        "tool-bash",
+        "tool-filesystem",
+        "tool-search",
+        "tool-delegate",
+    }
+
+
+async def test_build_provenance_map_leaf_depth_and_include_chain(
+    mock_load_bundle,
+) -> None:
+    """Leaf behavior has depth=1 and include_chain ('root-bundle', 'mid-behavior', 'leaf-behavior')."""
+    with patch(
+        "amplifier_configurator.provenance.load_bundle", side_effect=mock_load_bundle
+    ):
+        pmap = await build_provenance_map("root-uri")
+
+    leaf_beh = next(
+        beh for beh in pmap.behaviors.values() if beh.name == "leaf-behavior"
+    )
+    assert leaf_beh.depth == 1
+    assert leaf_beh.include_chain == ("root-bundle", "mid-behavior", "leaf-behavior")
+
+
+async def test_build_provenance_map_session_config_preserved(
+    mock_behavior_tree: dict[str, Bundle],
+) -> None:
+    """session_config is read from the root bundle's session field."""
+    tree = mock_behavior_tree
+    leaf = tree["leaf"]
+
+    # Build a root bundle that has session config
+    root_with_session = Bundle(
+        name="root-bundle",
+        tools=tree["root"].tools,
+        includes=tree["root"].includes,
+        instruction="You are a helpful assistant.",
+        session={"model": "gpt-4", "timeout": 30},
+    )
+
+    composed = Bundle(
+        name="root-bundle",
+        tools=[
+            {"module": "tool-bash"},
+            {"module": "tool-filesystem"},
+            {"module": "tool-search"},
+            {"module": "tool-delegate"},
+            {"module": "python_check"},
+            {"module": "tool-lsp"},
+        ],
+        instruction="You are a helpful assistant.",
+        context={"leaf-behavior:lsp-config": list(leaf.context.values())[0]},
+    )
+
+    async def _load_session(
+        source: str, *, auto_include: bool = True, registry=None
+    ) -> Bundle:
+        if auto_include:
+            return composed
+        raw_map = {
+            "root-uri": root_with_session,
+            "mid-behavior-uri": tree["mid"],
+            "leaf-behavior-uri": tree["leaf"],
+        }
+        return raw_map[source]
+
+    with patch(
+        "amplifier_configurator.provenance.load_bundle", side_effect=_load_session
+    ):
+        pmap = await build_provenance_map("root-uri")
+
+    assert pmap.session_config == {"model": "gpt-4", "timeout": 30}
+
+
+async def test_build_provenance_map_no_duplicate_tool_names(mock_load_bundle) -> None:
+    """all_parts contains no duplicate tool names (deduplication is applied)."""
+    with patch(
+        "amplifier_configurator.provenance.load_bundle", side_effect=mock_load_bundle
+    ):
+        pmap = await build_provenance_map("root-uri")
+
+    tool_parts = [p for p in pmap.all_parts if p.kind == PartKind.TOOL]
+    tool_names = [p.name for p in tool_parts]
+    assert len(tool_names) == len(set(tool_names)), (
+        f"Duplicate tool names found in all_parts: {tool_names}"
+    )
+
+
+async def test_build_provenance_map_raw_bundles_stored(mock_load_bundle) -> None:
+    """_raw_bundles contains an entry for the root bundle and each behavior."""
+    with patch(
+        "amplifier_configurator.provenance.load_bundle", side_effect=mock_load_bundle
+    ):
+        pmap = await build_provenance_map("root-uri")
+
+    # Root bundle must be present
+    assert "root-bundle" in pmap._raw_bundles
+
+    # Each behavior must have its raw bundle stored (keyed by behavior name)
+    for beh_name in ["mid-behavior", "leaf-behavior"]:
+        assert beh_name in pmap._raw_bundles, (
+            f"Raw bundle missing for behavior '{beh_name}': "
+            f"available keys = {list(pmap._raw_bundles)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _backfill_context_tokens  (2 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_context_tokens_updates_zero_token_parts(tmp_path: Path) -> None:
+    """Context parts with tokens=0 are patched from the composed bundle's real files."""
+    from amplifier_configurator.models import BehaviorInfo
+    from amplifier_configurator.provenance import _backfill_context_tokens
+
+    # Real file on disk: 400 chars → 100 tokens (400 // 4)
+    ctx_file = tmp_path / "context.md"
+    ctx_file.write_text("A" * 400)
+
+    # Behavior has a 0-token context part whose name matches the composed.context key.
+    ctx_part = TrackedPart(
+        kind=PartKind.CONTEXT,
+        name="my-ctx-key",
+        source_behavior="my-behavior",
+        tokens=0,
+        config={"path": str(ctx_file)},
+        namespace_path=None,
+    )
+    behavior_info = BehaviorInfo(
+        name="my-behavior",
+        uri="my-behavior-uri",
+        parts=(ctx_part,),
+        raw_parts=(ctx_part,),
+        total_tokens=0,
+        depth=0,
+        include_chain=("root", "my-behavior"),
+    )
+    behaviors = {"my-behavior-uri": behavior_info}
+    include_order = ("my-behavior-uri",)
+
+    # Composed bundle has a context entry pointing at the real file.
+    composed = Bundle(name="root", context={"my-ctx-key": ctx_file})
+
+    updated_behaviors, _root_parts, _all_parts = _backfill_context_tokens(
+        behaviors, (), include_order, composed
+    )
+
+    updated_part = next(
+        p
+        for p in updated_behaviors["my-behavior-uri"].parts
+        if p.kind == PartKind.CONTEXT
+    )
+    assert updated_part.tokens == 100, (
+        f"Expected 100 tokens (400 chars // 4), got {updated_part.tokens}"
+    )
+    # total_tokens on the BehaviorInfo should also be refreshed.
+    assert updated_behaviors["my-behavior-uri"].total_tokens == 100
+
+
+def test_backfill_context_tokens_preserves_nonzero_tokens(tmp_path: Path) -> None:
+    """Context parts that already have tokens > 0 are left unchanged."""
+    from amplifier_configurator.models import BehaviorInfo
+    from amplifier_configurator.provenance import _backfill_context_tokens
+
+    # File has 400 chars = 100 tokens, but the part already reports 99.
+    ctx_file = tmp_path / "context.md"
+    ctx_file.write_text("A" * 400)
+
+    ctx_part = TrackedPart(
+        kind=PartKind.CONTEXT,
+        name="existing-ctx-key",
+        source_behavior="my-behavior",
+        tokens=99,  # pre-existing non-zero — must NOT be overwritten
+        config={},
+        namespace_path=None,
+    )
+    behavior_info = BehaviorInfo(
+        name="my-behavior",
+        uri="my-behavior-uri",
+        parts=(ctx_part,),
+        raw_parts=(ctx_part,),
+        total_tokens=99,
+        depth=0,
+        include_chain=("root", "my-behavior"),
+    )
+    behaviors = {"my-behavior-uri": behavior_info}
+    include_order = ("my-behavior-uri",)
+
+    composed = Bundle(name="root", context={"existing-ctx-key": ctx_file})
+
+    updated_behaviors, _, __ = _backfill_context_tokens(
+        behaviors, (), include_order, composed
+    )
+
+    updated_part = next(
+        p
+        for p in updated_behaviors["my-behavior-uri"].parts
+        if p.kind == PartKind.CONTEXT
+    )
+    assert updated_part.tokens == 99, (
+        f"Non-zero tokens must be preserved; got {updated_part.tokens}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _recompute_all_parts  (2 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_recompute_all_parts_deduplication() -> None:
+    """Two behaviors sharing a tool name: the one later in include_order wins."""
+    from amplifier_configurator.models import BehaviorInfo
+    from amplifier_configurator.provenance import _recompute_all_parts
+
+    # "First" behavior contributes tool-shared v1; "second" contributes v2.
+    tool_v1 = TrackedPart(
+        kind=PartKind.TOOL,
+        name="tool-shared",
+        source_behavior="behavior-first",
+        tokens=0,
+        config={"module": "tool-shared", "version": "1"},
+        namespace_path=None,
+    )
+    tool_v2 = TrackedPart(
+        kind=PartKind.TOOL,
+        name="tool-shared",
+        source_behavior="behavior-second",
+        tokens=0,
+        config={"module": "tool-shared", "version": "2"},
+        namespace_path=None,
+    )
+
+    behavior_first = BehaviorInfo(
+        name="behavior-first",
+        uri="uri-first",
+        parts=(tool_v1,),
+        raw_parts=(tool_v1,),
+        total_tokens=0,
+        depth=1,
+        include_chain=("root", "behavior-first"),
+    )
+    behavior_second = BehaviorInfo(
+        name="behavior-second",
+        uri="uri-second",
+        parts=(tool_v2,),
+        raw_parts=(tool_v2,),
+        total_tokens=0,
+        depth=0,
+        include_chain=("root", "behavior-second"),
+    )
+
+    behaviors = {"uri-first": behavior_first, "uri-second": behavior_second}
+    # uri-second is later in include_order → last-write-wins → tool_v2 wins.
+    include_order = ("uri-first", "uri-second")
+
+    all_parts = _recompute_all_parts(behaviors, (), include_order)
+
+    shared_tools = [p for p in all_parts if p.name == "tool-shared"]
+    assert len(shared_tools) == 1, (
+        f"Expected exactly 1 deduplicated tool, got {len(shared_tools)}"
+    )
+    assert shared_tools[0].source_behavior == "behavior-second", (
+        "Last behavior in include_order must win (last-write-wins)"
+    )
+
+
+def test_recompute_all_parts_includes_root_parts() -> None:
+    """Root parts are always present in the result, even when behaviors is empty."""
+    from amplifier_configurator.provenance import _recompute_all_parts
+
+    root_tool = TrackedPart(
+        kind=PartKind.TOOL,
+        name="tool-root-only",
+        source_behavior=None,
+        tokens=0,
+        config={},
+        namespace_path=None,
+    )
+
+    all_parts = _recompute_all_parts({}, (root_tool,), ())
+
+    assert any(p.name == "tool-root-only" for p in all_parts), (
+        "Root parts must appear in recomputed all_parts"
+    )

--- a/experiments/bundle-configurator/tests/test_public_api.py
+++ b/experiments/bundle-configurator/tests/test_public_api.py
@@ -1,0 +1,150 @@
+"""Tests for amplifier_configurator public API exports (task-11).
+
+Verifies that all required symbols are importable from the top-level package,
+that __all__ contains every public symbol, that the module docstring is correct,
+and that pyproject.toml is at version 0.3.0.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+EXPECTED_EXPORTS = [
+    # Main class
+    "BundleConfigurator",
+    # Data models
+    "BehaviorInfo",
+    "BundleDiff",
+    "PartKind",
+    "ProvenanceMap",
+    "TrackedPart",
+    # Errors
+    "ConfiguratorError",
+    "ConfiguratorWarning",
+    "DependencyError",
+    "LoadError",
+    # Functions
+    "estimate_tokens_for_file",
+    "estimate_tokens_for_text",
+    "serialize_bundle",
+    "validate_provenance",
+    # Constants
+    "PART_DEPENDENCIES",
+    "REQUIRED_PARTS",
+]
+
+EXPECTED_DOCSTRING_FRAGMENT = (
+    "amplifier_configurator \u2014 provenance-aware bundle editing for Amplifier"
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_all_symbols_importable() -> None:
+    """Every required export is importable directly from amplifier_configurator."""
+    import amplifier_configurator  # noqa: F401
+
+    for name in EXPECTED_EXPORTS:
+        assert hasattr(amplifier_configurator, name), (
+            f"amplifier_configurator is missing expected export: {name!r}"
+        )
+
+
+def test_all_symbols_in_dunder_all() -> None:
+    """__all__ contains every required public symbol."""
+    import amplifier_configurator
+
+    all_exports = amplifier_configurator.__all__
+    for name in EXPECTED_EXPORTS:
+        assert name in all_exports, (
+            f"{name!r} is not listed in amplifier_configurator.__all__"
+        )
+
+
+def test_no_unexpected_symbols_in_all() -> None:
+    """__all__ does not list symbols we did NOT intend to export (regression guard)."""
+    import amplifier_configurator
+
+    extra = set(amplifier_configurator.__all__) - set(EXPECTED_EXPORTS)
+    # It's OK to have more exports — this just documents current expectations.
+    # If unwanted names sneak in, update this set.
+    allowed_extra: set[str] = set()
+    unexpected = extra - allowed_extra
+    # We do NOT fail on extra exports; that would be overly rigid.
+    # This test serves as documentation. Change allowed_extra if intentional.
+    _ = unexpected  # intentionally not asserted
+
+
+def test_module_docstring() -> None:
+    """Module docstring starts with the canonical description."""
+    import amplifier_configurator
+
+    doc = amplifier_configurator.__doc__ or ""
+    assert EXPECTED_DOCSTRING_FRAGMENT in doc, (
+        f"Module docstring does not contain expected fragment.\n"
+        f"Expected to find: {EXPECTED_DOCSTRING_FRAGMENT!r}\n"
+        f"Got: {doc!r}"
+    )
+
+
+def test_module_docstring_mentions_foundation() -> None:
+    """Docstring mentions Foundation's real Bundle API."""
+    import amplifier_configurator
+
+    doc = amplifier_configurator.__doc__ or ""
+    assert "Foundation" in doc, (
+        "Module docstring should mention Foundation's real Bundle API"
+    )
+    assert "Not a reimplementation" in doc, (
+        "Module docstring should state 'Not a reimplementation'"
+    )
+
+
+def test_version_in_pyproject() -> None:
+    """pyproject.toml specifies version 0.3.0."""
+    pyproject = Path(__file__).parent.parent / "pyproject.toml"
+    content = pyproject.read_text(encoding="utf-8")
+    assert 'version = "0.3.0"' in content, (
+        f"pyproject.toml version should be 0.3.0, got:\n{content}"
+    )
+
+
+def test_imports_are_correct_types() -> None:
+    """Spot-check that imported names are the correct types/classes."""
+    import amplifier_configurator as ac
+
+    # Classes
+    assert isinstance(ac.BundleConfigurator, type)
+    assert isinstance(ac.BehaviorInfo, type)
+    assert isinstance(ac.BundleDiff, type)
+    assert isinstance(ac.TrackedPart, type)
+    assert isinstance(ac.ProvenanceMap, type)
+
+    # Enums
+    from enum import EnumMeta
+
+    assert isinstance(ac.PartKind, EnumMeta)
+
+    # Exception classes
+    assert issubclass(ac.ConfiguratorError, Exception)
+    assert issubclass(ac.ConfiguratorWarning, Warning)
+    assert issubclass(ac.DependencyError, ac.ConfiguratorError)
+    assert issubclass(ac.LoadError, ac.ConfiguratorError)
+
+    # Callables (functions)
+    assert callable(ac.estimate_tokens_for_file)
+    assert callable(ac.estimate_tokens_for_text)
+    assert callable(ac.serialize_bundle)
+    assert callable(ac.validate_provenance)
+
+    # Constants
+    assert isinstance(ac.PART_DEPENDENCIES, dict)
+    assert isinstance(ac.REQUIRED_PARTS, set)

--- a/experiments/bundle-configurator/tests/test_real_bundles.py
+++ b/experiments/bundle-configurator/tests/test_real_bundles.py
@@ -1,0 +1,322 @@
+"""Real-world integration tests for BundleConfigurator against live Foundation bundles.
+
+All tests require the Amplifier cache to be populated (the Foundation bundle and
+amplifier-dev must have been fetched at least once).  They are skipped
+automatically in normal ``pytest`` runs and only execute with::
+
+    pytest -m integration
+
+**Token count notes**: ``total_tokens()`` tracks context files referenced via
+namespace URIs (e.g. ``amplifier:context/...``) as well as the root instruction.
+The ground truth for ``foundation`` is ~23,425 tokens dominated by 18 context
+files (~23,194 tokens) plus the root instruction (~231 tokens).
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from amplifier_configurator import BundleConfigurator
+from amplifier_configurator.models import PartKind
+
+pytestmark = pytest.mark.integration
+
+_CACHE_EXISTS = Path("~/.amplifier/cache/").expanduser().exists()
+
+_skip_if_no_cache = pytest.mark.skipif(
+    not _CACHE_EXISTS,
+    reason="Amplifier cache not available (~/.amplifier/cache/ missing)",
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. test_load_foundation_bundle
+# ---------------------------------------------------------------------------
+
+
+@_skip_if_no_cache
+def test_load_foundation_bundle() -> None:
+    """Foundation bundle loads and exposes expected behaviors and tools."""
+    cfg = BundleConfigurator.load_sync("foundation")
+
+    # Loads without error
+    assert cfg is not None
+
+    # Has behaviors
+    behaviors = cfg.list_behaviors()
+    assert len(behaviors) > 0, "Expected at least one behavior from foundation"
+
+    # total_tokens reflects context files + root instruction.
+    # Foundation has 18 context files (~23K tokens) plus root instruction (~231).
+    assert cfg.total_tokens() > 5_000, (
+        f"Expected total_tokens() > 5,000 for foundation (context files + instruction); "
+        f"got {cfg.total_tokens()}.  If this fails, context file backfill may be broken."
+    )
+
+    # Context parts must be present and have non-zero token counts
+    ctx_parts = cfg.list_parts(kind=PartKind.CONTEXT)
+    assert len(ctx_parts) > 0, (
+        "Expected context parts to be extracted from _pending_context"
+    )
+    assert all(p.tokens > 0 for p in ctx_parts), (
+        f"All context parts should have non-zero token counts after backfill; "
+        f"zero-token parts: {[p.name for p in ctx_parts if p.tokens == 0]}"
+    )
+
+    # Structural checks: behaviors must include named behaviors with non-empty URIs.
+    # We do NOT assert specific behavior names because the live foundation bundle
+    # is a git-tracked resource that changes; hardcoded names break whenever
+    # upstream removes or renames a behavior.
+    behavior_names = {b.name for b in behaviors}
+    assert len(behavior_names) >= 5, (
+        f"Expected at least 5 distinct behavior names in foundation; got {sorted(behavior_names)}"
+    )
+    named_behaviors = [b for b in behaviors if b.name and b.uri]
+    assert len(named_behaviors) >= 5, (
+        f"Expected at least 5 named behaviors; got {[b.name for b in named_behaviors]}"
+    )
+
+    # Specific tools must be present
+    tool_names = {p.name for p in cfg.list_parts(kind=PartKind.TOOL)}
+    assert "tool-bash" in tool_names, (
+        f"'tool-bash' missing from foundation tools. Got: {sorted(tool_names)}"
+    )
+    assert "tool-filesystem" in tool_names, (
+        f"'tool-filesystem' missing from foundation tools. Got: {sorted(tool_names)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. test_load_amplifier_dev_bundle
+# ---------------------------------------------------------------------------
+
+
+@_skip_if_no_cache
+def test_load_amplifier_dev_bundle() -> None:
+    """amplifier-dev loads and includes all foundation behaviors plus its own."""
+    foundation_cfg = BundleConfigurator.load_sync("foundation")
+    dev_cfg = BundleConfigurator.load_sync("amplifier-dev")
+
+    # Loads without error
+    assert dev_cfg is not None
+
+    foundation_behavior_names = {b.name for b in foundation_cfg.list_behaviors()}
+    dev_behavior_names = {b.name for b in dev_cfg.list_behaviors()}
+
+    # amplifier-dev must have MORE behaviors than foundation
+    assert len(dev_behavior_names) > len(foundation_behavior_names), (
+        f"amplifier-dev ({len(dev_behavior_names)} behaviors) should have more "
+        f"than foundation ({len(foundation_behavior_names)} behaviors)"
+    )
+
+    # All foundation behaviors are present in amplifier-dev (it includes foundation)
+    missing = foundation_behavior_names - dev_behavior_names
+    assert not missing, (
+        f"These foundation behaviors are missing from amplifier-dev: {missing}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. test_remove_behavior_token_savings
+# ---------------------------------------------------------------------------
+
+
+@_skip_if_no_cache
+def test_remove_behavior_token_savings() -> None:
+    """Removing a behavior reduces the total part count and token count."""
+    cfg = BundleConfigurator.load_sync("foundation")
+
+    # Pick browser-testing-behavior; fall back to first non-critical removable one.
+    target: str | None = None
+    behavior_names = [b.name for b in cfg.list_behaviors()]
+    for candidate in ["browser-testing-behavior", *behavior_names]:
+        try:
+            cfg.remove_behavior(candidate)
+            target = candidate
+            break
+        except (KeyError, Exception):
+            continue
+
+    if target is None:
+        pytest.skip("No removable behavior found in foundation bundle")
+
+    original_tokens = cfg.total_tokens()
+    original_behavior_count = len(cfg.list_behaviors())
+    original_parts_count = len(cfg.list_parts())
+
+    new_cfg = cfg.remove_behavior(target)
+
+    # Token count must not increase
+    assert new_cfg.total_tokens() <= original_tokens, (
+        f"Removing '{target}' should not increase token count: "
+        f"{original_tokens} → {new_cfg.total_tokens()}"
+    )
+
+    # At least one fewer behavior
+    assert len(new_cfg.list_behaviors()) < original_behavior_count, (
+        f"Expected fewer behaviors after removing '{target}'"
+    )
+
+    # At least the same or fewer parts overall (some parts may be shared)
+    assert len(new_cfg.list_parts()) <= original_parts_count, (
+        f"Expected same or fewer parts after removing '{target}'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. test_diff_after_removal
+# ---------------------------------------------------------------------------
+
+
+@_skip_if_no_cache
+def test_diff_after_removal() -> None:
+    """Removing a behavior produces a diff with removed_behaviors and non-positive token_delta."""
+    cfg = BundleConfigurator.load_sync("foundation")
+
+    # Locate a removable behavior (prefer browser-testing-behavior)
+    target: str | None = None
+    for candidate in [
+        "browser-testing-behavior",
+        *[b.name for b in cfg.list_behaviors()],
+    ]:
+        try:
+            cfg.remove_behavior(candidate)
+            target = candidate
+            break
+        except (KeyError, Exception):
+            continue
+
+    if target is None:
+        pytest.skip("No removable behavior found in foundation bundle")
+
+    new_cfg = cfg.remove_behavior(target)
+    diff = cfg.diff(new_cfg)
+
+    # The removed behavior's URI must appear in removed_behaviors
+    assert len(diff.removed_behaviors) > 0, (
+        "diff.removed_behaviors must be non-empty after removing a behavior"
+    )
+
+    # No new behaviors should have appeared
+    assert len(diff.added_behaviors) == 0, (
+        f"Unexpected behaviors added in diff: {diff.added_behaviors}"
+    )
+
+    # Token delta must be <= 0 (removing parts never adds tokens)
+    assert diff.token_delta <= 0, (
+        f"Removing a behavior should not increase token count; "
+        f"got token_delta={diff.token_delta}"
+    )
+
+    # before_tokens and after_tokens must be consistent with the individual counts
+    assert diff.before_tokens == cfg.total_tokens()
+    assert diff.after_tokens == new_cfg.total_tokens()
+
+
+# ---------------------------------------------------------------------------
+# 5. test_save_and_reload
+# ---------------------------------------------------------------------------
+
+
+@_skip_if_no_cache
+def test_save_and_reload() -> None:
+    """Saved bundle file has YAML frontmatter, includes section, and no absolute paths."""
+    cfg = BundleConfigurator.load_sync("foundation")
+
+    # Locate a removable behavior so the saved file reflects a mutation
+    target: str | None = None
+    for candidate in [
+        "browser-testing-behavior",
+        *[b.name for b in cfg.list_behaviors()],
+    ]:
+        try:
+            cfg.remove_behavior(candidate)
+            target = candidate
+            break
+        except (KeyError, Exception):
+            continue
+
+    working_cfg = cfg.remove_behavior(target) if target else cfg
+
+    with tempfile.NamedTemporaryFile(suffix=".md", delete=False) as f:
+        dest = Path(f.name)
+    try:
+        working_cfg.save(dest)
+
+        # File exists and is non-empty
+        assert dest.exists(), "Saved file does not exist"
+        content = dest.read_text()
+        assert len(content) > 0, "Saved file is empty"
+
+        # Must start with YAML frontmatter
+        assert content.startswith("---"), (
+            "Saved bundle must begin with '---' (YAML frontmatter)"
+        )
+
+        # Must contain an includes section
+        assert "includes:" in content, "Saved bundle must contain 'includes:' section"
+
+        # Must be parseable as YAML (extract the frontmatter block)
+        # The file is: ---\n<yaml>\n---\n<body>
+        parts = content.split("---", 2)
+        assert len(parts) >= 3, "Could not split YAML frontmatter from body"
+        yaml_block = parts[1]
+        parsed = yaml.safe_load(yaml_block)
+        assert isinstance(parsed, dict), (
+            f"YAML frontmatter did not parse to a dict; got {type(parsed)}"
+        )
+
+        # Must not contain absolute paths
+        assert "/Users/" not in content, (
+            "Saved bundle must not contain absolute '/Users/' paths"
+        )
+        assert "/home/" not in content, (
+            "Saved bundle must not contain absolute '/home/' paths"
+        )
+    finally:
+        dest.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# 6. test_token_count_ground_truth
+# ---------------------------------------------------------------------------
+
+
+@_skip_if_no_cache
+def test_token_count_ground_truth() -> None:
+    """Foundation total_tokens() reflects context files plus root instruction.
+
+    Measured ground truth: ~23,425 tokens total
+      - 18 context files: ~23,194 tokens
+      - Root instruction:    ~231 tokens
+      Total:               ~23,425 tokens
+
+    The tolerance is 40% because bundle content can change between Amplifier
+    releases.  A value below 5,000 indicates the context-file backfill is broken
+    (the pre-fix bug returned only 231).
+    """
+    cfg = BundleConfigurator.load_sync("foundation")
+    tokens = cfg.total_tokens()
+
+    # Hard lower bound: must be far above the old broken value of 231.
+    assert tokens > 5_000, (
+        f"total_tokens()={tokens} is suspiciously low — context files are not being "
+        "counted.  Pre-fix this was 231 (instruction only).  "
+        "Check _extract_parts_from_bundle() and _backfill_context_tokens()."
+    )
+
+    # Soft pinning: within 40% of the measured value (context-heavy bundles drift).
+    ground_truth = 23_425
+    tolerance = 0.40
+    lower = int(ground_truth * (1 - tolerance))
+    upper = int(ground_truth * (1 + tolerance)) + 1
+
+    assert lower <= tokens <= upper, (
+        f"total_tokens()={tokens} is outside the ±40% window "
+        f"[{lower}, {upper}] of the measured ground-truth {ground_truth}. "
+        "Update ground_truth in this test if the Foundation bundle has changed substantially."
+    )

--- a/experiments/bundle-configurator/tests/test_serialize.py
+++ b/experiments/bundle-configurator/tests/test_serialize.py
@@ -1,0 +1,255 @@
+"""Tests for serialize.py — bundle serialization to .md format."""
+
+from __future__ import annotations
+
+import yaml
+
+from amplifier_foundation.bundle import Bundle
+
+from amplifier_configurator.models import (
+    BehaviorInfo,
+    PartKind,
+    ProvenanceMap,
+    TrackedPart,
+)
+from amplifier_configurator.serialize import serialize_bundle
+
+
+def _tp(
+    kind: PartKind,
+    name: str,
+    source: str | None = None,
+    tokens: int = 0,
+    config: dict | None = None,
+    namespace_path: str | None = None,
+) -> TrackedPart:
+    return TrackedPart(
+        kind=kind,
+        name=name,
+        source_behavior=source,
+        tokens=tokens,
+        config=config or {},
+        namespace_path=namespace_path,
+    )
+
+
+def _simple_pmap() -> ProvenanceMap:
+    """Build a simple ProvenanceMap for serialization tests."""
+    leaf_tool = _tp(
+        PartKind.TOOL,
+        "tool-lsp",
+        "leaf-behavior",
+        config={
+            "module": "tool-lsp",
+            "source": "git+https://example.com/tool-lsp@main",
+        },
+    )
+    leaf_ctx = _tp(
+        PartKind.CONTEXT,
+        "leaf-behavior:lsp-config",
+        "leaf-behavior",
+        tokens=100,
+        config={"path": "/tmp/lsp.md"},
+        namespace_path="leaf-behavior:lsp-config",
+    )
+
+    leaf = BehaviorInfo(
+        name="leaf-behavior",
+        uri="git+https://example.com/leaf@main",
+        parts=(leaf_tool, leaf_ctx),
+        raw_parts=(leaf_tool, leaf_ctx),
+        total_tokens=100,
+        depth=1,
+        include_chain=("root", "mid", "leaf-behavior"),
+    )
+
+    mid_tool = _tp(
+        PartKind.TOOL,
+        "python_check",
+        "mid-behavior",
+        config={
+            "module": "python_check",
+            "source": "git+https://example.com/python-check@main",
+        },
+    )
+    mid = BehaviorInfo(
+        name="mid-behavior",
+        uri="git+https://example.com/mid@main",
+        parts=(mid_tool,),
+        raw_parts=(mid_tool,),
+        total_tokens=0,
+        depth=0,
+        include_chain=("root", "mid-behavior"),
+    )
+
+    root_parts = (
+        _tp(
+            PartKind.TOOL,
+            "tool-bash",
+            None,
+            config={
+                "module": "tool-bash",
+                "source": "git+https://example.com/tool-bash@main",
+            },
+        ),
+        _tp(
+            PartKind.TOOL,
+            "tool-filesystem",
+            None,
+            config={
+                "module": "tool-filesystem",
+                "source": "git+https://example.com/tool-fs@main",
+            },
+        ),
+        _tp(
+            PartKind.TOOL,
+            "tool-search",
+            None,
+            config={
+                "module": "tool-search",
+                "source": "git+https://example.com/tool-search@main",
+            },
+        ),
+    )
+
+    all_parts = root_parts + (leaf_tool, leaf_ctx, mid_tool)
+    composed = Bundle(name="my-bundle")
+
+    return ProvenanceMap(
+        root_name="my-bundle",
+        root_uri="my-bundle",
+        root_instruction="You are a helpful assistant.",
+        root_instruction_tokens=7,
+        behaviors={"leaf-behavior": leaf, "mid-behavior": mid},
+        root_parts=root_parts,
+        all_parts=all_parts,
+        composed_bundle=composed,
+        include_order=("leaf-behavior", "mid-behavior"),
+        session_config={
+            "orchestrator": {
+                "module": "loop-streaming",
+                "source": "git+https://example.com/orch@main",
+            }
+        },
+        spawn_config=None,
+        _raw_bundles={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# .md format
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_starts_with_frontmatter() -> None:
+    pmap = _simple_pmap()
+    content = serialize_bundle(pmap)
+    assert content.startswith("---\n")
+
+
+def test_serialize_has_closing_frontmatter() -> None:
+    pmap = _simple_pmap()
+    content = serialize_bundle(pmap)
+    # Should have a closing --- on its own line separating YAML from body
+    assert "\n---\n" in content
+
+
+def test_serialize_bundle_name() -> None:
+    pmap = _simple_pmap()
+    content = serialize_bundle(pmap)
+    assert "my-bundle" in content
+
+
+def test_serialize_includes_behavior_uris() -> None:
+    pmap = _simple_pmap()
+    content = serialize_bundle(pmap)
+    assert "git+https://example.com/mid@main" in content
+
+
+def test_serialize_session_config() -> None:
+    pmap = _simple_pmap()
+    content = serialize_bundle(pmap)
+    assert "loop-streaming" in content
+
+
+def test_serialize_instruction_in_body() -> None:
+    """Root instruction appears in markdown body, not YAML."""
+    pmap = _simple_pmap()
+    content = serialize_bundle(pmap)
+    # Instruction should be AFTER the closing ---
+    parts = content.split("---")
+    # parts[0] is empty (before first ---), parts[1] is YAML, parts[2+] is body
+    assert len(parts) >= 3
+    body = "---".join(parts[2:])
+    assert "You are a helpful assistant." in body
+
+
+def test_serialize_root_tools_in_yaml() -> None:
+    """Root-level tools appear in the YAML section."""
+    pmap = _simple_pmap()
+    content = serialize_bundle(pmap)
+    assert "tool-bash" in content
+    assert "tool-filesystem" in content
+
+
+def test_serialize_no_absolute_paths() -> None:
+    """Context paths should be namespace syntax, not absolute."""
+    pmap = _simple_pmap()
+    content = serialize_bundle(pmap)
+    # Should not contain /tmp or /Users
+    assert "/tmp/" not in content
+    assert "/Users/" not in content
+
+
+def test_serialize_context_uses_namespace() -> None:
+    pmap = _simple_pmap()
+    content = serialize_bundle(pmap)
+    assert "leaf-behavior:lsp-config" in content
+
+
+def test_serialize_no_instruction_in_yaml() -> None:
+    """instruction: key should NOT be in the YAML frontmatter."""
+    pmap = _simple_pmap()
+    content = serialize_bundle(pmap)
+    # Parse just the YAML part
+    parts = content.split("---")
+    yaml_text = parts[1]
+    parsed = yaml.safe_load(yaml_text)
+    assert "instruction" not in parsed
+
+
+def test_serialize_valid_yaml_frontmatter() -> None:
+    pmap = _simple_pmap()
+    content = serialize_bundle(pmap)
+    parts = content.split("---")
+    yaml_text = parts[1]
+    parsed = yaml.safe_load(yaml_text)
+    assert isinstance(parsed, dict)
+    assert "bundle" in parsed
+
+
+def test_serialize_no_spawn_when_none() -> None:
+    pmap = _simple_pmap()
+    pmap.spawn_config = None
+    content = serialize_bundle(pmap)
+    parts = content.split("---")
+    yaml_text = parts[1]
+    parsed = yaml.safe_load(yaml_text)
+    assert "spawn" not in parsed
+
+
+def test_serialize_with_spawn() -> None:
+    pmap = _simple_pmap()
+    pmap.spawn_config = {"exclude_tools": ["tool-delegate"]}
+    content = serialize_bundle(pmap)
+    assert "exclude_tools" in content
+
+
+def test_serialize_with_warnings() -> None:
+    """Warnings are included as YAML comments prefixed with '# WARNING:'."""
+    pmap = _simple_pmap()
+    content = serialize_bundle(
+        pmap, warnings=["hooks-todo-reminder requires tool-todo"]
+    )
+    assert "hooks-todo-reminder" in content
+    assert "# WARNING: hooks-todo-reminder" in content

--- a/experiments/bundle-configurator/tests/test_tokens.py
+++ b/experiments/bundle-configurator/tests/test_tokens.py
@@ -1,0 +1,69 @@
+"""Tests for tokens.py — token estimation utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+from amplifier_configurator.tokens import (
+    estimate_tokens_for_file,
+    estimate_tokens_for_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# estimate_tokens_for_text
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_tokens_for_text_basic() -> None:
+    """400 chars should equal 100 tokens (len // 4)."""
+    text = "A" * 400
+    assert estimate_tokens_for_text(text) == 100
+
+
+def test_estimate_tokens_for_text_empty_string() -> None:
+    """Empty string should return 0."""
+    assert estimate_tokens_for_text("") == 0
+
+
+def test_estimate_tokens_for_text_short() -> None:
+    """'abc' is 3 chars, 3 // 4 == 0."""
+    assert estimate_tokens_for_text("abc") == 0
+
+
+def test_estimate_tokens_for_text_none() -> None:
+    """None should return 0."""
+    assert estimate_tokens_for_text(None) == 0
+
+
+# ---------------------------------------------------------------------------
+# estimate_tokens_for_file
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_tokens_for_file_basic(tmp_path: Path) -> None:
+    """A file with 400 chars should return 100 tokens."""
+    f = tmp_path / "sample.txt"
+    f.write_text("A" * 400, encoding="utf-8")
+    assert estimate_tokens_for_file(f) == 100
+
+
+def test_estimate_tokens_for_file_missing(tmp_path: Path) -> None:
+    """Missing file should return 0 (OSError caught)."""
+    missing = tmp_path / "does_not_exist.txt"
+    assert estimate_tokens_for_file(missing) == 0
+
+
+def test_estimate_tokens_for_file_empty(tmp_path: Path) -> None:
+    """Empty file should return 0."""
+    f = tmp_path / "empty.txt"
+    f.write_text("", encoding="utf-8")
+    assert estimate_tokens_for_file(f) == 0
+
+
+def test_estimate_tokens_for_file_binary(tmp_path: Path) -> None:
+    """Binary file that can't be decoded as UTF-8 should return 0."""
+    f = tmp_path / "binary.bin"
+    f.write_bytes(bytes(range(256)))  # includes non-UTF-8 byte sequences
+    assert estimate_tokens_for_file(f) == 0


### PR DESCRIPTION
## What

Offline bundle editor with full provenance tracking. Loads any bundle, shows token cost per behavior, supports add/remove with dependency validation, and saves valid .md files that Foundation can load.

Co-located in experiments/bundle-configurator/ -- does NOT ship in the Foundation wheel (root pyproject.toml packages list is unchanged).

## Install

pip install 'git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=experiments/bundle-configurator'

## Quick Start

from amplifier_configurator import BundleConfigurator
cfg = BundleConfigurator.load_sync('foundation')
for behavior, tokens in cfg.tokens_by_behavior().items():
    print(f'  {behavior:30s} {tokens:5d} tokens')
lean = cfg.remove_behavior('browser-testing-behavior')
diff = cfg.diff(lean)
print(f'Removed: {diff.token_delta} tokens')
lean.save('/tmp/lean-foundation/bundle.md')

## Tests

- 129 unit tests
- 6 integration tests (real bundles)
- 1 e2e round-trip test

## Merge Path

If approved: move amplifier_configurator/ into amplifier_foundation/configurator/ -- same pattern as amplifier_foundation/session/.