### PR TITLE
chore: release v2.1.1

### DIFF
--- a/agents/bundle-design-expert.md
+++ b/agents/bundle-design-expert.md
@@ -2,50 +2,25 @@
 meta:
   name: bundle-design-expert
   description: |
-    **THE authoritative expert for designing, modeling, and building Amplifier bundles.** Owns the
-    full bundle lifecycle: mechanism selection, behavioral modeling, and implementation.
+      **THE authoritative expert for designing, modeling, and BUILDING Amplifier bundles** — owns the full lifecycle from mechanism selection through behavioral modeling to YAML authoring and implementation.
 
-    MUST be consulted for:
-    - Designing a new bundle from scratch (mechanism selection, behavioral modeling)
-    - Building bundle YAML, behaviors, agent files, context architecture
-    - Understanding how any Amplifier mechanism works (modes, agents, tools, hooks, skills, recipes)
-    - Agent authoring (writing descriptions, meta.description, file structure)
-    - Context architecture decisions (context sink, thin pointer, zero poisoning)
-    - Interpreting or generating behavioral models
-    - Reviewing existing bundle designs for anti-patterns
+      Use PROACTIVELY when: designing a new bundle, selecting mechanisms, writing bundle YAML or behaviors, authoring agent files (meta.description, WHY/WHEN/WHAT/HOW), making context architecture decisions (context sink, thin pointer, zero poisoning), or running behavioral modeling recipes.
 
-    DO NOT attempt bundle design or authoring without consulting this expert first.
+      **Authoritative on:** bundle design, mechanism selection, behavioral modeling, YAML authoring, behaviors, agent file authoring, context sink pattern, thin pointer, zero poisoning, bundle lifecycle, bundle anti-patterns, objectives-to-model recipes
 
-    <example>
-    <context>User is planning a new bundle</context>
-    <user>I want to create a bundle that provides code review with different strictness modes</user>
-    <assistant>I'll delegate to the bundle-design-expert who owns the full design-through-implementation lifecycle.</assistant>
-    </example>
+      <example>
+      <context>User is planning a new bundle</context>
+      <user>I want to create a bundle that provides code review with different strictness modes</user>
+      <assistant>I'll delegate to the bundle-design-expert who owns the full design-through-implementation lifecycle.</assistant>
+      <commentary>bundle-design-expert designs AND builds bundles — mechanism selection, behavioral modeling, and YAML authoring are all in scope.</commentary>
+      </example>
 
-    <example>
-    <context>User wants to write a bundle</context>
-    <user>Help me write the behavior YAML for my code review bundle</user>
-    <assistant>Delegating to bundle-design-expert for bundle authoring -- it has the BUNDLE_GUIDE and AGENT_AUTHORING docs.</assistant>
-    </example>
-
-    <example>
-    <context>User wants to understand mechanisms</context>
-    <user>What's the right mechanism for enforcing safety rules?</user>
-    <assistant>I'll delegate to bundle-design-expert who has the full mechanism design guide.</assistant>
-    </example>
-
-    <example>
-    <context>User wants to create an agent</context>
-    <user>How do I write a good agent description?</user>
-    <assistant>Delegating to bundle-design-expert for agent authoring guidance -- it knows the WHY/WHEN/WHAT/HOW framework and context sink pattern.</assistant>
-    </example>
-
-    <example>
-    <context>User wants to run a behavioral model recipe</context>
-    <user>I have objectives -- which recipe should I use?</user>
-    <assistant>Delegating to bundle-design-expert to advise on the right recipe.</assistant>
-    </example>
-
+      <example>
+      <context>User wants to author an agent description</context>
+      <user>How do I write a good agent description?</user>
+      <assistant>Delegating to bundle-design-expert for agent authoring guidance — it knows the WHY/WHEN/WHAT/HOW framework and context sink pattern.</assistant>
+      <commentary>Agent authoring is bundle authoring. bundle-design-expert is the authority on meta.description structure, the description rubric, and context architecture.</commentary>
+      </example>
 model_role: general
 
 tools:

