### PR TITLE
feat(validate): detect silent-failure patterns in bundle.md structure

### DIFF
--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -1,9 +1,17 @@
 # validate-bundle-repo.yaml
-# Repository-Wide Bundle Validator Recipe v3.3.0
+# Repository-Wide Bundle Validator Recipe v3.4.0
 # Validates an entire bundle repository against structural requirements, conventions,
 # and Amplifier bundle philosophy (context sink pattern, thin behaviors, tool placement)
 #
 # CHANGELOG:
+# v3.4.0 - YAML Structure Lint for silent-failure detection
+#        - New Phase 1.5: yaml-structure-lint checks ALL discovered bundles
+#        - Detects includes: nested under bundle: (silently dropped by parser)
+#        - Detects unrecognized dict keys in includes (only 'bundle:' valid)
+#        - Motivated by bkrabach/amplifier-bundle-parallax-discovery (5 agents silent-fail)
+#        - quality-classification incorporates structure_lint_issues
+#        - synthesize-report includes YAML Structure Lint section
+#
 # v3.3.0 - Opt-in recipe validation integration
 #        - New context vars: validate_recipes, validate_all, recipes_dir, known_agents
 #        - Phase 0.1: validate-all-flags step expands validate_all convenience flag
@@ -124,7 +132,7 @@ description: |
   - All measurements use TOKENS (len/4), never line counts
   
   For single bundle validation, use validate-bundle.yaml instead.
-version: "3.3.0"
+version: "3.4.0"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "repository", "packaging", "hygiene", "context-sink"]
 
@@ -728,6 +736,202 @@ steps:
     timeout: 60
     on_error: "fail"
     depends_on: ["packaging-check", "build-check", "set-default-build-check"]
+
+  # ============================================================================
+  # PHASE 1.5: YAML Structure Lint (v3.4.0)
+  # Checks ALL discovered bundles for silent-failure structural bugs:
+  #
+  # Bug 1: includes: nested under bundle: instead of top-level
+  #   Bundle.from_dict() reads data.get('includes', []) — top-level only.
+  #   Nested bundle.includes is silently invisible. All includes are lost.
+  #
+  # Bug 2: Unrecognized dict keys in includes entries
+  #   _parse_include() only checks for 'bundle:' key in dict entries.
+  #   Any other key (e.g., 'behavior:', 'include:') returns None silently.
+  #
+  # Runs EARLY (before BundleRegistry validation) because these bugs cause
+  # bundles to appear to load "successfully" but with missing includes —
+  # the most insidious kind of failure.
+  # ============================================================================
+
+  - id: "yaml-structure-lint"
+    type: "bash"
+    command: |
+      python3 << 'EOF'
+      import json
+      import sys
+      from pathlib import Path
+
+      try:
+          import yaml
+      except ImportError:
+          print(json.dumps({
+              "phase": "yaml_structure_lint",
+              "skipped": True,
+              "passed": True,
+              "reason": "PyYAML not available",
+              "bundles_checked": 0,
+              "errors": [],
+              "bundle_results": []
+          }))
+          sys.exit(0)
+
+      discovery = json.loads('''{{discovery_results}}''')
+
+      # Collect all bundle files from all categories
+      all_bundle_files = []
+      for category, paths in discovery.get("bundles_found", {}).items():
+          for bundle_path in paths:
+              all_bundle_files.append({"path": bundle_path, "category": category})
+
+      results = {
+          "phase": "yaml_structure_lint",
+          "bundles_checked": 0,
+          "errors": [],
+          "warnings": [],
+          "bundle_results": [],
+          "passed": True
+      }
+
+      for bundle_info in all_bundle_files:
+          bundle_path = bundle_info["path"]
+          category = bundle_info["category"]
+          results["bundles_checked"] += 1
+
+          bundle_result = {
+              "path": bundle_path,
+              "category": category,
+              "name": Path(bundle_path).stem,
+              "errors": [],
+              "passed": True
+          }
+
+          path = Path(bundle_path).resolve()
+          if not path.exists():
+              results["bundle_results"].append(bundle_result)
+              continue
+
+          try:
+              content = path.read_text()
+          except Exception:
+              results["bundle_results"].append(bundle_result)
+              continue
+
+          # Parse YAML (handle .md frontmatter)
+          yaml_data = None
+          if path.suffix == '.md':
+              if content.startswith('---'):
+                  parts = content.split('---', 2)
+                  if len(parts) >= 2:
+                      try:
+                          yaml_data = yaml.safe_load(parts[1])
+                      except yaml.YAMLError:
+                          results["bundle_results"].append(bundle_result)
+                          continue
+              else:
+                  results["bundle_results"].append(bundle_result)
+                  continue
+          else:
+              try:
+                  yaml_data = yaml.safe_load(content)
+              except yaml.YAMLError:
+                  results["bundle_results"].append(bundle_result)
+                  continue
+
+          if not isinstance(yaml_data, dict):
+              results["bundle_results"].append(bundle_result)
+              continue
+
+          # Extract bundle name for better error messages
+          bundle_section = yaml_data.get("bundle")
+          if isinstance(bundle_section, dict):
+              bundle_result["name"] = bundle_section.get("name", bundle_result["name"])
+
+          # ── Bug 1: includes: nested under bundle: instead of top-level ──
+          if isinstance(bundle_section, dict) and "includes" in bundle_section:
+              nested_includes = bundle_section["includes"]
+              count = len(nested_includes) if isinstance(nested_includes, list) else 1
+              error = {
+                  "type": "nested_includes",
+                  "severity": "ERROR",
+                  "bundle_path": bundle_path,
+                  "bundle_name": bundle_result["name"],
+                  "category": category,
+                  "count": count,
+                  "message": (
+                      f"'includes:' is nested under 'bundle:' in {Path(bundle_path).name} — "
+                      f"{count} include(s) SILENTLY DROPPED. "
+                      f"Bundle.from_dict() reads data.get('includes', []) from top-level only."
+                  ),
+                  "fix": (
+                      "Move 'includes:' to the top level (same indent as 'bundle:').\n"
+                      "  BROKEN:\n"
+                      "    bundle:\n"
+                      "      name: my-bundle\n"
+                      "      includes:        # WRONG: nested\n"
+                      "        - bundle: foo\n"
+                      "  CORRECT:\n"
+                      "    bundle:\n"
+                      "      name: my-bundle\n"
+                      "    includes:            # RIGHT: top level\n"
+                      "      - bundle: foo"
+                  )
+              }
+              bundle_result["errors"].append(error)
+              results["errors"].append(error)
+              bundle_result["passed"] = False
+              results["passed"] = False
+
+          # ── Bug 2: Unrecognized dict keys in includes entries ──
+          top_includes = yaml_data.get("includes", [])
+          if isinstance(top_includes, list):
+              for idx, inc in enumerate(top_includes):
+                  if isinstance(inc, dict):
+                      keys = list(inc.keys())
+                      if "bundle" not in keys:
+                          bad_keys = [k for k in keys]
+                          error = {
+                              "type": "unrecognized_include_key",
+                              "severity": "ERROR",
+                              "bundle_path": bundle_path,
+                              "bundle_name": bundle_result["name"],
+                              "category": category,
+                              "index": idx,
+                              "unrecognized_keys": bad_keys,
+                              "message": (
+                                  f"includes[{idx}] in {Path(bundle_path).name} has key "
+                                  f"'{bad_keys[0]}' — NOT RECOGNIZED. Only 'bundle:' is valid. "
+                                  f"This entry is SILENTLY DROPPED by _parse_include()."
+                              ),
+                              "fix": (
+                                  f"Change '- {bad_keys[0]}: ...' to '- bundle: ...'.\n"
+                                  "  Valid formats: '- bundle: name', '- bundle: ns:path', "
+                                  "'- bundle: git+https://...', or bare string '- name'"
+                              )
+                          }
+                          bundle_result["errors"].append(error)
+                          results["errors"].append(error)
+                          bundle_result["passed"] = False
+                          results["passed"] = False
+
+          results["bundle_results"].append(bundle_result)
+
+      results["summary"] = {
+          "bundles_checked": results["bundles_checked"],
+          "errors_total": len(results["errors"]),
+          "nested_includes_count": len([e for e in results["errors"] if e["type"] == "nested_includes"]),
+          "unrecognized_keys_count": len([e for e in results["errors"] if e["type"] == "unrecognized_include_key"]),
+          "bundles_with_errors": len([b for b in results["bundle_results"] if not b["passed"]]),
+          "passed": results["passed"]
+      }
+
+      print(json.dumps(results))
+      EOF
+    output: "structure_lint"
+    parse_json: true
+    timeout: 60
+    on_error: "continue"
+    depends_on: ["repo-discovery"]
 
   # ============================================================================
   # PHASE 2: Individual Bundle Validation
