### PR TITLE
feat(build-up): harmonize agent dispatch rubric (USE WHEN / DO NOT USE WHEN)

### DIFF
--- a/experiments/build-up/agents/explorer.md
+++ b/experiments/build-up/agents/explorer.md
@@ -2,8 +2,17 @@
 meta:
   name: explorer
   description: |
-    Multi-file exploration and codebase survey. Use whenever the parent needs a structured
-    understanding of code, docs, or configuration spanning more than a single known file.
+    Multi-file exploration and codebase survey. Read-only reconnaissance.
+
+    USE WHEN: the parent needs structured understanding of code, docs, or configuration
+    spanning more than a single known file. Triggering questions: "how does X work?",
+    "where is Y defined?", "what depends on Z?", "find everything related to A", "trace
+    the flow of B", "survey the auth/config/<feature>".
+
+    DO NOT USE WHEN: a single known file needs reading (the parent should delegate that
+    to a more focused agent or, if the file is small, summarize the request directly to
+    `coder`); design or architecture decisions need to be made (route to `planner`); a
+    spec already exists and you just need code (route to `coder`).
 
     REQUIRES in the delegation instruction:
       - The objective or question to answer

--- a/experiments/build-up/agents/planner.md
+++ b/experiments/build-up/agents/planner.md
@@ -10,6 +10,15 @@ meta:
       - DESIGN: produce an implementation spec — file paths, interfaces, success criteria.
       - REVIEW: critique existing code or design for simplicity and correctness.
 
+    USE WHEN: design or architecture decisions need to be made; an implementation spec
+    needs to be written; existing code or a design needs review for simplicity, correctness,
+    or scope; questions like "how should we build X?", "design Y", "add feature Z",
+    "critique this", "review this module".
+
+    DO NOT USE WHEN: a complete spec already exists (route to `coder` directly);
+    exploration is needed first to understand the territory (route to `explorer`); the
+    change is trivial enough to spec inline in a delegate call to `coder`.
+
     Returns: structured spec or review with concrete next-action recommendations.
 
     Examples:


### PR DESCRIPTION
This is Iteration 3 of small follow-on improvements to the `experiments/build-up/` bundle, derived from the Medium-article survey in `medium-synthesis/`. Brings `explorer` and `planner` up to the same description-format already used by `coder` and `tester`, so all four build-up agents now follow the Pankaj description-as-dispatch rubric.

## What changed

| File | Change |
|---|---|
| `experiments/build-up/agents/explorer.md` | Replaced lead "Use whenever the parent needs..." sentence with structured `USE WHEN:` / `DO NOT USE WHEN:` blocks. Added concrete trigger phrases ("how does X work?", "where is Y defined?", "trace the flow of Z", etc.) and explicit disambiguation from `coder` and `planner`. |
| `experiments/build-up/agents/planner.md` | Inserted `USE WHEN:` / `DO NOT USE WHEN:` block between the "Three modes" body and the `Returns:` line. Added trigger phrases ("how should we build X?", "design Y", "review this module") and disambiguation from `coder` (skip if spec exists) and `explorer` (skip if exploration needed first). |
| `experiments/build-up/agents/coder.md` | Unchanged. Already follows the rubric. |
| `experiments/build-up/agents/tester.md` | Unchanged. Already follows the rubric. |

Net diff: +20 lines, -2 lines, two files touched.

## The rubric being harmonized to

All four build-up agents' descriptions now follow this shape:

  - role + specialty in one sentence
  - `USE WHEN:` triggering conditions in user-spoken language
  - `DO NOT USE WHEN:` disambiguation from sibling agents
  - `REQUIRES:` (where applicable) pre-conditions for the delegation
  - `Returns:` shape of the structured output
  - `Examples:` concrete user-phrasing → dispatch mapping

## Why

Pankaj's data on Anthropic's skill unit-test work (March 2026) shows description optimization improved trigger accuracy on 5 of 6 internal skills. The four build-up agents are the right place to pilot this rubric because they're a contained scope (4 files, single bundle) where regressions are easy to isolate. Ecosystem-wide rollout to the broader skill collection (~50 skills across multiple repos) is reserved for a follow-on iteration once this rubric is validated.

## Verification

- Foundation full test suite: `1258 passed, 1 skipped, 2 warnings` — no regression from `b4487a1`.
- YAML frontmatter on all four agents parses cleanly. `meta.description` is a non-empty string.
- The recitation line shipped in #193 and the conservative deletions shipped in #194 remain intact.

## Out of scope

(reserved for follow-on iterations):
- Paraphrase test infrastructure to actually MEASURE trigger accuracy improvements (proposal O in `medium-synthesis/00-SYNTHESIS.md` — strategic tier; needs a parallel-isolated-agents test harness with blind comparator).
- Ecosystem-wide rollout to skills outside build-up. The build-up pilot is the rubric validation; if it holds up under real use, the same audit applies to `amplifier-bundle-skills` and other curated skill collections.
- Iteration 4: prompt-caching audit at the provider layer (proposal E).

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>