### PR TITLE
feat: rename routing_matrix capability → model_role_resolver

### DIFF
--- a/modules/hooks-session-naming/README.md
+++ b/modules/hooks-session-naming/README.md
@@ -43,8 +43,10 @@ Session naming is a simple classification task; it does not need the priority mo
 
 Resolution order:
 
-1. **`model_role`** — Resolved against `coordinator.session_state["routing_matrix"]`
-   via `resolve_model_role` from `hooks-routing`. Defaults to `"fast"`.
+1. **`model_role`** — Resolved against the `model_role_resolver` capability
+   (registered by whichever routing bundle is active — typically the
+   matrix-based one shipped in `amplifier-bundle-routing-matrix`). Defaults to
+   `"fast"`.
 
 2. **Fallback** — `next(iter(providers.values()))` — the first/priority provider.
    Used when `model_role` is `None`, or when resolution fails.

--- a/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
+++ b/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
@@ -475,43 +475,37 @@ class SessionNamingHook:
             model_override: str | None = None
 
             if self.config.model_role:
-                routing_matrix = getattr(self.coordinator, "session_state", {}).get(
-                    "routing_matrix"
+                # Look up the model_role_resolver capability registered by
+                # whichever routing bundle (matrix-based, cost-aware, etc.)
+                # is active in this session. Duck-typed contract:
+                #     async def resolve(model_role) -> list[ProviderPreference]
+                resolver = (
+                    self.coordinator.get_capability("model_role_resolver")
+                    if hasattr(self.coordinator, "get_capability")
+                    else None
                 )
-                if routing_matrix:
-                    try:
-                        from amplifier_module_hooks_routing.resolver import (
-                            resolve_model_role,
-                        )
-
-                        roles = [self.config.model_role]
-                        matrix = routing_matrix.get("roles", {})
-                        resolved = await resolve_model_role(roles, matrix, providers)
-                        if resolved:
-                            resolved_provider_name = resolved[0]["provider"]
-                            model_override = resolved[0].get("model")
-                            # Find the provider whose key contains the resolved name
-                            for key, p in providers.items():
-                                if resolved_provider_name.lower() in key.lower():
-                                    provider = p
-                                    break
-                        else:
-                            logger.warning(
-                                "model_role %r resolved to no candidates",
-                                self.config.model_role,
-                            )
-                    except ImportError:
-                        logger.debug(
-                            "model_role %r specified but hooks-routing not installed,"
-                            " falling back to priority provider",
-                            self.config.model_role,
-                        )
-                else:
+                if resolver is None:
                     logger.debug(
-                        "model_role %r set but no routing_matrix in session state,"
-                        " falling back to priority provider",
+                        "model_role %r set but no model_role_resolver capability"
+                        " registered, falling back to priority provider",
                         self.config.model_role,
                     )
+                else:
+                    resolved = await resolver.resolve(self.config.model_role)
+                    if resolved:
+                        # ProviderPreference attrs: .provider, .model, .config
+                        resolved_provider_name = resolved[0].provider
+                        model_override = resolved[0].model
+                        # Find the provider whose key contains the resolved name
+                        for key, p in providers.items():
+                            if resolved_provider_name.lower() in key.lower():
+                                provider = p
+                                break
+                    else:
+                        logger.warning(
+                            "model_role %r resolved to no candidates",
+                            self.config.model_role,
+                        )
 
             # Fallback: use first/priority provider
             if provider is None:

--- a/modules/hooks-session-naming/tests/test_session_naming.py
+++ b/modules/hooks-session-naming/tests/test_session_naming.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-import sys
-import types
-from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from amplifier_foundation.spawn_utils import ProviderPreference
 
 import pytest
 
@@ -38,11 +37,16 @@ def _make_mock_provider() -> MagicMock:
 def _make_coordinator(
     *,
     providers: dict | None = None,
-    session_state: dict | None = None,
+    model_role_resolver=None,
 ) -> MagicMock:
-    """Return a coordinator mock wired for session-naming tests."""
+    """Return a coordinator mock wired for session-naming tests.
+
+    ``model_role_resolver`` is the duck-typed capability the consumer code
+    looks up via ``coordinator.get_capability("model_role_resolver")``.
+    Pass ``None`` (default) to simulate "no routing bundle installed".
+    """
     coordinator = MagicMock()
-    coordinator.session_state = session_state or {}
+    coordinator.session_state = {}
     coordinator.hooks = MagicMock()
     coordinator.hooks.emit = AsyncMock()
     coordinator.hooks.register = MagicMock()
@@ -55,20 +59,22 @@ def _make_coordinator(
     coordinator.get = MagicMock(
         side_effect=lambda key: _providers if key == "providers" else None
     )
+    capabilities: dict = {"model_role_resolver": model_role_resolver}
+    coordinator.get_capability = MagicMock(side_effect=capabilities.get)
     return coordinator
 
 
 def _make_hook(
     *,
     providers: dict | None = None,
-    session_state: dict | None = None,
+    model_role_resolver=None,
     model_role: str | None = None,
     initial_trigger_turn: int = 2,
 ) -> SessionNamingHook:
     """Return a SessionNamingHook with mocked coordinator."""
     coordinator = _make_coordinator(
         providers=providers,
-        session_state=session_state,
+        model_role_resolver=model_role_resolver,
     )
     config = SessionNamingConfig(
         initial_trigger_turn=initial_trigger_turn,
@@ -77,52 +83,21 @@ def _make_hook(
     return SessionNamingHook(coordinator, config)
 
 
-def _install_mock_routing(
+def _make_resolver(
     *,
-    resolve_fn=None,
-    find_fn=None,
-) -> Callable[[], None]:
-    """Inject a mock amplifier_module_hooks_routing.resolver into sys.modules.
+    return_value: list | None = None,
+    name: str = "test-matrix",
+):
+    """Build a duck-typed ``model_role_resolver`` mock.
 
-    Returns a cleanup() callable — always call it in a finally block.
-
-    Usage:
-        cleanup = _install_mock_routing(resolve_fn=AsyncMock(...))
-        try:
-            ...
-        finally:
-            cleanup()
+    The new capability contract is:
+        async def resolve(model_role: str | list[str]) -> list[ProviderPreference]
+    Tests pass the mock via ``_make_hook(model_role_resolver=resolver)``.
     """
-    mock_resolver_mod = types.ModuleType("amplifier_module_hooks_routing.resolver")
-    if resolve_fn is not None:
-        mock_resolver_mod.resolve_model_role = resolve_fn  # type: ignore[attr-defined]
-    if find_fn is not None:
-        mock_resolver_mod.find_provider_by_type = find_fn  # type: ignore[attr-defined]
-
-    mock_routing_mod = types.ModuleType("amplifier_module_hooks_routing")
-
-    originals: dict = {}
-    for mod_name in (
-        "amplifier_module_hooks_routing",
-        "amplifier_module_hooks_routing.resolver",
-    ):
-        if mod_name in sys.modules:
-            originals[mod_name] = sys.modules[mod_name]
-
-    sys.modules["amplifier_module_hooks_routing"] = mock_routing_mod
-    sys.modules["amplifier_module_hooks_routing.resolver"] = mock_resolver_mod
-
-    def cleanup() -> None:
-        for mod_name in (
-            "amplifier_module_hooks_routing",
-            "amplifier_module_hooks_routing.resolver",
-        ):
-            if mod_name in originals:
-                sys.modules[mod_name] = originals[mod_name]
-            elif mod_name in sys.modules:
-                del sys.modules[mod_name]
-
-    return cleanup
+    resolver = MagicMock()
+    resolver.name = name
+    resolver.resolve = AsyncMock(return_value=return_value if return_value is not None else [])
+    return resolver
 
 
 # =============================================================================
@@ -345,98 +320,48 @@ class TestModelRoleResolution:
             "provider-openai": openai_provider,
         }
 
-        routing_matrix = {
-            "roles": {
-                "fast": {
-                    "candidates": [{"provider": "anthropic", "model": "claude-haiku-*"}]
-                }
-            }
-        }
-
-        mock_resolve = AsyncMock(
+        resolver = _make_resolver(
             return_value=[
-                {"provider": "anthropic", "model": "claude-haiku-4-5", "config": {}}
+                ProviderPreference(provider="anthropic", model="claude-haiku-4-5", config={}),
             ]
         )
-        cleanup = _install_mock_routing(resolve_fn=mock_resolve)
-        try:
-            hook = _make_hook(
-                providers=providers,
-                session_state={"routing_matrix": routing_matrix},
-                model_role="fast",
-            )
-            await hook._call_provider("name this session")
-
-            assert anthropic_provider.complete.called, (
-                "Expected anthropic provider to be called based on model_role resolution"
-            )
-            assert not openai_provider.complete.called
-
-            mock_resolve.assert_called_once()
-            call_args = mock_resolve.call_args
-            assert call_args[0][0] == ["fast"], "Must pass [model_role] as roles list"
-
-            call_kwargs = anthropic_provider.complete.call_args
-            request = call_kwargs[0][0]
-            assert request.model == "claude-haiku-4-5"
-        finally:
-            cleanup()
-
-    @pytest.mark.asyncio
-    async def test_model_role_falls_back_when_routing_not_installed(
-        self, caplog
-    ) -> None:
-        """ImportError on hooks-routing → falls back to priority provider, logs warning."""
-        priority_provider = _make_mock_provider()
-        providers = {"provider-priority": priority_provider}
-
-        for mod_name in (
-            "amplifier_module_hooks_routing",
-            "amplifier_module_hooks_routing.resolver",
-        ):
-            sys.modules.pop(mod_name, None)
-
         hook = _make_hook(
             providers=providers,
-            session_state={"routing_matrix": {"roles": {}}},
+            model_role_resolver=resolver,
             model_role="fast",
         )
+        await hook._call_provider("name this session")
 
-        import logging
-
-        with caplog.at_level(logging.DEBUG):
-            await hook._call_provider("name this session")
-
-        assert priority_provider.complete.called, (
-            "Must fall back to priority provider when hooks-routing not available"
+        assert anthropic_provider.complete.called, (
+            "Expected anthropic provider to be called based on model_role resolution"
         )
-        assert any(
-            "hooks-routing" in msg or "model_role" in msg for msg in caplog.messages
-        ), "Must log a debug message mentioning model_role or hooks-routing"
+        assert not openai_provider.complete.called
 
+        resolver.resolve.assert_called_once()
+        call_args = resolver.resolve.call_args
+        assert call_args[0][0] == "fast", "Must pass model_role as a string"
+
+        call_kwargs = anthropic_provider.complete.call_args
+        request = call_kwargs[0][0]
+        assert request.model == "claude-haiku-4-5"
     @pytest.mark.asyncio
-    async def test_model_role_falls_back_when_no_routing_matrix(self) -> None:
-        """No routing_matrix in session_state → falls back to priority provider."""
+    async def test_model_role_falls_back_when_no_resolver_capability(self) -> None:
+        """No model_role_resolver capability → falls back to priority provider."""
         priority_provider = _make_mock_provider()
         providers = {"provider-priority": priority_provider}
 
-        mock_resolve = AsyncMock(return_value=[])
-        cleanup = _install_mock_routing(resolve_fn=mock_resolve)
-        try:
-            hook = _make_hook(
-                providers=providers,
-                session_state={},
-                model_role="fast",
-            )
-            await hook._call_provider("name this session")
+        resolver = _make_resolver(return_value=[])
+        hook = _make_hook(
+            providers=providers,
+            model_role_resolver=None,
+            model_role="fast",
+        )
+        await hook._call_provider("name this session")
 
-            assert priority_provider.complete.called, (
-                "Must fall back to priority provider when routing_matrix absent"
-            )
-            mock_resolve.assert_not_called()
-        finally:
-            cleanup()
-
+        assert priority_provider.complete.called, (
+            "Must fall back to priority provider when model_role_resolver capability is absent"
+        )
+        resolver.resolve.assert_not_called()
     @pytest.mark.asyncio
     async def test_no_model_role_uses_priority_provider(self) -> None:
         """Without model_role, existing behavior is preserved (priority provider)."""

--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -765,50 +765,39 @@ Agent usage notes:
                 ProviderPreference.from_dict(p) for p in raw_provider_prefs
             ]
 
-        # Model role resolution via routing matrix (caller override)
-        # provider_preferences wins when both are provided (explicit pin overrides matrix)
+        # Model role resolution via the model_role_resolver capability (caller override)
+        # provider_preferences wins when both are provided (explicit pin overrides resolver).
+        #
+        # The capability is generic — the routing-matrix bundle ships the
+        # default matrix-based implementation, but other strategies (cost-aware,
+        # latency-aware, availability-aware) may register an alternate resolver
+        # under the same key. We duck-type against the contract:
+        #     async def resolve(model_role) -> list[ProviderPreference]
         raw_model_role = input.get("model_role", "").strip()
         if raw_model_role and provider_preferences is None:
-            routing_state = getattr(self.coordinator, "session_state", {}).get(
-                "routing_matrix"
+            resolver = (
+                self.coordinator.get_capability("model_role_resolver")
+                if hasattr(self.coordinator, "get_capability")
+                else None
             )
-            if routing_state:
-                try:
-                    from amplifier_module_hooks_routing.resolver import (
-                        resolve_model_role,
-                    )
-
-                    roles = [raw_model_role]
-                    matrix = routing_state.get("roles", {})
-                    providers = self.coordinator.get("providers") or {}
-                    resolved = await resolve_model_role(roles, matrix, providers)
-                    if resolved:
-                        provider_preferences = [
-                            ProviderPreference(
-                                provider=r["provider"],
-                                model=r["model"],
-                                config=r.get("config", {}),
-                            )
-                            for r in resolved
-                        ]
-                    else:
-                        logger.warning(
-                            "model_role '%s' resolved to no candidates "
-                            "(available roles: %s, installed providers: %s)",
-                            raw_model_role,
-                            list(matrix.keys()),
-                            list(providers.keys()),
-                        )
-                except ImportError:
-                    logger.warning(
-                        "model_role '%s' specified but amplifier_module_hooks_routing not available",
-                        raw_model_role,
-                    )
-            else:
+            if resolver is None:
                 logger.warning(
-                    "model_role '%s' specified but no routing_matrix in session state",
+                    "model_role '%s' specified but no model_role_resolver "
+                    "capability is registered (install a routing bundle)",
                     raw_model_role,
                 )
+            else:
+                resolved = await resolver.resolve(raw_model_role)
+                if resolved:
+                    # Resolver returns list[ProviderPreference] (foundation public type).
+                    provider_preferences = list(resolved)
+                else:
+                    logger.warning(
+                        "model_role '%s' resolved to no candidates against "
+                        "installed providers (resolver=%s)",
+                        raw_model_role,
+                        getattr(resolver, "name", type(resolver).__name__),
+                    )
 
         # Validate instruction (always required)
         if not instruction:

--- a/modules/tool-delegate/tests/test_delegate_model_role.py
+++ b/modules/tool-delegate/tests/test_delegate_model_role.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import logging
-import sys
-import types
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from amplifier_foundation.spawn_utils import ProviderPreference
 from amplifier_module_tool_delegate import DelegateTool
 
 
@@ -21,16 +20,24 @@ def _make_delegate_tool(
     *,
     spawn_fn=None,
     agents: dict | None = None,
-    session_state: dict | None = None,
+    model_role_resolver=None,
 ) -> DelegateTool:
-    """Create a DelegateTool with mocked coordinator for model_role testing."""
+    """Create a DelegateTool with mocked coordinator for model_role testing.
+
+    ``model_role_resolver`` is the duck-typed capability the consumer code
+    looks up via ``coordinator.get_capability("model_role_resolver")``.
+    Pass ``None`` (default) to simulate "no routing bundle installed" —
+    consumer should log a warning and pass ``provider_preferences=None`` to
+    spawn_fn. Pass a mock with ``async def resolve(role)`` to simulate an
+    active routing strategy.
+    """
     coordinator = MagicMock()
     coordinator.session_id = "parent-session-123"
 
     coordinator.config = {"agents": agents or {}}
 
-    # Session state for routing matrix availability
-    coordinator.session_state = session_state or {}
+    # session_state remains a real dict for any non-routing test concerns.
+    coordinator.session_state = {}
 
     capabilities: dict = {
         "session.spawn": spawn_fn
@@ -47,6 +54,8 @@ def _make_delegate_tool(
         "agents.list": lambda: agents or {},
         "agents.get": lambda name: (agents or {}).get(name),
         "self_delegation_depth": 0,
+        # Capability under test — None means "no routing bundle installed".
+        "model_role_resolver": model_role_resolver,
     }
 
     def get_capability(name):
@@ -64,38 +73,21 @@ def _make_delegate_tool(
     return DelegateTool(coordinator, config)
 
 
-def _install_mock_resolver(mock_resolve_fn):
-    """Install a mock amplifier_module_hooks_routing.resolver module in sys.modules.
+def _make_resolver(
+    *,
+    return_value: list | None = None,
+    name: str = "test-matrix",
+):
+    """Build a duck-typed model_role_resolver mock.
 
-    Returns a cleanup function to remove it.
+    The new capability contract is:
+        async def resolve(model_role: str | list[str]) -> list[ProviderPreference]
+    Tests pass the mock via ``_make_delegate_tool(model_role_resolver=resolver)``.
     """
-    mock_resolver_mod = types.ModuleType("amplifier_module_hooks_routing.resolver")
-    mock_resolver_mod.resolve_model_role = mock_resolve_fn  # type: ignore[attr-defined]
-
-    mock_hooks_routing_mod = types.ModuleType("amplifier_module_hooks_routing")
-
-    originals = {}
-    for mod_name in (
-        "amplifier_module_hooks_routing",
-        "amplifier_module_hooks_routing.resolver",
-    ):
-        if mod_name in sys.modules:
-            originals[mod_name] = sys.modules[mod_name]
-
-    sys.modules["amplifier_module_hooks_routing"] = mock_hooks_routing_mod
-    sys.modules["amplifier_module_hooks_routing.resolver"] = mock_resolver_mod
-
-    def cleanup():
-        for mod_name in (
-            "amplifier_module_hooks_routing",
-            "amplifier_module_hooks_routing.resolver",
-        ):
-            if mod_name in originals:
-                sys.modules[mod_name] = originals[mod_name]
-            elif mod_name in sys.modules:
-                del sys.modules[mod_name]
-
-    return cleanup
+    resolver = MagicMock()
+    resolver.name = name
+    resolver.resolve = AsyncMock(return_value=return_value if return_value is not None else [])
+    return resolver
 
 
 # =============================================================================
@@ -120,69 +112,50 @@ class TestDelegateModelRole:
         )
 
         # Mock the resolver to return a resolved preference
-        mock_resolve = AsyncMock(
+        resolver = _make_resolver(
             return_value=[
-                {"provider": "anthropic", "model": "claude-haiku-3.5", "config": {}}
+                ProviderPreference(provider="anthropic", model="claude-haiku-3.5", config={}),
             ]
         )
-        cleanup = _install_mock_resolver(mock_resolve)
-
-        try:
-            tool = _make_delegate_tool(
-                spawn_fn=spawn_fn,
-                agents={
-                    "test-agent": {
-                        "description": "A test agent",
-                    }
-                },
-                session_state={
-                    "routing_matrix": {
-                        "roles": {
-                            "fast": {
-                                "candidates": [
-                                    {
-                                        "provider": "anthropic",
-                                        "model": "claude-haiku-*",
-                                    },
-                                ]
-                            }
-                        }
-                    }
-                },
-            )
-            # Wire up providers on coordinator.get("providers")
-            tool.coordinator.get = MagicMock(
-                side_effect=lambda key: (
-                    {"provider-anthropic": MagicMock()} if key == "providers" else None
-                )
-            )
-
-            await tool.execute(
-                {
-                    "agent": "test-agent",
-                    "instruction": "Do something fast",
-                    "context_depth": "none",
-                    "model_role": "fast",
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={
+                "test-agent": {
+                    "description": "A test agent",
                 }
+            },
+            model_role_resolver=resolver,
+        )
+        # Wire up providers on coordinator.get("providers")
+        tool.coordinator.get = MagicMock(
+            side_effect=lambda key: (
+                {"provider-anthropic": MagicMock()} if key == "providers" else None
             )
+        )
 
-            spawn_fn.assert_called_once()
-            _, kwargs = spawn_fn.call_args
-            prefs = kwargs["provider_preferences"]
-            assert prefs is not None, (
-                "Expected resolved provider_preferences from model_role"
-            )
-            assert len(prefs) >= 1
-            assert prefs[0].provider == "anthropic"
-            assert prefs[0].model == "claude-haiku-3.5"
+        await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Do something fast",
+                "context_depth": "none",
+                "model_role": "fast",
+            }
+        )
 
-            # Verify resolver was called with correct args
-            mock_resolve.assert_called_once()
-            call_args = mock_resolve.call_args
-            assert call_args[0][0] == ["fast"]  # roles
-        finally:
-            cleanup()
+        spawn_fn.assert_called_once()
+        _, kwargs = spawn_fn.call_args
+        prefs = kwargs["provider_preferences"]
+        assert prefs is not None, (
+            "Expected resolved provider_preferences from model_role"
+        )
+        assert len(prefs) >= 1
+        assert prefs[0].provider == "anthropic"
+        assert prefs[0].model == "claude-haiku-3.5"
 
+        # Verify resolver was called with correct args
+        resolver.resolve.assert_called_once()
+        call_args = resolver.resolve.call_args
+        assert call_args[0][0] == "fast"  # raw_model_role
     @pytest.mark.asyncio
     async def test_provider_preferences_overrides_model_role(self):
         """Explicit provider_preferences wins over model_role when both provided."""
@@ -197,55 +170,36 @@ class TestDelegateModelRole:
         )
 
         # Even with resolver available, it should NOT be called
-        mock_resolve = AsyncMock(return_value=[])
-        cleanup = _install_mock_resolver(mock_resolve)
+        resolver = _make_resolver(return_value=[])
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={
+                "test-agent": {"description": "A test agent"},
+            },
+            model_role_resolver=resolver,
+        )
 
-        try:
-            tool = _make_delegate_tool(
-                spawn_fn=spawn_fn,
-                agents={
-                    "test-agent": {"description": "A test agent"},
-                },
-                session_state={
-                    "routing_matrix": {
-                        "roles": {
-                            "fast": {
-                                "candidates": [
-                                    {
-                                        "provider": "anthropic",
-                                        "model": "claude-haiku-3.5",
-                                    },
-                                ]
-                            }
-                        }
-                    }
-                },
-            )
+        await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Do something",
+                "context_depth": "none",
+                "model_role": "fast",
+                "provider_preferences": [
+                    {"provider": "openai", "model": "gpt-5.2"},
+                ],
+            }
+        )
 