@@ -2109,6 +2313,13 @@ steps:
       except (json.JSONDecodeError, ValueError):
           recipe_validation = {"quality_level": "good", "skipped": True, "summary": "Recipe validation not performed"}
 
+      # v3.4.0: Parse YAML structure lint results
+      structure_lint_raw = '''{{structure_lint}}'''
+      try:
+          structure_lint = json.loads(structure_lint_raw)
+      except (json.JSONDecodeError, ValueError):
+          structure_lint = {"passed": True, "skipped": True, "errors": []}
+
       # Handle case where individual validation was skipped
       if individual.get("skipped", False):
           # v3.2.0: Check if this is an environment limitation (not a bundle problem)
@@ -2219,6 +2430,7 @@ steps:
               "experiment_issues": [],
               "context_sink_issues": [],
               "tool_placement_issues": [],
+              "structure_lint_issues": [],  # v3.4.0
               # v3.2.0: Environment status tracking
               "environment_status": {
                   "validation_mode": env_check.get("validation_mode", "unknown"),
@@ -2359,11 +2571,25 @@ steps:
                   "severity": "INFO"
               })
 
+          # v3.4.0: YAML Structure Lint errors (highest priority — silent data loss)
+          if not structure_lint.get("skipped", False) and not structure_lint.get("passed", True):
+              for error in structure_lint.get("errors", []):
+                  results["structure_lint_issues"].append({
+                      "type": error.get("type"),
+                      "bundle_path": error.get("bundle_path"),
+                      "bundle_name": error.get("bundle_name"),
+                      "category": error.get("category"),
+                      "message": error.get("message"),
+                      "severity": "ERROR",
+                      "fix": error.get("fix", "")
+                  })
+
           # Determine overall quality level
           # Priority: critical > needs_work > polish > good
           
           critical_count = results["summary"]["critical"]
           critical_count += len([i for i in results["packaging_issues"] if i.get("severity") == "critical"])
+          critical_count += len([i for i in results["structure_lint_issues"] if i.get("severity") == "ERROR"])
           critical_count += len([i for i in results["hygiene_issues"] if i.get("severity") == "ERROR"])
           critical_count += len([i for i in results["completeness_issues"] if i.get("severity") == "ERROR"])
           critical_count += len([i for i in results["experiment_issues"] if i.get("severity") == "ERROR"])
@@ -2422,7 +2648,8 @@ steps:
               "experiments_passed": experiments.get("passed", True),
               "total_hygiene_errors": len(results["hygiene_issues"]) + len(results["completeness_issues"]) + len(results["experiment_issues"]),
               "context_sink_warnings": len([i for i in results["context_sink_issues"] if i.get("severity") == "WARNING"]),
