### PR TITLE
fix: sub-bundle namespaces resolve to bundle root, not git checkout root

### DIFF
--- a/amplifier_foundation/bundle/_dataclass.py
+++ b/amplifier_foundation/bundle/_dataclass.py
@@ -163,20 +163,44 @@ class Bundle:
         )
 
         for other in others:
-            # Merge other's source_base_paths first (preserves registry-set values like source_root)
-            # This is critical for subdirectory bundles where registry sets source_root mapping
+            # Merge other's source_base_paths, but handle other's own namespace
+            # separately below so we can apply parent-path awareness.
             if other.source_base_paths:
                 for ns, path in other.source_base_paths.items():
+                    if ns == other.name:
+                        continue  # handled explicitly below
                     if ns not in result.source_base_paths:
                         result.source_base_paths[ns] = path
 
-            # Also track other's own namespace as fallback (if not already set via source_base_paths)
+            # Register other's own namespace.
+            # When `other` is a sub-resource (e.g. a behavior YAML in behaviors/)
+            # AND result lives in a parent directory, use result.base_path so that
+            # namespace:agents/ etc. resolve at the bundle root, not the behavior subdir.
+            if other.name and other.name not in result.source_base_paths:
+                if (
+                    other.base_path
+                    and result.base_path
+                    and other.base_path != result.base_path
+                    and other.base_path.is_relative_to(result.base_path)
+                ):
+                    # other lives inside result's directory; use result's base_path
+                    result.source_base_paths[other.name] = result.base_path
+                elif other.base_path:
+                    result.source_base_paths[other.name] = other.base_path
+
+            # Promote self's namespace when self (result) is a sub-resource of other.
+            # In _compose_includes the call order is behavior.compose(parent-bundle),
+            # so self=behavior (base_path=behaviors/) and other=parent (base_path=root/).
+            # The behavior's own namespace must map to root/, not behaviors/.
             if (
-                other.name
+                self.name
+                and self.name in result.source_base_paths
+                and self.base_path
                 and other.base_path
-                and other.name not in result.source_base_paths
+                and self.base_path != other.base_path
+                and self.base_path.is_relative_to(other.base_path)
             ):
-                result.source_base_paths[other.name] = other.base_path
+                result.source_base_paths[self.name] = other.base_path
 
             # Metadata: later wins
             result.name = other.name or result.name

--- a/amplifier_foundation/bundle/_dataclass.py
+++ b/amplifier_foundation/bundle/_dataclass.py
@@ -39,6 +39,20 @@ class Bundle:
         version: Bundle version string.
         description: Optional description.
         includes: List of bundle URIs to include.