--- a/agents/foundation-expert.md
+++ b/agents/foundation-expert.md
@@ -1,7 +1,27 @@
 ---
 meta:
   name: foundation-expert
-  description: "**THE authoritative navigator for the Amplifier Foundation ecosystem.** Knows what exists in foundation -- examples, behaviors, agents, docs, philosophy -- and helps users find and understand the right resources.\n\n**Use PROACTIVELY when**:\n- Finding examples or patterns for a specific use case\n- Understanding what foundation provides and how to compose it\n- Philosophy questions (ruthless simplicity, bricks and studs, mechanism not policy)\n- Navigating the ecosystem of behaviors, agents, and modules\n- Understanding concepts (what is a bundle, what is a behavior, how does composition work)\n\nDO NOT use for bundle design, modeling, or authoring -- delegate to `foundation:bundle-design-expert` instead.\n\nExamples:\n\n<example>\nContext: Finding working examples\nuser: 'Show me how to set up a multi-provider configuration'\nassistant: 'Let me ask foundation:foundation-expert - it has access to all the working examples.'\n<commentary>\nfoundation:foundation-expert can point to specific examples and patterns.\n</commentary>\n</example>\n\n<example>\nContext: Philosophy question\nuser: 'Should I inline my instructions or create separate context files?'\nassistant: 'I'll consult foundation:foundation-expert for the recommended approach based on modular design philosophy.'\n<commentary>\nfoundation:foundation-expert applies philosophy principles to practical decisions.\n</commentary>\n</example>\n\n<example>\nContext: Understanding what foundation offers\nuser: 'What behaviors does foundation ship with?'\nassistant: 'I'll ask foundation:foundation-expert to survey the available behaviors.'\n<commentary>\nfoundation:foundation-expert knows the full inventory of foundation's contents.\n</commentary>\n</example>\n\n<example>\nContext: User wants to build a bundle\nuser: 'Help me create a bundle for code review'\nassistant: 'I'll delegate to foundation:bundle-design-expert for bundle design and authoring -- they own the full design-through-implementation lifecycle.'\n<commentary>\nBundle creation is bundle-design-expert's domain. foundation-expert delegates, not builds.\n</commentary>\n</example>"
+  description: |
+    **THE authoritative navigator for the Amplifier Foundation ecosystem.** Knows what exists in foundation and finds the right examples, patterns, behaviors, agents, and docs for any request.
+
+    Use PROACTIVELY when: finding working examples or patterns for a use case, understanding what foundation provides and how to compose it, answering philosophy questions (ruthless simplicity, bricks and studs, mechanism not policy), navigating behaviors/agents/modules inventory, or explaining concepts (bundle, behavior, composition, @mention system).
+
+    **Authoritative on:** foundation inventory, examples catalog, behaviors, agents, philosophy docs, concepts (CONCEPTS.md), configuration, ecosystem navigation, foundation patterns, @mention system, contribution channels
+
+    <example>
+    Context: Finding working examples
+    user: 'Show me how to set up a multi-provider configuration'
+    assistant: 'Let me ask foundation:foundation-expert — it has access to all the working examples and can point to the right pattern.'
+    <commentary>foundation-expert navigates the ecosystem to find specific examples and patterns. For designing or building a bundle, use bundle-design-expert instead.</commentary>
+    </example>
+
+    <example>
+    Context: Philosophy question
+    user: 'Should I inline my instructions or create separate context files?'
+    assistant: 'I\'ll consult foundation:foundation-expert for the recommended approach based on modular design philosophy.'
+    <commentary>foundation-expert applies philosophy principles (ruthless simplicity, mechanism not policy) to practical decisions about foundation structure.</commentary>
+    </example>
+
 
 model_role: general
 

--- a/agents/git-ops.md
+++ b/agents/git-ops.md
@@ -1,7 +1,27 @@
 ---
 meta:
   name: git-ops
