### PR TITLE
fix(exp-lean): context.inject → context.include so dev agent roster actually loads

### DIFF
--- a/experiments/exp-lean/behaviors/lean-amplifier-dev.yaml
+++ b/experiments/exp-lean/behaviors/lean-amplifier-dev.yaml
@@ -33,5 +33,5 @@ agents:
 # Per-bundle agent roster context (describes the 7 agents above).
 # Pairs with delegation-mechanics.md loaded by lean-foundation.
 context:
-  inject:
+  include:
     - foundation:experiments/exp-lean/context/exp-lean-amplifier-dev-agents.md


### PR DESCRIPTION
#173 moved per-bundle agent-roster context out of the shared foundation context and into `lean-amplifier-dev.yaml`, but the new block uses `context.inject:` — a key the bundle parser does not recognize. The parser only accepts `context.include:` for list-valued file entries and silently drops everything else, so `exp-lean-amplifier-dev-agents.md` never makes it into the dev bundle's context. The intended +2K dev-only delta became a +0 change.

This PR changes one key from `inject` to `include`. Verified against `amplifier_foundation/bundle/_parse_config.py::_parse_context`:

- `_parse_context({'inject': [...]},  None)` → `({}, {})`          # dropped
- `_parse_context({'include': [...]}, None)` → `({}, {file: ...})` # kept

No other callers use `inject` in amplifier-foundation — this was an isolated typo in a new file added by #173.

Follow-up (separate issue recommended): the tool-delegate module's `base_description` in `modules/tool-delegate/amplifier_module_tool_delegate/__init__.py:211-217` hardcodes `foundation:explorer`, `foundation:bug-hunter`, etc. This is inaccurate on any bundle that does not register those specific agent names (including `exp-lean-foundation`). Pre-existing — unrelated to this PR.