### PR TITLE
feat(foundation): RuntimeOverlay primitive for runtime capability overlays

### DIFF
--- a/amplifier_foundation/__init__.py
+++ b/amplifier_foundation/__init__.py
@@ -20,6 +20,10 @@ from __future__ import annotations
 # Core classes
 from amplifier_foundation.bundle import Bundle
 from amplifier_foundation.configurator import SessionConfigurator
+from amplifier_foundation.configurator import (
+    RuntimeOverlay,
+    TransitionResult,
+)  # re-export for hooks-mode
 
 # Reference implementations
 from amplifier_foundation.cache.disk import DiskCache
@@ -112,6 +116,8 @@ __all__ = [
     # Core
     "Bundle",
     "SessionConfigurator",
+    "RuntimeOverlay",
+    "TransitionResult",
     "BundleRegistry",
     "BundleState",
     "UpdateInfo",

--- a/amplifier_foundation/bundle/_dataclass.py
+++ b/amplifier_foundation/bundle/_dataclass.py
@@ -735,6 +735,51 @@ def _load_agent_file_metadata(path: Path, fallback_name: str) -> dict[str, Any]:
     return result
 
 
+def _load_mode_file_metadata(path: Path, fallback_name: str) -> dict[str, Any]:
+    """Load mode config from a .md file.
+
+    Extracts metadata from the mode: frontmatter section, including name,
+    description, advertised flag, contributes block, and any additional keys.
+    The markdown body is included as the instruction.
+
+    Args:
+        path: Path to mode .md file
+        fallback_name: Name to use if not specified in file
+
+    Returns:
+        Dict with name, description, advertised, contributes, instruction
+        (from markdown body), and any additional mode section keys.
+    """
+    from amplifier_foundation.io.frontmatter import parse_frontmatter
+
+    text = path.read_text(encoding="utf-8")
+    frontmatter, body = parse_frontmatter(text)
+
+    # Modes use mode: section
+    mode_section = frontmatter.get("mode", {})
+    if not isinstance(mode_section, dict):
+        mode_section = {}
+
+    # Build result with backward-compatible defaults
+    result: dict[str, Any] = {
+        "name": mode_section.get("name", fallback_name),
+        "description": mode_section.get("description", ""),
+        "advertised": mode_section.get("advertised", True),
+        "contributes": mode_section.get("contributes", {}) or {},
+    }
+
+    # Pass through remaining mode_section keys verbatim if not already in result
+    for key, value in mode_section.items():
+        if key not in result:
+            result[key] = value
+
+    # Include instruction from markdown body
+    if body and body.strip():
+        result["instruction"] = body.strip()
+
+    return result
+
+
 def _parse_context(
     context_config: dict[str, Any], base_path: Path | None
 ) -> tuple[dict[str, Path], dict[str, str]]:

--- a/amplifier_foundation/bundle/_dataclass.py
+++ b/amplifier_foundation/bundle/_dataclass.py
@@ -642,6 +642,78 @@ class Bundle:
                 )
                 warnings.append(msg)
                 logger.warning(msg)
+                continue
+
+            # Inner shape validation for each supported category
+            _KNOWN_CONTRIBUTES_KEYS = frozenset({"agents", "context", "skills"})
+            for key in contributes:
+                if key not in _KNOWN_CONTRIBUTES_KEYS:
+                    msg = (
+                        f"{mode_path.name}: unknown key {key!r} in 'contributes'"
+                        f" — expected one of {sorted(_KNOWN_CONTRIBUTES_KEYS)}"
+                    )
+                    warnings.append(msg)
+                    logger.warning(msg)
+
+            # agents: must be dict[str, dict]
+            agents_val = contributes.get("agents")
+            if agents_val is not None:
+                if not isinstance(agents_val, dict):
+                    msg = (
+                        f"{mode_path.name}: 'contributes.agents' must be a dict"
+                        f" mapping str \u2192 dict; got {type(agents_val).__name__}"
+                    )
+                    warnings.append(msg)
+                    logger.warning(msg)
+                else:
+                    for agent_name, agent_cfg in agents_val.items():
+                        if not isinstance(agent_cfg, dict):
+                            msg = (
+                                f"{mode_path.name}: 'contributes.agents[{agent_name!r}]'"
+                                f" must be a dict; got {type(agent_cfg).__name__}"
+                            )
+                            warnings.append(msg)
+                            logger.warning(msg)
+
+            # context: must be list[str]
+            context_val = contributes.get("context")
+            if context_val is not None:
+                if not isinstance(context_val, list):
+                    msg = (
+                        f"{mode_path.name}: 'contributes.context' must be a list"
+                        f" of strings; got {type(context_val).__name__}"
+                    )
+                    warnings.append(msg)
+                    logger.warning(msg)
+                else:
+                    for i, entry in enumerate(context_val):
+                        if not isinstance(entry, str):
+                            msg = (
+                                f"{mode_path.name}: 'contributes.context[{i}]'"
+                                f" must be a string; got {type(entry).__name__}"
+                            )
+                            warnings.append(msg)
+                            logger.warning(msg)
+
+            # skills: must be list[str]
+            skills_val = contributes.get("skills")
+            if skills_val is not None:
+                if not isinstance(skills_val, list):
+                    msg = (
+                        f"{mode_path.name}: 'contributes.skills' must be a list"
+                        f" of strings; got {type(skills_val).__name__}"
+                    )
+                    warnings.append(msg)
+                    logger.warning(msg)
+                else:
+                    for i, entry in enumerate(skills_val):
+                        if not isinstance(entry, str):
+                            msg = (
+                                f"{mode_path.name}: 'contributes.skills[{i}]'"
+                                f" must be a string; got {type(entry).__name__}"
+                            )
+                            warnings.append(msg)
+                            logger.warning(msg)
 
         return warnings
 

--- a/amplifier_foundation/bundle/_dataclass.py
+++ b/amplifier_foundation/bundle/_dataclass.py
@@ -433,7 +433,7 @@ class Bundle:
         # Validates contributes structure; actual module activation for contributed
         # sources defers to v1.1 when contributes.tools joins.
         # Warnings are logged but do not fail prepare().
-        self.validate_modes()
+        mode_warnings = self.validate_modes()
 
         # Activate all modules and get their paths
         module_paths = await activator.activate_all(
@@ -455,6 +455,7 @@ class Bundle:
             resolver=resolver,
             bundle=self,
             bundle_package_paths=bundle_package_paths,
+            mode_warnings=mode_warnings,
         )
 
     def resolve_context_path(self, name: str) -> Path | None:

--- a/amplifier_foundation/bundle/_dataclass.py
+++ b/amplifier_foundation/bundle/_dataclass.py
@@ -429,6 +429,12 @@ class Bundle:
                         if isinstance(mod_spec, dict) and "source" in mod_spec:
                             modules_to_activate.append(resolve_source(mod_spec))
 