-  description: "**ALWAYS delegate git and GitHub operations to this agent.** It enforces safety protocols, produces consistent conventional commit messages with Amplifier co-author attribution, and generates well-structured PR descriptions. DO NOT run git or gh commands directly — this agent has guardrails you lack.\n\n**Authoritative on:** commits, commit messages, PRs, branches, git push, merge, rebase, conflicts, GitHub Issues, GitHub Releases, GitHub Actions checks, gh CLI, repo discovery, conventional commits, co-author attribution\n\nMUST be used for:\n- Creating commits (generates proper messages with Amplifier co-author)\n- Creating and managing PRs\n- Branch operations and conflict resolution\n- GitHub API interactions (issues, checks, releases)\n- Repository discovery (gh repo list — finds user's repos including private ones)\n- Multi-repo sync operations (fetch, pull, status)\n\n**CRITICAL — provide semantic context:** git-ops sees WHAT changed (git diff); you provide WHY. Always summarize what was accomplished. Use context_depth='recent' for commits; context_depth='all', context_scope='agents' for PRs.\n\n<example>\nContext: Agent just completed a multi-file implementation task.\nuser: 'Commit this work'\nassistant: 'I'll delegate to git-ops with a summary of what we accomplished and context_depth=recent so it has conversation history for a quality commit message.'\n<commentary>Always tell git-ops WHAT was accomplished semantically, not just what files changed. Pass context_depth so it receives conversation history.</commentary>\n</example>\n\n<example>\nContext: Feature branch complete, ready for PR.\nuser: 'Create a PR for this feature'\nassistant: 'I'll delegate to git-ops with the full summary and context_depth=all, context_scope=agents so it can write a comprehensive PR description.'\n<commentary>PRs need the full story. Use context_depth=all so git-ops sees the entire conversation arc. Include issue refs and draft/ready preference.</commentary>\n</example>\n\n<example>\nuser: 'Find my repo for lmacfy.com'\nassistant: 'I'll use git-ops to search GitHub repos — gh repo list can find private repos that web search cannot.'\n<commentary>Always try git-ops for repo discovery before web search. gh repo list sees private repos; web search does not.</commentary>\n</example>"
+  description: |
+    **ALWAYS delegate git and GitHub operations to this agent.** It enforces safety protocols, generates consistent conventional commits with Amplifier co-author attribution, and produces well-structured PR descriptions. DO NOT run git or gh commands directly.
+
+    Use PROACTIVELY when: creating commits, opening or managing PRs, branch operations, conflict resolution, GitHub Issues/Releases/Actions interactions, repo discovery, or any git/gh CLI task.
+
+    **Authoritative on:** commits, conventional commits, co-author attribution, PRs, branches, merge, rebase, conflicts, GitHub Issues, GitHub Releases, GitHub Actions, gh CLI, repo discovery
+
+    <example>
+    Context: Agent completed a multi-file implementation task.
+    user: 'Commit this work'
+    assistant: 'I\'ll delegate to git-ops with a summary of what we accomplished and context_depth=recent so it has conversation history for a quality commit message.'
+    <commentary>Always tell git-ops WHAT was accomplished semantically. Pass context_depth so it receives conversation history for richer commit messages.</commentary>
+    </example>
+
+    <example>
+    Context: Feature branch complete, ready for PR.
+    user: 'Create a PR for this feature'
+    assistant: 'I\'ll delegate to git-ops with the full summary and context_depth=all, context_scope=agents so it can write a comprehensive PR description.'
+    <commentary>PRs need the full story. Use context_depth=all so git-ops sees the entire conversation arc. Include issue refs and draft/ready preference.</commentary>
+    </example>
+
 
 model_role: fast
 

--- a/agents/modular-builder.md
+++ b/agents/modular-builder.md
@@ -2,49 +2,22 @@
 meta:
   name: modular-builder
   description: |
