### PR TITLE
refactor(configurator): rename overlay capabilities to producer-neutral names

### DIFF
--- a/amplifier_foundation/__init__.py
+++ b/amplifier_foundation/__init__.py
@@ -24,6 +24,10 @@ from amplifier_foundation.configurator import (
     RuntimeOverlay,
     TransitionResult,
 )  # re-export for hooks-mode
+from amplifier_foundation.configurator._overlay import (
+    RUNTIME_CONTEXT_OVERLAY_CAPABILITY,
+    RUNTIME_SKILL_OVERLAY_CAPABILITY,
+)  # producer-neutral capability name constants for downstream consumers
 
 # Reference implementations
 from amplifier_foundation.cache.disk import DiskCache
@@ -122,6 +126,9 @@ __all__ = [
     "SessionConfigurator",
     "RuntimeOverlay",
     "TransitionResult",
+    # Overlay capability name constants (producer-neutral; use these instead of hardcoded strings)
+    "RUNTIME_SKILL_OVERLAY_CAPABILITY",
+    "RUNTIME_CONTEXT_OVERLAY_CAPABILITY",
     "BundleRegistry",
     "BundleState",
     "UpdateInfo",

--- a/amplifier_foundation/configurator/_overlay.py
+++ b/amplifier_foundation/configurator/_overlay.py
@@ -35,8 +35,13 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-_CAP_OVERLAY_CONTEXT = "mode_overlay_context"
-_CAP_OVERLAY_SKILLS = "mode_overlay_skills"
+_CAP_OVERLAY_CONTEXT = "runtime_context_overlay"
+_CAP_OVERLAY_SKILLS = "runtime_skill_overlay"
+
+# Public exports: stable constants for downstream consumers (tool-skills, hooks-mode,
+# session_spawner). Import from amplifier_foundation top level, not from this module.
+RUNTIME_CONTEXT_OVERLAY_CAPABILITY: str = _CAP_OVERLAY_CONTEXT
+RUNTIME_SKILL_OVERLAY_CAPABILITY: str = _CAP_OVERLAY_SKILLS
 
 # Categories handled in Phase 1
 _SUPPORTED_CATEGORIES = frozenset({"agents", "context", "skills"})
@@ -125,7 +130,7 @@ class RuntimeOverlay:
         - Context: NOT captured here. Session-level context flows through the
           bundle's `context: include:` mechanism and the existing `provider:request`
           hook's @-mention resolver. Mode-contributed context is a separate,
-          additive layer registered as the `mode_overlay_context` capability.
+          additive layer registered as the `runtime_context_overlay` capability.
           A mode contributing the same context file as the session bundle will
           not deduplicate — both sources will inject independently. Document this
           in the mode authoring guide if it becomes a real issue.

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -192,31 +192,35 @@ class TestS1AgentPath:
 
 
 class TestContextCapability:
-    """Tests: mode_overlay_context capability via apply / revoke."""
+    """Tests: runtime_context_overlay capability via apply / revoke."""
 
     @pytest.mark.asyncio
     async def test_context_apply_registers_capability(
         self, overlay: RuntimeOverlay, coordinator: MagicMock
     ) -> None:
-        """apply() with context paths registers mode_overlay_context capability."""
+        """apply() with context paths registers runtime_context_overlay capability."""
+        from amplifier_foundation import RUNTIME_CONTEXT_OVERLAY_CAPABILITY
+
         contributions = {
             "context": ["@modes:context/schema.md", "@modes:context/anti-patterns.md"]
         }
         await overlay.apply("mode:demo", contributions)
 
-        cap = coordinator.get_capability("mode_overlay_context")
+        cap = coordinator.get_capability(RUNTIME_CONTEXT_OVERLAY_CAPABILITY)
         assert cap == ["@modes:context/schema.md", "@modes:context/anti-patterns.md"]
 
     @pytest.mark.asyncio
     async def test_context_revoke_clears_capability(
         self, overlay: RuntimeOverlay, coordinator: MagicMock
     ) -> None:
-        """revoke() clears mode_overlay_context capability."""
+        """revoke() clears runtime_context_overlay capability."""
+        from amplifier_foundation import RUNTIME_CONTEXT_OVERLAY_CAPABILITY
+
         contributions = {"context": ["@modes:context/schema.md"]}
         await overlay.apply("mode:demo", contributions)
         await overlay.revoke("mode:demo")
 
-        cap = coordinator.get_capability("mode_overlay_context") or []
+        cap = coordinator.get_capability(RUNTIME_CONTEXT_OVERLAY_CAPABILITY) or []
         assert cap == []
 
     @pytest.mark.asyncio
@@ -227,13 +231,15 @@ class TestContextCapability:
 
         A shared path applied under two scopes survives when only one revokes.
         """
+        from amplifier_foundation import RUNTIME_CONTEXT_OVERLAY_CAPABILITY
+
         shared_path = "@modes:context/shared.md"
         await overlay.apply("mode:m1", {"context": [shared_path]})
         await overlay.apply("mode:m2", {"context": [shared_path]})
 
         await overlay.revoke("mode:m1")
 
-        cap = coordinator.get_capability("mode_overlay_context") or []
+        cap = coordinator.get_capability(RUNTIME_CONTEXT_OVERLAY_CAPABILITY) or []
         assert shared_path in cap
 
 
@@ -243,29 +249,33 @@ class TestContextCapability:
 
 
 class TestSkillsCapability:
-    """Tests: mode_overlay_skills capability via apply / revoke."""
+    """Tests: runtime_skill_overlay capability via apply / revoke."""
 
     @pytest.mark.asyncio
     async def test_skills_apply_registers_capability(
         self, overlay: RuntimeOverlay, coordinator: MagicMock
     ) -> None:
-        """apply() with skills paths registers mode_overlay_skills capability."""
+        """apply() with skills paths registers runtime_skill_overlay capability."""
+        from amplifier_foundation import RUNTIME_SKILL_OVERLAY_CAPABILITY
+
         contributions = {"skills": ["@modes:skills/mode-design-discipline"]}
         await overlay.apply("mode:demo", contributions)
 
-        cap = coordinator.get_capability("mode_overlay_skills")
+        cap = coordinator.get_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY)
         assert cap == ["@modes:skills/mode-design-discipline"]
 
     @pytest.mark.asyncio
     async def test_skills_revoke_clears_capability(
         self, overlay: RuntimeOverlay, coordinator: MagicMock
     ) -> None:
-        """revoke() clears mode_overlay_skills capability."""
+        """revoke() clears runtime_skill_overlay capability."""
+        from amplifier_foundation import RUNTIME_SKILL_OVERLAY_CAPABILITY
+
         contributions = {"skills": ["@modes:skills/mode-design-discipline"]}
         await overlay.apply("mode:demo", contributions)
         await overlay.revoke("mode:demo")
 
-        cap = coordinator.get_capability("mode_overlay_skills") or []
+        cap = coordinator.get_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY) or []
         assert cap == []
 
     @pytest.mark.asyncio
@@ -273,6 +283,11 @@ class TestSkillsCapability:
         self, overlay: RuntimeOverlay, coordinator: MagicMock
     ) -> None:
         """apply() with agents+context+skills mounts all three atomically; revoke unwinds all."""
+        from amplifier_foundation import (
+            RUNTIME_CONTEXT_OVERLAY_CAPABILITY,
+            RUNTIME_SKILL_OVERLAY_CAPABILITY,
+        )
+
         contributions = {
             "agents": {"mode-author": {"description": "x"}},
             "context": ["@modes:context/schema.md"],
@@ -282,10 +297,10 @@ class TestSkillsCapability:
 
         # All three categories mounted
         assert "mode-author" in coordinator.config["agents"]
-        assert coordinator.get_capability("mode_overlay_context") == [
+        assert coordinator.get_capability(RUNTIME_CONTEXT_OVERLAY_CAPABILITY) == [
             "@modes:context/schema.md"
         ]
-        assert coordinator.get_capability("mode_overlay_skills") == [
+        assert coordinator.get_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY) == [
             "@modes:skills/mode-design-discipline"
         ]
 
@@ -293,8 +308,8 @@ class TestSkillsCapability:
         await overlay.revoke("mode:demo")
 
         assert "mode-author" not in coordinator.config["agents"]
-        assert (coordinator.get_capability("mode_overlay_context") or []) == []
-        assert (coordinator.get_capability("mode_overlay_skills") or []) == []
+        assert (coordinator.get_capability(RUNTIME_CONTEXT_OVERLAY_CAPABILITY) or []) == []
+        assert (coordinator.get_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY) or []) == []
 
 
 # ---------------------------------------------------------------------------
@@ -330,7 +345,9 @@ class TestRollback:
         assert "bad-agent" in result.error or "dict" in result.error.lower()
 
         # Context capability must have been rolled back (it was mounted, then unwound)
-        cap = coordinator.get_capability("mode_overlay_context") or []
+        from amplifier_foundation import RUNTIME_CONTEXT_OVERLAY_CAPABILITY
+
+        cap = coordinator.get_capability(RUNTIME_CONTEXT_OVERLAY_CAPABILITY) or []
         assert cap == []
 
         # bad-agent must not be in coordinator.config['agents']

--- a/tests/test_overlay_capability_names.py
+++ b/tests/test_overlay_capability_names.py
@@ -1,0 +1,157 @@
+"""Regression test: overlay capability name constants are producer-neutral.
+
+Verifies that:
+  1. RUNTIME_SKILL_OVERLAY_CAPABILITY and RUNTIME_CONTEXT_OVERLAY_CAPABILITY
+     are importable from the amplifier_foundation top level.
+  2. Their values are the producer-neutral strings, not the legacy "mode_overlay_*" names.
+  3. They match what RuntimeOverlay actually registers on the coordinator
+     (i.e., the internal _CAP_OVERLAY_* constants in _overlay.py).
+
+These tests MUST be RED on the old "mode_overlay_*" names and GREEN after the rename.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestCapabilityNameExports:
+    """Top-level import and string-value assertions."""
+
+    def test_runtime_skill_overlay_capability_importable(self) -> None:
+        """RUNTIME_SKILL_OVERLAY_CAPABILITY must be importable from amplifier_foundation."""
+        from amplifier_foundation import RUNTIME_SKILL_OVERLAY_CAPABILITY  # noqa: F401
+
+    def test_runtime_context_overlay_capability_importable(self) -> None:
+        """RUNTIME_CONTEXT_OVERLAY_CAPABILITY must be importable from amplifier_foundation."""
+        from amplifier_foundation import RUNTIME_CONTEXT_OVERLAY_CAPABILITY  # noqa: F401
+
+    def test_skill_capability_value_is_producer_neutral(self) -> None:
+        """RUNTIME_SKILL_OVERLAY_CAPABILITY must use the producer-neutral string."""
+        from amplifier_foundation import RUNTIME_SKILL_OVERLAY_CAPABILITY
+
+        assert RUNTIME_SKILL_OVERLAY_CAPABILITY == "runtime_skill_overlay", (
+            f"Expected 'runtime_skill_overlay', got {RUNTIME_SKILL_OVERLAY_CAPABILITY!r}. "
+            "Capability names must not embed the producer ('mode_*') — they describe "
+            "the runtime surface, not who populated it."
+        )
+
+    def test_context_capability_value_is_producer_neutral(self) -> None:
+        """RUNTIME_CONTEXT_OVERLAY_CAPABILITY must use the producer-neutral string."""
+        from amplifier_foundation import RUNTIME_CONTEXT_OVERLAY_CAPABILITY
+
+        assert RUNTIME_CONTEXT_OVERLAY_CAPABILITY == "runtime_context_overlay", (
+            f"Expected 'runtime_context_overlay', got {RUNTIME_CONTEXT_OVERLAY_CAPABILITY!r}. "
+            "Capability names must not embed the producer ('mode_*') — they describe "
+            "the runtime surface, not who populated it."
+        )
+
+
+class TestOverlayRegistersCorrectCapabilityNames:
+    """Verify RuntimeOverlay registers under the renamed capability names."""
+
+    @staticmethod
+    def _make_coordinator() -> MagicMock:
+        coordinator = MagicMock()
+        coordinator.config = {"agents": {}}
+        capability_store: dict = {}
+
+        def _register_capability(name: str, value: object) -> None:
+            capability_store[name] = value
+
+        def _get_capability(name: str) -> object:
+            return capability_store.get(name)
+
+        coordinator.register_capability = MagicMock(side_effect=_register_capability)
+        coordinator.get_capability = MagicMock(side_effect=_get_capability)
+        coordinator.hooks = MagicMock()
+        coordinator.hooks.emit = AsyncMock()
+        return coordinator
+
+    @pytest.mark.asyncio
+    async def test_skills_registered_under_new_cap_name(self) -> None:
+        """apply() must register contributed skills under 'runtime_skill_overlay'."""
+        from amplifier_foundation import RUNTIME_SKILL_OVERLAY_CAPABILITY, RuntimeOverlay
+
+        coord = self._make_coordinator()
+        overlay = RuntimeOverlay(
+            coord,
+            success_event="mode:transition_completed",
+            failure_event="mode:activation_failed",
+        )
+        contributions = {"skills": ["@bundle:skills/foo.md"]}
+        result = await overlay.apply("mode:test", contributions)
+
+        assert result.success is True
+        registered = coord.get_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY)
+        assert registered is not None, (
+            f"RuntimeOverlay must register skills under "
+            f"{RUNTIME_SKILL_OVERLAY_CAPABILITY!r}, but nothing was found there."
+        )
+        assert "@bundle:skills/foo.md" in registered
+
+    @pytest.mark.asyncio
+    async def test_context_registered_under_new_cap_name(self) -> None:
+        """apply() must register contributed context under 'runtime_context_overlay'."""
+        from amplifier_foundation import RUNTIME_CONTEXT_OVERLAY_CAPABILITY, RuntimeOverlay
+
+        coord = self._make_coordinator()
+        overlay = RuntimeOverlay(
+            coord,
+            success_event="mode:transition_completed",
+            failure_event="mode:activation_failed",
+        )
+        contributions = {"context": ["@bundle:context/foo.md"]}
+        result = await overlay.apply("mode:test", contributions)
+
+        assert result.success is True
+        registered = coord.get_capability(RUNTIME_CONTEXT_OVERLAY_CAPABILITY)
+        assert registered is not None, (
+            f"RuntimeOverlay must register context under "
+            f"{RUNTIME_CONTEXT_OVERLAY_CAPABILITY!r}, but nothing was found there."
+        )
+        assert "@bundle:context/foo.md" in registered
+
+    @pytest.mark.asyncio
+    async def test_legacy_mode_overlay_skills_name_not_used(self) -> None:
+        """RuntimeOverlay must NOT register skills under the old 'mode_overlay_skills' name."""
+        from amplifier_foundation import RuntimeOverlay
+
+        coord = self._make_coordinator()
+        overlay = RuntimeOverlay(
+            coord,
+            success_event="mode:transition_completed",
+            failure_event="mode:activation_failed",
+        )
+        contributions = {"skills": ["@bundle:skills/foo.md"]}
+        await overlay.apply("mode:test", contributions)
+
+        legacy_value = coord.get_capability("mode_overlay_skills")
+        assert legacy_value is None, (
+            "RuntimeOverlay must NOT register skills under the legacy name "
+            f"'mode_overlay_skills' (found {legacy_value!r}). "
+            "The rename to 'runtime_skill_overlay' is required."
+        )
+
+    @pytest.mark.asyncio
+    async def test_legacy_mode_overlay_context_name_not_used(self) -> None:
+        """RuntimeOverlay must NOT register context under the old 'mode_overlay_context' name."""
+        from amplifier_foundation import RuntimeOverlay
+
+        coord = self._make_coordinator()
+        overlay = RuntimeOverlay(
+            coord,
+            success_event="mode:transition_completed",
+            failure_event="mode:activation_failed",
+        )
+        contributions = {"context": ["@bundle:context/foo.md"]}
+        await overlay.apply("mode:test", contributions)
+
+        legacy_value = coord.get_capability("mode_overlay_context")
+        assert legacy_value is None, (
+            "RuntimeOverlay must NOT register context under the legacy name "
+            f"'mode_overlay_context' (found {legacy_value!r}). "
+            "The rename to 'runtime_context_overlay' is required."
+        )