-            await tool.execute(
-                {
-                    "agent": "test-agent",
-                    "instruction": "Do something",
-                    "context_depth": "none",
-                    "model_role": "fast",
-                    "provider_preferences": [
-                        {"provider": "openai", "model": "gpt-5.2"},
-                    ],
-                }
-            )
+        spawn_fn.assert_called_once()
+        _, kwargs = spawn_fn.call_args
+        prefs = kwargs["provider_preferences"]
+        assert len(prefs) == 1, "Explicit provider_preferences should win"
+        assert prefs[0].provider == "openai"
+        assert prefs[0].model == "gpt-5.2"
 
-            spawn_fn.assert_called_once()
-            _, kwargs = spawn_fn.call_args
-            prefs = kwargs["provider_preferences"]
-            assert len(prefs) == 1, "Explicit provider_preferences should win"
-            assert prefs[0].provider == "openai"
-            assert prefs[0].model == "gpt-5.2"
-
-            # Resolver should NOT have been called
-            mock_resolve.assert_not_called()
-        finally:
-            cleanup()
-
+        # Resolver should NOT have been called
+        resolver.resolve.assert_not_called()
     @pytest.mark.asyncio
     async def test_model_role_resolution_includes_config(self):
         """Config from resolved model_role is preserved in ProviderPreference."""
