### PR TITLE
exp: add hooks-compact stdout compression experiment bundle

### DIFF
--- a/experiments/exp-hooks-compact.md
+++ b/experiments/exp-hooks-compact.md
@@ -1,0 +1,68 @@
+---
+bundle:
+  name: exp-hooks-compact
+  version: 0.1.0
+  description: |
+    EXPERIMENTAL: foundation + stdout compression hook.
+
+    Adds hooks-compact to compress verbose bash STDOUT output (stderr untouched).
+    Everything else is identical to the standard foundation bundle.
+    Measured in isolation: 37% stdout reduction, 11% fewer turns,
+    18/20 scenarios pass with 0 task regressions.
+
+    Scope note: stderr is NOT compressed. Commands like `cargo build`, `clippy`,
+    and `curl -v` that write primarily to stderr see no compression.
+
+    Note: foundation already includes hook-shell which truncates output in a
+    different format. The A/B comparison is hook-shell truncation vs hooks-compact
+    compression, not raw vs compressed.
+
+    To use:
+      amplifier bundle add git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=experiments/exp-hooks-compact.md --name exp-hooks-compact
+      amplifier bundle use exp-hooks-compact
+
+    To revert to baseline:
+      amplifier bundle use foundation
+
+includes:
+  - bundle: foundation:bundle
+
+hooks:
+  - module: hooks-compact
+    source: git+https://github.com/samueljklee/amplifier-module-hooks-compact@main
+    config:
+      enabled: true
+      min_lines: 5
+      strip_ansi: true
+      show_savings: true
+      debug: false
+      telemetry:
+        local: true
+        db_path: "~/.amplifier/hooks-compact/telemetry.db"
+        retention_days: 90
+---
+
+# Experimental Foundation + Hooks Compact
+
+EXPERIMENTAL bundle for A/B testing stdout compression before wider rollout.
+
+## What's Different
+
+| Feature | foundation | exp-hooks-compact |
+|---------|-----------|-------------------|
+| Stdout compression | hook-shell truncation (different format) | hooks-compact (37% measured) |
+| Stderr | unchanged | unchanged |
+| Turn efficiency | baseline | 11% fewer turns (measured) |
+
+## A/B Testing
+
+```bash
+amplifier bundle use foundation          # baseline
+amplifier bundle use exp-hooks-compact   # experiment
+```
+
+## Scope Limitation
+
+Hooks-compact compresses stdout only. Commands writing primarily to stderr see no compression.
+
+@foundation:context/shared/common-system-base.md

--- a/experiments/exp-hooks-compact.md
+++ b/experiments/exp-hooks-compact.md
@@ -7,8 +7,10 @@ bundle:
 
     Adds hooks-compact to compress verbose bash STDOUT output (stderr untouched).
     Everything else is identical to the standard foundation bundle.
-    Measured in isolation: 37% stdout reduction, 11% fewer turns,
-    18/20 scenarios pass with 0 task regressions.
+    DTU-verified (36 sessions): 30-98% compression on matched bash output, zero
+    correctness regressions. Session-level turn/token effects are within LLM variance;
+    compression budget is reinvested in deeper exploration. See PR #178 comments for
+    full evidence (R2-R5).
 
     Scope note: stderr is NOT compressed. Commands like `cargo build`, `clippy`,
     and `curl -v` that write primarily to stderr see no compression.
@@ -29,7 +31,7 @@ includes:
 
 hooks:
   - module: hooks-compact
-    source: git+https://github.com/samueljklee/amplifier-module-hooks-compact@main
+    source: git+https://github.com/samueljklee/amplifier-module-hooks-compact@v0.1.0-canary.1
     config:
       enabled: true
       min_lines: 5
@@ -38,6 +40,7 @@ hooks:
       debug: false
       telemetry:
         local: true
+        remote: false
         db_path: "~/.amplifier/hooks-compact/telemetry.db"
         retention_days: 90
 ---
@@ -50,9 +53,9 @@ EXPERIMENTAL bundle for A/B testing stdout compression before wider rollout.
 
 | Feature | foundation | exp-hooks-compact |
 |---------|-----------|-------------------|
-| Stdout compression | hook-shell truncation (different format) | hooks-compact (37% measured) |
+| Stdout compression | hook-shell truncation (display layer) | hooks-compact (context-window layer, 30-98% on matched cmds) |
 | Stderr | unchanged | unchanged |
-| Turn efficiency | baseline | 11% fewer turns (measured) |
+| Session efficiency | baseline | within LLM variance; compression reinvested in deeper exploration |
 
 ## A/B Testing
 


### PR DESCRIPTION
## Summary