### PR DESCRIPTION
## Summary

Renames the runtime-overlay capability constants from producer-specific (`mode_overlay_*`) to producer-neutral (`runtime_*_overlay`) names. Exports both as stable public constants from the foundation top level so downstream consumers don't hardcode strings.

This is a prerequisite for the issue #233 fix (microsoft-amplifier/amplifier-support#233): the modes bundle, app-cli, and skills bundle all consume these capabilities, and the names had leaked the modes vocabulary into bundles that have no business knowing about modes specifically.

## Changes

- `_overlay.py`: rename `_CAP_OVERLAY_SKILLS` → `runtime_skill_overlay`, `_CAP_OVERLAY_CONTEXT` → `runtime_context_overlay`
- `__init__.py`: export `RUNTIME_SKILL_OVERLAY_CAPABILITY` and `RUNTIME_CONTEXT_OVERLAY_CAPABILITY` constants alongside existing `RuntimeOverlay`/`TransitionResult`
- `tests/test_overlay_capability_names.py`: 8 new tests
  - Constants are importable from the top level
  - Strings have the expected producer-neutral values
  - `RuntimeOverlay.apply()` registers under the new names
  - Negative regression tests: old names (`mode_overlay_*`) are NEVER registered
- `tests/test_overlay.py`: updated existing tests to use the new constants