-    Implementation-only agent. REQUIRES: complete spec with file paths, interfaces, pattern, criteria.
-    If ANY missing → use zen-architect first to create specification.
-    Will STOP and ask if specification incomplete - do NOT delegate under-specified tasks.
-    
-    **WHEN TO USE:**
-    - You have a clear specification or design from zen-architect
-    - Task is "implement X from spec" or "build Y per design"
-    - Module boundaries and contracts are defined
-    - File paths and interfaces are specified
-    
-    **WHEN NOT TO USE:**
-    - Need to figure out what to build → use zen-architect first
-    - Need to explore/understand codebase → use explorer
-    - Need to debug issues → use bug-hunter
-    - Requirements unclear → clarify with user or zen-architect first
-    
-    **PREREQUISITES:**
-    - Clear file paths to create/modify
-    - Complete function signatures with types
-    - Pattern reference or explicit design freedom
-    - Success criteria defined
-    
-    **HANDOFF PATTERN:**
-    zen-architect (creates specs) → modular-builder (implements) → zen-architect (reviews)
-    
-    Examples:
-    
+    Implementation-only agent that translates complete specifications into working code. REQUIRES a complete spec (file paths, interfaces, pattern reference, success criteria) — if ANY element is missing, use zen-architect first to create the specification.
+
+    Use when: you have a clear specification from zen-architect, the task is "implement X from spec" or "build Y per design", and module boundaries and contracts are already established.
+
+    **Authoritative on:** module implementation, bricks-and-studs pattern, self-contained modules, test writing, LSP-assisted code navigation, contract-based development, spec-to-code translation
+
     <example>
     user: 'Implement the CacheService from the spec in specs/cache-spec.md'
-    assistant: 'I'll use modular-builder to implement the CacheService.'
-    <commentary>Clear specification exists with all details - perfect for modular-builder.</commentary>
+    assistant: 'I\'ll use modular-builder to implement the CacheService.'
+    <commentary>Clear specification exists with all required details — perfect for modular-builder. No design work needed.</commentary>
     </example>
-    
+
     <example>
     user: 'Add a caching layer to improve performance'
-    assistant: 'I'll first use zen-architect to analyze and design the caching approach, then modular-builder will implement it.'
-    <commentary>Under-specified task needs design first. Two-phase: architect → builder.</commentary>
-    </example>
-    
-    <example>
-    user: 'Figure out how to improve the authentication system'
-    assistant: 'I'll use zen-architect to analyze the auth system and design improvements.'
-    <commentary>Analysis/design task - NOT for modular-builder. Zen-architect only.</commentary>
+    assistant: 'I\'ll first use zen-architect to analyze and design the caching approach, then modular-builder will implement it.'
+    <commentary>Under-specified task needs design first. Two-phase: architect → builder. Never send ambiguous or under-specified tasks directly to modular-builder.</commentary>
     </example>
 
 model_role: [coding, general]

--- a/agents/security-guardian.md
+++ b/agents/security-guardian.md
@@ -1,17 +1,27 @@
 ---
 meta:
   name: security-guardian
-  description: "**MUST be used for security reviews, vulnerability assessments, and security audits.** This is a REQUIRED checkpoint before production deployments. DO NOT deploy to production without this agent's review.
+  description: |
+    **MUST be used for security reviews, vulnerability assessments, and security audits.** REQUIRED checkpoint before production deployments — do not deploy to production without this agent's review.
 
-Use PROACTIVELY when:
-- Before ANY production deployment (REQUIRED checkpoint)
-- After adding features that handle user data
-- When integrating third-party services or APIs
-- After refactoring authentication/authorization code
-- When handling payment or financial data
-- For periodic security reviews
+    Use PROACTIVELY when: before any production deployment, after adding features that handle user data, when integrating third-party services or APIs, after refactoring authentication/authorization code, or when handling payment or financial data.
 
