### PR TITLE
feat(m3a): spawn bridge in PreparedBundle.spawn()

### DIFF
--- a/amplifier_foundation/__init__.py
+++ b/amplifier_foundation/__init__.py
@@ -94,6 +94,10 @@ from amplifier_foundation.sources.resolver import SimpleSourceResolver
 # Tracing utilities
 from amplifier_foundation.tracing import generate_sub_session_id
 
+# Cost bridge utilities (for app-layer spawn wrappers)
+from amplifier_foundation.bundle._prepared import bridge_child_cost
+from amplifier_foundation.bundle._prepared import sum_cost_usd
+
 # Session capability helpers (for modules to access session context)
 from amplifier_foundation.session.capabilities import get_working_dir
 from amplifier_foundation.session.capabilities import set_working_dir
@@ -177,6 +181,9 @@ __all__ = [
     "get_working_dir",
     "set_working_dir",
     "WORKING_DIR_CAPABILITY",
+    # Cost bridge utilities
+    "bridge_child_cost",
+    "sum_cost_usd",
     # Spawn utilities
     "ProviderPreference",
     "ModelResolutionResult",

--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -717,9 +717,9 @@ class PreparedBundle:
         # Execute instruction and cleanup
         try:
             response = await child_session.execute(instruction)
-            # Bridge child session cost to parent coordinator (_bridge_child_cost never raises)
+            # Bridge child session cost to parent coordinator (bridge_child_cost never raises)
             if parent_session:
-                await _bridge_child_cost(
+                await bridge_child_cost(
                     child_coordinator=child_session.coordinator,
                     parent_coordinator=parent_session.coordinator,
                     child_session_id=child_session.session_id,

--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 # Collects cost_usd contributions from a session.cost channel and returns the
 # total as Decimal, or None when no cost data is present (e.g. self-hosted models).
-def _sum_cost_usd(contributions: list) -> Decimal | None:
+def sum_cost_usd(contributions: list) -> Decimal | None:
     """Sum cost_usd from collect_contributions() results. Returns None if no cost data.
 
     None != Decimal("0"): None means cost unknown (no rate data); 0 means known-free.
@@ -51,7 +51,7 @@ def _sum_cost_usd(contributions: list) -> Decimal | None:
     return total
 
 
-async def _bridge_child_cost(
+async def bridge_child_cost(
     child_coordinator,
     parent_coordinator,
     child_session_id: str,
@@ -63,7 +63,7 @@ async def _bridge_child_cost(
     """
     try:
         child_contributions = await child_coordinator.collect_contributions("session.cost")
-        child_total = _sum_cost_usd(child_contributions)
+        child_total = sum_cost_usd(child_contributions)
 
         if child_total is not None:
             # Freeze value in default arg — child coordinator will be torn down after this

--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -27,9 +27,8 @@ from amplifier_foundation.bundle._dataclass import Bundle
 logger = logging.getLogger(__name__)
 
 
-# Intentionally duplicated across provider-anthropic, foundation, and hooks-streaming-ui.
-# These are separate repos with no shared utility dependency. The function is 10 lines —
-# the coordination cost of sharing outweighs the duplication cost.
+# Collects cost_usd contributions from a session.cost channel and returns the
+# total as Decimal, or None when no cost data is present (e.g. self-hosted models).
 def _sum_cost_usd(contributions: list) -> Decimal | None:
     """Sum cost_usd from collect_contributions() results. Returns None if no cost data."""
     total: Decimal | None = None

--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -30,15 +30,24 @@ logger = logging.getLogger(__name__)
 # Collects cost_usd contributions from a session.cost channel and returns the
 # total as Decimal, or None when no cost data is present (e.g. self-hosted models).
 def _sum_cost_usd(contributions: list) -> Decimal | None:
-    """Sum cost_usd from collect_contributions() results. Returns None if no cost data."""
+    """Sum cost_usd from collect_contributions() results. Returns None if no cost data.
+
+    None != Decimal("0"): None means cost unknown (no rate data); 0 means known-free.
+    Tolerates both Decimal and str values (providers may emit either).
+    Silently skips malformed values rather than raising.
+    """
     total: Decimal | None = None
     for c in contributions:
         if c and isinstance(c, dict):
             cost = c.get("cost_usd")
             if cost is not None:
-                total = (total or Decimal("0")) + (
-                    cost if isinstance(cost, Decimal) else Decimal(str(cost))
-                )
+                if isinstance(cost, Decimal):
+                    total = (total or Decimal("0")) + cost
+                else:
+                    try:
+                        total = (total or Decimal("0")) + Decimal(str(cost))
+                    except Exception:
+                        pass  # malformed cost_usd value; skip and degrade gracefully
     return total
 
 
@@ -47,15 +56,27 @@ async def _bridge_child_cost(
     parent_coordinator,
     child_session_id: str,
 ) -> None:
-    """Propagate child session cost to parent's session.cost channel."""
-    child_contributions = await child_coordinator.collect_contributions("session.cost")
-    child_total = _sum_cost_usd(child_contributions)
+    """Propagate child session cost to parent's session.cost channel. Never raises.
 
-    if child_total is not None:
-        parent_coordinator.register_contributor(
-            "session.cost",
-            f"delegate:{child_session_id}",
-            lambda total=child_total: {"cost_usd": total},
+    Cost accounting must not surface as a spawn failure. Any exception is logged as
+    a warning and swallowed so the caller always sees a clean return.
+    """
+    try:
+        child_contributions = await child_coordinator.collect_contributions("session.cost")
+        child_total = _sum_cost_usd(child_contributions)
+
+        if child_total is not None:
+            # Freeze value in default arg — child coordinator will be torn down after this
+            parent_coordinator.register_contributor(
+                "session.cost",
+                f"delegate:{child_session_id}",
+                lambda total=child_total: {"cost_usd": total},
+            )
+    except Exception:
+        logger.warning(
+            "Failed to bridge child session cost for %s; skipping",
+            child_session_id,
+            exc_info=True,
         )
 
 
@@ -696,7 +717,7 @@ class PreparedBundle:
         # Execute instruction and cleanup
         try:
             response = await child_session.execute(instruction)
-            # Bridge child session cost to parent coordinator
+            # Bridge child session cost to parent coordinator (_bridge_child_cost never raises)
             if parent_session:
                 await _bridge_child_cost(
                     child_coordinator=child_session.coordinator,

--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from dataclasses import field
+from decimal import Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -24,6 +25,39 @@ from amplifier_foundation.spawn_utils import apply_provider_preferences_with_res
 from amplifier_foundation.bundle._dataclass import Bundle
 
 logger = logging.getLogger(__name__)
+
+
+# Intentionally duplicated across provider-anthropic, foundation, and hooks-streaming-ui.
+# These are separate repos with no shared utility dependency. The function is 10 lines —
+# the coordination cost of sharing outweighs the duplication cost.
+def _sum_cost_usd(contributions: list) -> Decimal | None:
+    """Sum cost_usd from collect_contributions() results. Returns None if no cost data."""
+    total: Decimal | None = None
+    for c in contributions:
+        if c and isinstance(c, dict):
+            cost = c.get("cost_usd")
+            if cost is not None:
+                total = (total or Decimal("0")) + (
+                    cost if isinstance(cost, Decimal) else Decimal(str(cost))
+                )
+    return total
+
+
+async def _bridge_child_cost(
+    child_coordinator,
+    parent_coordinator,
+    child_session_id: str,
+) -> None:
+    """Propagate child session cost to parent's session.cost channel."""
+    child_contributions = await child_coordinator.collect_contributions("session.cost")
+    child_total = _sum_cost_usd(child_contributions)
+
+    if child_total is not None:
+        parent_coordinator.register_contributor(
+            "session.cost",
+            f"delegate:{child_session_id}",
+            lambda total=child_total: {"cost_usd": total},
+        )
 
 
 class BundleModuleSource:
@@ -663,6 +697,13 @@ class PreparedBundle:
         # Execute instruction and cleanup
         try:
             response = await child_session.execute(instruction)
+            # Bridge child session cost to parent coordinator
+            if parent_session:
+                await _bridge_child_cost(
+                    child_coordinator=child_session.coordinator,
+                    parent_coordinator=parent_session.coordinator,
+                    child_session_id=child_session.session_id,
+                )
         finally:
             # Unregister the temporary hook before cleanup
             unregister()

--- a/amplifier_foundation/serialization.py
+++ b/amplifier_foundation/serialization.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+from decimal import Decimal
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,10 @@ def sanitize_for_json(value: Any, *, max_depth: int = 50) -> Any:
     # Handle None and primitives (always serializable)
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
+
+    # Handle Decimal — convert to str to preserve precision (not float, which loses it)
+    if isinstance(value, Decimal):
+        return str(value)
 
     # Handle dicts recursively
     if isinstance(value, dict):

--- a/amplifier_foundation/serialization.py
+++ b/amplifier_foundation/serialization.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import logging
-from decimal import Decimal
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -44,10 +43,6 @@ def sanitize_for_json(value: Any, *, max_depth: int = 50) -> Any:
     # Handle None and primitives (always serializable)
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
-
-    # Handle Decimal — convert to str to preserve precision (not float, which loses it)
-    if isinstance(value, Decimal):
-        return str(value)
 
     # Handle dicts recursively
     if isinstance(value, dict):

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -117,6 +117,16 @@ Utilities for spawning sub-sessions with provider/model preferences.
 | `resolve_model_pattern` | `spawn_utils.py` | Resolve glob patterns (e.g., `claude-haiku-*`) to concrete model names |
 | `is_glob_pattern` | `spawn_utils.py` | Check if model string contains glob characters |
 
+
+## Cost Bridge Utilities
+
+Utilities for propagating child-session costs to parent coordinators in
+app-layer spawn wrappers. Import via `from amplifier_foundation import ...`.
+
+| Export | Source | Purpose |
+|--------|--------|---------|
+| `bridge_child_cost` | `bundle/_prepared.py` | Collect child session's `session.cost` contributions and register them as a single contributor on the parent coordinator. Never raises — errors are logged as warnings. |
+| `sum_cost_usd` | `bundle/_prepared.py` | Sum a list of `collect_contributions()` results into a single `Decimal \| None`. Returns `None` when no cost data is present. Tolerates both `Decimal` and `str` values. |
 ## Reading the Source
 
 Each source file has comprehensive docstrings. To read them:

--- a/tests/test_cost_bridge_foundation.py
+++ b/tests/test_cost_bridge_foundation.py
@@ -1,0 +1,34 @@
+"""Tests for cost bridge in PreparedBundle.spawn()."""
+
+from decimal import Decimal
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+@pytest.mark.asyncio
+async def test_prepared_bundle_spawn_bridges_child_cost():
+    """PreparedBundle.spawn() registers child cost on parent coordinator after execute()."""
+    child_coord = MagicMock()
+    child_coord.collect_contributions = AsyncMock(
+        return_value=[{"cost_usd": Decimal("0.06")}]
+    )
+
+    parent_coord = MagicMock()
+    registered = {}
+
+    def capture_register(channel, name, callback):
+        registered[(channel, name)] = callback
+
+    parent_coord.register_contributor = capture_register
+
+    from amplifier_foundation.bundle._prepared import _sum_cost_usd, _bridge_child_cost  # noqa: F401
+
+    await _bridge_child_cost(
+        child_coordinator=child_coord,
+        parent_coordinator=parent_coord,
+        child_session_id="foundation-child-001",
+    )
+
+    assert ("session.cost", "delegate:foundation-child-001") in registered
+    result = registered[("session.cost", "delegate:foundation-child-001")]()
+    assert result == {"cost_usd": Decimal("0.06")}

--- a/tests/test_cost_bridge_foundation.py
+++ b/tests/test_cost_bridge_foundation.py
@@ -2,7 +2,7 @@
 
 from decimal import Decimal
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 @pytest.mark.asyncio
@@ -32,3 +32,128 @@ async def test_prepared_bundle_spawn_bridges_child_cost():
     assert ("session.cost", "delegate:foundation-child-001") in registered
     result = registered[("session.cost", "delegate:foundation-child-001")]()
     assert result == {"cost_usd": Decimal("0.06")}
+
+
+@pytest.mark.asyncio
+async def test_spawn_calls_bridge_child_cost_with_parent():
+    """spawn() reaches bridge_child_cost — verifies wiring, not just the helper.
+
+    The unit test above exercises bridge_child_cost in isolation. This test
+    verifies the call site inside PreparedBundle.spawn() actually invokes the
+    function, catching any typo or refactor that severs the link.
+    """
+    # Child session mock — enough for spawn() to complete without real modules
+    child_session = MagicMock()
+    child_session.session_id = "child-test-001"
+    child_session.execute = AsyncMock(return_value="task complete")
+    child_session.cleanup = AsyncMock()
+    child_session.initialize = AsyncMock()
+
+    child_coord = MagicMock()
+    child_coord.mount = AsyncMock()
+    child_coord.register_capability = MagicMock()
+    child_coord.get = MagicMock(return_value=None)
+    child_coord.get_capability = MagicMock(return_value=None)
+    # hooks.register must return a callable (the unregister function)
+    child_coord.hooks.register = MagicMock(return_value=lambda: None)
+    child_session.coordinator = child_coord
+
+    # Parent session mock
+    parent_coord = MagicMock()
+    parent_session = MagicMock()
+    parent_session.session_id = "parent-test-001"
+    parent_session.coordinator = parent_coord
+
+    # Bundle mock — minimal surface used by spawn()
+    bundle = MagicMock()
+    bundle.compose.return_value = bundle
+    bundle.to_mount_plan.return_value = {}
+    bundle.base_path = None
+    bundle.instruction = None
+    bundle.context = None
+
+    from amplifier_foundation.bundle._prepared import PreparedBundle
+
+    prepared = PreparedBundle(
+        mount_plan={},
+        resolver=MagicMock(),
+        bundle=bundle,
+    )
+
+    bridge_calls = []
+
+    async def capture_bridge(child_coordinator, parent_coordinator, child_session_id):
+        bridge_calls.append(
+            {
+                "child_coordinator": child_coordinator,
+                "parent_coordinator": parent_coordinator,
+                "child_session_id": child_session_id,
+            }
+        )
+
+    with (
+        patch("amplifier_core.AmplifierSession", return_value=child_session),
+        patch(
+            "amplifier_foundation.bundle._prepared.bridge_child_cost",
+            capture_bridge,
+        ),
+    ):
+        await prepared.spawn(
+            child_bundle=bundle,
+            instruction="test task",
+            parent_session=parent_session,
+        )
+
+    assert len(bridge_calls) == 1, (
+        "bridge_child_cost must be called exactly once from spawn()"
+    )
+    assert bridge_calls[0]["child_coordinator"] is child_coord
+    assert bridge_calls[0]["parent_coordinator"] is parent_coord
+    assert bridge_calls[0]["child_session_id"] == "child-test-001"
+
+
+@pytest.mark.asyncio
+async def test_spawn_does_not_call_bridge_without_parent():
+    """spawn() skips bridge_child_cost when no parent_session is provided."""
+    child_session = MagicMock()
+    child_session.session_id = "child-no-parent-001"
+    child_session.execute = AsyncMock(return_value="done")
+    child_session.cleanup = AsyncMock()
+    child_session.initialize = AsyncMock()
+
+    child_coord = MagicMock()
+    child_coord.mount = AsyncMock()
+    child_coord.register_capability = MagicMock()
+    child_coord.get = MagicMock(return_value=None)
+    child_coord.get_capability = MagicMock(return_value=None)
+    child_coord.hooks.register = MagicMock(return_value=lambda: None)
+    child_session.coordinator = child_coord
+
+    bundle = MagicMock()
+    bundle.compose.return_value = bundle
+    bundle.to_mount_plan.return_value = {}
+    bundle.base_path = None
+    bundle.instruction = None
+    bundle.context = None
+
+    from amplifier_foundation.bundle._prepared import PreparedBundle
+
+    prepared = PreparedBundle(mount_plan={}, resolver=MagicMock(), bundle=bundle)
+
+    bridge_calls = []
+
+    async def capture_bridge(**kwargs):
+        bridge_calls.append(kwargs)
+
+    with (
+        patch("amplifier_core.AmplifierSession", return_value=child_session),
+        patch(
+            "amplifier_foundation.bundle._prepared.bridge_child_cost",
+            capture_bridge,
+        ),
+    ):
+        await prepared.spawn(child_bundle=bundle, instruction="rootless task")
+
+    assert len(bridge_calls) == 0, (
+        "bridge_child_cost must NOT be called without a parent"
+    )

--- a/tests/test_cost_bridge_foundation.py
+++ b/tests/test_cost_bridge_foundation.py
@@ -21,9 +21,9 @@ async def test_prepared_bundle_spawn_bridges_child_cost():
 
     parent_coord.register_contributor = capture_register
 
-    from amplifier_foundation.bundle._prepared import _sum_cost_usd, _bridge_child_cost  # noqa: F401
+    from amplifier_foundation import sum_cost_usd, bridge_child_cost  # noqa: F401
 
-    await _bridge_child_cost(
+    await bridge_child_cost(
         child_coordinator=child_coord,
         parent_coordinator=parent_coord,
         child_session_id="foundation-child-001",


### PR DESCRIPTION
## What

Adds spawn-boundary cost bridging to `PreparedBundle.spawn()` as part of the M3 cost management milestone.

### Context

`PreparedBundle.spawn()` is the third spawn site in the Amplifier ecosystem (alongside `spawn_sub_session` and `resume_sub_session` in app-cli). Any agent delegated via the foundation bundle layer goes through this path. Without bridging here, sub-agent costs invoked through the bundle system would not roll up to the parent session total.

### Change

Applies the same `_bridge_child_cost` pattern introduced in app-cli PR #171. After `child_session.execute()` returns and before cleanup, the child's `session.cost` contributions are summed and registered as a frozen contributor on the parent coordinator.

`_sum_cost_usd` is defined locally — this module has no shared utility dependency on app-cli, and the function is small enough that copying it is the right trade-off.

---