-              "tool_placement_suggestions": len(results["tool_placement_issues"])
+              "tool_placement_suggestions": len(results["tool_placement_issues"]),
+              "structure_lint_errors": len(results["structure_lint_issues"])
           }
 
           # v3.3.0: Recipe validation summary
@@ -2449,7 +2676,7 @@ steps:
     parse_json: true
     timeout: 60
     on_error: "fail"
-    depends_on: ["validate-all-bundles", "behavior-hygiene-validation", "standalone-completeness-validation", "experiments-validation", "context-sink-compliance", "tool-placement-analysis", "validate-recipes", "set-default-recipe-validation"]
+    depends_on: ["validate-all-bundles", "behavior-hygiene-validation", "standalone-completeness-validation", "experiments-validation", "context-sink-compliance", "tool-placement-analysis", "validate-recipes", "set-default-recipe-validation", "yaml-structure-lint"]
 
   # ============================================================================
   # PHASE 2.75: Initialize Optional Outputs
@@ -3075,6 +3302,11 @@ steps:
       {{recipe_validation}}
       ```
 
+      **YAML Structure Lint (v3.4.0):**
+      ```json
+      {{structure_lint}}
+      ```
+
       **Bundle Doc Freshness (Phase 6 v3):**
       ```json
       {{bundle_doc_freshness}}
@@ -3206,6 +3438,16 @@ steps:
       ### Suggestions (Consider) - LOW Priority
       Tool placement optimizations, context sink improvements
 
+      ### YAML Structure Lint (v3.4.0)
+      If structure_lint.passed == false:
+      - [CRITICAL ERROR] These are the HIGHEST PRIORITY findings — they cause SILENT DATA LOSS
+      - List each error with type, affected bundle, message, and fix
+      - For nested_includes: "X include(s) are silently invisible — agents/behaviors won't load"
+      - For unrecognized_include_key: "Entry silently dropped — only 'bundle:' key is recognized"
+      - Link to the root cause in the parser code
+      If structure_lint.passed == true:
+      - Note: "All bundles passed YAML structure lint — no silent-failure patterns detected"
+
       ### Bundle Doc Freshness (Phase 6 v3)
       If `bundle_doc_freshness.dot_available` is true, report:
       - bundle.dot status: fresh/stale/missing
@@ -3219,7 +3461,7 @@ steps:
 
       ## Metadata
       - Validated: [timestamp]
-      - Recipe: validate-bundle-repo v3.3.0
+      - Recipe: validate-bundle-repo v3.4.0
       - Validation Mode: [mode from env_check]
       - Foundation: [version or "not available"]
       - Quality Thresholds:

--- a/recipes/validate-single-bundle.yaml
+++ b/recipes/validate-single-bundle.yaml
@@ -5,6 +5,26 @@
 # Called by validate-bundle.yaml for each discovered bundle.
 # Can also be used directly for single-bundle validation.
 #
+# =============================================================================
+# CHANGELOG
+# =============================================================================
+#
+# v2.1.0 (2026-04-20):
+#   - NEW FEATURE: YAML Structure Lint (Step 0) — runs BEFORE dependency tracing
+#     * Detects 'includes:' nested under 'bundle:' (silently dropped by parser)
+#     * Detects unrecognized dict keys in includes entries (only 'bundle:' valid)
+#     * ROOT CAUSE: Bundle.from_dict() reads data.get('includes', []) from
+#       top-level only. _parse_include() only checks for 'bundle' key.
+#       Both bugs cause silent data loss — no error, no warning, includes
+#       simply vanish.
+#     * Fails early with actionable error messages referencing the fix pattern
+#     * Motivated by bkrabach/amplifier-bundle-parallax-discovery where 5 agents
+#       failed to register because all includes were nested under bundle:
+#
+# v2.0.0:
+#   - Initial version with accurate dependency tracing
+#   - Only counts context from actually-included behaviors
+#
 # Usage:
 #   amplifier tool invoke recipes operation=execute \
 #     recipe_path=foundation:recipes/validate-single-bundle.yaml \
@@ -14,14 +34,19 @@ name: validate-single-bundle
 description: |
   Validates a single Amplifier bundle by tracing its ACTUAL includes.
   
+  **v2.1.0: YAML Structure Lint**
+  - Detects `includes:` nested under `bundle:` (silently dropped by parser)
+  - Detects unrecognized dict keys in includes (only `bundle:` is valid)
+  - Runs BEFORE dependency tracing — fails early with actionable fixes
+  
   KEY IMPROVEMENT: Only counts context from behaviors that are actually
   included via `includes:`, not all behaviors in the repo.
   
   For example, if `shadow-amplifier` behavior is not in this bundle's
   includes chain, its context files won't be counted.
-version: "2.0.0"
+version: "2.1.0"
 author: "Amplifier Foundation Team"
-tags: ["bundle", "validation", "single", "dependency-tracing"]
+tags: ["bundle", "validation", "single", "dependency-tracing", "yaml-lint"]
 
 context:
   bundle_path: ""     # Required: Path to bundle file
@@ -30,6 +55,187 @@ context:
   repo_root: ""       # Required: Repository root directory
 
 steps:
+  # ============================================================================
+  # STEP 0: YAML Structure Lint (v2.1.0)
+  # Detects silent-failure structural bugs BEFORE dependency tracing.
+  #
+  # Bug 1: includes: nested under bundle: instead of top-level
+  #   Bundle.from_dict() reads data.get('includes', []) — top-level only.
+  #   Nested bundle.includes is silently invisible. All includes are lost.
+  #
+  # Bug 2: Unrecognized dict keys in includes entries
+  #   _parse_include() only checks for 'bundle:' key in dict entries.
+  #   Any other key (e.g., 'behavior:', 'include:') returns None silently.
+  #
+  # Fails early if either issue is found — prevents misleading trace results.
+  # ============================================================================
+
+  - id: "yaml-structure-lint"
+    type: "bash"
+    command: |
+      python3 << 'EOF'
+      import json
+      import sys
+      from pathlib import Path
+
+      try:
+          import yaml
+      except ImportError:
+          # If PyYAML unavailable, skip lint (trace-dependencies will also need it)
+          print(json.dumps({
+              "phase": "yaml_structure_lint",
+              "skipped": True,
+              "passed": True,
+              "reason": "PyYAML not available"
+          }))
+          sys.exit(0)
+
+      def lint_bundle_yaml_structure(bundle_path: str) -> dict:
+          """Check for silent-failure structural bugs in bundle YAML."""
+          results = {
+              "phase": "yaml_structure_lint",
+              "bundle_path": bundle_path,
+              "errors": [],
+              "warnings": [],
+              "passed": True
+          }
+
+          path = Path(bundle_path).resolve()
+          if not path.exists():
+              results["errors"].append({
+                  "type": "file_not_found",
+                  "severity": "ERROR",
+                  "message": f"Bundle file not found: {bundle_path}"
+              })
+              results["passed"] = False
+              return results
+
+          try:
+              content = path.read_text()
+          except Exception as e:
+              results["errors"].append({
+                  "type": "read_error",
+                  "severity": "ERROR",
+                  "message": f"Cannot read bundle file: {e}"
+              })
+              results["passed"] = False
+              return results
+
+          # Parse YAML (handle .md frontmatter)
+          yaml_data = None
+          if path.suffix == '.md':
+              if content.startswith('---'):
+                  parts = content.split('---', 2)
+                  if len(parts) >= 2:
+                      try:
+                          yaml_data = yaml.safe_load(parts[1])
+                      except yaml.YAMLError as e:
+                          results["errors"].append({
+                              "type": "yaml_parse_error",
+                              "severity": "ERROR",
+                              "message": f"Invalid YAML frontmatter: {e}"
+                          })
+                          results["passed"] = False
+                          return results
+              else:
+                  # .md without frontmatter — not a bundle file, skip
+                  return results
+          else:
+              try:
+                  yaml_data = yaml.safe_load(content)
+              except yaml.YAMLError as e:
+                  results["errors"].append({
+                      "type": "yaml_parse_error",
+                      "severity": "ERROR",
+                      "message": f"Invalid YAML: {e}"
+                  })
+                  results["passed"] = False
+                  return results
+
+          if not isinstance(yaml_data, dict):
+              return results
+
+          # ── Bug 1: includes: nested under bundle: instead of top-level ──
+          bundle_section = yaml_data.get("bundle")
+          if isinstance(bundle_section, dict) and "includes" in bundle_section:
+              nested_includes = bundle_section["includes"]
+              count = len(nested_includes) if isinstance(nested_includes, list) else 1
+              results["errors"].append({
+                  "type": "nested_includes",
+                  "severity": "ERROR",
+                  "count": count,
+                  "message": (
+                      f"'includes:' is nested under 'bundle:' — this is SILENTLY IGNORED "
+                      f"by the parser. {count} include(s) will be invisible at runtime. "
+                      f"Bundle.from_dict() reads data.get('includes', []) from the "
+                      f"top-level dict only. Anything under data['bundle']['includes'] "
+                      f"is silently dropped."
+                  ),
+                  "fix": (
+                      "Move 'includes:' to the top level (same indent level as 'bundle:').\n"
+                      "\n"
+                      "  BROKEN (nested — silently dropped):\n"
+                      "    bundle:\n"
+                      "      name: my-bundle\n"
+                      "      includes:          # WRONG: nested under bundle\n"
+                      "        - bundle: foundation\n"
+                      "\n"
+                      "  CORRECT (top-level — matches dot-graph, foundation patterns):\n"
+                      "    bundle:\n"
+                      "      name: my-bundle\n"
+                      "\n"
+                      "    includes:              # RIGHT: top level\n"
+                      "      - bundle: foundation"
+                  )
+              })
+              results["passed"] = False
+
+          # ── Bug 2: Unrecognized dict keys in includes entries ──
+          top_includes = yaml_data.get("includes", [])
+          if isinstance(top_includes, list):
+              for idx, inc in enumerate(top_includes):
+                  if isinstance(inc, dict):
+                      keys = list(inc.keys())
+                      if "bundle" not in keys:
+                          bad_keys = [k for k in keys]
+                          results["errors"].append({
+                              "type": "unrecognized_include_key",
+                              "severity": "ERROR",
+                              "index": idx,
+                              "unrecognized_keys": bad_keys,
+                              "message": (
+                                  f"includes[{idx}] has unrecognized key(s): {bad_keys}. "
+                                  f"Only 'bundle:' is a valid key for dict-style includes — "
+                                  f"this entry is SILENTLY DROPPED by _parse_include(). "
+                                  f"The parser only checks include.get('bundle'); any other "
+                                  f"key returns None and the entry vanishes."
+                              ),
+                              "fix": (
+                                  f"Change '- {bad_keys[0]}: ...' to '- bundle: ...'.\n"
+                                  "\n"
+                                  "  Valid include formats:\n"
+                                  "    - bundle: foundation                     # namespace reference\n"
+                                  "    - bundle: foundation:behaviors/agents    # namespaced path\n"
+                                  "    - bundle: git+https://github.com/...    # external git URL\n"
+                                  "    - foundation                             # bare string (also valid)"
+                              )
+                          })
+                          results["passed"] = False
+
+          return results
+
+      result = lint_bundle_yaml_structure("{{bundle_path}}")
+      print(json.dumps(result))
+
+      # Exit non-zero if errors found — fails the step early
+      if not result["passed"]:
+          sys.exit(1)
+      EOF
+    output: "structure_lint"
+    parse_json: true
+    timeout: 30
+    on_error: "fail"
+
   # ============================================================================
   # STEP 1: Trace actual includes for this specific bundle
   # ============================================================================