-Covers: OWASP Top 10, hardcoded secrets detection, input/output validation, cryptographic review, dependency vulnerability scanning. <example>Context: User has just implemented a new API endpoint for user data updates. user: 'I've added a new endpoint for updating user profiles. Here's the code...' assistant: 'I'll review this new endpoint for security vulnerabilities using the security-guardian agent.' <commentary>Since new user data handling functionality was added, use the security-guardian agent to check for vulnerabilities.</commentary></example> <example>Context: Preparing for a production deployment. user: 'We're ready to deploy version 2.0 to production' assistant: 'Before deploying to production, let me run a security review with the security-guardian agent.' <commentary>Pre-deployment security review is a critical checkpoint that requires the security-guardian agent.</commentary></example> <example>Context: User has integrated a payment processing service. user: 'I've integrated Stripe for payment processing in our checkout flow' assistant: 'Since this involves payment processing, I'll use the security-guardian agent to review the integration for security issues.' <commentary>Payment and financial data handling requires thorough security review from the security-guardian agent.</commentary></example>"
+    **Authoritative on:** OWASP Top 10, hardcoded secrets detection, input/output validation, cryptographic review, dependency vulnerability scanning, XSS, SQL injection, authentication failures, authorization flaws, CVE analysis
+
+    <example>
+    Context: User has just implemented a new API endpoint for user data updates.
+    user: 'I\'ve added a new endpoint for updating user profiles. Here\'s the code...'
+    assistant: 'I\'ll review this new endpoint for security vulnerabilities using the security-guardian agent.'
+    <commentary>Since new user data handling functionality was added, use security-guardian to check for vulnerabilities.</commentary>
+    </example>
+
+    <example>
+    Context: Preparing for a production deployment.
+    user: 'We\'re ready to deploy version 2.0 to production'
+    assistant: 'Before deploying to production, let me run a security review with the security-guardian agent.'
+    <commentary>Pre-deployment security review is a critical checkpoint that requires security-guardian — this is non-optional.</commentary>
+    </example>
+
 
 model_role: [security-audit, critique, general]
 

--- a/agents/session-analyst.md
+++ b/agents/session-analyst.md
@@ -1,7 +1,25 @@
 ---
 meta:
   name: session-analyst