Adds `experiments/exp-hooks-compact.md` — an opt-in experiment bundle that layers [`hooks-compact`](https://github.com/samueljklee/amplifier-module-hooks-compact) (a `tool:post` hook that compresses bash stdout via command-specific filters) on top of foundation. Teammates can switch between `foundation` (baseline) and `exp-hooks-compact` (experiment) via `bundle use` for A/B testing.

Follows the established `foundation/experiments/` convention (same shape as `exp-foundation.md`, `exp-amplifier-dev.md`, `exp-lean/*`, `delegation-only/*`).

## What's in this PR

One new file: `experiments/exp-hooks-compact.md` (~45 lines). No changes to any other foundation file.

**Key design decisions:**
- Thin-includes foundation via `- bundle: foundation:bundle` (first experiment to use this shape — DTU-verified in R1)
- Pins the hook module to `v0.1.0-canary.1` for cohort reproducibility
- All foundation behaviors flow through unchanged (tools, agents, session config, hook-shell, redaction)
- Hook runs at `priority=50` — after foundation's redaction hook, so it compresses already-sanitized output

## What's measured (5 DTU rounds, 36 unique sessions)

Detailed evidence in the comments below (R3, R4, R5). High-level summary:

| Claim | Evidence | Round |
|---|---|---|
| Zero task-correctness regressions | All scenarios completed correctly under both bundles across 36 sessions | R2–R5 |
| Deterministic filter compression on matched bash output | pytest 30.5% on failures (tracebacks preserved) / 98.1% on passes (one-liner); ruff 87.1%; git-status 82.0% | R3–R5 |
| Model can act correctly on compressed output | Multi-bug fix-cycle (E7): 3/3 experiment success, all bugs fixed correctly, median 2 pytest runs to green | R5 |
| Bundle composition works | `foundation:bundle` include syntax DTU-verified | R1–R2 |
| No retry penalty | Median pytest runs identical under both bundles in all scenarios | R3–R5 |
| Session-level turn/token effects | Within LLM variance at N=4 — compression budget reinvested in deeper exploration rather than shorter sessions. See R4 comment. | R4 |

## Scope limitations (honest disclosure)

- **Compresses stdout only.** Commands writing primarily to stderr (`cargo build`, `clippy`, `curl -v`) see no compression from this hook.
- **Two-layer pipeline with hook-shell.** Foundation's `hook-shell` truncates the terminal display; `hooks-compact` compresses the model's context window. Different layers, no conflict. The real hook signal lives in `~/.amplifier/hooks-compact/telemetry.db`, not in the CLI display.
- **Session-level wins aren't guaranteed.** Per-call compression is real and deterministic. Whether that translates to shorter sessions depends on workflow shape — the value scales with bash density (test-heavy workflows benefit most; small-output workflows are neutral).

## Rollout plan

This PR is Phase 0 (landing the experiment). Subsequent phases are tracked separately:

| Phase | Action |
|---|---|
| 0 | Land this PR |
| 1 | Opt-in broadcast to team with "freeze window" discipline during the test period (no main-branch pushes to hooks-compact during active testing) |
| 2 (future) | If validated, graduate hook to `foundation/behaviors/compact.yaml` (same trajectory `hooks-tool-truncation` took into `attractor-core`) |
| 3 (future) | Consider default-on inclusion in foundation bundle itself |

## Reviewer notes

- `hooks-compact` module currently lives at `samueljklee/amplifier-module-hooks-compact`. If foundation prefers a `microsoft/` origin, that's a Phase 2 (graduation) concern — out of scope here.
- The `includes: - bundle: foundation:bundle` shape is new. Alternatives are `git+https://github.com/microsoft/amplifier-foundation@main` or enumerating behaviors verbatim (15+ entries). Both work; `foundation:bundle` chosen for simplicity and to auto-track foundation evolution.
- No changes to any other foundation file.

## Reproduction (after merge)

```bash
amplifier bundle add \
  git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=experiments/exp-hooks-compact.md \
  --name exp-hooks-compact
amplifier bundle use exp-hooks-compact

# Verify the hook is active
amplifier run "echo hello && seq 1 50"
sqlite3 -header -column ~/.amplifier/hooks-compact/telemetry.db \
  "SELECT command, filter_used, savings_pct FROM compression_log ORDER BY id DESC LIMIT 5;"

# Revert to baseline
amplifier bundle use foundation
```

## Related prerequisite (merged)

- `samueljklee/amplifier-module-hooks-compact#2` — pre-canary hygiene sweep (Plans 1–4). Tagged `v0.1.0-canary.1`. This PR pins to that tag.

Generated with [Amplifier](https://github.com/microsoft/amplifier)
