### PR TITLE
fix(agents): drop redundant provider_preferences from agents that declare model_role

### DIFF
--- a/agents/bug-hunter.md
+++ b/agents/bug-hunter.md
@@ -5,24 +5,6 @@ meta:
 
 model_role: [coding, general]
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]-codex
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]-codex
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/ecosystem-expert.md
+++ b/agents/ecosystem-expert.md
@@ -42,20 +42,6 @@ meta:
 
 model_role: general
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-bash
     source: git+https://github.com/microsoft/amplifier-module-tool-bash@main

--- a/agents/explorer.md
+++ b/agents/explorer.md
@@ -5,20 +5,6 @@ meta:
 
 model_role: general
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/file-ops.md
+++ b/agents/file-ops.md
@@ -32,20 +32,6 @@ File-ops provides grep capabilities for content search with context lines.
 
 model_role: fast
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/foundation-expert.md
+++ b/agents/foundation-expert.md
@@ -5,20 +5,6 @@ meta:
 
 model_role: general
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/git-ops.md
+++ b/agents/git-ops.md
@@ -5,20 +5,6 @@ meta:
 
 model_role: fast
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
-
 tools:
   - module: tool-bash
     source: git+https://github.com/microsoft/amplifier-module-tool-bash@main

--- a/agents/integration-specialist.md
+++ b/agents/integration-specialist.md
@@ -5,20 +5,6 @@ meta:
 
 model_role: general
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/modular-builder.md
+++ b/agents/modular-builder.md
@@ -49,24 +49,6 @@ meta:
 
 model_role: [coding, general]
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]-codex
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]-codex
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/post-task-cleanup.md
+++ b/agents/post-task-cleanup.md
@@ -5,20 +5,6 @@ meta:
 
 model_role: fast
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/security-guardian.md
+++ b/agents/security-guardian.md
@@ -15,22 +15,6 @@ Covers: OWASP Top 10, hardcoded secrets detection, input/output validation, cryp
 
 model_role: [security-audit, critique, general]
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-opus-*
-  - provider: openai
-    model: gpt-5*-pro
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-opus-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/session-analyst.md
+++ b/agents/session-analyst.md
@@ -5,20 +5,6 @@ meta:
 
 model_role: fast
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/shell-exec.md
+++ b/agents/shell-exec.md
@@ -40,20 +40,6 @@ Shell-exec handles system commands safely with proper output capture.
 
 model_role: fast
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
-
 tools:
   - module: tool-bash
     source: git+https://github.com/microsoft/amplifier-module-tool-bash@main

--- a/agents/test-coverage.md
+++ b/agents/test-coverage.md
@@ -5,24 +5,6 @@ meta:
 
 model_role: [coding, general]
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-sonnet-*
-  - provider: openai
-    model: gpt-5.[0-9]-codex
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-sonnet-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]-codex
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main

--- a/agents/web-research.md
+++ b/agents/web-research.md
@@ -32,20 +32,6 @@ Web-research excels at finding external examples and community best practices.
 
 model_role: fast
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-haiku-*
-  - provider: openai
-    model: gpt-5-mini
-  - provider: openai
-    model: gpt-5-nano
-  - provider: google
-    model: gemini-*-flash
-  - provider: github-copilot
-    model: claude-haiku-*
-  - provider: github-copilot
-    model: gpt-5-mini
-
 tools:
   - module: tool-web
     source: git+https://github.com/microsoft/amplifier-module-tool-web@main

--- a/agents/zen-architect.md
+++ b/agents/zen-architect.md
@@ -5,22 +5,6 @@ meta:
 
 model_role: [reasoning, general]
 
-provider_preferences:
-  - provider: anthropic
-    model: claude-opus-*
-  - provider: openai
-    model: gpt-5*-pro
-  - provider: openai
-    model: gpt-5.[0-9]
-  - provider: google
-    model: gemini-*-pro-preview
-  - provider: google
-    model: gemini-*-pro
-  - provider: github-copilot
-    model: claude-opus-*
-  - provider: github-copilot
-    model: gpt-5.[0-9]
-
 tools:
   - module: tool-filesystem
     source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main


### PR DESCRIPTION
# Summary

Part of a coordinated 3-repo PR set that documents the spawn-time and resolver-time precedence policies that emerged from the recent `model_role_resolver` capability rename. No behavior change in any of the three — these are docs + dead-config cleanup.

# Context

After landing the `routing_matrix` → `model_role_resolver` rename (the prior 5-PR set), an audit surfaced that:

1. Spawn-time precedence (caller-passed prefs > agent overlay > parent defaults) was implicit in code comments + one test, never documented.
2. `hooks-routing.on_session_start` overwrites `agent_cfg["provider_preferences"]` with matrix-resolved values whenever `model_role` is declared — intentional matrix-strategy behavior, never documented.
3. Most foundation agents declared BOTH `model_role:` and `provider_preferences:` — the latter was being silently overwritten every session. Dead config.

The implicit precedence is intentional. The user's framing (per session discussion):

> Hard-pinned `provider_preferences` is the fallback when `model_role` isn't set. When `model_role` is set, the matrix wins — that's the whole point of the matrix strategy. Authors who want a fixed pin should omit `model_role`.

This PR set codifies that contract in the appropriate place per repo ownership:
- The **spawner** (app-cli) owns spawn-time precedence policy.
- The **matrix-strategy bundle** (routing-matrix) owns the clobber policy. Future routing-strategy bundles registering `model_role_resolver` MAY choose different interaction semantics.
- The **foundation agent set** is updated to match the documented invariant.

# Cross-repo PR set

- microsoft/amplifier-app-cli#??? — spawn-time precedence doc
- microsoft/amplifier-bundle-routing-matrix#??? — clobber policy doc
- microsoft/amplifier-foundation#??? — dead-config cleanup

Merge order doesn't matter (no consumer breaks). Land together for clarity.

# What changed in this repo

**Agent frontmatter cleanup. No behavior change.**

15 of 16 agents in `agents/*.md` declared BOTH `model_role:` AND `provider_preferences:`. Per the documented matrix-strategy behavior (companion PR microsoft/amplifier-bundle-routing-matrix#???), the hard-pinned `provider_preferences` is overwritten at `session:start` and never reaches the spawner. Dead config.

This PR removes the unused `provider_preferences:` block from those 15 agents, leaving `model_role:` and all other frontmatter fields unchanged.

Agents touched (all had both fields):
- bug-hunter, ecosystem-expert, explorer, file-ops, foundation-expert, git-ops, integration-specialist, modular-builder, post-task-cleanup, security-guardian, session-analyst, shell-exec, test-coverage, web-research, zen-architect

Agents NOT touched (already clean):
- bundle-design-expert (declared `model_role:` only)

**Special note on `explorer.md`**: the removed list also contained two `provider: google` entries which were doubly-dead — the gemini provider mounts under `gemini` (per `MATRIX_CURATOR_GUIDE.md`), so they'd have been unresolvable even if the matrix clobber didn't kill the full list first. Both gone.

Net diff: 0 lines added, ~226 lines removed across 15 agent files.

# Verification

Two foundation test suites that parse agent frontmatter ran clean (24 passed):
- tests/test_agent_metadata.py
- tests/test_validate_agents_model_role.py

No behavior change — the routing hook was already overwriting these values on every session:start. The visible config now matches the actual runtime behavior.

# Follow-up

After this set merges, plan is to empirically verify the documented precedence via context-intelligence graph queries on a DTU session — check `provider:request` events against the documented contract to confirm the implementation matches the words. That's a separate dispatch, not part of this PR set.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
