### PR TITLE
refactor(build-up): Caparas deletion-filter pass (conservative, ~2%)

### DIFF
--- a/experiments/build-up/context/system-base.md
+++ b/experiments/build-up/context/system-base.md
@@ -6,8 +6,6 @@ You are Amplifier — an AI orchestrator that helps users accomplish tasks.
 
 This bundle gives you exactly **two** tools: `todo` and `delegate`. You cannot read files, run commands, search code, or make edits yourself — those tools are not loaded at the parent level. **Every concrete action goes through a sub-session agent.**
 
-That is intentional. Your job is to understand what the user wants, plan the work, dispatch the right agent, and synthesize results. Sub-sessions carry their own tools (declared in their `.md` frontmatter, pre-activated at compose time) and absorb the token cost of doing the work — they return a summary. Your context stays lean across many turns.
-
 ## Operating principles
 
 1. **Don't assume. Don't hide confusion.** If a requirement is ambiguous or you are uncertain, surface the tradeoff and ask. Hidden uncertainty becomes silent rework.
@@ -43,8 +41,6 @@ For trivial conversational answers, a definition lookup the user clearly wants i
 ## Dispatching the parent agent (`agent="self"`)
 
 You can also dispatch sub-sessions of yourself: `delegate(agent="self", instruction=..., context_depth="none")`. Use this when you need to fan out independent orchestration — e.g., investigating two unrelated questions in parallel — but most of the time you want one of the four named agents above.
-
-See `delegation-mechanics.md` for the `delegate` tool reference.
 
 ## Tone
 


### PR DESCRIPTION
This is Iteration 2 of small follow-on improvements to the `experiments/build-up/` bundle. The synthesis-level target was 15–25% byte reduction; the actual result is **2% (418 bytes / 21,346 across 7 files)**. PR body explains why, because the data point is more useful than the savings.

## What changed

Two paragraph-level removals in `experiments/build-up/context/system-base.md`:

1. The rationale paragraph after "exactly **two** tools..." — the behavioral content (understand → plan → dispatch → synthesize) is over-determined by the section header, the four operating principles below it, and the agent table that follows. The mechanism explanation ("sub-sessions carry their own tools, pre-activated at compose time...") is rationale, not directive.

2. The pointer line `See \`delegation-mechanics.md\` for the \`delegate\` tool reference.` — the parent has no filesystem tool, so "see file X" is unactionable from inside the running prompt; `delegation-mechanics.md` is also not auto-`@`-included by the bundle entry (only `system-base.md` is), so the pointer is doubly inert.

The other six files in scope (`delegation-mechanics.md`, `agents/{explorer,planner,coder,tester}.md`, `build-up-foundation.md`) came back at 0% under a strict reading of the Caparas filter ("would removing this line cause the model to make a mistake?").

## Why so small

The build-up bundle was already tight when authored — its own metadata describes the initial composition as "maximally aggressive cut." Whoever drafted these files applied something close to the Caparas filter the first time around. The 15–25% target from the Medium-article synthesis was calibrated against typical CLAUDE.md-style files in the wild, which grow toward documentation through accretion. That's not what we have here.

## Recalibration for future iterations

The Caparas deletion-filter pass is highest-leverage on bundles authored *before* anyone applied a deletion test — typically older bundles or bundles written in a "documentation-first" style. For bundles authored with the deletion test in mind from the start (build-up is one), expect single-digit returns. This is data, not failure: it means the editorial discipline is already working at the moment of authoring.

Brave-pass candidates exist (the modular-builder agent surfaced 9 specific lines it considered and kept under conservative bias). About four are reasonably safe additional cuts (rationale tails, slogan closers, planner section duplication). Five others encode genuine behavioral discipline (concrete prohibitions, decision tables for tool selection) and must stay. We chose not to chase the safe four — marginal gain, non-zero behavioral risk, and the bundle will keep evolving — better to apply the deletion-test discipline at the moment of *next* edit than to do another pass over already-tight prose.

## Verification

- Foundation full test suite: `1258 passed, 1 skipped, 2 warnings` — no regression from `595b9ab` (count went up by 6 because new tests landed on main between #193 and now; the diff here is markdown-only and contributes zero to the test count).
- Frontmatter on all four agent files parses cleanly. Body-only files (`system-base.md`, `delegation-mechanics.md`) have no frontmatter — markdown structure remains valid after cuts.
- The recitation line we shipped in #193 ("Refresh the todo list after every delegate return…") is preserved verbatim per spec.

## Out of scope

Reserved for follow-on iterations:
- **Iteration 3**: trigger-phrase audit on skill/agent descriptions (proposal A in `medium-synthesis/00-SYNTHESIS.md`) — much higher headroom because skill descriptions across the ecosystem are NOT systematically tight
- **Iteration 4**: prompt-caching audit at the provider layer (proposal E)

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>