@@ -260,69 +214,47 @@ class TestDelegateModelRole:
         )
 
         # Resolver returns a result with non-empty config
-        mock_resolve = AsyncMock(
+        resolver = _make_resolver(
             return_value=[
-                {
-                    "provider": "anthropic",
-                    "model": "claude-sonnet-4-6",
-                    "config": {"reasoning_effort": "high"},
-                }
+                ProviderPreference(provider="anthropic",
+                    model="claude-sonnet-4-6",
+                    config={"reasoning_effort": "high"}),
             ]
         )
-        cleanup = _install_mock_resolver(mock_resolve)
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={
+                "coding-agent": {"description": "A coding agent"},
+            },
+            model_role_resolver=resolver,
+        )
+        tool.coordinator.get = MagicMock(
+            side_effect=lambda key: (
+                {"provider-anthropic": MagicMock()} if key == "providers" else None
+            )
+        )
 
-        try:
-            tool = _make_delegate_tool(
-                spawn_fn=spawn_fn,
-                agents={
-                    "coding-agent": {"description": "A coding agent"},
-                },
-                session_state={
-                    "routing_matrix": {
-                        "roles": {
-                            "coding": {
-                                "candidates": [
-                                    {
-                                        "provider": "anthropic",
-                                        "model": "claude-sonnet-4-6",
-                                        "config": {"reasoning_effort": "high"},
-                                    },
-                                ]
-                            }
-                        }
-                    }
-                },
-            )
-            tool.coordinator.get = MagicMock(
-                side_effect=lambda key: (
-                    {"provider-anthropic": MagicMock()} if key == "providers" else None
-                )
-            )
+        await tool.execute(
+            {
+                "agent": "coding-agent",
+                "instruction": "Write a function",
+                "context_depth": "none",
+                "model_role": "coding",
+            }
+        )
 
