### PR TITLE
fix(hooks): add name= to register() calls so /config show shows attribution

### DIFF
--- a/amplifier_foundation/configurator/_inspector.py
+++ b/amplifier_foundation/configurator/_inspector.py
@@ -27,6 +27,28 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Cycle-warning deduplication
+# ---------------------------------------------------------------------------
+
+# A cycle is a structural property of the include graph, not of individual
+# traversals.  walk_include_chains is called once per config item (~100-250
+# items per session), so a single cycle node would otherwise produce hundreds
+# of duplicate warnings.  This module-level set ensures each unique cycle node
+# is reported at most once per process lifetime.
+_WARNED_CYCLE_NODES: set[str] = set()
+
+
+def _reset_cycle_warnings_for_testing() -> None:
+    """Clear the deduplication set so cycle warnings can be re-emitted.
+
+    Intended for use in tests only — call this before each test case that
+    checks the cycle-warning emission count to prevent state from leaking
+    between test runs.
+    """
+    _WARNED_CYCLE_NODES.clear()
+
+
+# ---------------------------------------------------------------------------
 # Sentinel for redaction
 # ---------------------------------------------------------------------------
 
@@ -197,10 +219,16 @@ def walk_include_chains(
     def _all_paths_to_root(current: str, visited: frozenset[str]) -> list[list[str]]:
         """Return all root→leaf paths ending at *current* as lists of bundle names."""
         if current in visited:
-            _logger.warning(
-                "Cycle detected in bundle include graph at %r; breaking chain.",
-                current,
-            )
+            # Deduplicate: a cycle is a graph property, not a per-traversal event.
+            # walk_include_chains is called for every config item (~100-250 items),
+            # so without deduplication the same cycle node would produce hundreds of
+            # identical warnings.  Emit at most once per unique cycle node.
+            if current not in _WARNED_CYCLE_NODES:
+                _WARNED_CYCLE_NODES.add(current)
+                _logger.warning(
+                    "Cycle detected in bundle include graph at %r; breaking chain.",
+                    current,
+                )
             return [[current]]
 
         state = registry_dict.get(current)

--- a/amplifier_foundation/registry.py
+++ b/amplifier_foundation/registry.py
@@ -769,23 +769,46 @@ class BundleRegistry:
     ) -> None:
         """Record which bundles include which other bundles.
 
-        Updates both parent's 'includes' and children's 'included_by' fields.
+        REPLACES (not appends) parent's 'includes' list with *child_names* so
+        that stale entries from previous loads or renames are removed.  When a
+        dependency is renamed (e.g. 'terminal-tester' behavior → 'terminal-
+        tester-behavior'), the old name must be evicted; append-only logic would
+        leave the self-reference that creates a graph cycle.
+
+        Side-effects on the ``included_by`` lists:
+        - Bundles that were in the OLD includes list but are absent from the new
+          *child_names* have *parent_name* removed from their ``included_by``.
+        - Bundles in *child_names* gain *parent_name* in their ``included_by``
+          (idempotent — won't duplicate if already present).
+
         Persists registry state after recording.
 
         Args:
             parent_name: Name of the parent bundle.
-            child_names: Names of bundles included by parent.
+            child_names: Authoritative list of bundle names included by parent.
         """
-        # Update parent's includes list
         parent_state = self._registry.get(parent_name)
-        if parent_state:
-            if parent_state.includes is None:
-                parent_state.includes = []
-            for child_name in child_names:
-                if child_name not in parent_state.includes:
-                    parent_state.includes.append(child_name)
 
-        # Update each child's included_by list
+        # --- Clean up stale includes ------------------------------------------
+        # Identify which children were recorded in the *previous* load so we
+        # can remove this parent from their included_by when they drop out.
+        old_child_names: list[str] = (
+            list(parent_state.includes or []) if parent_state else []
+        )
+        removed_children = [c for c in old_child_names if c not in child_names]
+
+        for removed_name in removed_children:
+            removed_state = self._registry.get(removed_name)
+            if removed_state and removed_state.included_by:
+                removed_state.included_by = [
+                    n for n in removed_state.included_by if n != parent_name
+                ]
+
+        # --- Replace parent's includes list (not append) ----------------------
+        if parent_state:
+            parent_state.includes = list(child_names)
+
+        # --- Update each child's included_by list (idempotent append) ---------
         for child_name in child_names:
             child_state = self._registry.get(child_name)
             if child_state:

--- a/modules/hooks-progress-monitor/amplifier_module_hooks_progress_monitor/__init__.py
+++ b/modules/hooks-progress-monitor/amplifier_module_hooks_progress_monitor/__init__.py
@@ -224,7 +224,9 @@ async def mount(
     hooks = ProgressMonitorHooks(monitor_config)
 
     # Register hook - runs after tool execution to track operations
-    coordinator.hooks.register("tool:post", hooks.handle_tool_post, priority=50)
+    coordinator.hooks.register(
+        "tool:post", hooks.handle_tool_post, priority=50, name="hooks-progress-monitor"
+    )
 
     return {
         "name": "hooks-progress-monitor",

--- a/modules/hooks-todo-display/amplifier_module_hooks_todo_display/__init__.py
+++ b/modules/hooks-todo-display/amplifier_module_hooks_todo_display/__init__.py
@@ -28,16 +28,16 @@ class Colors:
     RESET = "\033[0m"
     BOLD = "\033[1m"
     DIM = "\033[2m"
-    
+
     # Status colors
     GREEN = "\033[32m"
     CYAN = "\033[36m"
     GRAY = "\033[90m"
-    
+
     # Bold variants
     BOLD_CYAN = "\033[1;36m"
     BOLD_GREEN = "\033[1;32m"
-    
+
     # Dim variants
     DIM_GREEN = "\033[2;32m"
     DIM_GRAY = "\033[2;37m"
@@ -48,11 +48,11 @@ class Symbols:
     COMPLETED = "✓"
     IN_PROGRESS = "▶"
     PENDING = "○"
-    
+
     # Progress bar
     FILL = "█"
     EMPTY = "░"
-    
+
     # Box drawing
     TOP_LEFT = "┌"
     TOP_RIGHT = "┐"
@@ -66,8 +66,11 @@ class Symbols:
 @dataclass
 class TodoDisplayConfig:
     """Configuration for todo display rendering."""
+
     mode: str = "full"  # "full", "condensed", "auto", "none"
-    compact_threshold: int = 7  # Switch to condensed at this count (only used when mode="auto")
+    compact_threshold: int = (
+        7  # Switch to condensed at this count (only used when mode="auto")
+    )
     show_progress_bar: bool = True
     progress_bar_width: int = 24
     max_width: int = 60  # Max width for item text
@@ -77,33 +80,33 @@ class TodoDisplayConfig:
 
 class TodoDisplayHooks:
     """Hook handlers for visual todo display."""
-    
+
     def __init__(self, config: TodoDisplayConfig):
         self.config = config
         self._pending_todos: list[dict] | None = None
-    
+
     async def handle_tool_pre(self, _event: str, data: dict[str, Any]) -> HookResult:
         """Capture todo data before tool execution for display after."""
         tool_name = data.get("tool_name", "")
         if tool_name != "todo":
             return HookResult(action="continue")
-        
+
         # Capture the todos being sent (for create/update actions)
         tool_input = data.get("tool_input", {})
         if isinstance(tool_input, dict):
             self._pending_todos = tool_input.get("todos")
-        
+
         return HookResult(action="continue")
-    
+
     async def handle_tool_post(self, _event: str, data: dict[str, Any]) -> HookResult:
         """Render todo progress display after tool execution."""
         tool_name = data.get("tool_name", "")
         if tool_name != "todo":
             return HookResult(action="continue")
-        
+
         if self.config.mode == "none":
             return HookResult(action="continue")
-        
+
         result = data.get("tool_response", data.get("result", {}))
         if isinstance(result, dict):
             output = result.get("output", result)
@@ -114,46 +117,50 @@ class TodoDisplayHooks:
                     # Clear pending todos
                     self._pending_todos = None
                     # Signal that we handled the display
-                    return HookResult(action="continue", metadata={"todo_displayed": True})
-        
+                    return HookResult(
+                        action="continue", metadata={"todo_displayed": True}
+                    )
+
         self._pending_todos = None
         return HookResult(action="continue")
-    
+
     def _render_todo_display(self, output: dict, data: dict) -> None:
         """Render the todo display based on configuration."""
         todos = output.get("todos", [])
-        
+
         # If no todos in output, try to use pending todos or show summary
         if not todos and self._pending_todos:
             todos = self._pending_todos
-        
+
         # Get counts
         count = output.get("count", len(todos))
         completed = output.get("completed", 0)
         in_progress = output.get("in_progress", 0)
         pending = output.get("pending", 0)
-        
+
         # If we have todos, calculate counts from them
         if todos:
             completed = sum(1 for t in todos if t.get("status") == "completed")
             in_progress = sum(1 for t in todos if t.get("status") == "in_progress")
             pending = sum(1 for t in todos if t.get("status") == "pending")
             count = len(todos)
-        
+
         # Determine display mode
         mode = self.config.mode
         if mode == "auto":
             mode = "condensed" if count > self.config.compact_threshold else "full"
-        
+
         # Handle sub-agent indentation
         indent = self._get_indent(data)
-        
+
         # Render based on mode
         if mode == "condensed" or not todos:
-            self._render_condensed(count, completed, in_progress, pending, todos, indent)
+            self._render_condensed(
+                count, completed, in_progress, pending, todos, indent
+            )
         else:
             self._render_full(todos, count, completed, indent)
-    
+
     def _get_indent(self, data: dict) -> str:
         """Get indentation prefix for sub-agent context."""
         session_id = data.get("session_id", "")
@@ -161,29 +168,29 @@ class TodoDisplayHooks:
         if "_" in session_id and not session_id.startswith("session_"):
             return "  │ "
         return ""
-    
+
     def _render_condensed(
-        self, 
-        count: int, 
-        completed: int, 
-        in_progress: int, 
+        self,
+        count: int,
+        completed: int,
+        in_progress: int,
         pending: int,
         todos: list[dict],
-        indent: str
+        indent: str,
     ) -> None:
         """Render single-line condensed progress view."""
         width = self.config.max_width
-        
+
         # Find current task
         current_task = ""
         for todo in todos:
             if todo.get("status") == "in_progress":
                 current_task = todo.get("activeForm", todo.get("content", ""))
                 break
-        
+
         # Build progress bar
         progress_bar = self._build_progress_bar(completed, count)
-        
+
         # Calculate available space for task text dynamically
         # Content format: " {progress_bar} {completed}/{count} {symbol} {task}"
         # Fixed elements: space(1) + progress_bar + space(1) + count_str + space(1) + symbol(1) + space(1)
@@ -191,7 +198,7 @@ class TodoDisplayHooks:
         fixed_len = 1 + self.config.progress_bar_width + 1 + len(count_str) + 1 + 1 + 1
         # Leave 1 char buffer for padding calculation
         max_task_len = max(10, width - fixed_len - 1)
-        
+
         # Build status line
         if count == completed:
             # All done!
@@ -202,7 +209,7 @@ class TodoDisplayHooks:
         else:
             # No current task, show counts
             status = f"{Colors.DIM_GRAY}{pending} pending{Colors.RESET}"
-        
+
         # Render
         if self.config.show_border:
             width = self.config.max_width
@@ -210,36 +217,46 @@ class TodoDisplayHooks:
             top_line = f"{Symbols.TOP_LEFT}{Symbols.HORIZONTAL}{title}{Symbols.HORIZONTAL * (width - len(title) - 1)}{Symbols.TOP_RIGHT}"
             content = f"{Symbols.VERTICAL} {progress_bar} {completed}/{count} {status}"
             # Pad content to width
-            visible_len = len(f" {self._strip_ansi(progress_bar)} {completed}/{count} {self._strip_ansi(status)}")
+            visible_len = len(
+                f" {self._strip_ansi(progress_bar)} {completed}/{count} {self._strip_ansi(status)}"
+            )
             padding = width - visible_len - 1
             content += " " * max(0, padding) + Symbols.VERTICAL
             bottom_line = f"{Symbols.BOTTOM_LEFT}{Symbols.HORIZONTAL * (width)}{Symbols.BOTTOM_RIGHT}"
-            
+
             _write(f"\n{indent}{Colors.DIM_GRAY}{top_line}{Colors.RESET}\n")
-            _write(f"{indent}{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}{content[1:]}\n")
+            _write(
+                f"{indent}{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}{content[1:]}\n"
+            )
             _write(f"{indent}{Colors.DIM_GRAY}{bottom_line}{Colors.RESET}\n")
         else:
             _write(f"\n{indent}{progress_bar} {completed}/{count} {status}\n")
-    
-    def _render_full(self, todos: list[dict], count: int, completed: int, indent: str) -> None:
+
+    def _render_full(
+        self, todos: list[dict], count: int, completed: int, indent: str
+    ) -> None:
         """Render full list with all items visible."""
         width = self.config.max_width
-        
+
         # Build lines
         lines = []
-        
+
         # Header
         title = f" {self.config.title} "
         if self.config.show_border:
-            lines.append(f"{Colors.DIM_GRAY}{Symbols.TOP_LEFT}{Symbols.HORIZONTAL}{title}{Symbols.HORIZONTAL * (width - len(title) - 1)}{Symbols.TOP_RIGHT}{Colors.RESET}")
-            lines.append(f"{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}{' ' * width}{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}")
-        
+            lines.append(
+                f"{Colors.DIM_GRAY}{Symbols.TOP_LEFT}{Symbols.HORIZONTAL}{title}{Symbols.HORIZONTAL * (width - len(title) - 1)}{Symbols.TOP_RIGHT}{Colors.RESET}"
+            )
+            lines.append(
+                f"{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}{' ' * width}{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}"
+            )
+
         # Items
         for todo in todos:
             status = todo.get("status", "pending")
             content = todo.get("content", "")
             active_form = todo.get("activeForm", content)
-            
+
             if status == "completed":
                 symbol = f"{Colors.DIM_GREEN}{Symbols.COMPLETED}{Colors.RESET}"
                 text = f"{Colors.DIM_GREEN}{self._truncate(content, width - 4)}{Colors.RESET}"
@@ -249,7 +266,7 @@ class TodoDisplayHooks:
             else:  # pending
                 symbol = f"{Colors.DIM_GRAY}{Symbols.PENDING}{Colors.RESET}"
                 text = f"{Colors.DIM_GRAY}{self._truncate(content, width - 4)}{Colors.RESET}"
-            
+
             if self.config.show_border:
                 # Calculate padding (need to account for ANSI codes)
                 visible_text = self._strip_ansi(f" {symbol} {text}")
@@ -257,65 +274,78 @@ class TodoDisplayHooks:
                 line = f"{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET} {symbol} {text}{' ' * max(0, padding)}{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}"
             else:
                 line = f" {symbol} {text}"
-            
+
             lines.append(line)
-        
+
         # Progress bar
         if self.config.show_progress_bar:
             if self.config.show_border:
-                lines.append(f"{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}{' ' * width}{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}")
-            
+                lines.append(
+                    f"{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}{' ' * width}{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}"
+                )
+
             progress_bar = self._build_progress_bar(completed, count)
             progress_text = f" {progress_bar} {completed}/{count}"
-            
+
             if count == completed:
-                progress_text += f" {Colors.BOLD_GREEN}{Symbols.COMPLETED} Complete{Colors.RESET}"
-            
+                progress_text += (
+                    f" {Colors.BOLD_GREEN}{Symbols.COMPLETED} Complete{Colors.RESET}"
+                )
+
             if self.config.show_border:
                 visible_len = len(self._strip_ansi(progress_text))
                 padding = width - visible_len
-                lines.append(f"{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}{progress_text}{' ' * max(0, padding)}{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}")
-                lines.append(f"{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}{' ' * width}{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}")
+                lines.append(
+                    f"{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}{progress_text}{' ' * max(0, padding)}{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}"
+                )
+                lines.append(
+                    f"{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}{' ' * width}{Colors.DIM_GRAY}{Symbols.VERTICAL}{Colors.RESET}"
+                )
             else:
                 lines.append(progress_text)
-        
+
         # Footer
         if self.config.show_border:
-            lines.append(f"{Colors.DIM_GRAY}{Symbols.BOTTOM_LEFT}{Symbols.HORIZONTAL * (width)}{Symbols.BOTTOM_RIGHT}{Colors.RESET}")
-        
+            lines.append(
+                f"{Colors.DIM_GRAY}{Symbols.BOTTOM_LEFT}{Symbols.HORIZONTAL * (width)}{Symbols.BOTTOM_RIGHT}{Colors.RESET}"
+            )
+
         # Print all lines
         _write("\n")
         for line in lines:
             _write(f"{indent}{line}\n")
-    
+
     def _build_progress_bar(self, completed: int, total: int) -> str:
         """Build a visual progress bar."""
         if total == 0:
             return f"{Colors.DIM_GRAY}{Symbols.EMPTY * self.config.progress_bar_width}{Colors.RESET}"
-        
+
         filled = int((completed / total) * self.config.progress_bar_width)
         empty = self.config.progress_bar_width - filled
-        
+
         return (
             f"{Colors.GREEN}{Symbols.FILL * filled}{Colors.RESET}"
             f"{Colors.DIM_GRAY}{Symbols.EMPTY * empty}{Colors.RESET}"
         )
-    
+
     def _truncate(self, text: str, max_len: int) -> str:
         """Truncate text with ellipsis if too long."""
         if len(text) <= max_len:
             return text
-        return text[:max_len - 1] + "…"
-    
+        return text[: max_len - 1] + "…"
+
     def _strip_ansi(self, text: str) -> str:
         """Remove ANSI codes from text for length calculation."""
         import re
-        return re.sub(r'\033\[[0-9;]*m', '', text)
+
+        return re.sub(r"\033\[[0-9;]*m", "", text)
 
 
-async def mount(coordinator: Any, config: dict[str, Any] | None = None) -> dict[str, Any]:
+async def mount(
+    coordinator: Any, config: dict[str, Any] | None = None
+) -> dict[str, Any]:
     """Mount the todo display hooks module.
-    
+
     Config options:
         mode: "full" | "condensed" | "auto" | "none" (default: "auto")
         compact_threshold: int (default: 7) - item count to switch to condensed
@@ -326,7 +356,7 @@ async def mount(coordinator: Any, config: dict[str, Any] | None = None) -> dict[
         title: str (default: "Todo")
     """
     config = config or {}
-    
+
     display_config = TodoDisplayConfig(
         mode=config.get("mode", "full"),
         compact_threshold=config.get("compact_threshold", 7),
@@ -336,14 +366,18 @@ async def mount(coordinator: Any, config: dict[str, Any] | None = None) -> dict[
         show_border=config.get("show_border", True),
         title=config.get("title", "Todo"),
     )
-    
+
     hooks = TodoDisplayHooks(display_config)
-    
+
     # Register hooks with high priority to run before generic tool display
     # Lower number = higher priority
-    coordinator.hooks.register("tool:pre", hooks.handle_tool_pre, priority=5)
-    coordinator.hooks.register("tool:post", hooks.handle_tool_post, priority=5)
-    
+    coordinator.hooks.register(
+        "tool:pre", hooks.handle_tool_pre, priority=5, name="hooks-todo-display-pre"
+    )
+    coordinator.hooks.register(
+        "tool:post", hooks.handle_tool_post, priority=5, name="hooks-todo-display-post"
+    )
+
     return {
         "name": "hooks-todo-display",
         "version": "0.1.0",

--- a/tests/test_configurator.py
+++ b/tests/test_configurator.py
@@ -18,6 +18,7 @@ from amplifier_foundation.configurator import (
 from amplifier_foundation.configurator._inspector import (
     _build_include_path,
     _build_include_paths,
+    _reset_cycle_warnings_for_testing,
 )
 from amplifier_foundation.configurator._types import IncludeStep, Origin
 
@@ -3243,7 +3244,7 @@ class TestWalkIncludeChains:
             "reality-check-behavior": _make_state(
                 name="reality-check-behavior",
                 included_by=[],  # no parents → topological root
-                is_root=False,   # structural: it's a nested bundle
+                is_root=False,  # structural: it's a nested bundle
             ),
             "terminal-tester": _make_state(
                 name="terminal-tester",
@@ -3411,3 +3412,127 @@ class TestMultiSourceIncludePaths:
         assert len(result) == 1
         names = [s.bundle for s in result[0]]
         assert names == ["root", "foundation"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for Bug A — cycle warning deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestWalkIncludeChainsCycleWarningDedupe:
+    """walk_include_chains emits the cycle warning at most once per unique cycle node.
+
+    A cycle in the include graph is a property of the graph structure, not of
+    individual traversals.  With ~241 items each triggering their own traversal,
+    a single cycle node was previously logged hundreds of times.  After the fix,
+    each unique cycle node should produce exactly one WARNING per session.
+    """
+
+    def test_cycle_warning_emitted_exactly_once_for_single_cycle(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Calling walk_include_chains many times on the same cycle emits the
+        warning exactly once — not once per call."""
+        # Reset the deduplication set before the test so state from other tests
+        # does not interfere.
+        _reset_cycle_warnings_for_testing()
+
+        registry_dict: dict[str, Any] = {
+            # terminal-tester self-cycle (the real-world scenario)
+            "terminal-tester": _make_state(
+                name="terminal-tester",
+                included_by=["terminal-tester"],  # self-cycle
+                is_root=True,
+            ),
+            "foundation": _make_state(
+                name="foundation",
+                included_by=["terminal-tester"],
+            ),
+        }
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            # Simulate ~100 items each triggering a traversal through the cycle
+            for _ in range(100):
+                walk_include_chains("foundation", registry_dict)
+
+        # Exactly one warning about "terminal-tester" should appear
+        cycle_warnings = [
+            r
+            for r in caplog.records
+            if "Cycle detected" in r.message and "terminal-tester" in r.message
+        ]
+        assert len(cycle_warnings) == 1, (
+            f"Expected exactly 1 cycle warning for 'terminal-tester', "
+            f"got {len(cycle_warnings)}: {[r.message for r in cycle_warnings]}"
+        )
+
+    def test_cycle_warning_once_per_unique_cycle_node(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Two distinct cycle nodes each produce exactly one warning (not N each)."""
+        _reset_cycle_warnings_for_testing()
+
+        registry_dict: dict[str, Any] = {
+            "A": _make_state(name="A", included_by=["B"]),
+            "B": _make_state(name="B", included_by=["A"]),
+            "leaf": _make_state(name="leaf", included_by=["A"]),
+        }
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(50):
+                walk_include_chains("leaf", registry_dict)
+
+        cycle_warnings = [r for r in caplog.records if "Cycle detected" in r.message]
+        # Two distinct cycle-entry nodes (A and B), each warned at most once
+        warned_nodes = {r.message for r in cycle_warnings}
+        assert len(warned_nodes) <= 2, (
+            f"Expected ≤2 unique cycle warnings, got {len(warned_nodes)}"
+        )
+        # Each node warned at most once (no duplicates)
+        assert len(cycle_warnings) == len(warned_nodes), (
+            f"Duplicate warnings detected: {[r.message for r in cycle_warnings]}"
+        )
+
+    def test_reset_cycle_warnings_allows_re_emission(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """After _reset_cycle_warnings_for_testing(), the warning can be emitted again."""
+        _reset_cycle_warnings_for_testing()
+
+        registry_dict: dict[str, Any] = {
+            "X": _make_state(name="X", included_by=["X"]),  # self-cycle
+            "leaf": _make_state(name="leaf", included_by=["X"]),
+        }
+
+        import logging
+
+        # First traversal — should produce 1 warning
+        with caplog.at_level(logging.WARNING):
+            walk_include_chains("leaf", registry_dict)
+
+        first_count = sum(
+            1
+            for r in caplog.records
+            if "Cycle detected" in r.message and "'X'" in r.message
+        )
+        assert first_count == 1
+
+        # Reset and re-traverse — should produce 1 warning again
+        _reset_cycle_warnings_for_testing()
+        caplog.clear()
+
+        with caplog.at_level(logging.WARNING):
+            walk_include_chains("leaf", registry_dict)
+
+        second_count = sum(
+            1
+            for r in caplog.records
+            if "Cycle detected" in r.message and "'X'" in r.message
+        )
+        assert second_count == 1, (
+            "After reset, warning should be emitted again (exactly once)"
+        )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,7 +4,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from amplifier_foundation.registry import BundleRegistry
+from amplifier_foundation.registry import BundleRegistry, BundleState
 
 
 class TestFindNearestBundleFile:
@@ -317,9 +317,10 @@ class TestSubdirectoryBundleLoading:
             # NOT to the checkout root.  Agents and context for 'recipes:' live under
             # behaviors/recipes/agents/ and behaviors/recipes/context/, not root/agents/.
             assert bundle.name == "recipes"
-            assert bundle.source_base_paths.get("recipes") == (
-                base / "behaviors" / "recipes"
-            ).resolve()
+            assert (
+                bundle.source_base_paths.get("recipes")
+                == (base / "behaviors" / "recipes").resolve()
+            )
 
     @pytest.mark.asyncio
     async def test_root_bundle_no_extra_source_base_paths(self) -> None:
@@ -464,7 +465,9 @@ class TestSubdirectoryBundleLoading:
             # Bug: with source_base_paths['subns'] = root/, it returned root/agents/foo.md (decoy)
             bundle.load_agent_metadata()
             agent_path = bundle.resolve_agent_path("subns:foo")
-            assert agent_path is not None, "resolve_agent_path('subns:foo') returned None"
+            assert agent_path is not None, (
+                "resolve_agent_path('subns:foo') returned None"
+            )
             assert agent_path.resolve() == (sub / "agents" / "foo.md").resolve(), (
                 f"resolve_agent_path('subns:foo') = {agent_path!r}, "
                 f"expected {(sub / 'agents' / 'foo.md').resolve()!r} — got the checkout-root decoy?"
@@ -499,16 +502,19 @@ class TestSubdirectoryBundleLoading:
             sub_behaviors = sub / "behaviors"
             sub_behaviors.mkdir()
             (sub_behaviors / "config.yaml").write_text(
-                "bundle:\n"
-                "  name: myns\n"
-                "  version: 1.0.0\n"
-                "  namespace_root: ..\n"
+                "bundle:\n  name: myns\n  version: 1.0.0\n  namespace_root: ..\n"
             )
 
             from amplifier_foundation.bundle._dataclass import Bundle
 
             bundle = Bundle.from_dict(
-                {"bundle": {"name": "myns", "version": "1.0.0", "namespace_root": ".."}},
+                {
+                    "bundle": {
+                        "name": "myns",
+                        "version": "1.0.0",
+                        "namespace_root": "..",
+                    }
+                },
                 base_path=sub_behaviors,
             )
 
@@ -571,7 +577,9 @@ class TestSubdirectoryBundleLoading:
             # Agent at behaviors/agents/bar.md resolves correctly with default
             agent_path = bundle.resolve_agent_path("subns:bar")
             assert agent_path is not None
-            assert agent_path.resolve() == (sub_behaviors / "agents" / "bar.md").resolve(), (
+            assert (
+                agent_path.resolve() == (sub_behaviors / "agents" / "bar.md").resolve()
+            ), (
                 f"Expected {(sub_behaviors / 'agents' / 'bar.md').resolve()!r}, "
                 f"got {agent_path!r}"
             )
@@ -619,7 +627,9 @@ class TestSubdirectoryBundleLoading:
                 "resolve_agent_path('foundation:bug-hunter') returned None for a root bundle. "
                 "The namespace==self.name fallback in resolve_agent_path() is broken."
             )
-            assert agent_path.resolve() == (base / "agents" / "bug-hunter.md").resolve(), (
+            assert (
+                agent_path.resolve() == (base / "agents" / "bug-hunter.md").resolve()
+            ), (
                 f"Expected {(base / 'agents' / 'bug-hunter.md').resolve()!r}, "
                 f"got {agent_path!r}"
             )
@@ -1530,3 +1540,178 @@ class TestIncludeSourceResolver:
             result = registry._resolve_include_source("plain-bundle-name")
             assert "plain-bundle-name" in resolver_calls
             assert result == "overridden://plain-bundle-name"
+
+
+# ---------------------------------------------------------------------------
+# Tests for Bug B — registry self-include edge / stale include relationships
+# ---------------------------------------------------------------------------
+
+
+class TestRecordIncludeRelationshipsIdempotent:
+    """_record_include_relationships replaces stale include edges, not appends.
+
+    Root cause: When a bundle dependency is renamed (e.g., terminal-tester's
+    behavior file was renamed from 'terminal-tester' to 'terminal-tester-behavior'),
+    _record_include_relationships used to APPEND to the existing includes list,
+    leaving stale self-references that created graph cycles.
+
+    After the fix, calling _record_include_relationships with the new child names
+    should REPLACE the old includes list and clean up stale included_by entries.
+    """
+
+    def test_replaces_stale_self_reference_in_includes(self) -> None:
+        """Stale self-reference is removed when _record_include_relationships is
+        called with the corrected child names (Bug B exact scenario)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry = BundleRegistry(home=Path(tmpdir) / "home")
+
+            # Simulate stale registry state after old behavior name 'terminal-tester'
+            registry.register(
+                {
+                    "terminal-tester": "git+https://github.com/example/terminal-tester@main",
+                    "foundation": "git+https://github.com/example/foundation@main",
+                    "terminal-tester-behavior": "git+https://github.com/example/terminal-tester@main#subdirectory=behaviors/terminal-tester.yaml",
+                }
+            )
+
+            tt_state = registry.get_state("terminal-tester")
+            assert isinstance(tt_state, BundleState)
+            fnd_state = registry.get_state("foundation")
+            assert isinstance(fnd_state, BundleState)
+
+            # Stale state: terminal-tester included itself (old behavior name was 'terminal-tester')
+            tt_state.includes = ["foundation", "terminal-tester"]  # self-reference!
+            tt_state.included_by = [
+                "terminal-tester",
+                "reality-check-behavior",
+            ]  # self-ref!
+            fnd_state.included_by = ["terminal-tester"]
+
+            # Now the bundle is re-loaded and the behavior is correctly identified
+            # as 'terminal-tester-behavior'. Record the corrected relationships.
+            registry._record_include_relationships(
+                "terminal-tester",
+                ["foundation", "terminal-tester-behavior"],
+            )
+
+            # The includes list should be the NEW list — no stale self-reference
+            assert tt_state.includes == ["foundation", "terminal-tester-behavior"], (
+                f"Expected ['foundation', 'terminal-tester-behavior'], "
+                f"got {tt_state.includes}"
+            )
+
+            # terminal-tester should NOT include itself
+            assert "terminal-tester" not in tt_state.includes, (
+                "Self-reference must be removed from includes"
+            )
+
+    def test_stale_included_by_cleaned_from_old_child(self) -> None:
+        """When a parent's includes change, old children's included_by is cleaned."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry = BundleRegistry(home=Path(tmpdir) / "home")
+
+            registry.register(
+                {
+                    "parent": "git+https://github.com/example/parent@main",
+                    "old-child": "git+https://github.com/example/old@main",
+                    "new-child": "git+https://github.com/example/new@main",
+                }
+            )
+
+            parent_state = registry.get_state("parent")
+            assert isinstance(parent_state, BundleState)
+            old_child_state = registry.get_state("old-child")
+            assert isinstance(old_child_state, BundleState)
+
+            # Stale state: parent included 'old-child' (now renamed to 'new-child')
+            parent_state.includes = ["old-child"]
+            old_child_state.included_by = ["parent"]
+
+            # Register 'new-child' so it has state
+            new_child_state = registry.get_state("new-child")
+            assert isinstance(new_child_state, BundleState)
+            new_child_state.included_by = []
+
+            # Record the corrected relationships
+            registry._record_include_relationships("parent", ["new-child"])
+
+            # parent.includes should now be ['new-child'] — stale 'old-child' removed
+            assert parent_state.includes == ["new-child"], (
+                f"Expected ['new-child'], got {parent_state.includes}"
+            )
+
+            # old-child.included_by should no longer contain 'parent'
+            assert "parent" not in (old_child_state.included_by or []), (
+                f"old-child.included_by should not contain 'parent', "
+                f"got {old_child_state.included_by}"
+            )
+
+            # new-child.included_by should contain 'parent'
+            assert "parent" in (new_child_state.included_by or []), (
+                f"new-child.included_by should contain 'parent', "
+                f"got {new_child_state.included_by}"
+            )
+
+    def test_no_self_reference_in_includes_after_reload(self) -> None:
+        """After fix, terminal-tester.includes must not contain 'terminal-tester'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry = BundleRegistry(home=Path(tmpdir) / "home")
+
+            registry.register(
+                {
+                    "terminal-tester": "git+https://github.com/example/tt@main",
+                    "foundation": "git+https://github.com/example/foundation@main",
+                    "terminal-tester-behavior": "git+https://example.com/tt@main#subdirectory=behaviors/tt.yaml",
+                }
+            )
+
+            tt_state = registry.get_state("terminal-tester")
+            assert isinstance(tt_state, BundleState)
+            tt_state.includes = ["foundation", "terminal-tester"]  # stale self-ref
+            tt_state.included_by = ["terminal-tester"]  # stale self-ref
+
+            # Simulate reload: record the true includes
+            registry._record_include_relationships(
+                "terminal-tester", ["foundation", "terminal-tester-behavior"]
+            )
+
+            assert "terminal-tester" not in (tt_state.includes or []), (
+                "terminal-tester must not be in its own includes after reload"
+            )
+
+    def test_multiple_parents_for_same_child_preserved(self) -> None:
+        """Multiple distinct parents can both include the same child; each parent's
+        reload only clears that parent's stale entries, not others'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry = BundleRegistry(home=Path(tmpdir) / "home")
+
+            registry.register(
+                {
+                    "parent-a": "git+https://github.com/example/a@main",
+                    "parent-b": "git+https://github.com/example/b@main",
+                    "child": "git+https://github.com/example/child@main",
+                }
+            )
+
+            child_state = registry.get_state("child")
+            assert isinstance(child_state, BundleState)
+
+            # Both parents include child; record parent-a first
+            registry._record_include_relationships("parent-a", ["child"])
+            registry._record_include_relationships("parent-b", ["child"])
+
+            # child.included_by should have BOTH parents
+            assert set(child_state.included_by or []) == {"parent-a", "parent-b"}, (
+                f"Both parents should appear in child.included_by, "
+                f"got {child_state.included_by}"
+            )
+
+            # Now parent-a is reloaded with the same child (idempotent)
+            registry._record_include_relationships("parent-a", ["child"])
+
+            # Still both parents; no duplication
+            assert set(child_state.included_by or []) == {"parent-a", "parent-b"}
+            assert child_state.included_by is not None
+            assert child_state.included_by.count("parent-a") == 1, (
+                "parent-a must not be duplicated in child.included_by"
+            )


### PR DESCRIPTION
## Problem

`/config show --detailed` displayed hooks from these two modules with auto-generated names like `_auto_tool:post_{uuid}` instead of proper attribution. Root cause: `coordinator.hooks.register()` calls in both modules omitted the `name=` kwarg. The Rust kernel falls back to `_auto_{event}_{uuid}` when `name` is None.

## Fix

Added `name=` to 3 `register()` calls across 2 modules:

### hooks-todo-display (2 calls)

| Event | Name |
|-------|------|
| `tool:pre` | `hooks-todo-display-pre` |
| `tool:post` | `hooks-todo-display-post` |

### hooks-progress-monitor (1 call)

| Event | Name |
|-------|------|
| `tool:post` | `hooks-progress-monitor` |

## Verification

- 1403 passed, 1 skipped — matches pre-change baseline exactly
- `python_check`: formatting clean; 1 pre-existing pyright error at line 121 of hooks-todo-display (unrelated to this change) and STUB warnings (false positives from the stub-checker treating todo-display code content as TODO stubs)

## Impact

No behaviour change — only hook naming. Once named, the existing attribution chain in amplifier-core picks up provenance correctly.