@@ -257,6 +463,7 @@ steps:
     parse_json: true
     timeout: 60
     on_error: "fail"
+    depends_on: ["yaml-structure-lint"]
 
   # ============================================================================
   # STEP 2: Context analysis using ONLY traced dependencies
@@ -488,6 +695,11 @@ steps:
       **Bundle:** {{bundle_name}} ({{bundle_type}})
       **Path:** {{bundle_path}}
 
+      **YAML Structure Lint (v2.1.0):**
+      ```json
+      {{structure_lint}}
+      ```
+
       **Dependency Trace:**
       ```json
       {{traced_deps}}
@@ -504,6 +716,19 @@ steps:
       
       **Verdict:** PASS | FAIL | PASS WITH WARNINGS
       
+      **IMPORTANT: If structure_lint.passed == false, the verdict MUST be FAIL.**
+      Structure lint errors indicate silently-dropped includes — the bundle will not
+      work as intended. These are the highest priority issues to fix.
+
+      **YAML Structure Lint:**
+      If structure_lint has errors, list them FIRST and PROMINENTLY:
+      - Each error with its type, message, and fix
+      - These are CRITICAL — they cause silent data loss at parse time
+      - The bundle's includes are being silently dropped
+      
+      If structure_lint.passed == true:
+      - Note: "YAML structure: OK — no silent-failure patterns detected"
+
       **Summary:**
       - Type: {{bundle_type}}
       - Name: (from traced_deps.bundle_name)

--- a/tests/test_validate_bundle_repo_integration.py
+++ b/tests/test_validate_bundle_repo_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for validate-bundle-repo.yaml v3.3.0 changes.
+"""Integration tests for validate-bundle-repo.yaml v3.4.0 changes.
 
 Verifies:
 - Valid YAML structure
@@ -64,30 +64,30 @@ class TestYAMLValidity:
 
 
 class TestVersionMetadata:
-    def test_version_is_3_3_0(self, recipe_data):
-        """version field must be '3.3.0' to reflect v3.3.0 changes."""
+    def test_version_is_3_4_0(self, recipe_data):
+        """version field must be '3.4.0' to reflect v3.4.0 changes."""
         data, _ = recipe_data
-        assert data["version"] == "3.3.0", (
-            f"Expected version '3.3.0', got '{data['version']}'. "
+        assert data["version"] == "3.4.0", (
+            f"Expected version '3.4.0', got '{data['version']}'. "
             "The version field must be bumped when significant changes are made."
         )
 
-    def test_header_comment_references_v3_3_0(self, recipe_data):
-        """File header comment must reference v3.3.0."""
+    def test_header_comment_references_v3_4_0(self, recipe_data):
+        """File header comment must reference v3.4.0."""
         _, content = recipe_data
-        # The first few lines should mention v3.3.0
+        # The first few lines should mention v3.4.0
         header_lines = content.split("\n")[:5]
         header = "\n".join(header_lines)
-        assert "3.3.0" in header, (
-            "Header comment must be updated to reference v3.3.0. "
+        assert "3.4.0" in header, (
+            "Header comment must be updated to reference v3.4.0. "
             f"Found header:\n{header}"
         )
 
-    def test_changelog_has_v3_3_0_entry(self, recipe_data):
-        """Changelog section must contain a v3.3.0 entry."""
+    def test_changelog_has_v3_4_0_entry(self, recipe_data):
+        """Changelog section must contain a v3.4.0 entry."""
         _, content = recipe_data
-        assert "v3.3.0" in content, (
-            "Changelog must contain a v3.3.0 entry describing the recipe validation "
+        assert "v3.4.0" in content, (
+            "Changelog must contain a v3.4.0 entry describing the recipe validation "
             "integration changes."
         )
 

--- a/tests/test_yaml_structure_lint.py
+++ b/tests/test_yaml_structure_lint.py
@@ -1,0 +1,552 @@
+"""Tests for YAML Structure Lint detection (v2.1.0 / v3.4.0).
+
+Verifies that the lint logic correctly detects:
+- Bug 1: includes: nested under bundle: (silently dropped by parser)
+- Bug 2: Unrecognized dict keys in includes entries (only 'bundle:' valid)
+
+These tests validate BOTH:
+1. The lint logic itself (unit tests with in-memory YAML)
+2. The recipe structure (integration tests on the recipe YAML files)
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+RECIPE_DIR = Path(__file__).parent.parent / "recipes"
+SINGLE_BUNDLE_RECIPE = RECIPE_DIR / "validate-single-bundle.yaml"
+BUNDLE_REPO_RECIPE = RECIPE_DIR / "validate-bundle-repo.yaml"
+
+
+@pytest.fixture(scope="module")
+def single_bundle_recipe():
+    """Load validate-single-bundle.yaml."""
+    if not SINGLE_BUNDLE_RECIPE.exists():
+        pytest.skip("validate-single-bundle.yaml not found")
+    content = SINGLE_BUNDLE_RECIPE.read_text(encoding="utf-8")
+    return yaml.safe_load(content), content
+
+
+@pytest.fixture(scope="module")
+def single_bundle_steps(single_bundle_recipe):
+    """Build a dict of steps keyed by id."""
+    data, _ = single_bundle_recipe
+    return {step["id"]: step for step in data.get("steps", []) if "id" in step}
+
+
+@pytest.fixture(scope="module")
+def bundle_repo_recipe():
+    """Load validate-bundle-repo.yaml."""
+    if not BUNDLE_REPO_RECIPE.exists():
+        pytest.skip("validate-bundle-repo.yaml not found")
+    content = BUNDLE_REPO_RECIPE.read_text(encoding="utf-8")
+    return yaml.safe_load(content), content
+
+
+@pytest.fixture(scope="module")
+def bundle_repo_steps(bundle_repo_recipe):
+    """Build a dict of steps keyed by id."""
+    data, _ = bundle_repo_recipe
+    return {step["id"]: step for step in data.get("steps", []) if "id" in step}
+
+
+# =============================================================================
+# UNIT TESTS: Lint Logic (in-memory YAML parsing)
+# =============================================================================
+
+
+def lint_yaml_data(yaml_data: dict) -> dict:
+    """Pure-logic lint check — same algorithm as the recipe step.
+
+    Returns {"passed": bool, "errors": [...]}
+    """
+    errors = []
+
+    # Bug 1: includes nested under bundle
+    bundle_section = yaml_data.get("bundle")
+    if isinstance(bundle_section, dict) and "includes" in bundle_section:
+        nested = bundle_section["includes"]
+        count = len(nested) if isinstance(nested, list) else 1
+        errors.append(
+            {
+                "type": "nested_includes",
+                "count": count,
+            }
+        )
+
+    # Bug 2: unrecognized dict keys in includes
+    top_includes = yaml_data.get("includes", [])
+    if isinstance(top_includes, list):
+        for idx, inc in enumerate(top_includes):
+            if isinstance(inc, dict):
+                if "bundle" not in inc:
+                    errors.append(
+                        {
+                            "type": "unrecognized_include_key",
+                            "index": idx,
+                            "keys": list(inc.keys()),
+                        }
+                    )
+
+    return {"passed": len(errors) == 0, "errors": errors}
+
+
+class TestLintLogicBug1NestedIncludes:
+    """Bug 1: includes: nested under bundle: instead of top-level."""
+
+    def test_detects_nested_includes(self):
+        """Nested includes under bundle: should be flagged as ERROR."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test-bundle
+              version: "1.0.0"
+              includes:
+                - bundle: foundation
+                - bundle: foundation:behaviors/agents
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert not result["passed"]
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["type"] == "nested_includes"
+        assert result["errors"][0]["count"] == 2
+
+    def test_top_level_includes_pass(self):
+        """Top-level includes should NOT be flagged."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test-bundle
+            includes:
+              - bundle: foundation
+              - bundle: foundation:behaviors/agents
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert result["passed"]
+        assert len(result["errors"]) == 0
+
+    def test_no_includes_at_all_passes(self):
+        """Bundle with no includes should pass."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test-bundle
+              version: "1.0.0"
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert result["passed"]
+
+    def test_nested_single_include(self):
+        """Even a single nested include should be caught."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test
+              includes:
+                - bundle: foundation
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert not result["passed"]
+        assert result["errors"][0]["count"] == 1
+
+    def test_both_nested_and_top_level(self):
+        """If includes exist both nested AND top-level, catch the nested one."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test
+              includes:
+                - bundle: this-is-hidden
+            includes:
+              - bundle: this-is-visible
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert not result["passed"]
+        nested_errors = [e for e in result["errors"] if e["type"] == "nested_includes"]
+        assert len(nested_errors) == 1
+
+
+class TestLintLogicBug2UnrecognizedKeys:
+    """Bug 2: Unrecognized dict keys in includes entries."""
+
+    def test_detects_behavior_key(self):
+        """'behavior:' key should be flagged — only 'bundle:' is valid."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test
+            includes:
+              - behavior: ./behaviors/foo.yaml
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert not result["passed"]
+        assert result["errors"][0]["type"] == "unrecognized_include_key"
+        assert "behavior" in result["errors"][0]["keys"]
+
+    def test_detects_include_key(self):
+        """'include:' key should be flagged."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test
+            includes:
+              - include: foundation:behaviors/agents
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert not result["passed"]
+
+    def test_bundle_key_passes(self):
+        """'bundle:' key should NOT be flagged — it's the valid key."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test
+            includes:
+              - bundle: foundation
+              - bundle: foundation:behaviors/agents
+              - bundle: git+https://github.com/foo/bar
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert result["passed"]
+
+    def test_bare_string_includes_pass(self):
+        """Bare string includes should NOT be flagged."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test
+            includes:
+              - foundation
+              - dot-graph
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert result["passed"]
+
+    def test_mixed_valid_and_invalid(self):
+        """Mix of valid and invalid should catch only the invalid ones."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test
+            includes:
+              - bundle: foundation
+              - behavior: ./behaviors/foo.yaml
+              - bundle: dot-graph:behaviors/dot-graph
+              - include: something
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert not result["passed"]
+        assert len(result["errors"]) == 2
+        # First bad entry is at index 1, second at index 3
+        assert result["errors"][0]["index"] == 1
+        assert result["errors"][1]["index"] == 3
+
+    def test_multiple_unrecognized_keys_in_one_entry(self):
+        """Dict with multiple non-bundle keys should be caught."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test
+            includes:
+              - behavior: foo
+                path: ./foo.yaml
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert not result["passed"]
+        # Both 'behavior' and 'path' are unrecognized
+        assert "behavior" in result["errors"][0]["keys"]
+        assert "path" in result["errors"][0]["keys"]
+
+
+class TestLintLogicBothBugs:
+    """Both bugs present simultaneously."""
+
+    def test_both_bugs_detected(self):
+        """Should detect BOTH nested includes AND unrecognized keys."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test
+              includes:
+                - bundle: hidden-foundation
+            includes:
+              - behavior: ./behaviors/foo.yaml
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert not result["passed"]
+        types = {e["type"] for e in result["errors"]}
+        assert "nested_includes" in types
+        assert "unrecognized_include_key" in types
+
+
+class TestLintLogicEdgeCases:
+    """Edge cases that should NOT false-positive."""
+
+    def test_empty_bundle_section(self):
+        """Empty bundle: section should not crash."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert result["passed"]
+
+    def test_bundle_as_string(self):
+        """bundle: as a string (not dict) should not crash."""
+        data = {"bundle": "foundation", "includes": [{"bundle": "foo"}]}
+        result = lint_yaml_data(data)
+        assert result["passed"]
+
+    def test_empty_includes_list(self):
+        """Empty includes list should pass."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: test
+            includes: []
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert result["passed"]
+
+    def test_includes_with_none_entries(self):
+        """None entries in includes should not crash."""
+        data = {"bundle": {"name": "test"}, "includes": [None, {"bundle": "foo"}]}
+        result = lint_yaml_data(data)
+        assert result["passed"]  # None is not a dict, so skipped
+
+    def test_no_bundle_section_at_all(self):
+        """YAML without a bundle: section should pass (not a bundle file)."""
+        data = yaml.safe_load(
+            textwrap.dedent("""
+            name: some-recipe
+            steps:
+              - id: step1
+        """)
+        )
+        result = lint_yaml_data(data)
+        assert result["passed"]
+
+
+# =============================================================================
+# INTEGRATION TESTS: validate-single-bundle.yaml recipe structure
+# =============================================================================
+
+
+class TestSingleBundleRecipeStructure:
+    """Verify validate-single-bundle.yaml has the yaml-structure-lint step."""
+
+    def test_version_is_2_1_0(self, single_bundle_recipe):
+        """Version must be bumped to 2.1.0."""
+        data, _ = single_bundle_recipe
+        assert data["version"] == "2.1.0", (
+            f"Expected version '2.1.0', got '{data['version']}'"
+        )
+
+    def test_yaml_structure_lint_step_exists(self, single_bundle_steps):
+        """yaml-structure-lint step must be present."""
+        assert "yaml-structure-lint" in single_bundle_steps
+
+    def test_yaml_structure_lint_is_bash(self, single_bundle_steps):
+        """yaml-structure-lint must be a bash step."""
+        step = single_bundle_steps.get("yaml-structure-lint", {})
+        assert step.get("type") == "bash"
+
+    def test_yaml_structure_lint_output(self, single_bundle_steps):
+        """yaml-structure-lint output must be 'structure_lint'."""
+        step = single_bundle_steps.get("yaml-structure-lint", {})
+        assert step.get("output") == "structure_lint"
+
+    def test_yaml_structure_lint_parse_json(self, single_bundle_steps):
+        """yaml-structure-lint must have parse_json: true."""
+        step = single_bundle_steps.get("yaml-structure-lint", {})
+        assert step.get("parse_json") is True
+
+    def test_yaml_structure_lint_on_error_fail(self, single_bundle_steps):
+        """yaml-structure-lint must fail early on errors."""
+        step = single_bundle_steps.get("yaml-structure-lint", {})
+        assert step.get("on_error") == "fail"
+
+    def test_trace_dependencies_depends_on_lint(self, single_bundle_steps):
+        """trace-dependencies must depend on yaml-structure-lint."""
+        step = single_bundle_steps.get("trace-dependencies", {})
+        depends = step.get("depends_on", [])
+        assert "yaml-structure-lint" in depends, (
+            "trace-dependencies must depend on yaml-structure-lint "
+            "so structural bugs are caught before dependency tracing"
+        )
+
+    def test_yaml_structure_lint_is_first_step(self, single_bundle_recipe):
+        """yaml-structure-lint must be the first step (runs before everything)."""
+        data, _ = single_bundle_recipe
+        steps = data.get("steps", [])
+        assert len(steps) > 0
+        assert steps[0]["id"] == "yaml-structure-lint"
+
+    def test_lint_command_checks_nested_includes(self, single_bundle_steps):
+        """Lint command must contain nested_includes detection logic."""
+        step = single_bundle_steps.get("yaml-structure-lint", {})
+        command = step.get("command", "")
+        assert "nested_includes" in command
+        assert "bundle" in command  # Checks bundle section
+
+    def test_lint_command_checks_unrecognized_keys(self, single_bundle_steps):
+        """Lint command must contain unrecognized key detection logic."""
+        step = single_bundle_steps.get("yaml-structure-lint", {})
+        command = step.get("command", "")
+        assert "unrecognized_include_key" in command
+
+    def test_generate_report_references_structure_lint(self, single_bundle_recipe):
+        """generate-report prompt must reference structure_lint results."""
+        _, content = single_bundle_recipe
+        assert "structure_lint" in content
+        assert "YAML Structure Lint" in content
+
+    def test_changelog_has_v2_1_0(self, single_bundle_recipe):
+        """Changelog must mention v2.1.0."""
+        _, content = single_bundle_recipe
+        assert "v2.1.0" in content
+
+
+# =============================================================================
+# INTEGRATION TESTS: validate-bundle-repo.yaml recipe structure
+# =============================================================================
+
+
+class TestBundleRepoRecipeStructure:
+    """Verify validate-bundle-repo.yaml has the yaml-structure-lint step."""
+
+    def test_version_is_3_4_0(self, bundle_repo_recipe):
+        """Version must be bumped to 3.4.0."""
+        data, _ = bundle_repo_recipe
+        assert data["version"] == "3.4.0", (
+            f"Expected version '3.4.0', got '{data['version']}'"
+        )
+
+    def test_yaml_structure_lint_step_exists(self, bundle_repo_steps):
+        """yaml-structure-lint step must be present."""
+        assert "yaml-structure-lint" in bundle_repo_steps
+
+    def test_yaml_structure_lint_is_bash(self, bundle_repo_steps):
+        """yaml-structure-lint must be a bash step."""
+        step = bundle_repo_steps.get("yaml-structure-lint", {})
+        assert step.get("type") == "bash"
+
+    def test_yaml_structure_lint_output(self, bundle_repo_steps):
+        """yaml-structure-lint output must be 'structure_lint'."""
+        step = bundle_repo_steps.get("yaml-structure-lint", {})
+        assert step.get("output") == "structure_lint"
+
+    def test_yaml_structure_lint_depends_on_discovery(self, bundle_repo_steps):
+        """yaml-structure-lint must depend on repo-discovery."""
+        step = bundle_repo_steps.get("yaml-structure-lint", {})
+        depends = step.get("depends_on", [])
+        assert "repo-discovery" in depends
+
+    def test_yaml_structure_lint_on_error_continue(self, bundle_repo_steps):
+        """yaml-structure-lint must have on_error: continue (non-blocking)."""
+        step = bundle_repo_steps.get("yaml-structure-lint", {})
+        assert step.get("on_error") == "continue"
+
+    def test_quality_classification_depends_on_lint(self, bundle_repo_steps):
+        """quality-classification must depend on yaml-structure-lint."""
+        step = bundle_repo_steps.get("quality-classification", {})
+        depends = step.get("depends_on", [])
+        assert "yaml-structure-lint" in depends, (
+            "quality-classification must depend on yaml-structure-lint"
+        )
+
+    def test_quality_classification_parses_structure_lint(self, bundle_repo_recipe):
+        """quality-classification command must parse structure_lint."""
+        _, content = bundle_repo_recipe
+        # The quality-classification step should reference structure_lint
+        assert "structure_lint" in content
+
+    def test_synthesize_report_includes_structure_lint(self, bundle_repo_recipe):
+        """synthesize-report must reference YAML Structure Lint."""
+        _, content = bundle_repo_recipe
+        assert "YAML Structure Lint" in content
+
+    def test_changelog_has_v3_4_0(self, bundle_repo_recipe):
+        """Changelog must mention v3.4.0."""
+        _, content = bundle_repo_recipe
+        assert "v3.4.0" in content
+
+
+# =============================================================================
+# REGRESSION TESTS: Parallax Discovery bug
+# =============================================================================
+
+
+class TestParallaxDiscoveryRegression:
+    """Regression test for the exact bug from parallax-discovery bundle."""
+
+    def test_parallax_discovery_pattern_detected(self):
+        """The exact YAML pattern from parallax-discovery should be caught.
+
+        This was the actual broken YAML that caused 5 agents to silently
+        not register. The includes were nested under bundle: instead of
+        being at the top level.
+        """
+        # Simplified version of the actual broken bundle.md frontmatter
+        broken_data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: parallax-discovery
+              version: "1.0.0"
+              description: "Parallax Discovery methodology"
+              includes:
+                - bundle: foundation
+                - bundle: parallax-discovery:behaviors/parallax-discovery
+                - bundle: parallax-discovery:behaviors/investigation-agents
+                - bundle: parallax-discovery:behaviors/synthesis
+                - bundle: parallax-discovery:behaviors/report-gen
+        """)
+        )
+        result = lint_yaml_data(broken_data)
+        assert not result["passed"], (
+            "The parallax-discovery nested-includes pattern MUST be caught"
+        )
+        assert result["errors"][0]["type"] == "nested_includes"
+        assert result["errors"][0]["count"] == 5
+
+    def test_parallax_discovery_fixed_pattern_passes(self):
+        """The fixed pattern (top-level includes) should pass."""
+        fixed_data = yaml.safe_load(
+            textwrap.dedent("""
+            bundle:
+              name: parallax-discovery
+              version: "1.0.0"
+              description: "Parallax Discovery methodology"
+
+            includes:
+              - bundle: foundation
+              - bundle: parallax-discovery:behaviors/parallax-discovery
+              - bundle: parallax-discovery:behaviors/investigation-agents
+              - bundle: parallax-discovery:behaviors/synthesis
+              - bundle: parallax-discovery:behaviors/report-gen
+        """)
+        )
+        result = lint_yaml_data(fixed_data)
+        assert result["passed"], "The fixed parallax-discovery pattern must pass"


### PR DESCRIPTION
## Summary

This PR adds detection for two silent-failure patterns in bundle validation recipes that prevent parser errors but silently drop bundle includes.

**Problem:** During development of amplifier-bundle-parallax-discovery, we discovered that bundles can "successfully" load while silently losing critical data:
- Bug 1: `includes:` nested under `bundle:` instead of top-level (parser silently reads only top-level)
- Bug 2: Dict keys like `- behavior: ...` instead of `- bundle: ...` (silently ignored by registry)

Both result in `BundleRegistry.load()` succeeding with zero includes — agents, behaviors, context all vanish.

## Changes

### `recipes/validate-single-bundle.yaml` (v2.0.0 → v2.1.0)
- New `yaml-structure-lint` step runs BEFORE `trace-dependencies`
- Detects both failure patterns early with actionable error messages
- Includes "fix it like this" pattern for immediate correction

### `recipes/validate-bundle-repo.yaml` (v3.3.0 → v3.4.0)  
- New Phase 1.5: `yaml-structure-lint` step iterates all discovered bundles
- Non-blocking validation so full repo report continues
- Wired into `quality-classification` and `synthesize-report`

### `tests/test_yaml_structure_lint.py` (NEW)
- 19 unit tests validating lint logic — ALL PASSING
- Regression test validates parallax-discovery patterns

## Verification

✅ YAML parses cleanly
✅ Recipe validation passes
✅ All unit tests pass (19/19)
✅ Regression tests pass

## Motivation

Requested after amplifier-bundle-parallax-discovery PR exposed this silent-failure mode. These parser drops are the most dangerous class of bundle bug — they prevent no errors but cause missing agents at recipe execution time.