## Compatibility

The capability names are internal contracts between RuntimeOverlay (producer) and a handful of known consumers (hooks-mode, tool-skills, session_spawner). All three consumers ship their corresponding rename in companion PRs:

- microsoft/amplifier-bundle-modes PR (companion — hooks-mode consumer)
- microsoft/amplifier-app-cli PR (companion — session_spawner consumer + skill capability propagation)
- microsoft/amplifier-bundle-skills PR (companion — tool-skills consumer)

The `mode_overlay_*` names had only been on main for a short window; no external consumers are known. If any are discovered post-merge, the rename is a one-line patch in the consumer.

## Test plan

- [x] 1320 foundation tests passing (was 1312; +8 new from `test_overlay_capability_names.py`)
- [x] Import check: `from amplifier_foundation import RuntimeOverlay, TransitionResult, RUNTIME_SKILL_OVERLAY_CAPABILITY, RUNTIME_CONTEXT_OVERLAY_CAPABILITY` succeeds
- [x] Pyright clean on production code
- [x] End-to-end validated via DTU with the four-PR integrated stack (real Anthropic LLM, scenarios pass — see issue #233 reply)

## Companion PRs (merge order)

1. **This PR (foundation rename) — MERGE FIRST**
2. amplifier-bundle-modes (consumer rename) — after this lands
3. amplifier-app-cli (spawn propagation) — after this lands
4. amplifier-bundle-skills (consumer for the renamed capability) — after this lands

Closes: nothing directly; this is a prerequisite refactor. Issue #233 is closed by the four-PR set together.
