### PR TITLE
fix(cost): replace per-child contributors with capability-attached aggregator

### DIFF
--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -26,6 +26,14 @@ from amplifier_foundation.bundle._dataclass import Bundle
 
 logger = logging.getLogger(__name__)
 
+# Coordinator capability key for bridged delegate costs.
+# Stored value: dict[child_session_id, Decimal]. Enables replace-on-dup semantics:
+# re-bridging the same child (multi-turn resume) updates its slot rather than
+# appending a new contributor each time. State lives on the coordinator itself
+# via register_capability, so it's bounded by coordinator lifetime — no module-
+# level state, no id() reuse hazard.
+_DELEGATE_COSTS_CAPABILITY = "_bridge_delegate_costs"
+
 
 # Collects cost_usd contributions from a session.cost channel and returns the
 # total as Decimal, or None when no cost data is present (e.g. self-hosted models).
@@ -58,20 +66,48 @@ async def bridge_child_cost(
 ) -> None:
     """Propagate child session cost to parent's session.cost channel. Never raises.
 
+    Uses a single "delegate-children" contributor per parent coordinator backed by a
+    mutable dict stored on the coordinator as a capability. Re-bridging the same child
+    on multi-turn resume replaces its slot in the dict rather than appending a new
+    contributor each time (which would N-tuple count costs across resumes).
+
+    State is attached to the coordinator via register_capability, so it lives and dies
+    with the coordinator — no module-level dict, no id() reuse hazard, no leak across
+    sessions.
+
     Cost accounting must not surface as a spawn failure. Any exception is logged as
     a warning and swallowed so the caller always sees a clean return.
     """
     try:
-        child_contributions = await child_coordinator.collect_contributions("session.cost")
+        child_contributions = await child_coordinator.collect_contributions(
+            "session.cost"
+        )
         child_total = sum_cost_usd(child_contributions)
 
         if child_total is not None:
-            # Freeze value in default arg — child coordinator will be torn down after this
-            parent_coordinator.register_contributor(
-                "session.cost",
-                f"delegate:{child_session_id}",
-                lambda total=child_total: {"cost_usd": total},
+            delegate_costs = parent_coordinator.get_capability(
+                _DELEGATE_COSTS_CAPABILITY
             )
+
+            if delegate_costs is None:
+                # First bridge for this coordinator — create the shared dict, attach
+                # it to the coordinator, and register one contributor that reads from
+                # it. Subsequent bridges find the existing dict and mutate it in place.
+                delegate_costs = {}
+                parent_coordinator.register_capability(
+                    _DELEGATE_COSTS_CAPABILITY, delegate_costs
+                )
+                parent_coordinator.register_contributor(
+                    "session.cost",
+                    "delegate-children",
+                    lambda d=delegate_costs: (
+                        {"cost_usd": sum(d.values())} if d else None
+                    ),
+                )
+
+            # Replace-on-dup: updating an existing key is idempotent across resumes
+            delegate_costs[child_session_id] = child_total
+
     except Exception:
         logger.warning(
             "Failed to bridge child session cost for %s; skipping",

--- a/tests/test_cost_bridge_foundation.py
+++ b/tests/test_cost_bridge_foundation.py
@@ -5,23 +5,44 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
+def _make_parent_coord() -> MagicMock:
+    """Return a MagicMock parent_coordinator with realistic capability/contributor state.
+
+    Emulates the real coordinator surface used by bridge_child_cost:
+    - get_capability / register_capability: dict-backed, behaves like the kernel
+    - register_contributor: captures (channel, name) -> callback in coord._contributors
+
+    Exposes coord._contributors and coord._register_calls for assertions.
+    """
+    coord = MagicMock()
+    caps: dict = {}
+    coord.get_capability = lambda name: caps.get(name)
+    coord.register_capability = lambda name, value: caps.__setitem__(name, value)
+
+    contributors: dict = {}
+    register_calls: list = []
+
+    def _capture(channel, name, callback):
+        register_calls.append((channel, name))
+        contributors[(channel, name)] = callback
+
+    coord.register_contributor = _capture
+    coord._contributors = contributors
+    coord._register_calls = register_calls
+    return coord
+
+
 @pytest.mark.asyncio
 async def test_prepared_bundle_spawn_bridges_child_cost():
-    """PreparedBundle.spawn() registers child cost on parent coordinator after execute()."""
+    """bridge_child_cost registers a single 'delegate-children' contributor on the parent."""
     child_coord = MagicMock()
     child_coord.collect_contributions = AsyncMock(
         return_value=[{"cost_usd": Decimal("0.06")}]
     )
 
-    parent_coord = MagicMock()
-    registered = {}
+    parent_coord = _make_parent_coord()
 
-    def capture_register(channel, name, callback):
-        registered[(channel, name)] = callback
-
-    parent_coord.register_contributor = capture_register
-
-    from amplifier_foundation import sum_cost_usd, bridge_child_cost  # noqa: F401
+    from amplifier_foundation import bridge_child_cost
 
     await bridge_child_cost(
         child_coordinator=child_coord,
@@ -29,9 +50,132 @@ async def test_prepared_bundle_spawn_bridges_child_cost():
         child_session_id="foundation-child-001",
     )
 
-    assert ("session.cost", "delegate:foundation-child-001") in registered
-    result = registered[("session.cost", "delegate:foundation-child-001")]()
+    # One contributor named "delegate-children", not per-child
+    assert ("session.cost", "delegate-children") in parent_coord._contributors
+    result = parent_coord._contributors[("session.cost", "delegate-children")]()
     assert result == {"cost_usd": Decimal("0.06")}
+
+
+@pytest.mark.asyncio
+async def test_bridge_child_cost_no_compounding_on_multi_turn_resume():
+    """Re-bridging the same child on resume replaces its slot — no N-tuple counting.
+
+    Bug: register_contributor appended a new entry each call. After N resumes of the
+    same child, collect_contributions returned N identical values summing to N× the
+    real cost. This test verifies that only the latest cost is ever counted.
+    """
+    parent_coord = _make_parent_coord()
+
+    from amplifier_foundation import bridge_child_cost
+
+    # Simulate 5 turns: child's cumulative cost grows each turn
+    cumulative_costs = ["0.10", "0.20", "0.30", "0.40", "0.50"]
+    for cost in cumulative_costs:
+        child_coord = MagicMock()
+        child_coord.collect_contributions = AsyncMock(
+            return_value=[{"cost_usd": Decimal(cost)}]
+        )
+        await bridge_child_cost(
+            child_coordinator=child_coord,
+            parent_coordinator=parent_coord,
+            child_session_id="resume-child-001",  # same child each turn
+        )
+
+    # register_contributor must only have been called once (first bridge)
+    assert len(parent_coord._register_calls) == 1, (
+        f"Expected 1 register_contributor call, got {len(parent_coord._register_calls)}. "
+        "Multi-turn compounding bug: a new contributor was registered each resume."
+    )
+
+    # The contributor must return the LATEST value (0.50), not the sum of all (1.50)
+    contributor_fn = parent_coord._contributors[("session.cost", "delegate-children")]
+    result = contributor_fn()
+    assert result == {"cost_usd": Decimal("0.50")}, (
+        f"Expected latest cumulative cost Decimal('0.50'), got {result}. "
+        "Multi-turn compounding bug: cost was N-tuple counted."
+    )
+
+
+@pytest.mark.asyncio
+async def test_bridge_child_cost_multiple_children_sum_correctly():
+    """Multiple distinct children are summed together in the single contributor."""
+    parent_coord = _make_parent_coord()
+
+    from amplifier_foundation import bridge_child_cost
+
+    for child_id, cost in [
+        ("child-A", "0.10"),
+        ("child-B", "0.20"),
+        ("child-C", "0.30"),
+    ]:
+        child_coord = MagicMock()
+        child_coord.collect_contributions = AsyncMock(
+            return_value=[{"cost_usd": Decimal(cost)}]
+        )
+        await bridge_child_cost(
+            child_coordinator=child_coord,
+            parent_coordinator=parent_coord,
+            child_session_id=child_id,
+        )
+
+    # Still only one contributor registered (not one per child)
+    assert len(parent_coord._register_calls) == 1, (
+        f"Expected 1 register_contributor call, got {len(parent_coord._register_calls)}."
+    )
+
+    # Contributor sums all three children: 0.10 + 0.20 + 0.30 = 0.60
+    contributor_fn = parent_coord._contributors[("session.cost", "delegate-children")]
+    result = contributor_fn()
+    assert result is not None
+    assert result["cost_usd"] == Decimal("0.60")
+
+
+@pytest.mark.asyncio
+async def test_bridge_child_cost_isolates_state_per_parent():
+    """Two distinct parents bridging children with the SAME id see ONLY their own.
+
+    Regression guard: under the previous module-level dict + id(coord) keying scheme,
+    a new coordinator allocated at a recycled memory address (after the prior one was
+    GC'd) would inherit stale entries — silently under-counting the new parent's costs
+    because register_contributor was skipped. State now lives on the coordinator itself
+    via register_capability, so this failure mode is impossible by construction: each
+    parent has its own capability dict, independent of memory address reuse.
+    """
+    parent_A = _make_parent_coord()
+    parent_B = _make_parent_coord()
+
+    from amplifier_foundation import bridge_child_cost
+
+    # Both parents bridge a child with the SAME session_id but different cumulative costs
+    child_for_A = MagicMock()
+    child_for_A.collect_contributions = AsyncMock(
+        return_value=[{"cost_usd": Decimal("0.10")}]
+    )
+    await bridge_child_cost(
+        child_coordinator=child_for_A,
+        parent_coordinator=parent_A,
+        child_session_id="child-X",
+    )
+
+    child_for_B = MagicMock()
+    child_for_B.collect_contributions = AsyncMock(
+        return_value=[{"cost_usd": Decimal("0.99")}]
+    )
+    await bridge_child_cost(
+        child_coordinator=child_for_B,
+        parent_coordinator=parent_B,
+        child_session_id="child-X",  # identical name, different parent
+    )
+
+    # Each parent must have its OWN contributor (one register call each)
+    assert len(parent_A._register_calls) == 1
+    assert len(parent_B._register_calls) == 1
+
+    # Each parent's contributor reflects only its own child's cost
+    contrib_A = parent_A._contributors[("session.cost", "delegate-children")]()
+    contrib_B = parent_B._contributors[("session.cost", "delegate-children")]()
+    assert contrib_A == {"cost_usd": Decimal("0.10")}
+    assert contrib_B == {"cost_usd": Decimal("0.99")}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix multi-turn cost compounding in `bridge_child_cost`. Previously, each call registered a per-child contributor via `register_contributor("session.cost", f"delegate:{child_session_id}", ...)` — and since `register_contributor` always appends with no dedup by name, multi-turn resumes of the same child added a new contributor each turn. After N resumes: N entries each holding the cumulative cost → N× over-count.

## Fix

Replace per-child contributors with a single `"delegate-children"` contributor per parent coordinator, backed by a mutable dict attached to the coordinator via `register_capability`. First bridge call registers the contributor and attaches the dict; subsequent calls find the existing dict via `get_capability` and mutate it in place — replace-on-dup semantics across multi-turn resumes, per-parent isolation by construction.

State lives and dies with the coordinator — no module-level dict, no `id()` reuse hazard.

- No Rust changes required
- Replace-on-dup semantics for multi-turn resumes
- Multiple distinct children summed in one contributor
- Per-parent isolation: each coordinator has its own state, independent of memory address reuse

## Tests

- `test_bridge_child_cost_no_compounding_on_multi_turn_resume` — 5 resumes of the same child → 1 register call, contributor returns latest value
- `test_bridge_child_cost_multiple_children_sum_correctly` — 3 distinct children → 1 register call, contributor returns the sum
- `test_bridge_child_cost_isolates_state_per_parent` — two distinct parents bridging children with the same id → each parent sees only its own
- Updated `test_prepared_bundle_spawn_bridges_child_cost` for the new contributor name and capability-attached state

## Validation

- Foundation test suite: cost bridge path 6/6 pass. No regression in any test that wasn't already failing on `main` (macOS path-normalization failures, unrelated).
- End-to-end validated in an isolated container: real multi-turn delegate session with the same child session_id resumed across multiple turns produces a single `"delegate-children"` contributor whose value matches the per-message cost sum exactly — no compounding observed.
