### PR TITLE
fix: dedupe cycle warnings + replace stale registry include edges

### DIFF
--- a/amplifier_foundation/configurator/_inspector.py
+++ b/amplifier_foundation/configurator/_inspector.py
@@ -27,6 +27,28 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Cycle-warning deduplication
+# ---------------------------------------------------------------------------
+
+# A cycle is a structural property of the include graph, not of individual
+# traversals.  walk_include_chains is called once per config item (~100-250
+# items per session), so a single cycle node would otherwise produce hundreds
+# of duplicate warnings.  This module-level set ensures each unique cycle node
+# is reported at most once per process lifetime.
+_WARNED_CYCLE_NODES: set[str] = set()
+
+
+def _reset_cycle_warnings_for_testing() -> None:
+    """Clear the deduplication set so cycle warnings can be re-emitted.
+
+    Intended for use in tests only — call this before each test case that
+    checks the cycle-warning emission count to prevent state from leaking
+    between test runs.
+    """
+    _WARNED_CYCLE_NODES.clear()
+
+
+# ---------------------------------------------------------------------------
 # Sentinel for redaction
 # ---------------------------------------------------------------------------
 
@@ -197,10 +219,16 @@ def walk_include_chains(
     def _all_paths_to_root(current: str, visited: frozenset[str]) -> list[list[str]]:
         """Return all root→leaf paths ending at *current* as lists of bundle names."""
         if current in visited:
-            _logger.warning(
-                "Cycle detected in bundle include graph at %r; breaking chain.",
-                current,
-            )
+            # Deduplicate: a cycle is a graph property, not a per-traversal event.
+            # walk_include_chains is called for every config item (~100-250 items),
+            # so without deduplication the same cycle node would produce hundreds of
+            # identical warnings.  Emit at most once per unique cycle node.
+            if current not in _WARNED_CYCLE_NODES:
+                _WARNED_CYCLE_NODES.add(current)
+                _logger.warning(
+                    "Cycle detected in bundle include graph at %r; breaking chain.",
+                    current,
+                )
             return [[current]]
 
         state = registry_dict.get(current)

--- a/amplifier_foundation/registry.py
+++ b/amplifier_foundation/registry.py
@@ -769,23 +769,46 @@ class BundleRegistry:
     ) -> None:
         """Record which bundles include which other bundles.
 
-        Updates both parent's 'includes' and children's 'included_by' fields.
+        REPLACES (not appends) parent's 'includes' list with *child_names* so
+        that stale entries from previous loads or renames are removed.  When a
+        dependency is renamed (e.g. 'terminal-tester' behavior → 'terminal-
+        tester-behavior'), the old name must be evicted; append-only logic would
+        leave the self-reference that creates a graph cycle.
+
+        Side-effects on the ``included_by`` lists:
+        - Bundles that were in the OLD includes list but are absent from the new
+          *child_names* have *parent_name* removed from their ``included_by``.
+        - Bundles in *child_names* gain *parent_name* in their ``included_by``
+          (idempotent — won't duplicate if already present).
+
         Persists registry state after recording.
 
         Args:
             parent_name: Name of the parent bundle.
-            child_names: Names of bundles included by parent.
+            child_names: Authoritative list of bundle names included by parent.
         """
-        # Update parent's includes list
         parent_state = self._registry.get(parent_name)
-        if parent_state:
-            if parent_state.includes is None:
-                parent_state.includes = []
-            for child_name in child_names:
-                if child_name not in parent_state.includes:
-                    parent_state.includes.append(child_name)
 
-        # Update each child's included_by list
+        # --- Clean up stale includes ------------------------------------------
+        # Identify which children were recorded in the *previous* load so we
+        # can remove this parent from their included_by when they drop out.
+        old_child_names: list[str] = (
+            list(parent_state.includes or []) if parent_state else []
+        )
+        removed_children = [c for c in old_child_names if c not in child_names]
+
+        for removed_name in removed_children:
+            removed_state = self._registry.get(removed_name)
+            if removed_state and removed_state.included_by:
+                removed_state.included_by = [
+                    n for n in removed_state.included_by if n != parent_name
+                ]
+
+        # --- Replace parent's includes list (not append) ----------------------
+        if parent_state:
+            parent_state.includes = list(child_names)
+
+        # --- Update each child's included_by list (idempotent append) ---------
         for child_name in child_names:
             child_state = self._registry.get(child_name)
             if child_state:

--- a/tests/test_configurator.py
+++ b/tests/test_configurator.py
@@ -18,6 +18,7 @@ from amplifier_foundation.configurator import (
 from amplifier_foundation.configurator._inspector import (
     _build_include_path,
     _build_include_paths,
+    _reset_cycle_warnings_for_testing,
 )
 from amplifier_foundation.configurator._types import IncludeStep, Origin
 
@@ -3243,7 +3244,7 @@ class TestWalkIncludeChains:
             "reality-check-behavior": _make_state(
                 name="reality-check-behavior",
                 included_by=[],  # no parents → topological root
-                is_root=False,   # structural: it's a nested bundle
+                is_root=False,  # structural: it's a nested bundle
             ),
             "terminal-tester": _make_state(
                 name="terminal-tester",
@@ -3411,3 +3412,127 @@ class TestMultiSourceIncludePaths:
         assert len(result) == 1
         names = [s.bundle for s in result[0]]
         assert names == ["root", "foundation"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for Bug A — cycle warning deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestWalkIncludeChainsCycleWarningDedupe:
+    """walk_include_chains emits the cycle warning at most once per unique cycle node.
+
+    A cycle in the include graph is a property of the graph structure, not of
+    individual traversals.  With ~241 items each triggering their own traversal,
+    a single cycle node was previously logged hundreds of times.  After the fix,
+    each unique cycle node should produce exactly one WARNING per session.
+    """
+
+    def test_cycle_warning_emitted_exactly_once_for_single_cycle(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Calling walk_include_chains many times on the same cycle emits the
+        warning exactly once — not once per call."""
+        # Reset the deduplication set before the test so state from other tests
+        # does not interfere.
+        _reset_cycle_warnings_for_testing()
+
+        registry_dict: dict[str, Any] = {
+            # terminal-tester self-cycle (the real-world scenario)
+            "terminal-tester": _make_state(
+                name="terminal-tester",
+                included_by=["terminal-tester"],  # self-cycle
+                is_root=True,
+            ),
+            "foundation": _make_state(
+                name="foundation",
+                included_by=["terminal-tester"],
+            ),
+        }
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            # Simulate ~100 items each triggering a traversal through the cycle
+            for _ in range(100):
+                walk_include_chains("foundation", registry_dict)
+
+        # Exactly one warning about "terminal-tester" should appear
+        cycle_warnings = [
+            r
+            for r in caplog.records
+            if "Cycle detected" in r.message and "terminal-tester" in r.message
+        ]
+        assert len(cycle_warnings) == 1, (
+            f"Expected exactly 1 cycle warning for 'terminal-tester', "
+            f"got {len(cycle_warnings)}: {[r.message for r in cycle_warnings]}"
+        )
+
+    def test_cycle_warning_once_per_unique_cycle_node(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Two distinct cycle nodes each produce exactly one warning (not N each)."""
+        _reset_cycle_warnings_for_testing()
+
+        registry_dict: dict[str, Any] = {
+            "A": _make_state(name="A", included_by=["B"]),
+            "B": _make_state(name="B", included_by=["A"]),
+            "leaf": _make_state(name="leaf", included_by=["A"]),
+        }
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(50):
+                walk_include_chains("leaf", registry_dict)
+
+        cycle_warnings = [r for r in caplog.records if "Cycle detected" in r.message]
+        # Two distinct cycle-entry nodes (A and B), each warned at most once
+        warned_nodes = {r.message for r in cycle_warnings}
+        assert len(warned_nodes) <= 2, (
+            f"Expected ≤2 unique cycle warnings, got {len(warned_nodes)}"
+        )
+        # Each node warned at most once (no duplicates)
+        assert len(cycle_warnings) == len(warned_nodes), (
+            f"Duplicate warnings detected: {[r.message for r in cycle_warnings]}"
+        )
+
+    def test_reset_cycle_warnings_allows_re_emission(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """After _reset_cycle_warnings_for_testing(), the warning can be emitted again."""
+        _reset_cycle_warnings_for_testing()
+
+        registry_dict: dict[str, Any] = {
+            "X": _make_state(name="X", included_by=["X"]),  # self-cycle
+            "leaf": _make_state(name="leaf", included_by=["X"]),
+        }
+
+        import logging
+
+        # First traversal — should produce 1 warning
+        with caplog.at_level(logging.WARNING):
+            walk_include_chains("leaf", registry_dict)
+
+        first_count = sum(
+            1
+            for r in caplog.records
+            if "Cycle detected" in r.message and "'X'" in r.message
+        )
+        assert first_count == 1
+
+        # Reset and re-traverse — should produce 1 warning again
+        _reset_cycle_warnings_for_testing()
+        caplog.clear()
+
+        with caplog.at_level(logging.WARNING):
+            walk_include_chains("leaf", registry_dict)
+
+        second_count = sum(
+            1
+            for r in caplog.records
+            if "Cycle detected" in r.message and "'X'" in r.message
+        )
+        assert second_count == 1, (
+            "After reset, warning should be emitted again (exactly once)"
+        )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,7 +4,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from amplifier_foundation.registry import BundleRegistry
+from amplifier_foundation.registry import BundleRegistry, BundleState
 
 
 class TestFindNearestBundleFile:
@@ -317,9 +317,10 @@ class TestSubdirectoryBundleLoading:
             # NOT to the checkout root.  Agents and context for 'recipes:' live under
             # behaviors/recipes/agents/ and behaviors/recipes/context/, not root/agents/.
             assert bundle.name == "recipes"
-            assert bundle.source_base_paths.get("recipes") == (
-                base / "behaviors" / "recipes"
-            ).resolve()
+            assert (
+                bundle.source_base_paths.get("recipes")
+                == (base / "behaviors" / "recipes").resolve()
+            )
 
     @pytest.mark.asyncio
     async def test_root_bundle_no_extra_source_base_paths(self) -> None:
@@ -464,7 +465,9 @@ class TestSubdirectoryBundleLoading:
             # Bug: with source_base_paths['subns'] = root/, it returned root/agents/foo.md (decoy)
             bundle.load_agent_metadata()
             agent_path = bundle.resolve_agent_path("subns:foo")
-            assert agent_path is not None, "resolve_agent_path('subns:foo') returned None"
+            assert agent_path is not None, (
+                "resolve_agent_path('subns:foo') returned None"
+            )
             assert agent_path.resolve() == (sub / "agents" / "foo.md").resolve(), (
                 f"resolve_agent_path('subns:foo') = {agent_path!r}, "
                 f"expected {(sub / 'agents' / 'foo.md').resolve()!r} — got the checkout-root decoy?"
@@ -499,16 +502,19 @@ class TestSubdirectoryBundleLoading:
             sub_behaviors = sub / "behaviors"
             sub_behaviors.mkdir()
             (sub_behaviors / "config.yaml").write_text(
-                "bundle:\n"
-                "  name: myns\n"
-                "  version: 1.0.0\n"
-                "  namespace_root: ..\n"
+                "bundle:\n  name: myns\n  version: 1.0.0\n  namespace_root: ..\n"
             )
 
             from amplifier_foundation.bundle._dataclass import Bundle
 
             bundle = Bundle.from_dict(
-                {"bundle": {"name": "myns", "version": "1.0.0", "namespace_root": ".."}},
+                {
+                    "bundle": {
+                        "name": "myns",
+                        "version": "1.0.0",
+                        "namespace_root": "..",
+                    }
+                },
                 base_path=sub_behaviors,
             )
 
@@ -571,7 +577,9 @@ class TestSubdirectoryBundleLoading:
             # Agent at behaviors/agents/bar.md resolves correctly with default
             agent_path = bundle.resolve_agent_path("subns:bar")
             assert agent_path is not None
-            assert agent_path.resolve() == (sub_behaviors / "agents" / "bar.md").resolve(), (
+            assert (
+                agent_path.resolve() == (sub_behaviors / "agents" / "bar.md").resolve()
+            ), (
                 f"Expected {(sub_behaviors / 'agents' / 'bar.md').resolve()!r}, "
                 f"got {agent_path!r}"
             )
@@ -619,7 +627,9 @@ class TestSubdirectoryBundleLoading:
                 "resolve_agent_path('foundation:bug-hunter') returned None for a root bundle. "
                 "The namespace==self.name fallback in resolve_agent_path() is broken."
             )
-            assert agent_path.resolve() == (base / "agents" / "bug-hunter.md").resolve(), (
+            assert (
+                agent_path.resolve() == (base / "agents" / "bug-hunter.md").resolve()
+            ), (
                 f"Expected {(base / 'agents' / 'bug-hunter.md').resolve()!r}, "
                 f"got {agent_path!r}"
             )
@@ -1530,3 +1540,178 @@ class TestIncludeSourceResolver:
             result = registry._resolve_include_source("plain-bundle-name")
             assert "plain-bundle-name" in resolver_calls
             assert result == "overridden://plain-bundle-name"
+
+
+# ---------------------------------------------------------------------------
+# Tests for Bug B — registry self-include edge / stale include relationships
+# ---------------------------------------------------------------------------
+
+
+class TestRecordIncludeRelationshipsIdempotent:
+    """_record_include_relationships replaces stale include edges, not appends.
+
+    Root cause: When a bundle dependency is renamed (e.g., terminal-tester's
+    behavior file was renamed from 'terminal-tester' to 'terminal-tester-behavior'),
+    _record_include_relationships used to APPEND to the existing includes list,
+    leaving stale self-references that created graph cycles.
+
+    After the fix, calling _record_include_relationships with the new child names
+    should REPLACE the old includes list and clean up stale included_by entries.
+    """
+
+    def test_replaces_stale_self_reference_in_includes(self) -> None:
+        """Stale self-reference is removed when _record_include_relationships is
+        called with the corrected child names (Bug B exact scenario)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry = BundleRegistry(home=Path(tmpdir) / "home")
+
+            # Simulate stale registry state after old behavior name 'terminal-tester'
+            registry.register(
+                {
+                    "terminal-tester": "git+https://github.com/example/terminal-tester@main",
+                    "foundation": "git+https://github.com/example/foundation@main",
+                    "terminal-tester-behavior": "git+https://github.com/example/terminal-tester@main#subdirectory=behaviors/terminal-tester.yaml",
+                }
+            )
+
+            tt_state = registry.get_state("terminal-tester")
+            assert isinstance(tt_state, BundleState)
+            fnd_state = registry.get_state("foundation")
+            assert isinstance(fnd_state, BundleState)
+
+            # Stale state: terminal-tester included itself (old behavior name was 'terminal-tester')
+            tt_state.includes = ["foundation", "terminal-tester"]  # self-reference!
+            tt_state.included_by = [
+                "terminal-tester",
+                "reality-check-behavior",
+            ]  # self-ref!
+            fnd_state.included_by = ["terminal-tester"]
+
+            # Now the bundle is re-loaded and the behavior is correctly identified
+            # as 'terminal-tester-behavior'. Record the corrected relationships.
+            registry._record_include_relationships(
+                "terminal-tester",
+                ["foundation", "terminal-tester-behavior"],
+            )
+
+            # The includes list should be the NEW list — no stale self-reference
+            assert tt_state.includes == ["foundation", "terminal-tester-behavior"], (
+                f"Expected ['foundation', 'terminal-tester-behavior'], "
+                f"got {tt_state.includes}"
+            )
+
+            # terminal-tester should NOT include itself
+            assert "terminal-tester" not in tt_state.includes, (
+                "Self-reference must be removed from includes"
+            )
+
+    def test_stale_included_by_cleaned_from_old_child(self) -> None:
+        """When a parent's includes change, old children's included_by is cleaned."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry = BundleRegistry(home=Path(tmpdir) / "home")
+
+            registry.register(
+                {
+                    "parent": "git+https://github.com/example/parent@main",
+                    "old-child": "git+https://github.com/example/old@main",
+                    "new-child": "git+https://github.com/example/new@main",
+                }
+            )
+
+            parent_state = registry.get_state("parent")
+            assert isinstance(parent_state, BundleState)
+            old_child_state = registry.get_state("old-child")
+            assert isinstance(old_child_state, BundleState)
+
+            # Stale state: parent included 'old-child' (now renamed to 'new-child')
+            parent_state.includes = ["old-child"]
+            old_child_state.included_by = ["parent"]
+
+            # Register 'new-child' so it has state
+            new_child_state = registry.get_state("new-child")
+            assert isinstance(new_child_state, BundleState)
+            new_child_state.included_by = []
+
+            # Record the corrected relationships
+            registry._record_include_relationships("parent", ["new-child"])
+
+            # parent.includes should now be ['new-child'] — stale 'old-child' removed
+            assert parent_state.includes == ["new-child"], (
+                f"Expected ['new-child'], got {parent_state.includes}"
+            )
+
+            # old-child.included_by should no longer contain 'parent'
+            assert "parent" not in (old_child_state.included_by or []), (
+                f"old-child.included_by should not contain 'parent', "
+                f"got {old_child_state.included_by}"
+            )
+
+            # new-child.included_by should contain 'parent'
+            assert "parent" in (new_child_state.included_by or []), (
+                f"new-child.included_by should contain 'parent', "
+                f"got {new_child_state.included_by}"
+            )
+
+    def test_no_self_reference_in_includes_after_reload(self) -> None:
+        """After fix, terminal-tester.includes must not contain 'terminal-tester'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry = BundleRegistry(home=Path(tmpdir) / "home")
+
+            registry.register(
+                {
+                    "terminal-tester": "git+https://github.com/example/tt@main",
+                    "foundation": "git+https://github.com/example/foundation@main",
+                    "terminal-tester-behavior": "git+https://example.com/tt@main#subdirectory=behaviors/tt.yaml",
+                }
+            )
+
+            tt_state = registry.get_state("terminal-tester")
+            assert isinstance(tt_state, BundleState)
+            tt_state.includes = ["foundation", "terminal-tester"]  # stale self-ref
+            tt_state.included_by = ["terminal-tester"]  # stale self-ref
+
+            # Simulate reload: record the true includes
+            registry._record_include_relationships(
+                "terminal-tester", ["foundation", "terminal-tester-behavior"]
+            )
+
+            assert "terminal-tester" not in (tt_state.includes or []), (
+                "terminal-tester must not be in its own includes after reload"
+            )
+
+    def test_multiple_parents_for_same_child_preserved(self) -> None:
+        """Multiple distinct parents can both include the same child; each parent's
+        reload only clears that parent's stale entries, not others'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry = BundleRegistry(home=Path(tmpdir) / "home")
+
+            registry.register(
+                {
+                    "parent-a": "git+https://github.com/example/a@main",
+                    "parent-b": "git+https://github.com/example/b@main",
+                    "child": "git+https://github.com/example/child@main",
+                }
+            )
+
+            child_state = registry.get_state("child")
+            assert isinstance(child_state, BundleState)
+
+            # Both parents include child; record parent-a first
+            registry._record_include_relationships("parent-a", ["child"])
+            registry._record_include_relationships("parent-b", ["child"])
+
+            # child.included_by should have BOTH parents
+            assert set(child_state.included_by or []) == {"parent-a", "parent-b"}, (
+                f"Both parents should appear in child.included_by, "
+                f"got {child_state.included_by}"
+            )
+
+            # Now parent-a is reloaded with the same child (idempotent)
+            registry._record_include_relationships("parent-a", ["child"])
+
+            # Still both parents; no duplication
+            assert set(child_state.included_by or []) == {"parent-a", "parent-b"}
+            assert child_state.included_by is not None
+            assert child_state.included_by.count("parent-a") == 1, (
+                "parent-a must not be duplicated in child.included_by"
+            )


### PR DESCRIPTION
## Summary

Two related bugs surfaced by `/config show` printing ~196 cycle warnings before rendering. Root causes confirmed and fixed with TDD.

---

## Bug A — Cycle warning excessive noise

**Symptom:** `/config show` prints `"Cycle detected in bundle include graph at 'terminal-tester'; breaking chain."` ~196 times.

**Root cause:** `configurator/_inspector.py` — `_all_paths_to_root` fired the warning on every traversal-hit (once per item × calls per item). A cycle is a property of the graph, not a per-traversal event.

**Fix:** Added module-level `_WARNED_CYCLE_NODES: set[str]` — each unique cycle node emits at most one WARNING per process lifetime. Exposed `_reset_cycle_warnings_for_testing()` for test isolation.

**Tests added** (`TestWalkIncludeChainsCycleWarningDedupe`):
- `test_cycle_warning_emitted_exactly_once_for_single_cycle` — calls `walk_include_chains` 100× through a self-cycle, asserts exactly 1 warning
- `test_cycle_warning_once_per_unique_cycle_node` — two-node A↔B cycle, asserts ≤2 unique warnings, each emitted at most once
- `test_reset_cycle_warnings_allows_re_emission` — verifies the reset helper works correctly

---

## Bug B — Registry self-include edge

**Symptom:** `~/.amplifier/registry.json` shows `terminal-tester.includes = ["foundation", "terminal-tester"]` (self-reference) and `included_by = ["terminal-tester", "reality-check-behavior"]`.

**Root cause:** `registry.py` — `_record_include_relationships` was **append-only**. After the terminal-tester behavior file was renamed from `name: terminal-tester` → `name: terminal-tester-behavior`, the new name was appended but the old name was never removed. The stale self-reference created the graph cycle triggering Bug A.

**Fix:** `_record_include_relationships` now:
1. Identifies bundles in the OLD includes list that are absent from the new `child_names`
2. Removes `parent_name` from those stale children's `included_by` lists  
3. **Replaces** (not appends) `parent_state.includes` with the new `child_names`
4. Idempotently appends to `included_by` on kept/new children (preserves multi-parent edges)

**Tests added** (`TestRecordIncludeRelationshipsIdempotent`):
- `test_replaces_stale_self_reference_in_includes` — exact terminal-tester scenario
- `test_stale_included_by_cleaned_from_old_child` — dropped bundles lose the parent from their `included_by`
- `test_no_self_reference_in_includes_after_reload` — terminal-tester must not appear in its own includes
- `test_multiple_parents_for_same_child_preserved` — multi-parent edges survive idempotent reload

---

## Verification

**Test suite:** 1403 passed, 0 failed, 1 skipped (up from 1396 — 7 new tests added)

**python_check (production files):** Clean — 0 errors, 0 warnings

**Live registry after fresh rebuild:**
```
=== terminal-tester ===
includes: None (not loaded this session — no stale data)
included_by: None

=== terminal-tester-behavior ===
included_by: ['reality-check-behavior']   ← no self-reference

=== Self-reference check ===
No self-references found in registry.
```

**`/config show`:** Ran twice in the live session — zero cycle warnings in output (Bug B fixed the root cause; Bug A's deduplication acts as defense-in-depth for any future legitimate cycles).

---

## Other bundles with namespace-prefix self-references

After the fix, scanning the rebuilt registry found **no self-references** across all registered bundles.

---

## Scope

- Modified: `amplifier_foundation/configurator/_inspector.py`, `amplifier_foundation/registry.py`
- Tests: `tests/test_configurator.py`, `tests/test_registry.py`
- No changes to amplifier-app-cli
- No `_provenance` field or other retcons introduced