-            await tool.execute(
-                {
-                    "agent": "coding-agent",
-                    "instruction": "Write a function",
-                    "context_depth": "none",
-                    "model_role": "coding",
-                }
-            )
-
-            spawn_fn.assert_called_once()
-            _, kwargs = spawn_fn.call_args
-            prefs = kwargs["provider_preferences"]
-            assert prefs is not None, (
-                "Expected resolved provider_preferences from model_role"
-            )
-            assert len(prefs) == 1
-            assert prefs[0].provider == "anthropic"
-            assert prefs[0].model == "claude-sonnet-4-6"
-            assert prefs[0].config == {"reasoning_effort": "high"}, (
-                f"Expected config={{'reasoning_effort': 'high'}}, got {prefs[0].config!r}"
-            )
-        finally:
-            cleanup()
-
+        spawn_fn.assert_called_once()
+        _, kwargs = spawn_fn.call_args
+        prefs = kwargs["provider_preferences"]
+        assert prefs is not None, (
+            "Expected resolved provider_preferences from model_role"
+        )
+        assert len(prefs) == 1
+        assert prefs[0].provider == "anthropic"
+        assert prefs[0].model == "claude-sonnet-4-6"
+        assert prefs[0].config == {"reasoning_effort": "high"}, (
+            f"Expected config={{'reasoning_effort': 'high'}}, got {prefs[0].config!r}"
+        )
     @pytest.mark.asyncio
     async def test_model_role_without_matrix_falls_through(self):
         """model_role with no routing matrix falls through gracefully."""
