### PR TITLE
fix(agents): correct provider name from "google" to "gemini" in agent frontmatter

### DIFF
--- a/agents/bug-hunter.md
+++ b/agents/bug-hunter.md
@@ -12,9 +12,9 @@ provider_preferences:
     model: gpt-5.[0-9]-codex
   - provider: openai
     model: gpt-5.[0-9]
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro-preview
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro
   - provider: github-copilot
     model: claude-sonnet-*

--- a/agents/ecosystem-expert.md
+++ b/agents/ecosystem-expert.md
@@ -47,9 +47,9 @@ provider_preferences:
     model: claude-sonnet-*
   - provider: openai
     model: gpt-5.[0-9]
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro-preview
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro
   - provider: github-copilot
     model: claude-sonnet-*

--- a/agents/explorer.md
+++ b/agents/explorer.md
@@ -10,9 +10,9 @@ provider_preferences:
     model: claude-sonnet-*
   - provider: openai
     model: gpt-5.[0-9]
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro-preview
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro
   - provider: github-copilot
     model: claude-sonnet-*

--- a/agents/file-ops.md
+++ b/agents/file-ops.md
@@ -39,7 +39,7 @@ provider_preferences:
     model: gpt-5-mini
   - provider: openai
     model: gpt-5-nano
-  - provider: google
+  - provider: gemini
     model: gemini-*-flash
   - provider: github-copilot
     model: claude-haiku-*

--- a/agents/foundation-expert.md
+++ b/agents/foundation-expert.md
@@ -10,9 +10,9 @@ provider_preferences:
     model: claude-sonnet-*
   - provider: openai
     model: gpt-5.[0-9]
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro-preview
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro
   - provider: github-copilot
     model: claude-sonnet-*

--- a/agents/git-ops.md
+++ b/agents/git-ops.md
@@ -12,7 +12,7 @@ provider_preferences:
     model: gpt-5-mini
   - provider: openai
     model: gpt-5-nano
-  - provider: google
+  - provider: gemini
     model: gemini-*-flash
   - provider: github-copilot
     model: claude-haiku-*

--- a/agents/integration-specialist.md
+++ b/agents/integration-specialist.md
@@ -10,9 +10,9 @@ provider_preferences:
     model: claude-sonnet-*
   - provider: openai
     model: gpt-5.[0-9]
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro-preview
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro
   - provider: github-copilot
     model: claude-sonnet-*

--- a/agents/modular-builder.md
+++ b/agents/modular-builder.md
@@ -56,9 +56,9 @@ provider_preferences:
     model: gpt-5.[0-9]-codex
   - provider: openai
     model: gpt-5.[0-9]
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro-preview
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro
   - provider: github-copilot
     model: claude-sonnet-*

--- a/agents/post-task-cleanup.md
+++ b/agents/post-task-cleanup.md
@@ -12,7 +12,7 @@ provider_preferences:
     model: gpt-5-mini
   - provider: openai
     model: gpt-5-nano
-  - provider: google
+  - provider: gemini
     model: gemini-*-flash
   - provider: github-copilot
     model: claude-haiku-*

--- a/agents/security-guardian.md
+++ b/agents/security-guardian.md
@@ -22,9 +22,9 @@ provider_preferences:
     model: gpt-5*-pro
   - provider: openai
     model: gpt-5.[0-9]
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro-preview
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro
   - provider: github-copilot
     model: claude-opus-*

--- a/agents/session-analyst.md
+++ b/agents/session-analyst.md
@@ -12,7 +12,7 @@ provider_preferences:
     model: gpt-5-mini
   - provider: openai
     model: gpt-5-nano
-  - provider: google
+  - provider: gemini
     model: gemini-*-flash
   - provider: github-copilot
     model: claude-haiku-*

--- a/agents/shell-exec.md
+++ b/agents/shell-exec.md
@@ -47,7 +47,7 @@ provider_preferences:
     model: gpt-5-mini
   - provider: openai
     model: gpt-5-nano
-  - provider: google
+  - provider: gemini
     model: gemini-*-flash
   - provider: github-copilot
     model: claude-haiku-*

--- a/agents/test-coverage.md
+++ b/agents/test-coverage.md
@@ -12,9 +12,9 @@ provider_preferences:
     model: gpt-5.[0-9]-codex
   - provider: openai
     model: gpt-5.[0-9]
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro-preview
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro
   - provider: github-copilot
     model: claude-sonnet-*

--- a/agents/web-research.md
+++ b/agents/web-research.md
@@ -39,7 +39,7 @@ provider_preferences:
     model: gpt-5-mini
   - provider: openai
     model: gpt-5-nano
-  - provider: google
+  - provider: gemini
     model: gemini-*-flash
   - provider: github-copilot
     model: claude-haiku-*

--- a/agents/zen-architect.md
+++ b/agents/zen-architect.md
@@ -12,9 +12,9 @@ provider_preferences:
     model: gpt-5*-pro
   - provider: openai
     model: gpt-5.[0-9]
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro-preview
-  - provider: google
+  - provider: gemini
     model: gemini-*-pro
   - provider: github-copilot
     model: claude-opus-*


### PR DESCRIPTION
# Summary

Narrow typo fix. Renames `provider: google` → `provider: gemini` across 15 agent files in `agents/*.md`. The gemini provider module (amplifier-module-provider-gemini) mounts under `gemini` in `coordinator.providers`, not `google` — per the 2026-04-22 note in [`amplifier-bundle-routing-matrix/docs/MATRIX_CURATOR_GUIDE.md`](https://github.com/microsoft/amplifier-bundle-routing-matrix/blob/main/docs/MATRIX_CURATOR_GUIDE.md). `provider: google` entries silently fail to resolve.

# Scope

24 renames across 15 agent files. Zero structural changes:

- `provider_preferences:` blocks intact (intentional bundle-portable fallback — see [`amplifier-bundle-routing-matrix#24`](https://github.com/microsoft/amplifier-bundle-routing-matrix/pull/24) for the documented dual-declaration design)
- `model_role:` fields untouched
- Agents without `provider: google` entries: not modified

Files modified: bug-hunter, ecosystem-expert, explorer, file-ops, foundation-expert, git-ops, integration-specialist, modular-builder, post-task-cleanup, security-guardian, session-analyst, shell-exec, test-coverage, web-research, zen-architect. Per-file rename counts: 24 total (most have 2 entries each — gemini-*-pro-preview and gemini-*-pro variants).

# Context

This PR replaces the closed PR #201, which incorrectly removed the entire `provider_preferences:` blocks from these agents under the false assumption that they were dead config. Per architectural clarification:

> `provider_preferences:` is the **universal mechanism** that works for ALL `AmplifierSession` instances regardless of installed bundles. `model_role:` is the **opt-in enhancement** that only activates when a routing bundle is installed. The dual-declaration pattern is intentional.

The `provider: google` entries are genuinely broken (wrong provider name); this PR fixes only those typos and leaves the otherwise-correct fallback lists intact.

# Verification

```
uv run pytest tests/test_agent_metadata.py tests/test_validate_agents_model_role.py --tb=line -q
→ 24 passed in 0.06s
```

Post-fix audit: `grep -rn 'provider: *google' agents/` returns 0 matches.

# Related

- amplifier-app-cli PR #177 — spawn-time precedence documentation
- amplifier-bundle-routing-matrix PR #24 — matrix-strategy dual-field documentation
- Closed (not merged): amplifier-foundation PR #201 — the incorrect cleanup-PR predecessor

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>