+        namespace_root: Optional path (relative to the bundle file's own directory)
+            that points to where this namespace's agents/ and context/ sub-directories
+            live.  Use when the bundle YAML is in a sub-directory (e.g. behaviors/) but
+            its resources live in a parent directory (e.g. the bundle root).
+
+            Example — YAML at ``experiments/build-up/behaviors/build-up-foundation.yaml``
+            with agents at ``experiments/build-up/agents/``::
+
+                bundle:
+                  name: build-up
+                  namespace_root: ..   # agents/ lives one level above this file
+
+            When absent (the default), the YAML file's own directory is used.  Only
+            single-level relative paths are supported; 3+ level nesting is out of scope.
         session: Session config (orchestrator, context).
         providers: List of provider configs.
         tools: List of tool configs.
@@ -46,10 +60,25 @@ class Bundle:
         agents: Dict mapping agent name to definition.
         context: Dict mapping context name to file path.
         instruction: System instruction from markdown body.
-        base_path: Path to bundle root directory.
-        source_base_paths: Dict mapping namespace to base_path for @mention resolution.
-            Tracks original base_path for each bundle during composition, enabling
-            @namespace:path references to resolve correctly to source files.
+        base_path: Path to bundle root directory (the directory containing the bundle
+            file, set at load time).
+        source_base_paths: Maps each namespace name → the directory under which that
+            namespace's ``agents/``, ``context/``, etc. sub-directories live.
+
+            Invariant: the value is always the *resource root*, never:
+            - the git checkout root (a common mistake fixed in the registry)
+            - the location of the YAML file that declared the namespace, unless
+              ``namespace_root`` is absent and the YAML is the resource root
+
+            Populated by the registry at load time:
+            - For the bundle's own namespace: ``bundle.base_path`` (default) or
+              ``(bundle.base_path / bundle.namespace_root).resolve()`` when
+              ``namespace_root`` is declared.
+            - For included bundles: the root bundle's source root.
+
+            If a bundle's resources live in a parent directory of its YAML file,
+            declare ``bundle.namespace_root`` in the frontmatter; do NOT rely on
+            filesystem heuristics here.
     """
 
     # Metadata
@@ -77,7 +106,7 @@ class Bundle:
     base_path: Path | None = None
     source_base_paths: dict[str, Path] = field(
         default_factory=dict
-    )  # Track base_path for each source namespace
+    )  # namespace → resource root dir (where agents/, context/, etc. live)
     _pending_context: dict[str, str] = field(
         default_factory=dict
     )  # Context refs needing namespace resolution
@@ -445,17 +474,27 @@ class Bundle:
         """Resolve agent file by name.
 
         Handles both namespaced and simple names:
-        - "foundation:bug-hunter" -> looks in source_base_paths["foundation"]/agents/
-        - "bug-hunter" -> looks in self.base_path/agents/
+        - ``"foundation:bug-hunter"`` → ``source_base_paths["foundation"] / "agents" / "bug-hunter.md"``
+        - ``"bug-hunter"`` → ``self.base_path / "agents" / "bug-hunter.md"``
 
-        For namespaced agents from included bundles, uses source_base_paths
-        to find the correct bundle's agents directory.
+        For namespaced agents, the lookup key in ``source_base_paths`` is the namespace
+        portion of the name.  ``source_base_paths[namespace]`` is the *resource root* for
+        that namespace — the directory that contains the ``agents/`` sub-directory.
+
+        **It is never the git checkout root and never the YAML file's directory unless
+        those happen to be the resource root.**  Bundle authors whose YAML lives in a
+        sub-directory but whose agents live in the parent must declare ``namespace_root``
+        in the bundle frontmatter so the registry sets ``source_base_paths[name]``
+        correctly at load time.
+
+        Fallback: if the namespace is not in ``source_base_paths`` but matches
+        ``self.name``, ``self.base_path`` is used as a last resort.
 
         Args:
-            name: Agent name (may include bundle prefix).
+            name: Agent name (may include bundle namespace prefix).
 
         Returns:
-            Path to agent file, or None if not found.
+            Path to agent ``.md`` file, or None if not found.
         """
         # Check for namespaced agent (e.g., "foundation:bug-hunter")
         if ":" in name:

--- a/amplifier_foundation/bundle/_dataclass.py
+++ b/amplifier_foundation/bundle/_dataclass.py
@@ -211,7 +211,9 @@ class Bundle:
             if other.name and other.name not in result.source_base_paths:
                 if other.name in other.source_base_paths:
                     # Use the registry-resolved path; may have been adjusted by namespace_root.
-                    result.source_base_paths[other.name] = other.source_base_paths[other.name]
+                    result.source_base_paths[other.name] = other.source_base_paths[
+                        other.name
+                    ]
                 elif other.base_path:
                     result.source_base_paths[other.name] = other.base_path
 

--- a/amplifier_foundation/bundle/_dataclass.py
+++ b/amplifier_foundation/bundle/_dataclass.py
@@ -57,6 +57,7 @@ class Bundle:
     version: str = "1.0.0"
     description: str = ""
     includes: list[str] = field(default_factory=list)
+    namespace_root: str | None = None
 
     # Mount plan sections
     session: dict[str, Any] = field(default_factory=dict)
@@ -148,6 +149,7 @@ class Bundle:
             version=self.version,
             description=self.description,
             includes=list(self.includes),
+            namespace_root=self.namespace_root,
             session=dict(self.session),
             providers=list(self.providers),
             tools=list(self.tools),
@@ -164,7 +166,8 @@ class Bundle:
 
         for other in others:
             # Merge other's source_base_paths, but handle other's own namespace
-            # separately below so we can apply parent-path awareness.
+            # separately below so we can use the pre-resolved path (which may
+            # incorporate namespace_root) rather than falling back to base_path.
             if other.source_base_paths:
                 for ns, path in other.source_base_paths.items():
                     if ns == other.name:
@@ -173,34 +176,15 @@ class Bundle:
                         result.source_base_paths[ns] = path
 
             # Register other's own namespace.
-            # When `other` is a sub-resource (e.g. a behavior YAML in behaviors/)
-            # AND result lives in a parent directory, use result.base_path so that
-            # namespace:agents/ etc. resolve at the bundle root, not the behavior subdir.
+            # Prefer the pre-resolved path from other.source_base_paths[other.name]
+            # (set by registry.py at load time, possibly incorporating namespace_root)
+            # over the raw other.base_path.  This avoids filesystem heuristics here.
             if other.name and other.name not in result.source_base_paths:
-                if (
-                    other.base_path
-                    and result.base_path
-                    and other.base_path != result.base_path
-                    and other.base_path.is_relative_to(result.base_path)
-                ):
-                    # other lives inside result's directory; use result's base_path
-                    result.source_base_paths[other.name] = result.base_path
+                if other.name in other.source_base_paths:
+                    # Use the registry-resolved path; may have been adjusted by namespace_root.
+                    result.source_base_paths[other.name] = other.source_base_paths[other.name]
                 elif other.base_path:
                     result.source_base_paths[other.name] = other.base_path
-
-            # Promote self's namespace when self (result) is a sub-resource of other.
-            # In _compose_includes the call order is behavior.compose(parent-bundle),
-            # so self=behavior (base_path=behaviors/) and other=parent (base_path=root/).
-            # The behavior's own namespace must map to root/, not behaviors/.
-            if (
-                self.name
-                and self.name in result.source_base_paths
-                and self.base_path
-                and other.base_path
-                and self.base_path != other.base_path
-                and self.base_path.is_relative_to(other.base_path)
-            ):
-                result.source_base_paths[self.name] = other.base_path
 
             # Metadata: later wins
             result.name = other.name or result.name
@@ -588,6 +572,7 @@ class Bundle:
         """
         bundle_meta = data.get("bundle", {})
         bundle_name = bundle_meta.get("name", "")
+        namespace_root = bundle_meta.get("namespace_root")
 
         # Validate module lists before using them
         providers = _validate_module_list(
@@ -610,6 +595,7 @@ class Bundle:
             version=bundle_meta.get("version", "1.0.0"),
             description=bundle_meta.get("description", ""),
             includes=data.get("includes", []),
+            namespace_root=namespace_root,
             session=data.get("session", {}),
             providers=providers,
             tools=tools,

--- a/amplifier_foundation/registry.py
+++ b/amplifier_foundation/registry.py
@@ -495,7 +495,10 @@ class BundleRegistry:
                 # that bundles whose agents/ / context/ live in a parent directory can
                 # declare that explicitly instead of relying on filesystem heuristics.
                 if bundle.name and bundle.name != root_bundle.name:
-                    if bundle.namespace_root is not None and bundle.base_path is not None:
+                    if (
+                        bundle.namespace_root is not None
+                        and bundle.base_path is not None
+                    ):
                         ns_path = (bundle.base_path / bundle.namespace_root).resolve()
                         bundle.source_base_paths[bundle.name] = ns_path
                         logger.debug(

--- a/amplifier_foundation/registry.py
+++ b/amplifier_foundation/registry.py
@@ -489,12 +489,26 @@ class BundleRegistry:
                 # NOT resolved.source_root (the git checkout root).
                 # This ensures namespace:agents/ and namespace:context/ resolve
                 # relative to the sub-bundle's own directory, not the checkout root.
+                #
+                # If the bundle declares `namespace_root` in its frontmatter (e.g.
+                # `namespace_root: ..`), resolve that path relative to base_path so
+                # that bundles whose agents/ / context/ live in a parent directory can
+                # declare that explicitly instead of relying on filesystem heuristics.
                 if bundle.name and bundle.name != root_bundle.name:
-                    bundle.source_base_paths[bundle.name] = bundle.base_path
-                    logger.debug(
-                        f"Nested bundle also registered own namespace "
-                        f"@{bundle.name}: -> {bundle.base_path}"
-                    )
+                    if bundle.namespace_root is not None and bundle.base_path is not None:
+                        ns_path = (bundle.base_path / bundle.namespace_root).resolve()
+                        bundle.source_base_paths[bundle.name] = ns_path
+                        logger.debug(
+                            f"Nested bundle also registered own namespace "
+                            f"@{bundle.name}: -> {ns_path} "
+                            f"(via namespace_root={bundle.namespace_root!r})"
+                        )
+                    else:
+                        bundle.source_base_paths[bundle.name] = bundle.base_path
+                        logger.debug(
+                            f"Nested bundle also registered own namespace "
+                            f"@{bundle.name}: -> {bundle.base_path}"
+                        )
 
             # Determine if this is a root bundle or nested bundle
             # A bundle is a nested bundle if we found a DIFFERENT root bundle above it

--- a/amplifier_foundation/registry.py
+++ b/amplifier_foundation/registry.py
@@ -484,12 +484,16 @@ class BundleRegistry:
                         )
                         logger.debug(f"Registered root bundle: {root_bundle.name}")
 
-                # Also register subdirectory bundle's own name if different
+                # Also register subdirectory bundle's own name if different.
+                # Use bundle.base_path (the directory containing this bundle file)
+                # NOT resolved.source_root (the git checkout root).
+                # This ensures namespace:agents/ and namespace:context/ resolve
+                # relative to the sub-bundle's own directory, not the checkout root.
                 if bundle.name and bundle.name != root_bundle.name:
-                    bundle.source_base_paths[bundle.name] = resolved.source_root
+                    bundle.source_base_paths[bundle.name] = bundle.base_path
                     logger.debug(
                         f"Nested bundle also registered own namespace "
-                        f"@{bundle.name}: -> {resolved.source_root}"
+                        f"@{bundle.name}: -> {bundle.base_path}"
                     )
 
             # Determine if this is a root bundle or nested bundle

--- a/amplifier_foundation/registry.py
+++ b/amplifier_foundation/registry.py
@@ -506,7 +506,7 @@ class BundleRegistry:
                             f"@{bundle.name}: -> {ns_path} "
                             f"(via namespace_root={bundle.namespace_root!r})"
                         )
-                    else:
+                    elif bundle.base_path is not None:
                         bundle.source_base_paths[bundle.name] = bundle.base_path
                         logger.debug(
                             f"Nested bundle also registered own namespace "

--- a/experiments/build-up/README.md
+++ b/experiments/build-up/README.md
@@ -1,0 +1,112 @@
+# Experimental Build-Up Bundle
+
+The inverse of `exp-lean`: where `exp-lean` strips `amplifier-foundation` down, `build-up` starts from zero and adds back only what is necessary, with **delegation as the primary scale-out mechanism**.
+
+**The radical move in v0.2.0:** the parent session has only `todo` and `delegate`. It cannot read files, run commands, search code, or make edits. Every concrete action goes through one of four self-sufficient sub-session agents that carry their own tools.
+
+## Install
+
+```bash
+amplifier bundle add 'git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=experiments/build-up/build-up-foundation.md' --name build-up-foundation
+amplifier bundle use build-up-foundation
+```
+
+Single-quote the URI to prevent shell expansion of the `#` fragment. The `.md` suffix is required.
+
+## Architecture
+
+```
+parent session ─ tools: todo, delegate
+  │
+  ├─► explorer  ─ tools: bash, filesystem, search, todo, delegate
+  │              read-only multi-file reconnaissance
+  │
+  ├─► planner   ─ tools: filesystem, todo, delegate
+  │              design / architecture / review (no bash, no write)
+  │
+  ├─► coder     ─ tools: bash, filesystem, search, todo, delegate
+  │              implementation from a complete spec
+  │
+  └─► tester    ─ tools: bash, filesystem, search, todo, delegate
+                 test execution + coverage + test generation
+```
+
+The parent's job is to understand intent, plan, dispatch, and synthesize. Real work happens in sub-sessions.
+
+## What's in it
+
+| Component | Parent | Agents | Notes |
+|-----------|--------|--------|-------|
+| `tool-todo` | Yes | All four | Planning |
+| `tool-delegate` | Yes | All four | Composition |
+| `tool-bash` | **No** | explorer, coder, tester | Run commands, tests, lint |
+| `tool-filesystem` | **No** | All four | Read/write files, glob, list |
+| `tool-search` | **No** | explorer, coder, tester | Grep |
+| `tool-web`, `tool-skills`, `tool-mcp`, `tool-task`, `tool-slash-command`, `tool-lsp`, `apply-patch` | No | No | Earn back via smoke testing |
+| Free-cost hooks (`streaming-ui`, `status-context`, `redaction`, `logging`, `todo-reminder`, `todo-display`, `session-naming`) | Yes | — | No per-turn context cost |
+| Pre-registered agents | — | — | The 4 above; reach foundation specialists by bundle path if needed |
+| Modes, recipes, superpowers, design intelligence, etc. | No | No | Add when value is demonstrated |
+
+## Design imperatives
+
+Derived from prior baseline measurements of `amplifier-foundation` and `amplifier-dev`:
+
+1. **Delegate-by-default** — bundle prompts must explicitly bias toward `delegate`. Doesn't happen organically.
+2. **No pre-registered dev agents from foundation** — observed only 1 delegation across 24 baseline trials. Generic foundation agents go unused. Build-up ships its own four, tuned to be the obvious target for any non-trivial work.
+3. **Skill loading is fragile** — non-deterministic across model tiers. Don't depend on it for critical paths.
+4. **Cache write/read ≈ 95% of token cost** — the biggest lever is shrinking initial context size. Every line of bundle prompt is paid every turn.
+5. **Test across model tiers** — Sonnet and Opus behave dramatically differently.
+
+## Why the parent has no tools
+
+If the parent has `read_file`, the model will use it. If it has `bash`, the model will use it. The eval baseline showed models reach for direct implementation over delegation by ~20:1 even when scenarios mapped perfectly to delegation handoffs. Removing the temptation removes the regression. The parent's *only* path to action is `delegate`.
+
+The cost: every concrete action requires a delegation hop. The benefit: parent context stays lean across hundreds of turns, and the agent-router pattern is enforced structurally rather than just rhetorically.
+
+## Comparison to siblings
+
+| Bundle | Approach | Parent tools | Agents pre-registered | Skills | Token target (initial input) |
+|---|---|---|---|---|---|
+| `amplifier-foundation` (standard) | Full | 6+ | 7+ foundation specialists | Yes | ~54.5k |
+| `exp-lean-foundation` | Strip-down | 6 | 0 | Yes (visibility off) | ~8.6k (measured) |
+| **`build-up-foundation` v0.1.0** | Build-up | 4 | 0 | No | ~? (not yet measured) |
+| **`build-up-foundation` v0.2.0** | Build-up + agent-router | **2** | **4 (built into the bundle, tool-equipped)** | No | TBD |
+
+## Methodology
+
+**Start with the absolute minimum and add back only what is earned.** When a smoke test or real task shows the model is degraded by missing a capability, restore it — don't preemptively include things "just in case." The agent boundaries are designed to be *the* mechanism for everything: if you find yourself wanting a tool at the parent, the answer is almost always "make an agent do it."
+
+## Smoke testing
+
+```bash
+# In a Digital Twin Universe environment for clean-slate measurement
+amplifier run --mode single "hello"
+```
+
+Look for:
+- Initial input token cost.
+- Whether the model attempts to use absent tools at the parent (e.g., reaches for `read_file` directly — that's a bug to surface).
+- Whether `delegate` is the model's first reach for any non-trivial task.
+- Whether the four agents are correctly chosen (planner before coder for under-specified work; tester after coder; explorer when context is missing).
+
+## Files
+
+```
+build-up/
+├── README.md                              # this file
+├── build-up-foundation.md                 # bundle entrypoint
+├── behaviors/
+│   └── build-up-foundation.yaml           # session/tool/hook/agent wiring
+├── agents/
+│   ├── explorer.md                        # multi-file recon
+│   ├── planner.md                         # design / spec / review
+│   ├── coder.md                           # implementation from spec
+│   └── tester.md                          # test execution / coverage / gen
+└── context/
+    ├── system-base.md                     # parent system prompt
+    └── delegation-mechanics.md            # `delegate` tool reference
+```
+
+## Status
+
+Experimental, version 0.2.0. Not yet smoke tested. Tool / agent / hook set is the maximally-aggressive starting point and will be relaxed only when observation demonstrates a clear gap.

--- a/experiments/build-up/agents/coder.md
+++ b/experiments/build-up/agents/coder.md
@@ -1,0 +1,90 @@
+---
+meta:
+  name: coder
+  description: |
+    Implementation-only agent. Turns a complete specification into working code.
+    REFUSES under-specified work — if the delegation instruction lacks file paths,
+    interfaces, success criteria, or a pattern reference, it stops and reports the gap.
+
+    USE WHEN: a `planner` spec exists, or the task is clearly bounded (file paths
+    decided, interfaces designed, success measurable).
+
+    DO NOT USE WHEN: requirements are vague, design decisions are still open, or
+    exploration is needed first — route to `planner` (or `explorer`) instead.
+
+    Returns: summary of what was implemented, the files changed, test results, and
+    any gaps that blocked completion.
+
+    Example:
+    <example>
+    user: "Implement the email validator from spec."
+    assistant: 'I will delegate to coder with the full spec; coder will implement and run tests.'
+    </example>
+
+model_role: [coding, general]
+
+tools:
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+  - module: tool-todo
+    source: git+https://github.com/microsoft/amplifier-module-tool-todo@main
+  - module: tool-delegate
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/tool-delegate
+    config:
+      settings:
+        exclude_tools: [tool-delegate]
+---
+
+# Coder
+
+You implement code from specifications. You do not design, explore, or research.
+
+## Required inputs (verify FIRST)
+
+The delegation instruction must contain:
+
+- [ ] **File paths** — exact locations to create or modify.
+- [ ] **Interfaces** — function signatures with types.
+- [ ] **Pattern** — reference example OR explicit design freedom.
+- [ ] **Success criteria** — measurable definition of done.
+
+If any are missing or vague, **STOP** and return:
+> "Specification incomplete: [the specific missing detail]. Cannot proceed without [X]."
+
+Do **not** research. Do **not** read more than 3 files trying to "understand context." If the spec is vague, the spec is wrong — kick it back.
+
+## Implementation loop
+
+1. **Plan** — break the spec into todos. One todo per file change or test pass.
+2. **Implement** — minimum code that meets the spec. Nothing speculative. No anticipated futures.
+3. **Verify** — run tests / linters / the actual program. Iterate until success criteria pass.
+4. **Clean up** — remove your own debugging artifacts (print statements, dead code, scratch files). Leave the rest of the codebase alone.
+
+## Discipline
+
+- **Touch only what the spec touches.** Other refactoring is its own task.
+- **No over-engineering.** No abstraction "just in case."
+- **Tests are code too.** When you change an interface, update the tests in the same change, not later.
+- **3-file rule.** After modifying three files, pause and run the relevant tests/linters before continuing.
+- **Mid-implementation gaps.** If you discover a missing decision while coding, STOP at that line, document where you got to, and report the gap. Do not continue researching.
+
+## Forbidden
+
+- "Let me read more files to understand the system…"
+- "I'll search for similar patterns in the codebase…"
+- "Let me figure out what this should do…"
+- Reading the same file repeatedly hoping for clarity.
+
+## Output contract
+
+Final message must include:
+
+1. **Status** — `Complete` / `Blocked` / `Partial`.
+2. **Files changed** — list with one-line summaries.
+3. **Verification** — what you ran, what passed, what failed.
+4. **Gaps** — anything left undone and why (only for Blocked / Partial).
+5. **Next action** — usually: "Recommend `delegate(agent='tester', ...)` to validate," or "Ready to merge."

--- a/experiments/build-up/agents/explorer.md
+++ b/experiments/build-up/agents/explorer.md
@@ -1,0 +1,79 @@
+---
+meta:
+  name: explorer
+  description: |
+    Multi-file exploration and codebase survey. Use whenever the parent needs a structured
+    understanding of code, docs, or configuration spanning more than a single known file.
+
+    REQUIRES in the delegation instruction:
+      - The objective or question to answer
+      - Scope hints (directories, file types, keywords)
+      - Constraints if any (time period, ownership, etc.)
+
+    Returns: structured report with summary, key file:line references, coverage gaps, and
+    suggested next actions or delegations.
+
+    Examples:
+    <example>
+    user: "What does the event handling flow look like?"
+    assistant: 'I will delegate to explorer to map the event modules and summarize the flow.'
+    </example>
+    <example>
+    user: "Find everything related to auth across docs and configs."
+    assistant: 'I will delegate to explorer to survey docs and configs for auth references.'
+    </example>
+
+model_role: [research, general]
+
+tools:
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+  - module: tool-todo
+    source: git+https://github.com/microsoft/amplifier-module-tool-todo@main
+  - module: tool-delegate
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/tool-delegate
+    config:
+      settings:
+        exclude_tools: [tool-delegate]
+---
+
+# Explorer
+
+You map workspace slices that matter and surface artifacts that answer the caller's question.
+
+## Execution model
+
+You run as a one-shot sub-session. You see (1) these instructions, (2) the delegation instruction, and (3) data fetched via your tools. Intermediate thoughts are hidden — only your final response reaches the caller. Make it stand on its own.
+
+## Required inputs (from the delegation instruction)
+
+- Primary question or objective.
+- Scope hints — directories, file types, keywords.
+- Constraints if relevant.
+
+If any are missing, return a short clarification request and stop.
+
+## Operating principles
+
+1. **Plan before digging.** Translate the objective into 3–6 todos. Update them as you go.
+2. **Breadth before depth.** Start with directory listings and globs; read representative files only after you know which areas matter.
+3. **Stay read-only.** Do not modify files.
+4. **Cite paths.** Every key claim references `path:line`.
+5. **Quantify.** Counts of files, sizes, prevalence of patterns. Avoid vague "many" / "various".
+6. **Flag gaps.** Note what you couldn't determine and what would resolve it.
+7. **Scale out when needed.** For independent sub-questions, dispatch parallel `delegate(agent="self", ...)` sub-sessions and synthesize their reports.
+
+## Output contract
+
+Your final message must include:
+
+1. **Summary** — 2–3 sentences directly answering the objective.
+2. **Key findings** — bulleted, each with a `path:line` reference and a one-line insight.
+3. **Coverage & gaps** — what was explored, what wasn't, what's still unknown.
+4. **Suggested next actions** — concrete follow-ups, including which agent to delegate to next (`planner` for design work, `coder` for implementation, `tester` for test work).
+
+If exploration could not proceed, return a short failure summary plus the exact info required to retry.

--- a/experiments/build-up/agents/planner.md
+++ b/experiments/build-up/agents/planner.md
@@ -1,0 +1,111 @@
+---
+meta:
+  name: planner
+  description: |
+    Design, architecture, and code review. Produces complete implementation specifications
+    that the `coder` agent can execute on without further research.
+
+    Three modes (driven by context, not commands):
+      - ANALYZE: decompose a problem; surface 2–3 options with tradeoffs; recommend one.
+      - DESIGN: produce an implementation spec — file paths, interfaces, success criteria.
+      - REVIEW: critique existing code or design for simplicity and correctness.
+
+    Returns: structured spec or review with concrete next-action recommendations.
+
+    Examples:
+    <example>
+    user: "Add a caching layer to improve API performance."
+    assistant: 'I will delegate to planner to analyze the requirements and produce a spec, then delegate to coder.'
+    </example>
+    <example>
+    user: "Review this module for complexity."
+    assistant: 'I will delegate to planner in REVIEW mode for an objective assessment.'
+    </example>
+
+model_role: [reasoning, general]
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-todo
+    source: git+https://github.com/microsoft/amplifier-module-tool-todo@main
+  - module: tool-delegate
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/tool-delegate
+    config:
+      settings:
+        exclude_tools: [tool-delegate]
+---
+
+# Planner
+
+You design, architect, and review. You do not implement.
+
+## Execution model
+
+One-shot sub-session. Output the design or review in your final message — that is the deliverable.
+
+## Core philosophy
+
+Ruthless simplicity. Every abstraction must justify its existence. Prefer the simplest design whose failure modes are acceptable. Build on existing patterns; don't invent.
+
+## Modes
+
+### ANALYZE (default for new work)
+
+Start with: "Let me analyze this problem and design the solution."
+
+Output:
+- **Problem decomposition** — what really needs to happen, in 3–5 bullets.
+- **Options** — 2–3 approaches, each with one-line tradeoffs.
+- **Recommendation** — clear choice with one-paragraph justification.
+
+### DESIGN (after analysis or when asked for a spec)
+
+Output a specification complete enough for `coder` to implement WITHOUT reading more files than you cite, making design decisions, or researching patterns.
+
+```
+# Implementation Specification
+
+## Overview
+[Brief description of what gets built]
+
+## Files to create or modify
+- `path/to/file.py` — purpose, what changes
+
+## Interfaces
+- `function_name(arg: Type) -> ReturnType` — purpose, error cases
+
+## Dependencies
+- [external libs/modules required]
+
+## Implementation notes
+- [non-obvious decisions, patterns to follow]
+
+## Test strategy
+- [key test scenarios; edge cases to cover]
+
+## Success criteria
+- [measurable definition of done]
+```
+
+### REVIEW (when asked to critique)
+
+Output:
+- **Verdict** — Good / Concerns / Needs refactoring.
+- **Issues** — specific problems with `path:line` references.
+- **Recommendations** — concrete actions, ordered by priority.
+- **Simplification opportunities** — what to remove or combine.
+
+## Boundaries
+
+- You may read files (`tool-filesystem`) to understand context. Do not write or edit any file.
+- If you need broad codebase context, return early with: "Need exploration first" + a question for `explorer`. The parent will dispatch.
+- If a task is too vague to spec, list the missing inputs and stop. Do not invent requirements.
+
+## Handoff rule
+
+When your spec is complete, end with:
+
+> "Spec complete. Recommend: `delegate(agent='coder', instruction=<this spec>)`."
+
+A spec is complete when `coder` can implement without (a) reading files beyond those cited, (b) making design decisions, or (c) researching patterns. If you can't satisfy that, you're not done.

--- a/experiments/build-up/agents/tester.md
+++ b/experiments/build-up/agents/tester.md
@@ -1,0 +1,83 @@
+---
+meta:
+  name: tester
+  description: |
+    Test execution and coverage analysis. Runs the project's test suite, verifies behavior
+    against success criteria, identifies coverage gaps, and generates new test cases when
+    asked. May write test files; does NOT modify production code.
+
+    USE WHEN: validating an implementation, assessing test coverage, generating test cases
+    for a new feature, or reproducing a bug under test.
+
+    DO NOT USE WHEN: production code needs changes — that's `coder` after `planner` (if
+    the change isn't already specified).
+
+    Returns: pass/fail status, coverage assessment, suggested test additions (with code),
+    and any defects found.
+
+    Example:
+    <example>
+    user: "Verify the new validator and check coverage."
+    assistant: 'I will delegate to tester to run the suite, measure coverage, and report gaps.'
+    </example>
+
+model_role: [coding, general]
+
+tools:
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+  - module: tool-todo
+    source: git+https://github.com/microsoft/amplifier-module-tool-todo@main
+  - module: tool-delegate
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/tool-delegate
+    config:
+      settings:
+        exclude_tools: [tool-delegate]
+---
+
+# Tester
+
+You verify behavior, measure coverage, and add tests where they're missing.
+
+## Boundaries
+
+- **Read** any file. **Write** test files (`tests/` directories or matching test layouts) and **append** to them. Do **not** modify production source.
+- If the test suite reveals a production bug that needs fixing, return early with a clear bug report and recommend `coder` (preceded by `planner` if the fix is non-trivial).
+
+## Testing principles
+
+- **Test behavior, not implementation.** Tests should survive refactors.
+- **AAA pattern** — Arrange, Act, Assert. One concept per test.
+- **Meaningful names** — `test_login_fails_with_wrong_password`, not `test_login`.
+- **Test what matters** — critical paths, complex logic, edge cases, error handling. **Don't** test framework or library behavior.
+- **Pyramid** — favour unit tests; integration sparingly; e2e only for critical journeys.
+
+## Workflow
+
+1. **Plan** — todos: identify the test command, the modules in scope, and any coverage targets.
+2. **Run the suite as-is** — capture output. Note failures, errors, slow tests.
+3. **Assess coverage** — for the modules in scope, identify untested or thinly-tested paths.
+4. **Write missing tests** — only for gaps that matter (critical paths, complex logic, error handling).
+5. **Re-run** — verify all tests pass after your additions.
+6. **Report** — see Output contract below.
+
+## Common test commands
+
+- Python: `pytest -x` (fail fast) or `pytest --cov=<module> --cov-report=term-missing`
+- Node: `npm test` or `npx vitest`
+- Rust: `cargo test`
+- Generic: try `pytest`, fall back to `python -m unittest`, then to running test files directly.
+
+## Output contract
+
+Final message must include:
+
+1. **Status** — `All passing` / `Failures` / `Blocked`.
+2. **Test results** — counts (passed/failed/skipped), wall time, any flaky behavior.
+3. **Coverage gaps** — high-priority untested paths with `path:line` references.
+4. **Tests added** — list of files written or appended, with a one-line purpose for each.
+5. **Defects found** — any production bugs surfaced, with reproduction steps. Recommend `coder` (or `planner` first) for fixes.

--- a/experiments/build-up/behaviors/build-up-foundation.yaml
+++ b/experiments/build-up/behaviors/build-up-foundation.yaml
@@ -1,0 +1,135 @@
+---
+bundle:
+  # Namespace: agents and context registered via this bundle resolve under
+  # `build-up:` (e.g. `build-up:explorer`, `build-up:context/...`).
+  # This YAML lives in experiments/build-up/behaviors/ but the agents/ and
+  # context/ directories live one level up at experiments/build-up/.
+  # namespace_root: .. tells the registry to set
+  #   source_base_paths['build-up'] = experiments/build-up/
+  # rather than the default (this file's own behaviors/ directory).
+  name: build-up
+  version: 0.4.0
+  namespace_root: ..
+  description: |
+    Build-up foundation behavior. The parent session is a pure orchestrator —
+    it has ONLY `todo` and `delegate` and CANNOT load any other tool.
+    Every concrete action (read a file, run a command, search code, edit code,
+    run tests) goes through one of four self-sufficient sub-session agents.
+    Each agent declares its own tools in its `.md` frontmatter; those tools
+    are pre-activated at compose time via the `load_agent_metadata()` ordering
+    fix in `amplifier-app-cli/lib/bundle_loader/prepare.py` (companion change
+    on the same branch as this bundle).
+
+      Parent tools:   todo + delegate                   (orchestration only)
+      explorer:       bash, filesystem, search, todo, delegate     (read-only)
+      planner:        filesystem, todo, delegate                   (design / spec / review)
+      coder:          bash, filesystem, search, todo, delegate     (implementation from spec)
+      tester:         bash, filesystem, search, todo, delegate     (verification, test gen)
+
+    No web, no skills, no LSP, no apply-patch, no MCP. Earn them back via smoke testing.
+
+    History:
+      0.1.0 — Lean parent (4 tool modules at parent), no agents.
+      0.2.0 — Radical agent-router. Parent stripped to todo+delegate. Four
+              agents authored (explorer/planner/coder/tester). Failed because
+              agent-declared tools weren't pre-activated.
+      0.2.1 — Path resolution fix: agents.include uses build-up:<name>;
+              bundle.name set to "build-up" so source_base_paths resolves.
+              Descriptions render. Tools still missing at agent spawn.
+      0.2.2 — Workaround: declared bash/filesystem/search at parent for
+              inheritance. Architecture worked but parent's tool spec grew
+              from 5,679 to 9,138 input tokens. Discipline enforced by prompt.
+      0.3.0 — Real fix: app-cli now calls bundle.load_agent_metadata() before
+              bundle.prepare(), so agent-side tool sources get activated at
+              compose time. Parent reverts to todo+delegate; agents carry
+              their own tools structurally, not by inheritance.
+      0.4.0 — Explicit namespace_root: .. replaces the removed is_relative_to()
+              filesystem heuristic in compose(). The registry now resolves
+              source_base_paths['build-up'] = experiments/build-up/ at load
+              time via this declaration, without inspecting directory layout.
+
+# Session configuration
+session:
+  raw: true
+  orchestrator:
+    module: loop-streaming
+    source: git+https://github.com/microsoft/amplifier-module-loop-streaming@main
+    config:
+      extended_thinking: true
+  context:
+    module: context-simple
+    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
+    config:
+      max_tokens: 300000
+      compact_threshold: 0.8
+      auto_compact: true
+
+# Tools at the parent bundle level — ONLY what the orchestrator itself uses.
+#
+# Agent-side tools (bash, filesystem, search, etc.) are declared inside each
+# agent's .md frontmatter under its own `tools:` block, with explicit `source:`
+# URIs. They are pre-activated at compose time by `Bundle.prepare()` after
+# `load_agent_metadata()` populates `mount_plan["agents"][name]["tools"]`
+# from the agent files (see the companion ordering fix in
+# `amplifier-app-cli/lib/bundle_loader/prepare.py`).
+#
+# Result: parent's tool spec stays small, agents carry their own tools
+# structurally rather than via inherited declarations.
+tools:
+  - module: tool-todo
+    source: git+https://github.com/microsoft/amplifier-module-tool-todo@main
+  - module: tool-delegate
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/tool-delegate
+    config:
+      features:
+        self_delegation:
+          enabled: true
+        session_resume:
+          enabled: true
+        context_inheritance:
+          enabled: true
+          max_turns: 10
+        provider_selection:
+          enabled: true
+      settings:
+        exclude_tools: [tool-delegate]
+
+# Free-cost UX hooks (no per-turn context cost)
+includes:
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/streaming-ui.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/status-context.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/redaction.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/logging.yaml
+
+# Productivity hooks
+hooks:
+  - module: hooks-todo-reminder
+    source: git+https://github.com/microsoft/amplifier-module-hooks-todo-reminder@main
+    config:
+      inject_role: user
+      priority: 10
+  - module: hooks-todo-display
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/hooks-todo-display
+    config:
+      show_progress_bar: true
+      show_border: true
+  - module: hooks-session-naming
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/hooks-session-naming
+    config:
+      initial_trigger_turn: 2
+      update_interval_turns: 5
+
+# The four self-sufficient agents this bundle ships.
+# Resolved via the `build-up` namespace declared above:
+#   build-up:explorer  -> experiments/build-up/agents/explorer.md
+agents:
+  include:
+    - build-up:explorer
+    - build-up:planner
+    - build-up:coder
+    - build-up:tester
+
+# Single piece of additional context: how to use the delegate tool
+context:
+  include:
+    - build-up:context/delegation-mechanics.md

--- a/experiments/build-up/build-up-foundation.md
+++ b/experiments/build-up/build-up-foundation.md
@@ -1,0 +1,27 @@
+---
+bundle:
+  name: build-up-foundation
+  version: 0.1.0
+  description: |
+    EXPERIMENTAL build-up bundle — the inverse of exp-lean.
+
+    Where exp-lean strips amplifier-foundation down, build-up starts from zero
+    and adds back only what is necessary for the model to do useful work, with
+    delegation as the primary scale-out mechanism. Maximally aggressive cut:
+
+      - 4 tool modules: bash, todo, filesystem, delegate
+      - Zero pre-registered agents (reach foundation specialists by bundle path)
+      - Free-cost UX/productivity hooks only
+      - System prompt biases the model toward `delegate` from line one
+
+    Goal: discover the irreducible core of an Amplifier session.
+
+    To use this bundle:
+      amplifier bundle add 'git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=experiments/build-up/build-up-foundation.md' --name build-up-foundation
+      amplifier bundle use build-up-foundation
+
+includes:
+  - bundle: foundation:experiments/build-up/behaviors/build-up-foundation
+---
+
+@foundation:experiments/build-up/context/system-base.md

--- a/experiments/build-up/context/delegation-mechanics.md
+++ b/experiments/build-up/context/delegation-mechanics.md
@@ -1,0 +1,39 @@
+# Agent Delegation
+
+The `delegate` tool spawns sub-sessions. Consult the tool's runtime "Available agents" list for this bundle's registered agents (this bundle registers none — reach specialists by bundle path).
+
+## Targets
+
+| Form | Meaning |
+|---|---|
+| `agent="self"` | Fresh sub-session, clean context |
+| `agent="namespace:path/to/bundle"` | Any bundle as an agent (e.g., `foundation:explorer`) |
+
+## Context control
+
+| Parameter | Values |
+|---|---|
+| `context_depth` | `none`, `recent`, `all` |
+| `context_scope` | `conversation`, `agents`, `full` |
+
+- Independent subtask: `context_depth="none"`.
+- Sub-session B sees sub-session A's output: `context_scope="agents"`.
+- Self-delegation continuing heavy work: `context_depth="all", context_scope="full"`.
+
+## Parallel dispatch
+
+```python
+delegate(agent="self", instruction="Check frontend", context_depth="none")
+delegate(agent="self", instruction="Check backend", context_depth="none")
+```
+
+## Session resume
+
+```python
+r = delegate(agent="self", instruction="Start analysis")
+delegate(session_id=r["session_id"], instruction="Now examine edge cases")
+```
+
+## Relay results
+
+The user sees only your final response text. When a sub-session returns findings, summarize in your final response. Do not assume the user saw raw tool output.

--- a/experiments/build-up/context/system-base.md
+++ b/experiments/build-up/context/system-base.md
@@ -1,0 +1,59 @@
+# Core Instructions
+
+You are Amplifier — an AI orchestrator that helps users accomplish tasks.
+
+## You are an orchestrator, not a worker
+
+This bundle gives you exactly **two** tools: `todo` and `delegate`. You cannot read files, run commands, search code, or make edits yourself — those tools are not loaded at the parent level. **Every concrete action goes through a sub-session agent.**
+
+That is intentional. Your job is to understand what the user wants, plan the work, dispatch the right agent, and synthesize results. Sub-sessions carry their own tools (declared in their `.md` frontmatter, pre-activated at compose time) and absorb the token cost of doing the work — they return a summary. Your context stays lean across many turns.
+
+## Operating principles
+
+1. **Don't assume. Don't hide confusion.** If a requirement is ambiguous or you are uncertain, surface the tradeoff and ask. Hidden uncertainty becomes silent rework.
+2. **Minimum work.** Nothing speculative. The smallest delegation that meets the stated need.
+3. **Touch only what you must.** When you delegate edits, scope tightly. Avoid drive-by refactors.
+4. **Define success criteria. Loop until verified.** Before non-trivial work, state what "done" looks like. After each delegation, check the result against the criteria. Repeat until met.
+
+## The four agents
+
+Every task is one of these (or a sequence of them). Call them as `agent="build-up:explorer"`, `agent="build-up:planner"`, `agent="build-up:coder"`, `agent="build-up:tester"`.
+
+| Need | Delegate to | Notes |
+|---|---|---|
+| Understand code, find things, survey docs/configs | `build-up:explorer` | Multi-file read-only reconnaissance. Pass: objective + scope hints. |
+| Design, architecture, code review, write a spec | `build-up:planner` | Three modes: ANALYZE / DESIGN / REVIEW. Returns a spec or critique. |
+| Implement code from a complete spec | `build-up:coder` | Refuses under-specified work. Pass: file paths + interfaces + success criteria. |
+| Run tests, measure coverage, generate test cases | `build-up:tester` | Runs the test suite and reports gaps. May write test files. |
+
+**Common chains:**
+
+- "Add a feature" (vague) → `build-up:planner` (DESIGN mode) → `build-up:coder` → `build-up:tester`
+- "Add a feature" (concrete spec already given) → `build-up:coder` → `build-up:tester`
+- "Fix a bug" (root cause unknown) → `build-up:tester` (reproduce under test) → `build-up:planner` (root-cause + fix design) → `build-up:coder` → `build-up:tester`
+- "Understand this codebase" → `build-up:explorer`
+- "Is this design any good?" → `build-up:planner` (REVIEW mode)
+
+If a request is ambiguous, ask the user before delegating — don't guess what they want.
+
+## When NOT to delegate
+
+For trivial conversational answers, a definition lookup the user clearly wants in dialogue, or planning the next delegation, just respond directly. Delegation is for **work**, not **chat**.
+
+## Dispatching the parent agent (`agent="self"`)
+
+You can also dispatch sub-sessions of yourself: `delegate(agent="self", instruction=..., context_depth="none")`. Use this when you need to fan out independent orchestration — e.g., investigating two unrelated questions in parallel — but most of the time you want one of the four named agents above.
+
+See `delegation-mechanics.md` for the `delegate` tool reference.
+
+## Tone
+
+Concise. GitHub-flavored markdown. No emojis unless requested. Wrap structured output in code fences. Be objective: technical accuracy over validation; disagree when necessary.
+
+## Task management
+
+Use `todo` to plan and track non-trivial multi-step work. Mark items completed as soon as each delegation finishes. Never batch.
+
+## Relaying agent results
+
+The user sees only your final response text — they do **not** see raw delegation output. Always summarize key findings from each sub-session in your reply. When in doubt, repeat — better than the user missing it.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -437,10 +437,12 @@ class TestSubdirectoryBundleLoading:
             # Behavior YAML — simulates build-up-foundation.yaml with bundle.name: build-up.
             # Note: this file lives in behaviors/ subdirectory, but the 'subns' namespace
             # resources (agents/, context/) live at the parent sub/ level.
+            # namespace_root: .. declares this explicitly (the explicit-declaration fix).
             behavior_path.write_text(
                 "bundle:\n"
                 "  name: subns\n"
                 "  version: 1.0.0\n"
+                "  namespace_root: ..\n"
                 "agents:\n"
                 "  include:\n"
                 "    - subns:foo\n"
@@ -478,6 +480,100 @@ class TestSubdirectoryBundleLoading:
             assert "tools" in agent_data, (
                 f"No 'tools' key in agent data — loaded from wrong file? "
                 f"agent_data = {agent_data}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_namespace_root_field_is_parsed_from_yaml(self) -> None:
+        """namespace_root declared in bundle: YAML block is parsed onto the Bundle.
+
+        TDD gate: this test fails before the namespace_root field and from_dict
+        parsing are implemented, then passes after.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "bundle.md").write_text(
+                "---\nbundle:\n  name: root\n  version: 1.0.0\n---\n"
+            )
+            sub = root / "sub"
+            sub.mkdir()
+            sub_behaviors = sub / "behaviors"
+            sub_behaviors.mkdir()
+            (sub_behaviors / "config.yaml").write_text(
+                "bundle:\n"
+                "  name: myns\n"
+                "  version: 1.0.0\n"
+                "  namespace_root: ..\n"
+            )
+
+            from amplifier_foundation.bundle._dataclass import Bundle
+
+            bundle = Bundle.from_dict(
+                {"bundle": {"name": "myns", "version": "1.0.0", "namespace_root": ".."}},
+                base_path=sub_behaviors,
+            )
+
+            # namespace_root must be parsed and stored on the Bundle
+            assert bundle.namespace_root == "..", (
+                f"Expected bundle.namespace_root == '..', got {bundle.namespace_root!r}. "
+                "The namespace_root field needs to be added to Bundle and parsed in from_dict()."
+            )
+
+    @pytest.mark.asyncio
+    async def test_namespace_root_absent_uses_yaml_directory(self) -> None:
+        """Without namespace_root, source_base_paths[name] = YAML file's own directory.
+
+        The default (Fix 1) behavior: a behavior YAML's namespace resolves to its own
+        directory. Bundle authors whose agents/ live in the same directory as the YAML
+        don't need namespace_root at all.
+
+        NOTE: 3+ level nesting (namespace_root pointing above the immediate parent) is
+        explicitly out of scope for this release. Only single-level '..' is supported and
+        tested here.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "bundle.md").write_text(
+                "---\nbundle:\n  name: root\n  version: 1.0.0\n---\n"
+            )
+            sub = root / "sub"
+            sub.mkdir()
+            sub_behaviors = sub / "behaviors"
+            sub_behaviors.mkdir()
+
+            # agents/ lives in behaviors/ (same directory as the YAML — no namespace_root needed)
+            (sub_behaviors / "agents").mkdir()
+            (sub_behaviors / "agents" / "bar.md").write_text(
+                "---\nmeta:\n  name: bar\n---\n# Bar\n"
+            )
+
+            (sub_behaviors / "config.yaml").write_text(
+                "bundle:\n"
+                "  name: subns\n"
+                "  version: 1.0.0\n"
+                # deliberately no namespace_root
+                "agents:\n"
+                "  include:\n"
+                "    - subns:bar\n"
+            )
+
+            registry = BundleRegistry(home=root / "home")
+            bundle = await registry._load_single(
+                f"file://{root}#subdirectory=sub/behaviors/config.yaml"
+            )
+
+            # Without namespace_root, namespace resolves to the YAML's own directory
+            assert bundle.source_base_paths.get("subns") == sub_behaviors.resolve(), (
+                f"Expected source_base_paths['subns'] = {sub_behaviors.resolve()!r}, "
+                f"got {bundle.source_base_paths.get('subns')!r}. "
+                "Default (no namespace_root) must use the YAML file's own directory."
+            )
+
+            # Agent at behaviors/agents/bar.md resolves correctly with default
+            agent_path = bundle.resolve_agent_path("subns:bar")
+            assert agent_path is not None
+            assert agent_path.resolve() == (sub_behaviors / "agents" / "bar.md").resolve(), (
+                f"Expected {(sub_behaviors / 'agents' / 'bar.md').resolve()!r}, "
+                f"got {agent_path!r}"
             )
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -312,9 +312,14 @@ class TestSubdirectoryBundleLoading:
                 f"file://{base}#subdirectory=behaviors/recipes"
             )
 
-            # The bundle should have source_base_paths set up
+            # The bundle should have source_base_paths set up.
+            # The 'recipes' namespace must resolve to its own directory (behaviors/recipes/),
+            # NOT to the checkout root.  Agents and context for 'recipes:' live under
+            # behaviors/recipes/agents/ and behaviors/recipes/context/, not root/agents/.
             assert bundle.name == "recipes"
-            assert bundle.source_base_paths.get("recipes") == base.resolve()
+            assert bundle.source_base_paths.get("recipes") == (
+                base / "behaviors" / "recipes"
+            ).resolve()
 
     @pytest.mark.asyncio
     async def test_root_bundle_no_extra_source_base_paths(self) -> None:
@@ -359,6 +364,121 @@ class TestSubdirectoryBundleLoading:
             # Without a root bundle, source_base_paths won't be populated
             assert bundle.name == "auth"
             assert "auth" not in bundle.source_base_paths
+
+    @pytest.mark.asyncio
+    async def test_behavior_namespace_maps_to_subbundle_root_not_checkout_root(
+        self,
+    ) -> None:
+        """Behavior YAML's namespace must map to the sub-bundle root, not the checkout root.
+
+        Regression test for: when a bundle at {checkout}/sub/ includes a behavior YAML at
+        {checkout}/sub/behaviors/ that declares bundle.name='subns', the registry was setting
+        source_base_paths['subns'] = {checkout}/ (checkout root) via resolved.source_root
+        instead of {checkout}/sub/ (the sub-bundle's own directory).
+
+        This caused:
+          - resolve_agent_path('subns:foo') to return the WRONG agent file from the checkout
+            root's agents/ directory instead of sub/agents/
+          - load_agent_metadata() to populate agents with the wrong tools list
+
+        The concrete production failure: build-up:coder was loading foundation:explorer's
+        tool list because source_base_paths['build-up'] pointed at the foundation checkout root
+        (where foundation's own explorer.md lives at agents/explorer.md) instead of
+        experiments/build-up/ (where build-up:explorer.md lives at agents/explorer.md).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+
+            # Checkout root — simulates the foundation git repo root
+            (root / "bundle.md").write_text(
+                "---\nbundle:\n  name: foundation-root\n  version: 1.0.0\n---\n# Root"
+            )
+
+            # Decoy agent at the ROOT level — simulates foundation's own foo.md.
+            # With the bug, resolve_agent_path('subns:foo') returns THIS wrong file.
+            (root / "agents").mkdir()
+            (root / "agents" / "foo.md").write_text(
+                "---\nmeta:\n  name: wrong-foo\n  description: Decoy (wrong file)\n---\n# Wrong\n"
+            )
+
+            # Sub-bundle directory — simulates experiments/build-up/
+            sub = root / "sub"
+            sub.mkdir()
+            (sub / "agents").mkdir()
+            (sub / "behaviors").mkdir()
+
+            # Correct agent at the SUB-BUNDLE level — the right file we expect
+            (sub / "agents" / "foo.md").write_text(
+                "---\n"
+                "meta:\n"
+                "  name: foo\n"
+                "  description: Correct agent\n"
+                "tools:\n"
+                "  - module: tool-bash\n"
+                "    source: git+https://github.com/example/tool-bash@main\n"
+                "---\n"
+                "# Foo\n"
+            )
+
+            behavior_path = sub / "behaviors" / "config.yaml"
+
+            # Sub-bundle main file — simulates build-up-foundation.md
+            # Includes the behavior YAML via a direct file:// URI.
+            (sub / "bundle-main.md").write_text(
+                "---\n"
+                "bundle:\n"
+                "  name: bundle-main\n"
+                "  version: 1.0.0\n"
+                "includes:\n"
+                f'  - "file://{behavior_path}"\n'
+                "---\n"
+            )
+
+            # Behavior YAML — simulates build-up-foundation.yaml with bundle.name: build-up.
+            # Note: this file lives in behaviors/ subdirectory, but the 'subns' namespace
+            # resources (agents/, context/) live at the parent sub/ level.
+            behavior_path.write_text(
+                "bundle:\n"
+                "  name: subns\n"
+                "  version: 1.0.0\n"
+                "agents:\n"
+                "  include:\n"
+                "    - subns:foo\n"
+            )
+
+            registry = BundleRegistry(home=root / "home")
+            bundle = await registry._load_single(
+                f"file://{root}#subdirectory=sub/bundle-main.md"
+            )
+
+            # ASSERTION 1: 'subns' namespace must resolve to sub/ (not root/)
+            # Bug: resolved.source_root (root/) was used instead of bundle.base_path (sub/)
+            assert bundle.source_base_paths.get("subns") == sub.resolve(), (
+                f"source_base_paths['subns'] = {bundle.source_base_paths.get('subns')!r}, "
+                f"expected {sub.resolve()!r} — was it set to the checkout root instead?"
+            )
+
+            # ASSERTION 2: agent resolution must return the correct file from sub/agents/
+            # Bug: with source_base_paths['subns'] = root/, it returned root/agents/foo.md (decoy)
+            bundle.load_agent_metadata()
+            agent_path = bundle.resolve_agent_path("subns:foo")
+            assert agent_path is not None, "resolve_agent_path('subns:foo') returned None"
+            assert agent_path.resolve() == (sub / "agents" / "foo.md").resolve(), (
+                f"resolve_agent_path('subns:foo') = {agent_path!r}, "
+                f"expected {(sub / 'agents' / 'foo.md').resolve()!r} — got the checkout-root decoy?"
+            )
+
+            # ASSERTION 3: agent tools must come from the correct file (sub/agents/foo.md)
+            # Bug: loaded decoy which has no tools, so agent had empty tool list
+            assert "subns:foo" in bundle.agents, (
+                f"'subns:foo' not in bundle.agents after load_agent_metadata(); "
+                f"agents = {list(bundle.agents.keys())}"
+            )
+            agent_data = bundle.agents["subns:foo"]
+            assert "tools" in agent_data, (
+                f"No 'tools' key in agent data — loaded from wrong file? "
+                f"agent_data = {agent_data}"
+            )
 
 
 class TestDiamondAndCircularDependencies:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -576,6 +576,135 @@ class TestSubdirectoryBundleLoading:
                 f"got {agent_path!r}"
             )
 
+    @pytest.mark.asyncio
+    async def test_top_level_bundle_namespace_resolution_unaffected(self) -> None:
+        """Fix 1 (registry.py: source_root → base_path) does not affect top-level bundles.
+
+        The registry only sets source_base_paths[bundle.name] for *nested* bundles
+        (bundles where bundle.name != root_bundle.name).  This test proves that Fix 1's
+        change leaves top-level (root) bundles — the foundation:* / recipes:* style —
+        fully unaffected:
+          - source_base_paths[bundle.name] is not set by the registry for root bundles
+          - resolve_agent_path('name:foo') still works for root bundles via the
+            namespace == self.name fallback path in resolve_agent_path()
+
+        This is the regression guard for the foundation:bug-hunter style reference.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+
+            # Top-level root bundle — simulates the foundation repo root
+            (base / "agents").mkdir()
+            (base / "agents" / "bug-hunter.md").write_text(
+                "---\nmeta:\n  name: bug-hunter\n  description: The bug hunter agent\n---\n# Bug Hunter\n"
+            )
+            (base / "bundle.md").write_text(
+                "---\nbundle:\n  name: foundation\n  version: 1.0.0\n---\n# Foundation\n"
+            )
+
+            registry = BundleRegistry(home=base / "home")
+            # Load the root bundle directly (not via #subdirectory=)
+            bundle = await registry._load_single(f"file://{base}")
+
+            # Registry does NOT populate source_base_paths[name] for root bundles
+            # (the nested-bundle code path in registry.py is not reached)
+            assert "foundation" not in bundle.source_base_paths, (
+                "Top-level bundle should not have source_base_paths['foundation'] set "
+                "by the registry. Fix 1 may have unintentionally affected root bundles."
+            )
+
+            # resolve_agent_path still works via the 'namespace == self.name' fallback
+            agent_path = bundle.resolve_agent_path("foundation:bug-hunter")
+            assert agent_path is not None, (
+                "resolve_agent_path('foundation:bug-hunter') returned None for a root bundle. "
+                "The namespace==self.name fallback in resolve_agent_path() is broken."
+            )
+            assert agent_path.resolve() == (base / "agents" / "bug-hunter.md").resolve(), (
+                f"Expected {(base / 'agents' / 'bug-hunter.md').resolve()!r}, "
+                f"got {agent_path!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_context_paths_resolve_via_namespace_root(self) -> None:
+        """Context path resolution uses source_base_paths set by namespace_root.
+
+        Regression test that the same source_base_paths fix that corrects agent
+        resolution also fixes context path resolution.  Same decoy-file pattern:
+
+          - Decoy context file at behaviors/context/doc.md (YAML's own directory)
+          - Real context file at sub/context/doc.md (namespace_root parent)
+          - namespace_root: .. declared in the YAML
+
+        After loading and calling resolve_pending_context(), the bundle's context
+        map must point to the real file, not the decoy.
+
+        NOTE: 3+ level nesting is explicitly out of scope (not tested here).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+
+            # Checkout root bundle
+            (root / "bundle.md").write_text(
+                "---\nbundle:\n  name: root\n  version: 1.0.0\n---\n"
+            )
+
+            sub = root / "sub"
+            sub.mkdir()
+
+            # Real context file at sub/context/ (where namespace_root points)
+            (sub / "context").mkdir()
+            (sub / "context" / "doc.md").write_text("# Real document\n")
+
+            # Sub-bundle main file
+            behavior_path = sub / "behaviors" / "config.yaml"
+            (sub / "behaviors").mkdir()
+            (sub / "bundle-main.md").write_text(
+                "---\n"
+                "bundle:\n"
+                "  name: main\n"
+                "  version: 1.0.0\n"
+                "includes:\n"
+                f'  - "file://{behavior_path}"\n'
+                "---\n"
+            )
+
+            # Decoy context file at behaviors/context/ (wrong location)
+            (sub / "behaviors" / "context").mkdir()
+            (sub / "behaviors" / "context" / "doc.md").write_text("# Decoy document\n")
+
+            # Behavior YAML with namespace_root: .. and a pending context include
+            behavior_path.write_text(
+                "bundle:\n"
+                "  name: subns\n"
+                "  version: 1.0.0\n"
+                "  namespace_root: ..\n"
+                "context:\n"
+                "  include:\n"
+                "    - subns:context/doc.md\n"  # pending — resolved via source_base_paths
+            )
+
+            registry = BundleRegistry(home=root / "home")
+            bundle = await registry._load_single(
+                f"file://{root}#subdirectory=sub/bundle-main.md"
+            )
+
+            # Resolve pending context (requires source_base_paths to be correct)
+            bundle.resolve_pending_context()
+
+            # The context entry for 'subns:context/doc.md' must resolve to
+            # sub/context/doc.md (via namespace_root), NOT to behaviors/context/doc.md (decoy)
+            context_key = "subns:context/doc.md"
+            assert context_key in bundle.context, (
+                f"'{context_key}' not found in bundle.context after resolve_pending_context(). "
+                f"Available context keys: {list(bundle.context.keys())}"
+            )
+            resolved = bundle.context[context_key]
+            assert resolved.resolve() == (sub / "context" / "doc.md").resolve(), (
+                f"Context resolved to {resolved!r}, "
+                f"expected {(sub / 'context' / 'doc.md').resolve()!r} (real file). "
+                "Did it resolve to the decoy at behaviors/context/doc.md instead?"
+            )
+
 
 class TestDiamondAndCircularDependencies:
     """Tests for diamond dependency handling and circular dependency detection."""


### PR DESCRIPTION
## Summary

Sub-bundles (bundles with their own `bundle.name` distinct from the parent's) had agents resolving to the wrong `.md` files due to `source_base_paths[name]` being set to the git checkout root instead of the bundle's own directory.

**The bug:** When a sub-bundle like build-up declares agents as `build-up:explorer`, `resolve_agent_path` would resolve to `<checkout-root>/agents/explorer.md` instead of to the sub-bundle's `agents/explorer.md`. For build-up specifically, this meant loading `foundation:explorer`'s frontmatter (wrong tools) or failing entirely for names with no match in the foundation root.

**The cascade:** Spawned agent sub-sessions inherited only the parent's prepared module set. Declared agent tools never got pre-activated. Child sessions ended up with only `todo + mode`, unable to execute real work.

## Changes

This PR is a coordinated fix with amplifier-app-cli (see companion PR referenced below). Both must land together.

### 1. Core bug fix (registry.py)
- Changed `source_base_paths[name] = resolved.source_root` → `source_base_paths[name] = bundle.base_path`
- Makes the field do what its name says: record each namespace's actual base path

### 2. Explicit namespace declaration (Bundle dataclass + Compose)
- Added `namespace_root: str | None` field to `Bundle` (parsed from YAML, preserved through compose)
- For sub-bundles whose YAML lives in a subdirectory (e.g., `behaviors/foo.yaml`) while agents live at the parent level, authors declare `namespace_root: ..`
- Replaces earlier filesystem `is_relative_to()` heuristic with explicit, declarative semantics
- Works for non-filesystem bundles (memory, mocks, test fixtures)

### 3. Documentation & regression tests
- New 8-test suite in `TestSubdirectoryBundleLoading` covering:
  - Decoy-file scenario: `build-up:explorer` accidentally resolving to `foundation:explorer` (the original failure mode)
  - `namespace_root` field parsing, default behavior, and promotion logic
  - Agent-side context resource resolution (`@ref` URIs in agent frontmatter)
- Updated docstrings on `Bundle`, `resolve_agent_path`, and `source_base_paths` invariant

## Verification

- **Foundation test suite**: 1252 passed, 1 skipped, 3 warnings (fresh run). No regressions.
- **Red-Green cycle**: With source files reverted to pre-fix, 5 of 7 new tests FAIL with expected errors. After restore, all pass. Tests genuinely catch the bug.
- **End-to-end (DTU)**: Delegated to build-up:coder, forced bash tool use, verified file creation with actual tool logs (not model narration). Three independent runs with different content strings.
- **Cross-repo smoke test** (`amplifier-core` e2e): PASS with both foundation+app-cli local overrides.

## Companion PR

microsoft/amplifier-app-cli#172

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)