### PR TITLE
fix: redirect tool-skills source from deprecated standalone to amplifier-bundle-skills

### DIFF
--- a/behaviors/agents.yaml
+++ b/behaviors/agents.yaml
@@ -34,7 +34,7 @@ tools:
 
   # Register foundation's own skills directory for discovery
   - module: tool-skills
-    source: git+https://github.com/microsoft/amplifier-module-tool-skills@main
+    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
     config:
       skills:
         - "git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=skills"

--- a/experiments/exp-foundation.md
+++ b/experiments/exp-foundation.md
@@ -35,7 +35,7 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-bundle-design-intelligence@main#subdirectory=behaviors/design-intelligence.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-python-dev@main
   - bundle: git+https://github.com/microsoft/amplifier-bundle-shadow@main
-  - bundle: git+https://github.com/microsoft/amplifier-module-tool-skills@main#subdirectory=behaviors/skills.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills#subdirectory=behaviors/skills.yaml
   - bundle: git+https://github.com/microsoft/amplifier-module-hook-shell@main#subdirectory=behaviors/hook-shell.yaml
   - bundle: git+https://github.com/microsoft/amplifier-module-tool-mcp@main#subdirectory=behaviors/mcp.yaml
 

--- a/experiments/exp-lean/behaviors/lean-foundation.yaml
+++ b/experiments/exp-lean/behaviors/lean-foundation.yaml
@@ -37,7 +37,7 @@ tools:
     source: git+https://github.com/microsoft/amplifier-module-tool-todo@main
   # On-demand context loading via skills
   - module: tool-skills
-    source: git+https://github.com/microsoft/amplifier-module-tool-skills@main
+    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
     config:
       visibility:
         enabled: false  # Disable per-turn skill listing to save ~1,250 tokens/turn


### PR DESCRIPTION
## What this changes

Redirects the `tool-skills` module source URL from the deprecated standalone repo `amplifier-module-tool-skills` to its current maintained location in `amplifier-bundle-skills/modules/tool-skills/`.

## Why

The standalone `amplifier-module-tool-skills` repo is deprecated — its HEAD commit (`8082cbb`) is a deprecation notice pointing users to `amplifier-bundle-skills`. However, many bundles across the Microsoft/Amplifier org still reference the deprecated URL directly via `git+https://github.com/microsoft/amplifier-module-tool-skills@main`.

This matters because **the fork-skill recursion guard fix (commit `408131a` in amplifier-bundle-skills) was never backported to the standalone repo.** Bundles resolving `tool-skills` from the old URL silently load pre-fix code that lacks the guard.

## Real-world impact

A recently diagnosed incident: a single `load_skill("adversarial-review")` call spawned **4,733 forked subagent sessions in a linear chain** before external cancellation — approximately 6 hours of runaway execution. Root cause: the pre-fix tool-skills module was loaded (despite the fix existing in `amplifier-bundle-skills`) because the bundle chain resolved `tool-skills` from the deprecated repo.

Cleaning up these URL references across the org ensures the fix actually loads wherever tool-skills is used.

## Files changed

- `behaviors/agents.yaml`
- `experiments/exp-foundation.md`
- `experiments/exp-lean/behaviors/lean-foundation.yaml`

## Verification

- `grep -r "amplifier-module-tool-skills@main"` in the affected files returns 0 matches after the change
- YAML/Markdown syntax preserved (no functional changes beyond the URL substitution)
- Module identity unchanged — registered `tool-skills` still mounts identically, just from a more current source

## Related

Part of a coordinated cleanup across 8 microsoft/amplifier-bundle-* repos and this one. Sister PRs being opened in parallel; all can be merged independently.