@@ -341,7 +273,7 @@ class TestDelegateModelRole:
             agents={
                 "test-agent": {"description": "A test agent"},
             },
-            session_state={},  # No routing_matrix
+            model_role_resolver=None,  # Simulate "no routing bundle installed"
         )
 
         result = await tool.execute(
@@ -383,72 +315,53 @@ class TestModelRoleObservabilityWarnings:
         )
 
         # Resolver returns empty list — role exists in matrix but no provider matched
-        mock_resolve = AsyncMock(return_value=[])
-        cleanup = _install_mock_resolver(mock_resolve)
-
-        try:
-            tool = _make_delegate_tool(
-                spawn_fn=spawn_fn,
-                agents={"test-agent": {"description": "A test agent"}},
-                session_state={
-                    "routing_matrix": {
-                        "roles": {
-                            "coding": {
-                                "candidates": [
-                                    {
-                                        "provider": "anthropic",
-                                        "model": "claude-sonnet-4-6",
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
+        resolver = _make_resolver(return_value=[])
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={"test-agent": {"description": "A test agent"}},
+            model_role_resolver=resolver,
+        )
+        tool.coordinator.get = MagicMock(
+            side_effect=lambda key: (
+                {"provider-openai": MagicMock()} if key == "providers" else None
             )
-            tool.coordinator.get = MagicMock(
-                side_effect=lambda key: (
-                    {"provider-openai": MagicMock()} if key == "providers" else None
-                )
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="amplifier_module_tool_delegate"
+        ):
+            result = await tool.execute(
+                {
+                    "agent": "test-agent",
+                    "instruction": "Write some code",
+                    "context_depth": "none",
+                    "model_role": "coding",
+                }
             )
 
-            with caplog.at_level(
-                logging.WARNING, logger="amplifier_module_tool_delegate"
-            ):
-                result = await tool.execute(
-                    {
-                        "agent": "test-agent",
-                        "instruction": "Write some code",
-                        "context_depth": "none",
-                        "model_role": "coding",
-                    }
-                )
+        # Should still succeed — fall-through is graceful
+        assert result.success is True
 
-            # Should still succeed — fall-through is graceful
-            assert result.success is True
+        # Resolver was called but returned empty
+        resolver.resolve.assert_called_once()
 
-            # Resolver was called but returned empty
-            mock_resolve.assert_called_once()
+        # spawn received provider_preferences=None (resolution failed)
+        spawn_fn.assert_called_once()
+        _, kwargs = spawn_fn.call_args
+        assert kwargs["provider_preferences"] is None, (
+            "Empty resolution should leave provider_preferences as None"
+        )
 
-            # spawn received provider_preferences=None (resolution failed)
-            spawn_fn.assert_called_once()
-            _, kwargs = spawn_fn.call_args
-            assert kwargs["provider_preferences"] is None, (
-                "Empty resolution should leave provider_preferences as None"
-            )
-
-            # Warning was emitted — must mention the role, available roles, and providers
-            warning_messages = [
-                r.message for r in caplog.records if r.levelno == logging.WARNING
-            ]
-            assert any("coding" in str(m) for m in warning_messages), (
-                f"Expected WARNING mentioning 'coding' role; got: {warning_messages}"
-            )
-        finally:
-            cleanup()
-
+        # Warning was emitted — must mention the role, available roles, and providers
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("coding" in str(m) for m in warning_messages), (
+            f"Expected WARNING mentioning 'coding' role; got: {warning_messages}"
+        )
     @pytest.mark.asyncio
     async def test_model_role_without_matrix_logs_warning(self, caplog):
-        """model_role with no routing_matrix logs WARNING (not just DEBUG)."""
+        """model_role with no model_role_resolver capability logs WARNING (not just DEBUG)."""
         spawn_fn = AsyncMock(
             return_value={
                 "output": "done",
@@ -462,7 +375,7 @@ class TestModelRoleObservabilityWarnings:
         tool = _make_delegate_tool(
             spawn_fn=spawn_fn,
             agents={"test-agent": {"description": "A test agent"}},
-            session_state={},  # No routing_matrix
+            model_role_resolver=None,  # Simulate "no routing bundle installed"
         )
 
         with caplog.at_level(logging.WARNING, logger="amplifier_module_tool_delegate"):
@@ -492,7 +405,7 @@ class TestModelRoleObservabilityWarnings:
             if r.levelno == logging.DEBUG and "fast" in str(r.message)
         ]
         assert not debug_only, (
-            f"Expected WARNING (not DEBUG) for missing routing_matrix; "
+            f"Expected WARNING (not DEBUG) for missing model_role_resolver; "
             f"found DEBUG: {debug_only}"
         )
 
@@ -518,63 +431,44 @@ class TestProviderRoutingInResult:
             }
         )
 
-        mock_resolve = AsyncMock(
+        resolver = _make_resolver(
             return_value=[
-                {"provider": "anthropic", "model": "claude-sonnet-4-6", "config": {}}
+                ProviderPreference(provider="anthropic", model="claude-sonnet-4-6", config={}),
             ]
         )
-        cleanup = _install_mock_resolver(mock_resolve)
-
-        try:
-            tool = _make_delegate_tool(
-                spawn_fn=spawn_fn,
-                agents={"test-agent": {"description": "A test agent"}},
-                session_state={
-                    "routing_matrix": {
-                        "roles": {
-                            "coding": {
-                                "candidates": [
-                                    {
-                                        "provider": "anthropic",
-                                        "model": "claude-sonnet-4-6",
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={"test-agent": {"description": "A test agent"}},
+            model_role_resolver=resolver,
+        )
+        tool.coordinator.get = MagicMock(
+            side_effect=lambda key: (
+                {"provider-anthropic": MagicMock()} if key == "providers" else None
             )
-            tool.coordinator.get = MagicMock(
-                side_effect=lambda key: (
-                    {"provider-anthropic": MagicMock()} if key == "providers" else None
-                )
-            )
+        )
 
-            result = await tool.execute(
-                {
-                    "agent": "test-agent",
-                    "instruction": "Write code",
-                    "context_depth": "none",
-                    "model_role": "coding",
-                }
-            )
+        result = await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Write code",
+                "context_depth": "none",
+                "model_role": "coding",
+            }
+        )
 
-            assert result.success is True
-            assert result.output is not None
-            assert "provider_routing" in result.output, (
-                f"Expected 'provider_routing' key in output; got keys: {list(result.output.keys())}"
-            )
+        assert result.success is True
+        assert result.output is not None
+        assert "provider_routing" in result.output, (
+            f"Expected 'provider_routing' key in output; got keys: {list(result.output.keys())}"
+        )
 
-            routing = result.output["provider_routing"]
-            assert routing["model_role"] == "coding"
-            assert routing["resolved"] is not None, (
-                "Successful resolution should produce non-null 'resolved'"
-            )
-            assert len(routing["resolved"]) >= 1
-            assert routing["resolved"][0]["provider"] == "anthropic"
-        finally:
-            cleanup()
-
+        routing = result.output["provider_routing"]
+        assert routing["model_role"] == "coding"
+        assert routing["resolved"] is not None, (
+            "Successful resolution should produce non-null 'resolved'"
+        )
+        assert len(routing["resolved"]) >= 1
+        assert routing["resolved"][0]["provider"] == "anthropic"
     @pytest.mark.asyncio
     async def test_provider_routing_in_result_on_failure(self):
         """Failed model_role resolution returns provider_routing with resolved=None."""
@@ -589,57 +483,38 @@ class TestProviderRoutingInResult:
         )
 
         # Resolver returns empty — no candidates matched installed providers
-        mock_resolve = AsyncMock(return_value=[])
-        cleanup = _install_mock_resolver(mock_resolve)
-
-        try:
-            tool = _make_delegate_tool(
-                spawn_fn=spawn_fn,
-                agents={"test-agent": {"description": "A test agent"}},
-                session_state={
-                    "routing_matrix": {
-                        "roles": {
-                            "coding": {
-                                "candidates": [
-                                    {
-                                        "provider": "anthropic",
-                                        "model": "claude-sonnet-4-6",
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
+        resolver = _make_resolver(return_value=[])
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={"test-agent": {"description": "A test agent"}},
+            model_role_resolver=resolver,
+        )
+        tool.coordinator.get = MagicMock(
+            side_effect=lambda key: (
+                {"provider-openai": MagicMock()} if key == "providers" else None
             )
-            tool.coordinator.get = MagicMock(
-                side_effect=lambda key: (
-                    {"provider-openai": MagicMock()} if key == "providers" else None
-                )
-            )
+        )
 
-            result = await tool.execute(
-                {
-                    "agent": "test-agent",
-                    "instruction": "Write code",
-                    "context_depth": "none",
-                    "model_role": "coding",
-                }
-            )
+        result = await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Write code",
+                "context_depth": "none",
+                "model_role": "coding",
+            }
+        )
 
-            assert result.success is True
-            assert result.output is not None
-            assert "provider_routing" in result.output, (
-                "provider_routing should be present even on resolution failure"
-            )
+        assert result.success is True
+        assert result.output is not None
+        assert "provider_routing" in result.output, (
+            "provider_routing should be present even on resolution failure"
+        )
 
-            routing = result.output["provider_routing"]
-            assert routing["model_role"] == "coding"
-            assert routing["resolved"] is None, (
-                "Empty resolution should produce resolved=None"
-            )
-        finally:
-            cleanup()
-
+        routing = result.output["provider_routing"]
+        assert routing["model_role"] == "coding"
+        assert routing["resolved"] is None, (
+            "Empty resolution should produce resolved=None"
+        )
 
 # =============================================================================
 # Tests: Fix 2 — delegate:agent_spawned event includes routing intent
@@ -662,85 +537,70 @@ class TestAgentSpawnedEventIncludesRouting:
             }
         )
 
-        mock_resolve = AsyncMock(
+        resolver = _make_resolver(
             return_value=[
-                {"provider": "anthropic", "model": "claude-haiku-3.5", "config": {}}
+                ProviderPreference(provider="anthropic", model="claude-haiku-3.5", config={}),
             ]
         )
-        cleanup = _install_mock_resolver(mock_resolve)
-
-        try:
-            tool = _make_delegate_tool(
-                spawn_fn=spawn_fn,
-                agents={"test-agent": {"description": "A test agent"}},
-                session_state={
-                    "routing_matrix": {
-                        "roles": {
-                            "fast": {
-                                "candidates": [
-                                    {"provider": "anthropic", "model": "claude-haiku-*"}
-                                ]
-                            }
-                        }
-                    }
-                },
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={"test-agent": {"description": "A test agent"}},
+            model_role_resolver=resolver,
+        )
+        tool.coordinator.get = MagicMock(
+            side_effect=lambda key: (
+                {"provider-anthropic": MagicMock()} if key == "providers" else None
             )
-            tool.coordinator.get = MagicMock(
-                side_effect=lambda key: (
-                    {"provider-anthropic": MagicMock()} if key == "providers" else None
+        )
+
+        # Set up a mock hooks object so events are emitted
+        mock_hooks = MagicMock()
+        mock_hooks.emit = AsyncMock()
+        tool.coordinator.get = MagicMock(
+            side_effect=lambda key: (
+                mock_hooks
+                if key == "hooks"
+                else (
+                    {"provider-anthropic": MagicMock()}
+                    if key == "providers"
+                    else None
                 )
             )
+        )
 
-            # Set up a mock hooks object so events are emitted
-            mock_hooks = MagicMock()
-            mock_hooks.emit = AsyncMock()
-            tool.coordinator.get = MagicMock(
-                side_effect=lambda key: (
-                    mock_hooks
-                    if key == "hooks"
-                    else (
-                        {"provider-anthropic": MagicMock()}
-                        if key == "providers"
-                        else None
-                    )
-                )
-            )
+        await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Do something fast",
+                "context_depth": "none",
+                "model_role": "fast",
+            }
+        )
 
-            await tool.execute(
-                {
-                    "agent": "test-agent",
-                    "instruction": "Do something fast",
-                    "context_depth": "none",
-                    "model_role": "fast",
-                }
-            )
+        # Find the agent_spawned event call
+        spawned_calls = [
+            call
+            for call in mock_hooks.emit.call_args_list
+            if call.args[0] == "delegate:agent_spawned"
+        ]
+        assert len(spawned_calls) == 1, (
+            f"Expected exactly one delegate:agent_spawned event; got {len(spawned_calls)}"
+        )
 
-            # Find the agent_spawned event call
-            spawned_calls = [
-                call
-                for call in mock_hooks.emit.call_args_list
-                if call.args[0] == "delegate:agent_spawned"
-            ]
-            assert len(spawned_calls) == 1, (
-                f"Expected exactly one delegate:agent_spawned event; got {len(spawned_calls)}"
-            )
+        payload = spawned_calls[0].args[1]
 
-            payload = spawned_calls[0].args[1]
+        # model_role must be present
+        assert "model_role" in payload, (
+            f"Expected 'model_role' in event payload; got keys: {list(payload.keys())}"
+        )
+        assert payload["model_role"] == "fast"
 
-            # model_role must be present
-            assert "model_role" in payload, (
-                f"Expected 'model_role' in event payload; got keys: {list(payload.keys())}"
-            )
-            assert payload["model_role"] == "fast"
-
-            # provider_preferences must be present — non-null because resolution succeeded
-            assert "provider_preferences" in payload, (
-                f"Expected 'provider_preferences' in event payload; got keys: {list(payload.keys())}"
-            )
-            assert payload["provider_preferences"] is not None, (
-                "provider_preferences should be non-null after successful resolution"
-            )
-            assert len(payload["provider_preferences"]) >= 1
-            assert payload["provider_preferences"][0]["provider"] == "anthropic"
-        finally:
-            cleanup()
+        # provider_preferences must be present — non-null because resolution succeeded
+        assert "provider_preferences" in payload, (
+            f"Expected 'provider_preferences' in event payload; got keys: {list(payload.keys())}"
+        )
+        assert payload["provider_preferences"] is not None, (
+            "provider_preferences should be non-null after successful resolution"
+        )
+        assert len(payload["provider_preferences"]) >= 1
+        assert payload["provider_preferences"][0]["provider"] == "anthropic"


### PR DESCRIPTION
# Summary

This is part of a coordinated cross-repo PR set that renames the routing matrix capability from `routing_matrix` to `model_role_resolver` and reshapes the contract so multiple routing strategies (matrix-based, cost-aware, latency-aware, etc.) can be supported under a single generic capability name.

**No backward-compat shim.** The old `session_state["routing_matrix"]` storage is dropped entirely. The new contract is a duck-typed capability:

```python
resolver = coordinator.get_capability("model_role_resolver")
if resolver is not None:
    provider_preferences = await resolver.resolve(model_role)  # list[ProviderPreference]
```

# Why

Code-reading audit revealed that `amplifier-module-tool-skills` (and its newer canonical home `amplifier-bundle-skills`) was looking up `coordinator.get_capability("routing_matrix")` — a capability that was never registered. The matrix was only ever stored in `coordinator.session_state["routing_matrix"]`, which the recipe executor and tool-delegate read correctly. The fork-skill code's resolution path silently returned None and fell through to the parent's default provider — which, for users with `provider-anthropic` at `priority: 1`, meant fork skills declaring `model_role` always ran on anthropic regardless of the active routing matrix.

While renaming, the contract is reshaped from "matrix data dict in session_state" to "duck-typed resolver object as a capability" — generic enough to support routing strategies beyond the matrix-based one (cost-aware, latency-aware, availability-aware, custom user logic).

# Cross-repo PR set

This change spans 5 repos and must merge close in time. The PR set:

- microsoft/amplifier-bundle-routing-matrix#22    — producer (defines the new contract + Matrix implementation)
- microsoft/amplifier-foundation#197                — consumers (tool-delegate, hooks-session-naming)
- microsoft/amplifier-bundle-recipes#75            — consumer (tool-recipes)
- microsoft/amplifier-bundle-skills#14            — consumer (canonical fork-skill location, fixes pre-existing bug)
- microsoft/amplifier-module-tool-skills#28       — consumer (deprecated mirror, fixes same bug)

Merge order does not strictly matter (no consumer breaks if it merges before the producer — they fail-forward via `logger.warning(...)` when no resolver is registered), but landing them within a window of an hour or two is best.

# What changed in this repo

**Consumers (two modules in this repo).**

- `modules/tool-delegate/amplifier_module_tool_delegate/__init__.py` — collapsed the existing `try: import resolve_model_role; ... except ImportError` block (~38 lines) to a single `coordinator.get_capability("model_role_resolver")` lookup with `await resolver.resolve(role)` (~15 lines).
- `modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py` — same shape replacement; also switched field access from dict-style (`resolved[0]["provider"]`) to attribute-style (`resolved[0].provider`) since the resolver returns `ProviderPreference` objects.
- `modules/hooks-session-naming/README.md` — updated resolution-order docs to reference `model_role_resolver`.
- Tests rewritten to inject a mock resolver via a `model_role_resolver=` kwarg on the test factory rather than via `sys.modules` patching. 57 tests pass across the two modules.

# Tests

- All existing tests updated to the new contract.
- New regression test in tool-skills (both bundle-skills and tool-skills) reproduces the fork-skill bug: pre-fix it FAILS (resolver never called), post-fix it PASSES.
- No backward-compat — any consumer we missed will surface as a runtime warning ("model_role specified but no model_role_resolver capability available") and we'll fix that consumer in a follow-up.

# Out of scope (intentionally)

- The user-facing CLI command `amplifier routing matrix set <name>` and `set_routing_matrix(...)` API in `amplifier-app-cli` are NOT renamed. Those refer to which matrix YAML file to load, which is the matrix bundle's user-facing surface; they remain matrix-specific by design.
- The `session.routing` capability (different from `routing_matrix` — used for user-supplied overrides) is NOT renamed.
- No formal `Protocol` class — the contract is duck-typed, documented in `MatrixModelRoleResolver`'s docstring. If a future bug suggests stricter typing helps, revisit then.
- This PR set is scoped to the rename + reshape + fork-skill bug fix. The smoke test infrastructure for foundation modules (which has a pre-existing pytest-collection quirk requiring per-module installs) is unchanged; verification is via per-repo CI.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>