### PR TITLE
fix(tests): redirect tool-skills source in test fixtures from deprecated standalone to amplifier-bundle-skills

### DIFF
--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -294,7 +294,7 @@ class TestMergeModuleListsListConfig:
         parent = [
             {
                 "module": "tool-skills",
-                "source": "git+https://github.com/microsoft/amplifier-module-tool-skills@main",
+                "source": "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills",
                 "config": {
                     "skills": [
                         "git+https://github.com/obra/superpowers@main#subdirectory=skills",
@@ -306,7 +306,7 @@ class TestMergeModuleListsListConfig:
         child = [
             {
                 "module": "tool-skills",
-                "source": "git+https://github.com/microsoft/amplifier-module-tool-skills@main",
+                "source": "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills",
                 "config": {
                     "skills": [
                         "git+https://github.com/bkrabach/amplifier-bundle-parallax-discovery@main#subdirectory=skills",


### PR DESCRIPTION
## What this changes

Follow-up to #180 — updates 2 remaining test fixture references in `tests/test_dicts.py` that were intentionally skipped in the original sweep so a maintainer could review.

## Why

These fixtures use `git+https://github.com/microsoft/amplifier-module-tool-skills@main` as example source-URL data in config dicts. The tests exercise dict merge/parse operations and are not asserting on the URL value itself — updating keeps example data current and consistent with the rest of the ecosystem cleanup without changing test semantics.

The standalone `amplifier-module-tool-skills` repo is deprecated (HEAD `8082cbb` is a deprecation notice), and the fork-skill recursion guard fix in `amplifier-bundle-skills` (commit `408131a`) was never backported there. Keeping even fixture data aligned reduces the risk of future code paths inadvertently pulling from the deprecated source.

## Files changed

- `tests/test_dicts.py` (2 lines: 297, 309)

## Verification

- `pytest tests/test_dicts.py` — all tests still pass (dict-level operations unaffected by URL change)
- `grep "amplifier-module-tool-skills@main" tests/test_dicts.py` returns 0 matches after the change

## Related

Closes the test-fixture gap left by #180.