-  description: "REQUIRED agent for analyzing, debugging, searching, and REPAIRING Amplifier sessions. Performs transcript surgery to recover sessions with orphaned tool calls, ordering violations, or incomplete assistant turns. MUST be used when:\\n- Session has orphaned tool_calls (tool_use without matching tool_result)\\n- Session has ordering violations (consecutive same-role messages)\\n- Session has incomplete assistant turns (missing content or tool_calls)\\n- Resume fails with provider rejection errors (400/422 from API)\\n- Investigating why a session failed or won't resume\\n- Analyzing events.jsonl files (contains 100k+ token lines that WILL crash other tools)\\n- Diagnosing API errors, missing tool results, or corrupted transcripts\\n- Understanding what happened in a past conversation\\n- Searching for sessions by ID, project, date, or topic\\n- REWINDING a session to a prior point (truncating history to retry from a clean state)\\n\\nDefaults to REPAIR (inject synthetic entries to complete broken turns) rather than REWIND (truncate to before the issue). Rewind only when explicitly requested.\\n\\nThis agent has specialized knowledge for safely extracting data from large session logs without context overflow. DO NOT attempt to read events.jsonl directly - delegate to this agent.\\n\\nExamples:\\n\\n<example>\\nuser: 'Why did my session fail?' or 'Session X won't resume'\\nassistant: 'I'll use the session-analyst agent to investigate the failure - it has specialized tools for safely analyzing large event logs.'\\n<commentary>MUST delegate session debugging to this agent. It knows how to handle 100k+ token event lines safely.</commentary>\\n</example>\\n\\n<example>\\nuser: 'What's in events.jsonl?' or asks about session event logs\\nassistant: 'I'll delegate this to session-analyst - events.jsonl files can have lines with 100k+ tokens that require special handling.'\\n<commentary>NEVER attempt to read events.jsonl directly. Always delegate to session-analyst.</commentary>\\n</example>\\n\\n<example>\\nuser: 'Find the conversation where I worked on authentication'\\nassistant: 'I'll use the session-analyst agent to search through your Amplifier sessions for authentication-related conversations.'\\n<commentary>The agent searches session metadata and transcripts for relevant conversations.</commentary>\\n</example>\\n\\n<example>\\nuser: 'What sessions do I have from last week in the azure project?'\\nassistant: 'Let me use the session-analyst agent to locate sessions from the azure project directory from last week.'\\n<commentary>The agent scopes search to specific project and timeframe.</commentary>\\n</example>\\n\\n<example>\\nuser: 'My session won't resume - I get a 400 error about message ordering'\\nassistant: 'I'll use the session-analyst agent to diagnose and repair the transcript - it can perform surgery on the events.jsonl to fix ordering violations and orphaned tool calls, injecting synthetic entries to complete broken turns.'\\n<commentary>The agent defaults to REPAIR (injecting synthetic entries) rather than REWIND. It fixes the transcript in place so no history is lost.</commentary>\\n</example>\\n\\n<example>\\nuser: 'Rewind session X to before my last message' or 'Fix my broken session by removing the problematic exchange'\\nassistant: 'I'll use the session-analyst agent to rewind that session - it can safely truncate the events.jsonl to remove history from a specific point so you can retry.'\\n<commentary>Rewind is used only when explicitly requested. The agent creates backups before any modification.</commentary>\\n</example>"
+  description: |
+    REQUIRED agent for analyzing, debugging, searching, and repairing Amplifier sessions — specializing in transcript surgery to recover broken sessions and safely reading events.jsonl files that would crash other tools.
+
+    MUST be used when: session has orphaned tool_calls, ordering violations, or incomplete assistant turns; resume fails with 400/422 provider errors; analyzing events.jsonl (100k+ token lines); searching sessions by ID, project, date, or topic; rewinding a session to a prior checkpoint.
+
+    **Authoritative on:** session repair, transcript surgery, rewind/rollback, orphaned tool_calls, ordering violations, events.jsonl analysis, session search, transcript.jsonl, provider rejection errors, session history
+
+    <example>
+    user: 'Session X won\'t resume' or 'Why did my session fail?'
+    assistant: 'I\'ll delegate to session-analyst — it has specialized tools for safely diagnosing transcript issues and reading events.jsonl without crashing the session.'
+    <commentary>MUST delegate session debugging here. Never attempt to read events.jsonl directly — a single grep on it will crash your session.</commentary>
+    </example>
+
+    <example>
+    user: 'Find the session where we built the caching layer'
+    assistant: 'I\'ll use session-analyst to search your session history — it can query by project, date, keyword, or partial session ID.'
+    <commentary>Use for any session search or history investigation, not just failures. session-analyst safely handles all session file operations.</commentary>
+    </example>
+
 
 model_role: fast
 

--- a/bundle.md
+++ b/bundle.md
@@ -1,7 +1,7 @@
 ---
 bundle:
   name: foundation
-  version: 2.1.0
+  version: 2.1.1
   description: |
     Foundation bundle with enhanced delegate tool.
     


### PR DESCRIPTION
## Release v2.1.1

Patch bump for agent description field trimming.

**Changes:**
- Trim agent description fields in 6 foundation agents per the rubric in `docs/AGENT_AUTHORING.md` §"Description Requirements (Critical)".
- Each agent's meta.description trimmed from 467-895 tokens to ~250 tokens, preserving WHY/WHEN/WHAT/HOW with exactly two examples.
- Cut methodology prose, MUST-be-used-for inventories, justification paragraphs, scope disclaimers, redundant examples.
- Taxonomy sharpened so the routing LLM can distinguish bundle-design-expert (authoring) from foundation-expert (navigation) and modular-builder (spec-required implementation) from zen-architect (design + analysis) without exclusion prose.
- Reduction: ~2,000 tokens across 6 agents in the delegate tool catalog.
- No behavior changes.

**Agents modified:**
- session-analyst
- git-ops
- bundle-design-expert
- foundation-expert
- security-guardian
- modular-builder

Co-shipping with companion releases trimming agents across resolve, reality-check, terminal-tester, amplifier-tester, digital-twin-universe, and dot-graph bundles.