+        # Phase 1: schema-only modes walk.
+        # Validates contributes structure; actual module activation for contributed
+        # sources defers to v1.1 when contributes.tools joins.
+        # Warnings are logged but do not fail prepare().
+        self.validate_modes()
+
         # Activate all modules and get their paths
         module_paths = await activator.activate_all(
             modules_to_activate, progress_callback=progress_callback
@@ -596,6 +602,48 @@ class Bundle:
                     logger.warning(
                         f"Failed to load metadata for agent '{agent_name}': {e}"
                     )
+
+    def validate_modes(self) -> list[str]:
+        """Scan modes/ directory for .md files and validate their schema.
+
+        Phase 1 of the modes walk: schema-validation-only.  Checks that each
+        mode file is parseable and that its ``contributes`` block, when present,
+        is a dict.  Actual module activation for contributed sources is deferred
+        to v1.1 when ``contributes.tools`` joins.
+
+        Warnings are logged but do not fail prepare().
+
+        Returns:
+            List of warning strings (empty when everything is valid).
+        """
+        warnings: list[str] = []
+
+        if not self.base_path:
+            return warnings
+
+        modes_dir = self.base_path / "modes"
+        if not modes_dir.is_dir():
+            return warnings
+
+        for mode_path in sorted(modes_dir.glob("*.md")):
+            try:
+                meta = _load_mode_file_metadata(mode_path, fallback_name=mode_path.stem)
+            except Exception as exc:
+                msg = f"{mode_path.name}: failed to parse frontmatter: {exc}"
+                warnings.append(msg)
+                logger.warning(msg)
+                continue
+
+            contributes = meta.get("contributes", {})
+            if not isinstance(contributes, dict):
+                msg = (
+                    f"{mode_path.name}: 'contributes' must be a dict;"
+                    f" got {type(contributes).__name__}"
+                )
+                warnings.append(msg)
+                logger.warning(msg)
+
+        return warnings
 
     @classmethod
     def from_dict(cls, data: dict[str, Any], base_path: Path | None = None) -> Bundle:

--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -180,6 +180,7 @@ class PreparedBundle:
     resolver: BundleModuleResolver
     bundle: Bundle
     bundle_package_paths: list[str] = field(default_factory=list)
+    mode_warnings: list[str] = field(default_factory=list)
 
     def _build_bundles_for_resolver(self, bundle: "Bundle") -> dict[str, "Bundle"]:
         """Build bundle registry for mention resolution.

--- a/amplifier_foundation/configurator/__init__.py
+++ b/amplifier_foundation/configurator/__init__.py
@@ -8,6 +8,7 @@ All existing imports continue to work unchanged:
     from amplifier_foundation.configurator import SessionConfigurator
     from amplifier_foundation.configurator import _normalize_module_name, ...
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -20,7 +21,9 @@ from amplifier_foundation.configurator._provenance_utils import (
     _normalize_module_name as _normalize_module_name,  # noqa: F401
 )
 from amplifier_foundation.configurator._overlay import RuntimeOverlay as RuntimeOverlay  # noqa: F401 — re-export
-from amplifier_foundation.configurator._overlay import TransitionResult as TransitionResult  # noqa: F401 — re-export
+from amplifier_foundation.configurator._overlay import (
+    TransitionResult as TransitionResult,
+)  # noqa: F401 — re-export
 from amplifier_foundation.configurator._state_manager import BundleStateManager
 
 

--- a/amplifier_foundation/configurator/__init__.py
+++ b/amplifier_foundation/configurator/__init__.py
@@ -19,6 +19,8 @@ from amplifier_foundation.configurator._provenance_utils import (
     _lookup_prov_behavior as _lookup_prov_behavior,  # noqa: F401
     _normalize_module_name as _normalize_module_name,  # noqa: F401
 )
+from amplifier_foundation.configurator._overlay import RuntimeOverlay as RuntimeOverlay  # noqa: F401 — re-export
+from amplifier_foundation.configurator._overlay import TransitionResult as TransitionResult  # noqa: F401 — re-export
 from amplifier_foundation.configurator._state_manager import BundleStateManager
 
 
@@ -224,6 +226,8 @@ __all__ = [
     "SessionConfigurator",
     "BundleStateManager",
     "BundleInspector",
+    "RuntimeOverlay",
+    "TransitionResult",
     "_PROV_CATEGORY_MAP",
     "_normalize_module_name",
     "_build_normalized_prov_lookup",

--- a/amplifier_foundation/configurator/_overlay.py
+++ b/amplifier_foundation/configurator/_overlay.py
@@ -232,6 +232,48 @@ class RuntimeOverlay:
         return result
 
     # ------------------------------------------------------------------
+    # Debug / introspection helpers
+    # ------------------------------------------------------------------
+
+    def get_refcount(self, category: str, key: str) -> int:
+        """Return current refcount for (category, key). 0 if not tracked.
+
+        Args:
+            category:   Category name, e.g. ``'agents'``.
+            key:        Item key within the category.
+
+        Returns:
+            Current refcount (>= 0).  Returns 0 for any key that has never
+            been applied or has been fully revoked — never raises.
+        """
+        return self._refcounts.get((category, key), 0)
+
+    def dump_state(self) -> dict[str, Any]:
+        """Return a debug snapshot: scope_claims, refcounts (sorted), and owned items per category.
+
+        Suitable for printing during incident debugging. Read-only — does not
+        modify any overlay state.
+
+        Returns:
+            ``{
+                "scope_claims": {scope: list_of_(category, key)_tuples},
+                "refcounts":    {(category, key): count, …},  # sorted by (cat, key)
+                "owned":        {category: [key, …], …},
+            }``
+        """
+        return {
+            "scope_claims": {
+                scope: list(claims) for scope, claims in self._scope_claims.items()
+            },
+            "refcounts": dict(
+                sorted(self._refcounts.items(), key=lambda item: item[0])
+            ),
+            "owned": {
+                category: list(items.keys()) for category, items in self._owned.items()
+            },
+        }
+
+    # ------------------------------------------------------------------
     # Refcount helpers
     # ------------------------------------------------------------------
 

--- a/amplifier_foundation/configurator/_overlay.py
+++ b/amplifier_foundation/configurator/_overlay.py
@@ -1,0 +1,398 @@
+"""RuntimeOverlay — additive overlay of agents, context, and skills under named scopes.
+
+RuntimeOverlay sits as a peer to SessionConfigurator and drives the same live coordinator
+surfaces. Where SessionConfigurator toggles session-level items via stash/unstash,
+RuntimeOverlay adds *additive* contributions (agents, context, skills) under named scopes
+(typically 'mode:<name>') with refcount semantics:
+
+  - session baseline contributes +1 per existing item at construction
+  - each scope's apply() contributes +1 per declared item
+  - mount on 0 → 1; unmount on 1 → 0
+
+Phase 1 covers agents, context, skills. tools/config overrides reserved for v1.1.
+Event names are caller-injected (the modes bundle owns canonical names).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CAP_OVERLAY_CONTEXT = "mode_overlay_context"
+_CAP_OVERLAY_SKILLS = "mode_overlay_skills"
+
+# Categories handled in Phase 1
+_SUPPORTED_CATEGORIES = frozenset({"agents", "context", "skills"})
+# Categories reserved for future (silently skipped with debug log)
+_RESERVED_CATEGORIES = frozenset({"tools", "config"})
+
+
+# ---------------------------------------------------------------------------
+# TransitionResult dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TransitionResult:
+    """Result of a RuntimeOverlay apply() or revoke() call.
+
+    Attributes:
+        success:    True when the transition completed without error.
+        scope:      The scope name the transition targeted.
+        mounted:    (category, key) pairs mounted during this transition.
+        unmounted:  (category, key) pairs unmounted during this transition.
+        rolled_back: (category, key) pairs rolled back due to a failed apply.
+        error:      Human-readable error string when success is False.
+    """
+
+    success: bool
+    scope: str
+    mounted: list[tuple[str, str]] = field(default_factory=list)
+    unmounted: list[tuple[str, str]] = field(default_factory=list)
+    rolled_back: list[tuple[str, str]] = field(default_factory=list)
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# RuntimeOverlay
+# ---------------------------------------------------------------------------
+
+
+class RuntimeOverlay:
+    """Additive overlay of agents, context, and skills with refcount semantics.
+
+    Args:
+        coordinator:    Live session coordinator (same object SessionConfigurator holds).
+        success_event:  Event name emitted when apply/revoke succeeds.
+        failure_event:  Event name emitted when apply fails and rolls back.
+    """
+
+    def __init__(
+        self,
+        coordinator: Any,
+        *,
+        success_event: str,
+        failure_event: str,
+    ) -> None:
+        self._coordinator = coordinator
+        self._success_event = success_event
+        self._failure_event = failure_event
+
+        # refcounts: (category, key) → int
+        self._refcounts: dict[tuple[str, str], int] = {}
+
+        # scope_claims: scope_name → list of (category, key) in application order
+        self._scope_claims: dict[str, list[tuple[str, str]]] = {}
+
+        # _owned: per-category dict of items owned by this overlay
+        self._owned: dict[str, dict[str, Any]] = {
+            "agents": {},
+            "context": {},
+            "skills": {},
+        }
+
+        self._capture_baseline()
+
+    # ------------------------------------------------------------------
+    # Baseline capture
+    # ------------------------------------------------------------------
+
+    def _capture_baseline(self) -> None:
+        """Record refcount=1 for session-baseline agents.
+
+        S1 invariant: if a mode contributes the same agent name as the session
+        baseline, the refcount reaches 2 and _mount() is never called (no-op).
+
+        context/skills baseline is empty — session-level context flows through
+        bundle.context / tool-skills config, not through overlay capability.
+        """
+        for agent_name in self._coordinator.config.get("agents") or {}:
+            rc_key: tuple[str, str] = ("agents", agent_name)
+            self._refcounts[rc_key] = 1
+
+    # ------------------------------------------------------------------
+    # Public API: apply / revoke
+    # ------------------------------------------------------------------
+
+    async def apply(
+        self, scope: str, contributions: dict[str, Any]
+    ) -> TransitionResult:
+        """Mount all contributions under *scope* with refcount semantics.
+
+        Args:
+            scope:          Unique scope identifier, e.g. ``'mode:demo'``.
+            contributions:  Dict mapping category → payload.
+
+        Returns:
+            A :class:`TransitionResult` indicating success/failure and what
+            was mounted (or rolled back).
+        """
+        if scope in self._scope_claims:
+            # Idempotent: already applied — return success no-op
+            return TransitionResult(success=True, scope=scope)
+
+        result = TransitionResult(success=True, scope=scope)
+        applied_in_this_call: list[tuple[str, str]] = []
+
+        try:
+            for category, payload in contributions.items():
+                if category in _RESERVED_CATEGORIES:
+                    logger.debug(
+                        "RuntimeOverlay.apply: skipping reserved category %r "
+                        "(scope=%r) — reserved for v1.1",
+                        category,
+                        scope,
+                    )
+                    continue
+
+                if category not in _SUPPORTED_CATEGORIES:
+                    logger.warning(
+                        "RuntimeOverlay.apply: unknown category %r in scope %r — skipping",
+                        category,
+                        scope,
+                    )
+                    continue
+
+                # Normalise into (key, value) pairs
+                if category == "agents":
+                    items = self._normalise_agents(payload)
+                else:
+                    items = self._normalise_path_list(payload)
+
+                for key, value in items:
+                    self._increment(category, key, value)
+                    rc_pair: tuple[str, str] = (category, key)
+                    applied_in_this_call.append(rc_pair)
+                    result.mounted.append(rc_pair)
+
+        except Exception as exc:
+            # Atomic rollback in reverse order
+            for rc_pair in reversed(applied_in_this_call):
+                try:
+                    self._decrement(rc_pair[0], rc_pair[1])
+                    result.rolled_back.append(rc_pair)
+                except Exception as rollback_exc:
+                    logger.debug(
+                        "RuntimeOverlay.apply rollback failed for %r: %s",
+                        rc_pair,
+                        rollback_exc,
+                    )
+            result.mounted.clear()
+            result.success = False
+            result.error = str(exc)
+            await self._emit(self._failure_event, scope, result)
+            return result
+
+        self._scope_claims[scope] = list(applied_in_this_call)
+        await self._emit(self._success_event, scope, result)
+        return result
+
+    async def revoke(self, scope: str) -> TransitionResult:
+        """Unmount all contributions for *scope* with refcount semantics.
+
+        Args:
+            scope:  The scope name previously passed to :meth:`apply`.
+
+        Returns:
+            A :class:`TransitionResult` indicating success/failure and what
+            was unmounted.
+        """
+        if scope not in self._scope_claims:
+            # Idempotent: scope was never applied — return success no-op
+            result = TransitionResult(success=True, scope=scope)
+            await self._emit(self._success_event, scope, result)
+            return result
+
+        claims = self._scope_claims.pop(scope)
+        result = TransitionResult(success=True, scope=scope)
+
+        for rc_pair in reversed(claims):
+            try:
+                self._decrement(rc_pair[0], rc_pair[1])
+                result.unmounted.append(rc_pair)
+            except Exception as exc:
+                logger.warning(
+                    "RuntimeOverlay.revoke: error unmounting %r in scope %r: %s",
+                    rc_pair,
+                    scope,
+                    exc,
+                )
+                result.success = False
+                result.error = str(exc)
+
+        await self._emit(self._success_event, scope, result)
+        return result
+
+    # ------------------------------------------------------------------
+    # Refcount helpers
+    # ------------------------------------------------------------------
+
+    def _increment(self, category: str, key: str, value: Any) -> None:
+        """Increment refcount for (category, key); mount when crossing 0 → 1."""
+        rc_key: tuple[str, str] = (category, key)
+        before = self._refcounts.get(rc_key, 0)
+        self._refcounts[rc_key] = before + 1
+        if before == 0:
+            self._mount(category, key, value)
+
+    def _decrement(self, category: str, key: str) -> None:
+        """Decrement refcount for (category, key); unmount when crossing 1 → 0."""
+        rc_key: tuple[str, str] = (category, key)
+        before = self._refcounts.get(rc_key, 0)
+        if before <= 0:
+            raise RuntimeError(
+                f"RuntimeOverlay refcount underflow for {rc_key!r}: "
+                f"refcount is already {before}"
+            )
+        new_rc = before - 1
+        if new_rc == 0:
+            self._unmount(category, key)
+            del self._refcounts[rc_key]
+        else:
+            self._refcounts[rc_key] = new_rc
+
+    # ------------------------------------------------------------------
+    # Mount / unmount
+    # ------------------------------------------------------------------
+
+    def _mount(self, category: str, key: str, value: Any) -> None:
+        """Actually mount one item into the live coordinator surface."""
+        if category == "agents":
+            agents: dict = self._coordinator.config.setdefault("agents", {})
+            agents[key] = value
+            self._owned["agents"][key] = value
+        elif category in ("context", "skills"):
+            self._owned[category][key] = value
+            self._refresh_capability(category)
+        else:
+            raise ValueError(f"RuntimeOverlay._mount: unknown category {category!r}")
+
+    def _unmount(self, category: str, key: str) -> None:
+        """Actually unmount one item from the live coordinator surface."""
+        if category == "agents":
+            self._coordinator.config.get("agents", {}).pop(key, None)
+            self._owned["agents"].pop(key, None)
+        elif category in ("context", "skills"):
+            self._owned[category].pop(key, None)
+            self._refresh_capability(category)
+        else:
+            raise ValueError(f"RuntimeOverlay._unmount: unknown category {category!r}")
+
+    # ------------------------------------------------------------------
+    # Capability refresh
+    # ------------------------------------------------------------------
+
+    def _refresh_capability(self, category: str) -> None:
+        """Register the current owned keys as a capability on the coordinator.
+
+        Args:
+            category:   ``'context'`` or ``'skills'``.
+        """
+        cap_name = (
+            _CAP_OVERLAY_CONTEXT if category == "context" else _CAP_OVERLAY_SKILLS
+        )
+        self._coordinator.register_capability(
+            cap_name, list(self._owned[category].keys())
+        )
+
+    # ------------------------------------------------------------------
+    # Normalisation helpers (static)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalise_agents(payload: Any) -> list[tuple[str, Any]]:
+        """Validate and flatten an agents contribution payload.
+
+        Args:
+            payload:    Must be a ``dict[str, dict]``.
+
+        Returns:
+            List of ``(name, cfg)`` tuples.
+
+        Raises:
+            ValueError: If payload is not a dict or contains non-dict entries.
+        """
+        if not isinstance(payload, dict):
+            raise ValueError(
+                f"RuntimeOverlay: 'agents' contribution must be a dict, got {type(payload)!r}"
+            )
+        result: list[tuple[str, Any]] = []
+        for name, cfg in payload.items():
+            if not isinstance(cfg, dict):
+                raise ValueError(
+                    f"RuntimeOverlay: agent config for {name!r} must be a dict, "
+                    f"got {type(cfg)!r}"
+                )
+            result.append((name, cfg))
+        return result
+
+    @staticmethod
+    def _normalise_path_list(payload: Any) -> list[tuple[str, str]]:
+        """Validate and flatten a context/skills path-list contribution payload.
+
+        Args:
+            payload:    Must be a ``list[str]``.
+
+        Returns:
+            List of ``(entry, entry)`` tuples (key == value == path string).
+
+        Raises:
+            ValueError: If payload is not a list or contains non-string entries.
+        """
+        if not isinstance(payload, list):
+            raise ValueError(
+                f"RuntimeOverlay: path-list contribution must be a list, "
+                f"got {type(payload)!r}"
+            )
+        result: list[tuple[str, str]] = []
+        for entry in payload:
+            if not isinstance(entry, str):
+                raise ValueError(
+                    f"RuntimeOverlay: path-list entry must be a string, got {type(entry)!r}"
+                )
+            result.append((entry, entry))
+        return result
+
+    # ------------------------------------------------------------------
+    # Event emission (best-effort)
+    # ------------------------------------------------------------------
+
+    async def _emit(
+        self, event_name: str, scope: str, result: TransitionResult
+    ) -> None:
+        """Emit a coordinator hook event; swallows exceptions (best-effort).
+
+        Args:
+            event_name: The event identifier to emit.
+            scope:      The scope the transition targeted.
+            result:     The :class:`TransitionResult` for this transition.
+        """
+        try:
+            await self._coordinator.hooks.emit(
+                event_name,
+                {
+                    "scope": scope,
+                    "success": result.success,
+                    "mounted": result.mounted,
+                    "unmounted": result.unmounted,
+                    "rolled_back": result.rolled_back,
+                    "error": result.error,
+                },
+            )
+        except Exception as exc:
+            logger.debug(
+                "RuntimeOverlay._emit: failed to emit event %r for scope %r: %s",
+                event_name,
+                scope,
+                exc,
+            )
+
+
+__all__ = ["RuntimeOverlay", "TransitionResult"]

--- a/amplifier_foundation/configurator/_overlay.py
+++ b/amplifier_foundation/configurator/_overlay.py
@@ -11,6 +11,16 @@ RuntimeOverlay adds *additive* contributions (agents, context, skills) under nam
 
 Phase 1 covers agents, context, skills. tools/config overrides reserved for v1.1.
 Event names are caller-injected (the modes bundle owns canonical names).
+
+Design choice — caller-injected event names:
+The constructor takes `success_event` and `failure_event` as required keyword-only
+strings rather than importing fixed event constants from a hosting bundle. This
+keeps `RuntimeOverlay` standalone — the foundation library has no dependency on
+any specific bundle's event names. The modes bundle (and any future consumer)
+owns its canonical event vocabulary and passes the names in. Consumers that
+prefer not to emit events at all can pass any string they like; the event
+emission is fail-safe (exceptions in `_emit` are swallowed and logged at debug
+level, not propagated).
 """
 
 from __future__ import annotations

--- a/amplifier_foundation/configurator/_overlay.py
+++ b/amplifier_foundation/configurator/_overlay.py
@@ -107,11 +107,19 @@ class RuntimeOverlay:
     def _capture_baseline(self) -> None:
         """Record refcount=1 for session-baseline agents.
 
-        S1 invariant: if a mode contributes the same agent name as the session
-        baseline, the refcount reaches 2 and _mount() is never called (no-op).
-
-        context/skills baseline is empty — session-level context flows through
-        bundle.context / tool-skills config, not through overlay capability.
+        ASYMMETRY (intentional, v1):
+        - Agents: captured here. If a mode contributes an agent name that already
+          exists in the session config, the refcount reaches 2 and _mount() is
+          never called — the existing instance is preserved. This implements the
+          S1 overlap scenario for agents.
+        - Context: NOT captured here. Session-level context flows through the
+          bundle's `context: include:` mechanism and the existing `provider:request`
+          hook's @-mention resolver. Mode-contributed context is a separate,
+          additive layer registered as the `mode_overlay_context` capability.
+          A mode contributing the same context file as the session bundle will
+          not deduplicate — both sources will inject independently. Document this
+          in the mode authoring guide if it becomes a real issue.
+        - Skills: NOT captured here. Same rationale as context.
         """
         for agent_name in self._coordinator.config.get("agents") or {}:
             rc_key: tuple[str, str] = ("agents", agent_name)

--- a/amplifier_foundation/configurator/_overlay.py
+++ b/amplifier_foundation/configurator/_overlay.py
@@ -227,7 +227,8 @@ class RuntimeOverlay:
                 result.success = False
                 result.error = str(exc)
 
-        await self._emit(self._success_event, scope, result)
+        event_name = self._success_event if result.success else self._failure_event
+        await self._emit(event_name, scope, result)
         return result
 
     # ------------------------------------------------------------------

--- a/tests/test_bundle_prepare_modes_walk.py
+++ b/tests/test_bundle_prepare_modes_walk.py
@@ -1,0 +1,139 @@
+"""Tests for Bundle.validate_modes() — Phase 1 schema-only modes walk.
+
+validate_modes() scans self.base_path/'modes' for .md files, parses each,
+and logs WARN on malformed contributes blocks.  It does NOT call
+ModuleActivator (reserved for v1.1 when contributes.tools joins).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from amplifier_foundation.bundle import Bundle
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _write(p: Path, body: str) -> None:
+    """Write *body* to *p* as UTF-8."""
+    p.write_text(body, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+VALID_MODE_CONTENT = """\
+---
+mode:
+  name: demo-mode
+  description: A demo mode for tests
+  contributes:
+    agents:
+      mode-author:
+        source: "@modes:agents/mode-author"
+---
+Demo mode body.
+"""
+
+MALFORMED_CONTRIBUTES_CONTENT = """\
+---
+mode:
+  name: bad
+  contributes:
+    - item1
+    - item2
+---
+Mode with list-type contributes (should be a dict).
+"""
+
+
+@pytest.fixture
+def bundle_with_valid_mode(tmp_path: Path) -> Bundle:
+    """Bundle with modes/demo.md containing a well-formed contributes block."""
+    modes_dir = tmp_path / "modes"
+    modes_dir.mkdir()
+    _write(modes_dir / "demo.md", VALID_MODE_CONTENT)
+    return Bundle(name="modes", base_path=tmp_path)
+
+
+@pytest.fixture
+def bundle_with_malformed_contributes(tmp_path: Path) -> Bundle:
+    """Bundle with modes/bad.md where contributes is a list, not a dict."""
+    modes_dir = tmp_path / "modes"
+    modes_dir.mkdir()
+    _write(modes_dir / "bad.md", MALFORMED_CONTRIBUTES_CONTENT)
+    return Bundle(name="modes", base_path=tmp_path)
+
+
+@pytest.fixture
+def bundle_with_no_modes_dir(tmp_path: Path) -> Bundle:
+    """Bundle whose base_path has no modes/ directory at all."""
+    return Bundle(name="no-modes", base_path=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateModes:
+    """Tests for Bundle.validate_modes() schema-only walk."""
+
+    def test_validate_modes_returns_zero_warnings_for_valid_mode(
+        self, bundle_with_valid_mode: Bundle
+    ) -> None:
+        """A well-formed mode file produces no warnings."""
+        warnings = bundle_with_valid_mode.validate_modes()
+        assert warnings == []
+
+    def test_validate_modes_warns_on_non_dict_contributes(
+        self, bundle_with_malformed_contributes: Bundle
+    ) -> None:
+        """A mode with a list-typed contributes block produces one warning
+        that mentions both the filename and the word 'contributes'."""
+        warnings = bundle_with_malformed_contributes.validate_modes()
+        assert len(warnings) == 1
+        assert "bad.md" in warnings[0]
+        assert "contributes" in warnings[0]
+
+    def test_validate_modes_no_modes_dir_is_noop(
+        self, bundle_with_no_modes_dir: Bundle
+    ) -> None:
+        """When there is no modes/ directory the method returns an empty list."""
+        warnings = bundle_with_no_modes_dir.validate_modes()
+        assert warnings == []
+
+    def test_validate_modes_handles_yaml_error_as_warning(self, tmp_path: Path) -> None:
+        """A mode file with malformed YAML frontmatter is logged as a warning,
+        not a hard failure.  The warning must mention the filename."""
+        modes_dir = tmp_path / "modes"
+        modes_dir.mkdir()
+        _write(
+            modes_dir / "broken.md",
+            "---\nmode: name: broken\ncontributes: { not closed\n---\n",
+        )
+        bundle = Bundle(name="modes", base_path=tmp_path)
+        warnings = bundle.validate_modes()
+        assert len(warnings) == 1
+        assert "broken.md" in warnings[0]
+
+    def test_validate_modes_logs_warnings_via_logger(
+        self,
+        bundle_with_malformed_contributes: Bundle,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """validate_modes() emits the warning through the module logger so it
+        shows up in caplog when the WARNING level is captured."""
+        import logging
+
+        with caplog.at_level(
+            logging.WARNING, logger="amplifier_foundation.bundle._dataclass"
+        ):
+            bundle_with_malformed_contributes.validate_modes()
+
+        # At least one WARNING record must mention 'bad.md'
+        assert any("bad.md" in record.message for record in caplog.records)

--- a/tests/test_bundle_prepare_modes_walk.py
+++ b/tests/test_bundle_prepare_modes_walk.py
@@ -137,3 +137,80 @@ class TestValidateModes:
 
         # At least one WARNING record must mention 'bad.md'
         assert any("bad.md" in record.message for record in caplog.records)
+
+    def test_validate_modes_clean_on_existing_modes_bundle(
+        self, tmp_path: Path
+    ) -> None:
+        """Backward-compat smoke test: legacy mode files (no contributes block,
+        no advertised key) must parse cleanly and produce zero warnings.
+
+        Mirrors the shipped shape of modes in microsoft/amplifier-bundle-modes.
+        """
+        modes_dir = tmp_path / "modes"
+        modes_dir.mkdir()
+
+        # (a) plan.md — warn on bash, safe for read tools
+        _write(
+            modes_dir / "plan.md",
+            """\
+---
+mode:
+  name: plan
+  description: "Plan only — no writes."
+  shortcut: plan
+  default_action: warn
+  tools:
+    safe:
+      - read_file
+      - glob
+      - grep
+    warn:
+      - bash
+---
+You are in plan mode. Read-only.
+""",
+        )
+
+        # (b) careful.md — confirm before writes
+        _write(
+            modes_dir / "careful.md",
+            """\
+---
+mode:
+  name: careful
+  description: "Confirm before writes."
+  shortcut: careful
+  default_action: allow
+  tools:
+    confirm:
+      - write_file
+      - edit_file
+      - bash
+---
+Careful mode body.
+""",
+        )
+
+        # (c) explore.md — read-only exploration
+        _write(
+            modes_dir / "explore.md",
+            """\
+---
+mode:
+  name: explore
+  description: "Read-only exploration."
+  shortcut: explore
+  default_action: block
+  tools:
+    safe:
+      - read_file
+      - glob
+      - grep
+---
+Explore mode body.
+""",
+        )
+
+        bundle = Bundle(name="modes", base_path=tmp_path)
+        warnings = bundle.validate_modes()
+        assert warnings == []

--- a/tests/test_bundle_prepare_modes_walk.py
+++ b/tests/test_bundle_prepare_modes_walk.py
@@ -217,6 +217,49 @@ Explore mode body.
 
 
 # ---------------------------------------------------------------------------
+# Item 3: mode_warnings surfaced on PreparedBundle
+# ---------------------------------------------------------------------------
+
+
+class TestPreparedBundleModeWarnings:
+    """Tests: PreparedBundle.mode_warnings exposes validate_modes() output."""
+
+    @pytest.mark.asyncio
+    async def test_prepare_surfaces_mode_warnings_on_prepared_bundle(
+        self, tmp_path: Path
+    ) -> None:
+        """Bundle.prepare() populates PreparedBundle.mode_warnings with warnings
+        from validate_modes() so callers can inspect them post-prepare.
+        """
+        modes_dir = tmp_path / "modes"
+        modes_dir.mkdir()
+        _write(
+            modes_dir / "bad.md",
+            """\
+---
+mode:
+  name: bad
+  contributes:
+    - item1
+    - item2
+---
+""",
+        )
+        bundle = Bundle(name="modes", base_path=tmp_path)
+        prepared = await bundle.prepare(install_deps=False)
+
+        assert hasattr(prepared, "mode_warnings"), (
+            "PreparedBundle must have a mode_warnings attribute"
+        )
+        assert len(prepared.mode_warnings) >= 1, (
+            f"Expected at least one warning, got: {prepared.mode_warnings}"
+        )
+        assert any("bad.md" in w for w in prepared.mode_warnings), (
+            f"Expected 'bad.md' in warnings; got: {prepared.mode_warnings}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Item 2: inner shape validation for contributes block
 # ---------------------------------------------------------------------------
 

--- a/tests/test_bundle_prepare_modes_walk.py
+++ b/tests/test_bundle_prepare_modes_walk.py
@@ -214,3 +214,141 @@ Explore mode body.
         bundle = Bundle(name="modes", base_path=tmp_path)
         warnings = bundle.validate_modes()
         assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Item 2: inner shape validation for contributes block
+# ---------------------------------------------------------------------------
+
+
+class TestValidateModesInnerShapes:
+    """Tests for validate_modes() inner-shape validation of contributes keys."""
+
+    def _bundle_with_mode(self, tmp_path: Path, content: str) -> Bundle:
+        modes_dir = tmp_path / "modes"
+        modes_dir.mkdir(exist_ok=True)
+        _write(modes_dir / "subject.md", content)
+        return Bundle(name="modes", base_path=tmp_path)
+
+    def test_agents_as_list_produces_warning(self, tmp_path: Path) -> None:
+        """contributes.agents being a list (not a dict) must produce a warning."""
+        bundle = self._bundle_with_mode(
+            tmp_path,
+            """\
+---
+mode:
+  name: bad-agents
+  contributes:
+    agents:
+      - agent-one
+      - agent-two
+---
+""",
+        )
+        warnings = bundle.validate_modes()
+        assert len(warnings) == 1
+        assert "agents" in warnings[0]
+        assert "subject.md" in warnings[0]
+
+    def test_agents_with_non_dict_value_produces_warning(self, tmp_path: Path) -> None:
+        """contributes.agents mapping a string value (not dict) must produce a warning."""
+        bundle = self._bundle_with_mode(
+            tmp_path,
+            """\
+---
+mode:
+  name: bad-agent-value
+  contributes:
+    agents:
+      my-agent: "just a string"
+---
+""",
+        )
+        warnings = bundle.validate_modes()
+        assert len(warnings) == 1
+        assert "agents" in warnings[0]
+        assert "subject.md" in warnings[0]
+
+    def test_context_as_string_produces_warning(self, tmp_path: Path) -> None:
+        """contributes.context being a string (not a list) must produce a warning."""
+        bundle = self._bundle_with_mode(
+            tmp_path,
+            """\
+---
+mode:
+  name: bad-context
+  contributes:
+    context: "@modes:context/schema.md"
+---
+""",
+        )
+        warnings = bundle.validate_modes()
+        assert len(warnings) == 1
+        assert "context" in warnings[0]
+        assert "subject.md" in warnings[0]
+
+    def test_skills_with_non_string_entry_produces_warning(self, tmp_path: Path) -> None:
+        """contributes.skills list containing a non-string entry must produce a warning."""
+        bundle = self._bundle_with_mode(
+            tmp_path,
+            """\
+---
+mode:
+  name: bad-skills
+  contributes:
+    skills:
+      - "@modes:skills/good-skill"
+      - 42
+---
+""",
+        )
+        warnings = bundle.validate_modes()
+        assert len(warnings) == 1
+        assert "skills" in warnings[0]
+        assert "subject.md" in warnings[0]
+
+    def test_unknown_contributes_key_produces_warning(self, tmp_path: Path) -> None:
+        """An unknown top-level key in contributes must produce a warning (not failure)."""
+        bundle = self._bundle_with_mode(
+            tmp_path,
+            """\
+---
+mode:
+  name: unknown-key
+  contributes:
+    agents:
+      my-agent:
+        source: "@modes:agents/my-agent"
+    future_feature: some_value
+---
+""",
+        )
+        warnings = bundle.validate_modes()
+        assert len(warnings) == 1
+        assert "future_feature" in warnings[0]
+        assert "subject.md" in warnings[0]
+
+    def test_valid_full_contributes_block_produces_no_warnings(
+        self, tmp_path: Path
+    ) -> None:
+        """A fully populated valid contributes block must produce no warnings."""
+        bundle = self._bundle_with_mode(
+            tmp_path,
+            """\
+---
+mode:
+  name: valid-full
+  contributes:
+    agents:
+      mode-author:
+        source: "@modes:agents/mode-author"
+    context:
+      - "@modes:context/schema.md"
+      - "@modes:context/anti-patterns.md"
+    skills:
+      - "@modes:skills/mode-design-discipline"
+---
+""",
+        )
+        warnings = bundle.validate_modes()
+        assert warnings == []

--- a/tests/test_load_mode_metadata.py
+++ b/tests/test_load_mode_metadata.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
 
 from amplifier_foundation.bundle._dataclass import _load_mode_file_metadata
 
@@ -113,3 +114,19 @@ class TestLoadModeFileMetadata:
         result: dict[str, Any] = _load_mode_file_metadata(f, "nullcontrib")
 
         assert result["contributes"] == {}
+
+    def test_malformed_yaml_raises(self, tmp_path: Path) -> None:
+        """Malformed YAML frontmatter propagates yaml.YAMLError — loader does NOT swallow it.
+
+        Contract: _load_mode_file_metadata raises yaml.YAMLError on malformed frontmatter.
+        The prepare-walk caller is responsible for catching/logging the error.
+        Centralizing the catch there keeps observability consistent.
+        """
+        f = tmp_path / "broken.md"
+        f.write_text(
+            "---\nmode: name: broken\ncontributes: { not closed\n---\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(yaml.YAMLError):
+            _load_mode_file_metadata(f, fallback_name="broken")

--- a/tests/test_load_mode_metadata.py
+++ b/tests/test_load_mode_metadata.py
@@ -1,0 +1,79 @@
+"""Tests for _load_mode_file_metadata — happy path extraction."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from amplifier_foundation.bundle._dataclass import _load_mode_file_metadata
+
+
+DEMO_MODE_FRONTMATTER = """\
+---
+mode:
+  name: demo-mode
+  description: A demo mode for tests
+  shortcut: demo
+  advertised: false
+  default_action: block
+  tools:
+    safe:
+      - read_file
+      - grep
+  contributes:
+    agents:
+      mode-author:
+        source: "@modes:agents/mode-author"
+    context:
+      - "@modes:context/schema.md"
+    skills:
+      - "@modes:skills/mode-design-discipline"
+---
+Demo Mode body
+
+system reminder text
+"""
+
+
+@pytest.fixture
+def mode_file(tmp_path: Path) -> Path:
+    """Write a demo-mode.md with full frontmatter to tmp_path."""
+    f = tmp_path / "demo-mode.md"
+    f.write_text(DEMO_MODE_FRONTMATTER, encoding="utf-8")
+    return f
+
+
+class TestLoadModeFileMetadata:
+    """Tests for _load_mode_file_metadata happy-path extraction."""
+
+    def test_extracts_name_and_description(self, mode_file: Path) -> None:
+        """name and description are extracted from the mode: section."""
+        result: dict[str, Any] = _load_mode_file_metadata(mode_file, "fallback-name")
+
+        assert result["name"] == "demo-mode"
+        assert result["description"] == "A demo mode for tests"
+
+    def test_extracts_advertised_flag(self, mode_file: Path) -> None:
+        """advertised=false in frontmatter is extracted as Python False."""
+        result: dict[str, Any] = _load_mode_file_metadata(mode_file, "fallback-name")
+
+        assert result["advertised"] is False
+
+    def test_extracts_contributes_block(self, mode_file: Path) -> None:
+        """contributes block is extracted with agents, context, and skills."""
+        result: dict[str, Any] = _load_mode_file_metadata(mode_file, "fallback-name")
+
+        contrib = result.get("contributes")
+        assert isinstance(contrib, dict)
+        assert "mode-author" in contrib["agents"]
+        assert contrib["agents"]["mode-author"]["source"] == "@modes:agents/mode-author"
+        assert contrib["context"] == ["@modes:context/schema.md"]
+        assert contrib["skills"] == ["@modes:skills/mode-design-discipline"]
+
+    def test_includes_body_as_instruction(self, mode_file: Path) -> None:
+        """Markdown body is included as the 'instruction' key."""
+        result: dict[str, Any] = _load_mode_file_metadata(mode_file, "fallback-name")
+
+        assert "instruction" in result
+        assert "Demo Mode body" in result["instruction"]
+        assert "system reminder text" in result["instruction"]

--- a/tests/test_load_mode_metadata.py
+++ b/tests/test_load_mode_metadata.py
@@ -77,3 +77,39 @@ class TestLoadModeFileMetadata:
         assert "instruction" in result
         assert "Demo Mode body" in result["instruction"]
         assert "system reminder text" in result["instruction"]
+
+    def test_minimal_mode_defaults(self, tmp_path: Path) -> None:
+        """Backward compat: modes with only name+description get advertised=True, contributes={}."""
+        f = tmp_path / "minimal.md"
+        f.write_text(
+            "---\nmode:\n  name: minimal\n  description: Minimal mode\n---\n",
+            encoding="utf-8",
+        )
+
+        result: dict[str, Any] = _load_mode_file_metadata(f, "minimal")
+
+        assert result["advertised"] is True
+        assert result["contributes"] == {}
+
+    def test_fallback_name_when_no_mode_section(self, tmp_path: Path) -> None:
+        """Modes with no frontmatter fall back to the caller-provided name, with safe defaults."""
+        f = tmp_path / "noframe.md"
+        f.write_text("just markdown body, no frontmatter\n", encoding="utf-8")
+
+        result: dict[str, Any] = _load_mode_file_metadata(f, "noframe")
+
+        assert result["name"] == "noframe"
+        assert result["advertised"] is True
+        assert result["contributes"] == {}
+
+    def test_contributes_explicit_null_yields_empty_dict(self, tmp_path: Path) -> None:
+        """Explicit null contributes: (no value) is coerced to empty dict via `or {}`."""
+        f = tmp_path / "nullcontrib.md"
+        f.write_text(
+            "---\nmode:\n  name: nullcontrib\n  contributes:\n---\n",
+            encoding="utf-8",
+        )
+
+        result: dict[str, Any] = _load_mode_file_metadata(f, "nullcontrib")
+
+        assert result["contributes"] == {}

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -184,3 +184,54 @@ class TestS1AgentPath:
 
         # Baseline agent must still be present
         assert "baseline-agent" in coordinator.config["agents"]
+
+
+# ---------------------------------------------------------------------------
+# Context capability tests
+# ---------------------------------------------------------------------------
+
+
+class TestContextCapability:
+    """Tests: mode_overlay_context capability via apply / revoke."""
+
+    @pytest.mark.asyncio
+    async def test_context_apply_registers_capability(
+        self, overlay: RuntimeOverlay, coordinator: MagicMock
+    ) -> None:
+        """apply() with context paths registers mode_overlay_context capability."""
+        contributions = {
+            "context": ["@modes:context/schema.md", "@modes:context/anti-patterns.md"]
+        }
+        await overlay.apply("mode:demo", contributions)
+
+        cap = coordinator.get_capability("mode_overlay_context")
+        assert cap == ["@modes:context/schema.md", "@modes:context/anti-patterns.md"]
+
+    @pytest.mark.asyncio
+    async def test_context_revoke_clears_capability(
+        self, overlay: RuntimeOverlay, coordinator: MagicMock
+    ) -> None:
+        """revoke() clears mode_overlay_context capability."""
+        contributions = {"context": ["@modes:context/schema.md"]}
+        await overlay.apply("mode:demo", contributions)
+        await overlay.revoke("mode:demo")
+
+        cap = coordinator.get_capability("mode_overlay_context") or []
+        assert cap == []
+
+    @pytest.mark.asyncio
+    async def test_context_revoke_keeps_paths_referenced_by_other_scope(
+        self, overlay: RuntimeOverlay, coordinator: MagicMock
+    ) -> None:
+        """revoke() only removes paths whose refcount drops to zero.
+
+        A shared path applied under two scopes survives when only one revokes.
+        """
+        shared_path = "@modes:context/shared.md"
+        await overlay.apply("mode:m1", {"context": [shared_path]})
+        await overlay.apply("mode:m2", {"context": [shared_path]})
+
+        await overlay.revoke("mode:m1")
+
+        cap = coordinator.get_capability("mode_overlay_context") or []
+        assert shared_path in cap

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -422,3 +422,16 @@ class TestEventEmission:
         )
         assert result.success is True
         assert "a1" in coordinator.config["agents"]
+
+
+# ---------------------------------------------------------------------------
+# Package-level export tests
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_overlay_exported_from_configurator_package() -> None:
+    """RuntimeOverlay and TransitionResult are importable from the configurator package root."""
+    from amplifier_foundation.configurator import RuntimeOverlay, TransitionResult
+
+    assert RuntimeOverlay is not None
+    assert TransitionResult is not None

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -562,8 +562,108 @@ class TestDebugMethods:
         assert "mode:demo" in state["scope_claims"]
 
         # refcounts: (agents, mode-author) must have refcount >= 1
-        rc = {str(k): v for k, v in state["refcounts"].items()}
         assert any("mode-author" in str(k) for k in state["refcounts"])
 
         # owned: agents key must list mode-author
         assert "mode-author" in state["owned"].get("agents", [])
+
+
+# ---------------------------------------------------------------------------
+# Item 5: _owned / _refcounts invariant
+# ---------------------------------------------------------------------------
+
+
+def _assert_owned_refcount_invariant(overlay: RuntimeOverlay, label: str = "") -> None:
+    """Assert that _owned and _refcounts are in sync.
+
+    Invariant (for overlays with no session-baseline agents):
+      For every category C in overlay._owned:
+          set(_owned[C].keys())
+          == { k  for (C2, k), rc in _refcounts.items()  if C2 == C and rc > 0 }
+
+    In other words: every key in _owned[C] has a positive refcount, and every
+    key with a positive refcount in category C is present in _owned[C].
+
+    Note: this invariant assumes the overlay was created with no initial
+    session-baseline agents.  Baseline agents appear in _refcounts (rc=1) but
+    NOT in _owned (they were never mounted by the overlay).  The test below
+    uses an overlay with an empty agent baseline to avoid that asymmetry.
+    """
+    for category, owned_dict in overlay._owned.items():
+        owned_keys = set(owned_dict.keys())
+        positive_rc_keys = {
+            k
+            for (cat, k), rc in overlay._refcounts.items()
+            if cat == category and rc > 0
+        }
+        tag = f" [{label}]" if label else ""
+        assert owned_keys == positive_rc_keys, (
+            f"Invariant violated{tag} for category={category!r}: "
+            f"_owned keys={owned_keys} != positive-refcount keys={positive_rc_keys}"
+        )
+
+
+class TestOwnedRefcountInvariant:
+    """Invariant: _owned and _refcounts stay in sync across apply/revoke sequences."""
+
+    @pytest.mark.asyncio
+    async def test_invariant_holds_across_apply_revoke_sequence(self) -> None:
+        """After each step in a multi-scope sequence the _owned/_refcount invariant holds.
+
+        Sequence:
+          0. initial state (nothing applied)
+          1. apply scope-A: agent-x + context-path-1
+          2. apply scope-B: agent-x (overlap) + context-path-2
+          3. revoke scope-A: agent-x rc 2→1 (stays owned), path-1 rc 1→0 (unmounted)
+          4. revoke scope-B: agent-x rc 1→0 (unmounted), path-2 rc 1→0 (unmounted)
+
+        The overlay is created with NO initial agents so the baseline is empty
+        and the clean invariant (owned == positive-refcount-keys) holds at all
+        steps for all categories.
+        """
+        # Start with an empty-baseline overlay
+        coordinator = _make_coordinator(initial_agents=None)
+        ov = RuntimeOverlay(
+            coordinator,
+            success_event="mode:transition_completed",
+            failure_event="mode:activation_failed",
+        )
+
+        _assert_owned_refcount_invariant(ov, "initial")
+
+        # Step 1: apply scope-A
+        await ov.apply(
+            "scope-A",
+            {
+                "agents": {"agent-x": {"description": "x"}},
+                "context": ["@modes:context/path-1.md"],
+            },
+        )
+        _assert_owned_refcount_invariant(ov, "after apply scope-A")
+
+        # Step 2: apply scope-B (agent-x overlaps; path-2 is new)
+        await ov.apply(
+            "scope-B",
+            {
+                "agents": {"agent-x": {"description": "y"}},
+                "context": ["@modes:context/path-2.md"],
+            },
+        )
+        _assert_owned_refcount_invariant(ov, "after apply scope-B")
+
+        # Step 3: revoke scope-A (agent-x rc 2→1: stays; path-1 rc 1→0: unmounted)
+        await ov.revoke("scope-A")
+        _assert_owned_refcount_invariant(ov, "after revoke scope-A")
+
+        # Spot-check: agent-x still owned (rc=1), path-1 gone, path-2 still owned
+        assert ov.get_refcount("agents", "agent-x") == 1
+        assert ov.get_refcount("context", "@modes:context/path-1.md") == 0
+        assert ov.get_refcount("context", "@modes:context/path-2.md") == 1
+
+        # Step 4: revoke scope-B (agent-x rc 1→0: unmounted; path-2 rc 1→0: unmounted)
+        await ov.revoke("scope-B")
+        _assert_owned_refcount_invariant(ov, "after revoke scope-B")
+
+        # Everything fully unmounted
+        assert ov.get_refcount("agents", "agent-x") == 0
+        assert ov.get_refcount("context", "@modes:context/path-2.md") == 0

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -108,3 +108,79 @@ class TestS2AgentPath:
 
         assert result.success is True
         assert result.unmounted == []
+
+
+# ---------------------------------------------------------------------------
+# S1 tests: agent declared in both session baseline and mode contribution
+# ---------------------------------------------------------------------------
+
+
+class TestS1AgentPath:
+    """S1 tests: agent overlap with session baseline.
+
+    S1 invariant: when the same agent name is declared in the session baseline
+    AND contributed by a mode, the refcount goes 1→2 on apply (no remount, no
+    config replacement) and 2→1 on revoke (no unmount, agent stays).  §7.
+    """
+
+    @pytest.mark.asyncio
+    async def test_s1_agent_in_session_and_mode_no_unmount_on_revoke(self) -> None:
+        """S1: mode apply does not replace session-level config; revoke does not unmount.
+
+        Trace:
+          _capture_baseline → refcounts[('agents','mode-author')] = 1
+          apply → _increment → before=1, rc=2, _mount NOT called (before != 0)
+          revoke → _decrement → before=2, rc=1, _unmount NOT called (new_rc != 0)
+        """
+        coordinator = _make_coordinator(
+            initial_agents={"mode-author": {"description": "session-level"}}
+        )
+        overlay = RuntimeOverlay(
+            coordinator,
+            success_event="mode:transition_completed",
+            failure_event="mode:activation_failed",
+        )
+
+        # Apply mode with same agent name but a different (mode-level) description
+        result = await overlay.apply(
+            "mode:demo",
+            {"agents": {"mode-author": {"description": "mode-level"}}},
+        )
+        assert result.success is True
+
+        # S1 invariant: session-level config must NOT be replaced by mode contribution
+        assert (
+            coordinator.config["agents"]["mode-author"]["description"]
+            == "session-level"
+        )
+
+        # Revoke: refcount went 2→1 — agent must still be present with session-level desc
+        await overlay.revoke("mode:demo")
+        assert "mode-author" in coordinator.config["agents"]
+        assert (
+            coordinator.config["agents"]["mode-author"]["description"]
+            == "session-level"
+        )
+
+    @pytest.mark.asyncio
+    async def test_s1_baseline_agent_not_added_by_mode_apply_alone(self) -> None:
+        """S1: baseline agent persists after apply+revoke of mode with empty agents.
+
+        A mode that contributes no agents must not disturb the session baseline.
+        """
+        coordinator = _make_coordinator(
+            initial_agents={"baseline-agent": {"description": "baseline"}}
+        )
+        overlay = RuntimeOverlay(
+            coordinator,
+            success_event="mode:transition_completed",
+            failure_event="mode:activation_failed",
+        )
+
+        # Apply a mode that contributes nothing to agents
+        await overlay.apply("mode:demo", {"agents": {}})
+        # Revoke that mode
+        await overlay.revoke("mode:demo")
+
+        # Baseline agent must still be present
+        assert "baseline-agent" in coordinator.config["agents"]

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -295,3 +295,68 @@ class TestSkillsCapability:
         assert "mode-author" not in coordinator.config["agents"]
         assert (coordinator.get_capability("mode_overlay_context") or []) == []
         assert (coordinator.get_capability("mode_overlay_skills") or []) == []
+
+
+# ---------------------------------------------------------------------------
+# Rollback tests (§6 step 9, §12)
+# ---------------------------------------------------------------------------
+
+
+class TestRollback:
+    """Atomic rollback: prior mounts unwound in reverse when apply() fails mid-way."""
+
+    @pytest.mark.asyncio
+    async def test_apply_rollback_on_invalid_agent_payload(
+        self, overlay: RuntimeOverlay, coordinator: MagicMock
+    ) -> None:
+        """apply() failure mid-way rolls back prior mounts and leaves scope unapplied.
+
+        Sequence:
+          1. context contribution processed first (succeeds → mounted)
+          2. agents contribution processed next → _normalise_agents raises ValueError
+             for 'bad-agent': 'not-a-dict'
+          3. rollback unwinds context mount in reverse → context capability drops to []
+          4. scope NOT added to _scope_claims → retry with valid payload succeeds
+        """
+        bad_contributions = {
+            "context": ["@modes:context/ok.md"],
+            "agents": {"bad-agent": "not-a-dict"},
+        }
+        result = await overlay.apply("mode:bad", bad_contributions)
+
+        # Result must indicate failure with a descriptive error
+        assert result.success is False
+        assert result.error is not None
+        assert "bad-agent" in result.error or "dict" in result.error.lower()
+
+        # Context capability must have been rolled back (it was mounted, then unwound)
+        cap = coordinator.get_capability("mode_overlay_context") or []
+        assert cap == []
+
+        # bad-agent must not be in coordinator.config['agents']
+        assert "bad-agent" not in coordinator.config["agents"]
+
+        # Scope must NOT be marked applied — retry with valid payload must succeed
+        result2 = await overlay.apply(
+            "mode:bad", {"agents": {"good-agent": {"description": "x"}}}
+        )
+        assert result2.success is True
+        assert "good-agent" in coordinator.config["agents"]
+
+    @pytest.mark.asyncio
+    async def test_apply_rollback_emits_failure_event(self) -> None:
+        """apply() failure emits the failure event and does NOT emit the success event."""
+        coordinator = _make_coordinator()
+        fresh_overlay = RuntimeOverlay(
+            coordinator,
+            success_event="mode:transition_completed",
+            failure_event="mode:activation_failed",
+        )
+
+        await fresh_overlay.apply("mode:bad", {"agents": {"x": "not-a-dict"}})
+
+        emitted_events = [
+            call.args[0] for call in coordinator.hooks.emit.call_args_list
+        ]
+        assert "mode:activation_failed" in emitted_events
+        assert "mode:transition_completed" not in emitted_events

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -235,3 +235,63 @@ class TestContextCapability:
 
         cap = coordinator.get_capability("mode_overlay_context") or []
         assert shared_path in cap
+
+
+# ---------------------------------------------------------------------------
+# Skills capability tests
+# ---------------------------------------------------------------------------
+
+
+class TestSkillsCapability:
+    """Tests: mode_overlay_skills capability via apply / revoke."""
+
+    @pytest.mark.asyncio
+    async def test_skills_apply_registers_capability(
+        self, overlay: RuntimeOverlay, coordinator: MagicMock
+    ) -> None:
+        """apply() with skills paths registers mode_overlay_skills capability."""
+        contributions = {"skills": ["@modes:skills/mode-design-discipline"]}
+        await overlay.apply("mode:demo", contributions)
+
+        cap = coordinator.get_capability("mode_overlay_skills")
+        assert cap == ["@modes:skills/mode-design-discipline"]
+
+    @pytest.mark.asyncio
+    async def test_skills_revoke_clears_capability(
+        self, overlay: RuntimeOverlay, coordinator: MagicMock
+    ) -> None:
+        """revoke() clears mode_overlay_skills capability."""
+        contributions = {"skills": ["@modes:skills/mode-design-discipline"]}
+        await overlay.apply("mode:demo", contributions)
+        await overlay.revoke("mode:demo")
+
+        cap = coordinator.get_capability("mode_overlay_skills") or []
+        assert cap == []
+
+    @pytest.mark.asyncio
+    async def test_mixed_categories_in_one_apply(
+        self, overlay: RuntimeOverlay, coordinator: MagicMock
+    ) -> None:
+        """apply() with agents+context+skills mounts all three atomically; revoke unwinds all."""
+        contributions = {
+            "agents": {"mode-author": {"description": "x"}},
+            "context": ["@modes:context/schema.md"],
+            "skills": ["@modes:skills/mode-design-discipline"],
+        }
+        await overlay.apply("mode:demo", contributions)
+
+        # All three categories mounted
+        assert "mode-author" in coordinator.config["agents"]
+        assert coordinator.get_capability("mode_overlay_context") == [
+            "@modes:context/schema.md"
+        ]
+        assert coordinator.get_capability("mode_overlay_skills") == [
+            "@modes:skills/mode-design-discipline"
+        ]
+
+        # Revoke unwinds all three atomically
+        await overlay.revoke("mode:demo")
+
+        assert "mode-author" not in coordinator.config["agents"]
+        assert (coordinator.get_capability("mode_overlay_context") or []) == []
+        assert (coordinator.get_capability("mode_overlay_skills") or []) == []

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -489,3 +489,81 @@ class TestRevokeFailureEvent:
         assert "mode:transition_completed" not in emitted_events, (
             f"success_event was incorrectly emitted on failure; emitted: {emitted_events}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Item 4: debug methods — get_refcount and dump_state
+# ---------------------------------------------------------------------------
+
+
+class TestDebugMethods:
+    """Tests: get_refcount() and dump_state() introspection helpers."""
+
+    @pytest.mark.asyncio
+    async def test_get_refcount_returns_zero_for_unknown_key(
+        self, overlay: RuntimeOverlay
+    ) -> None:
+        """get_refcount() returns 0 for a key that has never been applied (no raise)."""
+        assert overlay.get_refcount("agents", "nonexistent") == 0
+
+    @pytest.mark.asyncio
+    async def test_get_refcount_reflects_applied_scope(
+        self, overlay: RuntimeOverlay
+    ) -> None:
+        """get_refcount() returns 1 after a scope contributes an agent."""
+        await overlay.apply(
+            "mode:demo", {"agents": {"mode-author": {"description": "x"}}}
+        )
+        assert overlay.get_refcount("agents", "mode-author") == 1
+
+    @pytest.mark.asyncio
+    async def test_get_refcount_increments_with_two_scopes(
+        self, overlay: RuntimeOverlay
+    ) -> None:
+        """get_refcount() returns 2 when two scopes contribute the same item."""
+        await overlay.apply(
+            "mode:demo1", {"agents": {"shared-agent": {"description": "x"}}}
+        )
+        await overlay.apply(
+            "mode:demo2", {"agents": {"shared-agent": {"description": "y"}}}
+        )
+        assert overlay.get_refcount("agents", "shared-agent") == 2
+
+    @pytest.mark.asyncio
+    async def test_get_refcount_drops_to_zero_after_revoke(
+        self, overlay: RuntimeOverlay
+    ) -> None:
+        """get_refcount() returns 0 after the only referencing scope is revoked."""
+        await overlay.apply(
+            "mode:demo", {"agents": {"mode-author": {"description": "x"}}}
+        )
+        await overlay.revoke("mode:demo")
+        assert overlay.get_refcount("agents", "mode-author") == 0
+
+    @pytest.mark.asyncio
+    async def test_dump_state_returns_expected_structure(
+        self, overlay: RuntimeOverlay
+    ) -> None:
+        """dump_state() returns scope_claims, refcounts, and owned keys."""
+        await overlay.apply(
+            "mode:demo",
+            {
+                "agents": {"mode-author": {"description": "x"}},
+                "context": ["@modes:context/schema.md"],
+            },
+        )
+        state = overlay.dump_state()
+
+        assert "scope_claims" in state
+        assert "refcounts" in state
+        assert "owned" in state
+
+        # scope_claims: mode:demo must be present
+        assert "mode:demo" in state["scope_claims"]
+
+        # refcounts: (agents, mode-author) must have refcount >= 1
+        rc = {str(k): v for k, v in state["refcounts"].items()}
+        assert any("mode-author" in str(k) for k in state["refcounts"])
+
+        # owned: agents key must list mode-author
+        assert "mode-author" in state["owned"].get("agents", [])

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -360,3 +360,65 @@ class TestRollback:
         ]
         assert "mode:activation_failed" in emitted_events
         assert "mode:transition_completed" not in emitted_events
+
+
+# ---------------------------------------------------------------------------
+# Event emission contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestEventEmission:
+    """Tests: event-emission contract for apply() and revoke()."""
+
+    @pytest.mark.asyncio
+    async def test_apply_emits_success_event_with_payload(
+        self, overlay: RuntimeOverlay, coordinator: MagicMock
+    ) -> None:
+        """apply() emits success_event with scope, success=True, and mounted delta."""
+        await overlay.apply("mode:demo", {"agents": {"a1": {"description": "x"}}})
+
+        success_calls = [
+            c
+            for c in coordinator.hooks.emit.call_args_list
+            if c.args[0] == "mode:transition_completed"
+        ]
+        assert len(success_calls) == 1
+        payload = success_calls[0].args[1]
+        assert payload["scope"] == "mode:demo"
+        assert payload["success"] is True
+        assert ("agents", "a1") in payload["mounted"]
+
+    @pytest.mark.asyncio
+    async def test_revoke_emits_success_event_with_unmounted(
+        self, overlay: RuntimeOverlay, coordinator: MagicMock
+    ) -> None:
+        """revoke() emits success_event with scope and unmounted delta."""
+        await overlay.apply("mode:demo", {"agents": {"a1": {"description": "x"}}})
+        coordinator.hooks.emit.reset_mock()
+        await overlay.revoke("mode:demo")
+
+        success_calls = [
+            c
+            for c in coordinator.hooks.emit.call_args_list
+            if c.args[0] == "mode:transition_completed"
+        ]
+        assert len(success_calls) == 1
+        payload = success_calls[0].args[1]
+        assert payload["scope"] == "mode:demo"
+        assert ("agents", "a1") in payload["unmounted"]
+
+    @pytest.mark.asyncio
+    async def test_event_emit_failure_does_not_break_apply(self) -> None:
+        """emit-side failures are swallowed (best-effort) and apply still succeeds."""
+        coordinator = _make_coordinator()
+        coordinator.hooks.emit.side_effect = RuntimeError("hook bus on fire")
+        fresh_overlay = RuntimeOverlay(
+            coordinator,
+            success_event="mode:transition_completed",
+            failure_event="mode:activation_failed",
+        )
+        result = await fresh_overlay.apply(
+            "mode:demo", {"agents": {"a1": {"description": "x"}}}
+        )
+        assert result.success is True
+        assert "a1" in coordinator.config["agents"]

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -435,3 +435,57 @@ def test_runtime_overlay_exported_from_configurator_package() -> None:
 
     assert RuntimeOverlay is not None
     assert TransitionResult is not None
+
+
+# ---------------------------------------------------------------------------
+# Item 1: revoke() failure event emission
+# ---------------------------------------------------------------------------
+
+
+class TestRevokeFailureEvent:
+    """Tests: revoke() emits failure_event when unmount raises, not success_event."""
+
+    @pytest.mark.asyncio
+    async def test_revoke_emits_failure_event_on_unmount_error(self) -> None:
+        """revoke() emits failure_event (not success_event) when _decrement raises.
+
+        The bug: revoke() always emits self._success_event at the end, even
+        after setting result.success = False due to an unmount exception.
+        """
+        coordinator = _make_coordinator()
+        fresh_overlay = RuntimeOverlay(
+            coordinator,
+            success_event="mode:transition_completed",
+            failure_event="mode:activation_failed",
+        )
+
+        # Apply a scope successfully
+        await fresh_overlay.apply(
+            "mode:demo",
+            {"agents": {"mode-author": {"description": "x"}}},
+        )
+        coordinator.hooks.emit.reset_mock()
+
+        # Monkey-patch _decrement to raise on the specific agent key
+        original_decrement = fresh_overlay._decrement
+
+        def failing_decrement(category: str, key: str) -> None:
+            if category == "agents" and key == "mode-author":
+                raise RuntimeError("simulated unmount failure")
+            return original_decrement(category, key)
+
+        fresh_overlay._decrement = failing_decrement  # type: ignore[method-assign]
+
+        result = await fresh_overlay.revoke("mode:demo")
+
+        assert result.success is False
+
+        emitted_events = [
+            call.args[0] for call in coordinator.hooks.emit.call_args_list
+        ]
+        assert "mode:activation_failed" in emitted_events, (
+            f"failure_event not emitted; emitted: {emitted_events}"
+        )
+        assert "mode:transition_completed" not in emitted_events, (
+            f"success_event was incorrectly emitted on failure; emitted: {emitted_events}"
+        )

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,0 +1,110 @@
+"""Tests for RuntimeOverlay - Phase 1 (S1 session baseline overlap + S2 mode-only).
+
+S1 (overlap with session baseline) and S2 (mode-only) for agent/context/skill categories.
+S3/S4 deferred to Phase 3.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amplifier_foundation.configurator._overlay import RuntimeOverlay, TransitionResult
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_coordinator(initial_agents=None, initial_capabilities=None):
+    """Build a MagicMock coordinator following test_configurator.py pattern.
+
+    Returns a MagicMock with:
+        .config = {'agents': dict(initial_agents or {})}
+        .register_capability / .get_capability backed by a capability_store dict
+        .hooks = MagicMock() with .hooks.emit = AsyncMock()
+    """
+    coordinator = MagicMock()
+    coordinator.config = {"agents": dict(initial_agents or {})}
+
+    capability_store: dict = dict(initial_capabilities or {})
+
+    def _register_capability(name, value):
+        capability_store[name] = value
+
+    def _get_capability(name):
+        return capability_store.get(name)
+
+    coordinator.register_capability = MagicMock(side_effect=_register_capability)
+    coordinator.get_capability = MagicMock(side_effect=_get_capability)
+    coordinator.hooks = MagicMock()
+    coordinator.hooks.emit = AsyncMock()
+
+    return coordinator
+
+
+@pytest.fixture
+def coordinator():
+    """Bare coordinator with no initial agents."""
+    return _make_coordinator()
+
+
+@pytest.fixture
+def overlay(coordinator):
+    """RuntimeOverlay bound to coordinator with canonical mode event names."""
+    return RuntimeOverlay(
+        coordinator,
+        success_event="mode:transition_completed",
+        failure_event="mode:activation_failed",
+    )
+
+
+# ---------------------------------------------------------------------------
+# S2 tests: mode-only agent contributions (no session baseline overlap)
+# ---------------------------------------------------------------------------
+
+
+class TestS2AgentPath:
+    """S2 tests: mode-only agent contributions (no session baseline overlap)."""
+
+    @pytest.mark.asyncio
+    async def test_s2_agent_apply_mounts_into_coordinator_config(
+        self, overlay: RuntimeOverlay, coordinator: MagicMock
+    ) -> None:
+        """apply() for agents category mounts agent into coordinator.config['agents']."""
+        contributions = {
+            "agents": {"mode-author": {"description": "A mode-author agent"}}
+        }
+        result: TransitionResult = await overlay.apply("mode:demo", contributions)
+
+        assert result.success is True
+        assert "mode-author" in coordinator.config["agents"]
+        assert (
+            coordinator.config["agents"]["mode-author"]["description"]
+            == "A mode-author agent"
+        )
+
+    @pytest.mark.asyncio
+    async def test_s2_agent_revoke_unmounts(
+        self, overlay: RuntimeOverlay, coordinator: MagicMock
+    ) -> None:
+        """revoke() removes previously applied agent from coordinator.config['agents']."""
+        contributions = {
+            "agents": {"mode-author": {"description": "A mode-author agent"}}
+        }
+
+        await overlay.apply("mode:demo", contributions)
+        assert "mode-author" in coordinator.config["agents"]
+
+        result = await overlay.revoke("mode:demo")
+
+        assert result.success is True
+        assert "mode-author" not in coordinator.config["agents"]
+
+    @pytest.mark.asyncio
+    async def test_revoke_unknown_scope_is_noop(self, overlay: RuntimeOverlay) -> None:
+        """revoke() on a scope that was never applied returns success with empty unmounted list."""
+        result = await overlay.revoke("mode:never-applied")
+
+        assert result.success is True
+        assert result.unmounted == []

--- a/tests/test_top_level_exports.py
+++ b/tests/test_top_level_exports.py
@@ -1,0 +1,58 @@
+"""Tests for top-level amplifier_foundation package exports.
+
+Ensures that key classes added in Phase 1 (RuntimeOverlay, TransitionResult)
+are importable directly from the top-level amplifier_foundation namespace,
+not only from amplifier_foundation.configurator.
+
+Regression guard: hooks-mode does
+    from amplifier_foundation import RuntimeOverlay
+at module load time inside _get_or_create_overlay().  If the top-level
+__init__.py does not re-export the class, every mode activation raises
+ImportError at runtime — not at import time, because the import is lazy.
+"""
+
+from __future__ import annotations
+
+
+class TestRuntimeOverlayTopLevelExport:
+    """RuntimeOverlay must be importable from the top-level package."""
+
+    def test_runtime_overlay_importable_from_top_level(self) -> None:
+        from amplifier_foundation import RuntimeOverlay  # noqa: F401
+
+        assert RuntimeOverlay is not None
+
+    def test_transition_result_importable_from_top_level(self) -> None:
+        from amplifier_foundation import TransitionResult  # noqa: F401
+
+        assert TransitionResult is not None
+
+    def test_top_level_and_submodule_runtime_overlay_are_same_class(self) -> None:
+        """Top-level import and submodule import must resolve to the same class object."""
+        from amplifier_foundation import RuntimeOverlay as TopLevel
+        from amplifier_foundation.configurator import RuntimeOverlay as SubModule
+
+        assert TopLevel is SubModule
+
+    def test_top_level_and_submodule_transition_result_are_same_class(self) -> None:
+        """Top-level import and submodule import must resolve to the same class object."""
+        from amplifier_foundation import TransitionResult as TopLevel
+        from amplifier_foundation.configurator import TransitionResult as SubModule
+
+        assert TopLevel is SubModule
+
+    def test_runtime_overlay_in_dunder_all(self) -> None:
+        """RuntimeOverlay must appear in __all__ so `from amplifier_foundation import *` works."""
+        import amplifier_foundation
+
+        assert "RuntimeOverlay" in amplifier_foundation.__all__, (
+            "RuntimeOverlay missing from amplifier_foundation.__all__"
+        )
+
+    def test_transition_result_in_dunder_all(self) -> None:
+        """TransitionResult must appear in __all__."""
+        import amplifier_foundation
+
+        assert "TransitionResult" in amplifier_foundation.__all__, (
+            "TransitionResult missing from amplifier_foundation.__all__"
+        )


### PR DESCRIPTION
## Summary

Introduces a new foundation-level primitive `RuntimeOverlay` for atomic, refcount-aware runtime capability overlays. Enables downstream consumers (starting with the modes bundle) to lazily mount agents/context/skills on activation and unmount cleanly on deactivation, with correct refcount semantics across overlap scenarios.

## Changes

- New: `RuntimeOverlay` and `TransitionResult` in `amplifier_foundation.configurator._overlay`, re-exported at package top level alongside existing utilities (`bridge_child_cost`, `generate_sub_session_id`)
- New: `_load_mode_file_metadata()` schema-only parser for mode `.md` frontmatter (mirrors the agent-spawn `_load_agent_file_metadata` pattern from #190)
- New: `Bundle.validate_modes()` walk in `Bundle.prepare()` — schema validation with inner shape checks; warnings surfaced via `PreparedBundle.mode_warnings` (new field)
- New: Debug methods `RuntimeOverlay.get_refcount(category, key)` and `RuntimeOverlay.dump_state()` for incident debugging
- Fix: `RuntimeOverlay.revoke()` emits failure_event (not success_event) on partial unmount failure
- Tests: +23 new tests; full suite 1289 → 1312 passing

## Why

Modes today can declare tool *policies* but cannot bring in additional capabilities. This adds the foundation primitive that enables modes to package speculative or token-heavy capabilities behind activation — zero attention cost when inactive, atomic apply/revoke when active.

The design is documented at `docs/designs/MODE_RUNTIME_OVERLAYS.md` in the companion bundle PR (see below).

## Test Plan

- [x] 1312 foundation tests passing (full suite, no regressions; includes +23 new tests for overlay + schema validation)
- [x] Pyright clean on production code
- [x] Top-level imports verified: `from amplifier_foundation import RuntimeOverlay, TransitionResult, bridge_child_cost, generate_sub_session_id` succeeds
- [x] End-to-end validated via amplifier-bundle-modes companion PR — DTU with real LLM calls, BEFORE/DURING/AFTER scenarios all pass
- [x] Independent context-intelligence event-log audit: 0 anomalies

## Companion PR

Will be filled in after modes-bundle PR creation.