### PR TITLE
feat(mentions): emit mentions:resolved event after each resolution pass

### DIFF
--- a/amplifier_foundation/bundle/_observability.py
+++ b/amplifier_foundation/bundle/_observability.py
@@ -26,6 +26,7 @@ _DEFAULT_SUBSCRIBER_MODULES: frozenset[str] = frozenset(
 # Rust kernel's ALL_EVENTS list.
 FOUNDATION_OBSERVABILITY_EVENTS: tuple[str, ...] = (
     "session:config",  # emitted by _session_exec.emit_raw_field_if_configured (PR #79)
+    "mentions:resolved",  # emitted by PreparedBundle system-prompt factory (PR #213)
 )
 
 

--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from dataclasses import dataclass
 from dataclasses import field
 from decimal import Decimal
@@ -34,62 +33,107 @@ logger = logging.getLogger(__name__)
 #: Event name registered via the observability.events contribution channel.
 _MENTIONS_RESOLVED_EVENT = "mentions:resolved"
 
-#: Pattern to extract bundle slug from cache paths like
-#: ``/…/.amplifier/cache/amplifier-foundation-c9094…/context/foo.md``
-_CACHE_SLUG_RE = re.compile(r"[/\\]amplifier-([a-zA-Z0-9_-]+)-[a-f0-9]{8,}[/\\]")
 
+def _determine_source_type(mention: str | None) -> str:
+    """Classify the syntactic form of a mention; return only the source_type label.
 
-def _extract_bundle_attribution(
-    mention: str | None,
-    path: Path,
-) -> tuple[str | None, str]:
-    """Return ``(bundle_namespace, source_type)`` for a resolved mention/path.
+    Bundle attribution is handled separately by ``_lookup_origins`` against
+    ``Bundle.origins``.  This function does *not* parse paths and does *not*
+    use any cache-directory heuristic.
 
-    The *mention* string determines source type when present (e.g.
-    ``@foundation:context/foo.md``).  For context files declared in the
-    ``context:`` YAML section without an ``@`` prefix, the cache path is
-    parsed to recover the bundle slug.
-
-    Returns:
-        A ``(bundle, source_type)`` tuple where ``bundle`` is ``None`` for
-        user-owned paths (home shortcut, relative path).
+    Returns one of:
+        - "bundle_namespace"       — e.g. ``@foundation:context/foo.md``
+        - "user_shortcut"          — e.g. ``@user:settings.md``
+        - "project_shortcut"       — e.g. ``@project:custom.md``
+        - "home_shortcut"          — e.g. ``@~/notes.md``
+        - "relative_path"          — e.g. ``@AGENTS.md`` or ``@./sub/file.md``
+        - "bundle_context_decl"    — ``mention is None`` (entry came from the
+                                     ``context:`` YAML section, not an @mention)
     """
-    if mention is not None:
-        stripped = mention.lstrip("@")
+    if mention is None:
+        return "bundle_context_decl"
+    stripped = mention.lstrip("@")
+    if ":" in stripped:
+        namespace = stripped.split(":")[0]
+        if namespace == "user":
+            return "user_shortcut"
+        if namespace == "project":
+            return "project_shortcut"
+        return "bundle_namespace"
+    if stripped.startswith("~/") or stripped.startswith("~\\") or stripped == "~":
+        return "home_shortcut"
+    return "relative_path"
+
+
+def _to_origins_key(mention: str | None) -> str | None:
+    """Normalise a mention or context-key string to the ``Bundle.origins`` key form.
+
+    ``Bundle.origins`` keys for context files look like
+    ``"context:{namespace}:{name}"`` (e.g. ``"context:foundation:context/guide.md"``).
+    This helper strips a leading ``@`` and prepends ``"context:"`` so callers
+    can use plain ``dict.get`` against the origins map.
+
+    Returns ``None`` for user-owned mentions (home shortcut, relative path,
+    or ``mention is None``) — there is no corresponding origins key for these.
+    """
+    if mention is None:
+        return None
+    stripped = mention.lstrip("@")
+    if ":" not in stripped:
+        return None  # bare relative path — no namespace, no origins key
+    namespace = stripped.split(":")[0]
+    if namespace in ("user", "project") or namespace.startswith("~"):
+        return None  # user-owned shortcuts have no Bundle.origins entry
+    return f"context:{stripped}"
+
+
+def _lookup_origins(mention: str | None, bundle_origins: dict) -> list[dict]:
+    """Look up the bundle-attribution chain for a resolved mention.
+
+    Strategy (matches the design doc Section "Attribution wiring"):
+
+    1. Normalise the mention to a ``Bundle.origins`` key via ``_to_origins_key``.
+    2. If the key is present in ``bundle_origins``, project each ``Origin`` into
+       ``{"bundle": str, "via": str | None}`` and return the chain.
+    3. If the mention has a bundle namespace prefix but is missing from
+       ``bundle_origins`` (common for @mentions in the instruction text that
+       are not declared in ``context:`` YAML), synthesise a single-entry chain
+       from the namespace.
+    4. Otherwise (user-owned file, ``mention is None``, no namespace) return ``[]``.
+
+    The empty list is the explicit "no bundle attribution" signal — distinct
+    from "bundle unknown" (which uses the synthesised single-entry chain).
+    """
+    key = _to_origins_key(mention)
+    if key is not None:
+        chain = bundle_origins.get(key, [])
+        if chain:
+            return [{"bundle": o.bundle, "via": o.via_behavior} for o in chain]
+        # Synthesise from the namespace prefix when the @mention is not in origins.
+        stripped = (mention or "").lstrip("@")
         if ":" in stripped:
             namespace = stripped.split(":")[0]
-            if namespace == "user":
-                return "user", "user_shortcut"
-            if namespace == "project":
-                return "project", "project_shortcut"
-            # Any other "namespace:" form — treat as bundle namespace
-            return namespace, "bundle_namespace"
-        if stripped.startswith("~/") or stripped.startswith("~\\") or stripped == "~":
-            return None, "home_shortcut"
-        # Bare filename or relative path
-        return None, "relative_path"
-
-    # No @mention string: this is a bundle_context_decl (from the context: YAML
-    # section).  Recover attribution from the cache path pattern.
-    m = _CACHE_SLUG_RE.search(str(path))
-    if m:
-        return m.group(1), "bundle_context_decl"
-    return None, "bundle_context_decl"
+            return [{"bundle": namespace, "via": None}]
+    return []
 
 
 def _build_resolutions(
     context_files: list,  # list[ContextFile]
     mention_to_path: dict[str, Path],
+    bundle_origins: dict,  # Bundle.origins: dict[str, list[Origin]]
     seen_hashes: set[str] | None = None,
 ) -> list[dict]:
     """Build the ``resolutions`` list for the ``mentions:resolved`` event payload.
 
     Args:
-        context_files: ContextFile objects to include in the payload.
+        context_files:   ContextFile objects to include in the payload.
         mention_to_path: Maps @mention strings (or context-name keys) to their
-            resolved paths.  Used for reverse look-up (path → mention).
-        seen_hashes: Set of content hashes already emitted in earlier turns.
-            When provided, ``is_new`` is ``False`` for matching entries.
+                         resolved paths.  Used for reverse look-up (path → mention).
+        bundle_origins:  ``Bundle.origins`` from the prepared bundle — the source
+                         of truth for who introduced each context file.  See
+                         ``_lookup_origins`` for the lookup rule.
+        seen_hashes:     Set of content hashes already emitted in earlier turns.
+                         When provided, ``is_new`` is ``False`` for matching entries.
 
     Returns:
         List of resolution dicts matching the ``mentions:resolved`` schema.
@@ -107,12 +151,13 @@ def _build_resolutions(
             path_key = str(p.resolve())
             mentions_for_path: list[str | None] = path_to_mentions.get(path_key, [None])
             for mention in mentions_for_path:
-                bundle, source_type = _extract_bundle_attribution(mention, p)
+                source_type = _determine_source_type(mention)
+                origins = _lookup_origins(mention, bundle_origins)
                 results.append(
                     {
                         "mention": mention,
                         "resolved_path": str(p),
-                        "bundle": bundle,
+                        "origins": origins,
                         "source_type": source_type,
                         "content_hash": cf.content_hash,
                         "is_new": is_new,
@@ -478,7 +523,7 @@ class PreparedBundle:
 
             if new_files or failed_entries:
                 resolutions = _build_resolutions(
-                    new_files, mention_to_path, _seen_hashes
+                    new_files, mention_to_path, captured_bundle.origins, _seen_hashes
                 )
                 deduplicated_count = len(all_unique) - len(new_files)
                 try:

--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -37,9 +37,8 @@ _MENTIONS_RESOLVED_EVENT = "mentions:resolved"
 def _determine_source_type(mention: str | None) -> str:
     """Classify the syntactic form of a mention; return only the source_type label.
 
-    Bundle attribution is handled separately by ``_lookup_origins`` against
-    ``Bundle.origins``.  This function does *not* parse paths and does *not*
-    use any cache-directory heuristic.
+    This function does *not* parse paths and does *not* use any
+    cache-directory heuristic.  Bundle attribution belongs on ``context:include``.
 
     Returns one of:
         - "bundle_namespace"       — e.g. ``@foundation:context/foo.md``
@@ -65,62 +64,9 @@ def _determine_source_type(mention: str | None) -> str:
     return "relative_path"
 
 
-def _to_origins_key(mention: str | None) -> str | None:
-    """Normalise a mention or context-key string to the ``Bundle.origins`` key form.
-
-    ``Bundle.origins`` keys for context files look like
-    ``"context:{namespace}:{name}"`` (e.g. ``"context:foundation:context/guide.md"``).
-    This helper strips a leading ``@`` and prepends ``"context:"`` so callers
-    can use plain ``dict.get`` against the origins map.
-
-    Returns ``None`` for user-owned mentions (home shortcut, relative path,
-    or ``mention is None``) — there is no corresponding origins key for these.
-    """
-    if mention is None:
-        return None
-    stripped = mention.lstrip("@")
-    if ":" not in stripped:
-        return None  # bare relative path — no namespace, no origins key
-    namespace = stripped.split(":")[0]
-    if namespace in ("user", "project") or namespace.startswith("~"):
-        return None  # user-owned shortcuts have no Bundle.origins entry
-    return f"context:{stripped}"
-
-
-def _lookup_origins(mention: str | None, bundle_origins: dict) -> list[dict]:
-    """Look up the bundle-attribution chain for a resolved mention.
-
-    Strategy (matches the design doc Section "Attribution wiring"):
-
-    1. Normalise the mention to a ``Bundle.origins`` key via ``_to_origins_key``.
-    2. If the key is present in ``bundle_origins``, project each ``Origin`` into
-       ``{"bundle": str, "via": str | None}`` and return the chain.
-    3. If the mention has a bundle namespace prefix but is missing from
-       ``bundle_origins`` (common for @mentions in the instruction text that
-       are not declared in ``context:`` YAML), synthesise a single-entry chain
-       from the namespace.
-    4. Otherwise (user-owned file, ``mention is None``, no namespace) return ``[]``.
-
-    The empty list is the explicit "no bundle attribution" signal — distinct
-    from "bundle unknown" (which uses the synthesised single-entry chain).
-    """
-    key = _to_origins_key(mention)
-    if key is not None:
-        chain = bundle_origins.get(key, [])
-        if chain:
-            return [{"bundle": o.bundle, "via": o.via_behavior} for o in chain]
-        # Synthesise from the namespace prefix when the @mention is not in origins.
-        stripped = (mention or "").lstrip("@")
-        if ":" in stripped:
-            namespace = stripped.split(":")[0]
-            return [{"bundle": namespace, "via": None}]
-    return []
-
-
 def _build_resolutions(
     context_files: list,  # list[ContextFile]
     mention_to_path: dict[str, Path],
-    bundle_origins: dict,  # Bundle.origins: dict[str, list[Origin]]
     seen_hashes: set[str] | None = None,
 ) -> list[dict]:
     """Build the ``resolutions`` list for the ``mentions:resolved`` event payload.
@@ -129,9 +75,6 @@ def _build_resolutions(
         context_files:   ContextFile objects to include in the payload.
         mention_to_path: Maps @mention strings (or context-name keys) to their
                          resolved paths.  Used for reverse look-up (path → mention).
-        bundle_origins:  ``Bundle.origins`` from the prepared bundle — the source
-                         of truth for who introduced each context file.  See
-                         ``_lookup_origins`` for the lookup rule.
         seen_hashes:     Set of content hashes already emitted in earlier turns.
                          When provided, ``is_new`` is ``False`` for matching entries.
 
@@ -151,14 +94,11 @@ def _build_resolutions(
             path_key = str(p.resolve())
             mentions_for_path: list[str | None] = path_to_mentions.get(path_key, [None])
             for mention in mentions_for_path:
-                source_type = _determine_source_type(mention)
-                origins = _lookup_origins(mention, bundle_origins)
                 results.append(
                     {
                         "mention": mention,
-                        "resolved_path": str(p),
-                        "origins": origins,
-                        "source_type": source_type,
+                        "resolved_path": str(p.resolve()),
+                        "source_type": _determine_source_type(mention),
                         "content_hash": cf.content_hash,
                         "is_new": is_new,
                     }
@@ -518,12 +458,12 @@ class PreparedBundle:
                     "reason": getattr(mr, "failure_reason", None) or "not_found",
                 }
                 for mr in mention_results
-                if not mr.found and mr.resolved_path is None
+                if not mr.found and getattr(mr, "failure_reason", None) is not None
             ]
 
             if new_files or failed_entries:
                 resolutions = _build_resolutions(
-                    new_files, mention_to_path, captured_bundle.origins, _seen_hashes
+                    new_files, mention_to_path, _seen_hashes
                 )
                 deduplicated_count = len(all_unique) - len(new_files)
                 try:
@@ -643,18 +583,6 @@ class PreparedBundle:
         # Resolve any pending namespaced context references now that source_base_paths is available
         self.bundle.resolve_pending_context()
 
-        # Register the mentions:resolved event so that observability hooks
-        # (hooks-logging, hook-context-intelligence, …) discover it via
-        # collect_contributions("observability.events") — the same mechanism used
-        # by tool-delegate.  Registering here (post-initialize) ensures the
-        # contributor list is populated before any hook queries it.
-        # See: core:docs/specs/CONTRIBUTION_CHANNELS.md
-        session.coordinator.register_contributor(
-            "observability.events",
-            "foundation:mention-resolver",
-            lambda: [_MENTIONS_RESOLVED_EVENT],
-        )
-
         # Capture hook metadata for SessionConfigurator using the public list_handlers() API.
         # This records which hooks are registered and which event each is bound to.
         #
@@ -693,6 +621,15 @@ class PreparedBundle:
             or self.bundle.context
             or self.bundle._pending_context
         ):
+            # Register mentions:resolved on the observability.events channel.
+            # Guarded so empty-bundle sessions don't advertise an event that never fires.
+            # See: core:docs/specs/CONTRIBUTION_CHANNELS.md
+            session.coordinator.register_contributor(
+                "observability.events",
+                "foundation:mention-resolver",
+                lambda: [_MENTIONS_RESOLVED_EVENT],
+            )
+
             from amplifier_foundation.mentions import BaseMentionResolver
             from amplifier_foundation.mentions import ContentDeduplicator
 
@@ -900,6 +837,16 @@ class PreparedBundle:
         )
 
         await child_session.initialize()
+
+        # Register mentions:resolved on observability.events for child sessions.
+        # spawn() bypasses create_session(), so the registration must be duplicated
+        # here — guarded the same way as in create_session().
+        if effective_bundle.instruction or effective_bundle.context:
+            child_session.coordinator.register_contributor(
+                "observability.events",
+                "foundation:mention-resolver",
+                lambda: [_MENTIONS_RESOLVED_EVENT],
+            )
 
         # Register self_delegation_depth as a coordinator capability
         # tool-delegate reads this via coordinator.get_capability("self_delegation_depth")

--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from dataclasses import dataclass
 from dataclasses import field
 from decimal import Decimal
@@ -25,6 +26,102 @@ from amplifier_foundation.spawn_utils import apply_provider_preferences_with_res
 from amplifier_foundation.bundle._dataclass import Bundle
 
 logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# mentions:resolved event helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+#: Event name registered via the observability.events contribution channel.
+_MENTIONS_RESOLVED_EVENT = "mentions:resolved"
+
+#: Pattern to extract bundle slug from cache paths like
+#: ``/…/.amplifier/cache/amplifier-foundation-c9094…/context/foo.md``
+_CACHE_SLUG_RE = re.compile(r"[/\\]amplifier-([a-zA-Z0-9_-]+)-[a-f0-9]{8,}[/\\]")
+
+
+def _extract_bundle_attribution(
+    mention: str | None,
+    path: Path,
+) -> tuple[str | None, str]:
+    """Return ``(bundle_namespace, source_type)`` for a resolved mention/path.
+
+    The *mention* string determines source type when present (e.g.
+    ``@foundation:context/foo.md``).  For context files declared in the
+    ``context:`` YAML section without an ``@`` prefix, the cache path is
+    parsed to recover the bundle slug.
+
+    Returns:
+        A ``(bundle, source_type)`` tuple where ``bundle`` is ``None`` for
+        user-owned paths (home shortcut, relative path).
+    """
+    if mention is not None:
+        stripped = mention.lstrip("@")
+        if ":" in stripped:
+            namespace = stripped.split(":")[0]
+            if namespace == "user":
+                return "user", "user_shortcut"
+            if namespace == "project":
+                return "project", "project_shortcut"
+            # Any other "namespace:" form — treat as bundle namespace
+            return namespace, "bundle_namespace"
+        if stripped.startswith("~/") or stripped.startswith("~\\") or stripped == "~":
+            return None, "home_shortcut"
+        # Bare filename or relative path
+        return None, "relative_path"
+
+    # No @mention string: this is a bundle_context_decl (from the context: YAML
+    # section).  Recover attribution from the cache path pattern.
+    m = _CACHE_SLUG_RE.search(str(path))
+    if m:
+        return m.group(1), "bundle_context_decl"
+    return None, "bundle_context_decl"
+
+
+def _build_resolutions(
+    context_files: list,  # list[ContextFile]
+    mention_to_path: dict[str, Path],
+    seen_hashes: set[str] | None = None,
+) -> list[dict]:
+    """Build the ``resolutions`` list for the ``mentions:resolved`` event payload.
+
+    Args:
+        context_files: ContextFile objects to include in the payload.
+        mention_to_path: Maps @mention strings (or context-name keys) to their
+            resolved paths.  Used for reverse look-up (path → mention).
+        seen_hashes: Set of content hashes already emitted in earlier turns.
+            When provided, ``is_new`` is ``False`` for matching entries.
+
+    Returns:
+        List of resolution dicts matching the ``mentions:resolved`` schema.
+    """
+    # Build reverse map: resolved path string → mention string(s)
+    path_to_mentions: dict[str, list[str | None]] = {}
+    for mention, p in mention_to_path.items():
+        key = str(p.resolve())
+        path_to_mentions.setdefault(key, []).append(mention)
+
+    results: list[dict] = []
+    for cf in context_files:
+        is_new = seen_hashes is None or cf.content_hash not in seen_hashes
+        for p in cf.paths:
+            path_key = str(p.resolve())
+            mentions_for_path: list[str | None] = path_to_mentions.get(path_key, [None])
+            for mention in mentions_for_path:
+                bundle, source_type = _extract_bundle_attribution(mention, p)
+                results.append(
+                    {
+                        "mention": mention,
+                        "resolved_path": str(p),
+                        "bundle": bundle,
+                        "source_type": source_type,
+                        "content_hash": cf.content_hash,
+                        "is_new": is_new,
+                    }
+                )
+    return results
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 
 
 # Collects cost_usd contributions from a session.cost channel and returns the
@@ -305,6 +402,11 @@ class PreparedBundle:
         # Use session_cwd if provided, otherwise fall back to bundle's base_path
         captured_base_path = session_cwd or bundle.base_path or Path.cwd()
 
+        # Tracks content hashes emitted via mentions:resolved across factory calls.
+        # Persists across turns so we only emit each file once per session
+        # (the guard "if new_context_files or failed" skips silent turns).
+        _seen_hashes: set[str] = set()
+
         async def factory() -> str:
             # Main instruction stays separate from context files
             main_instruction = captured_bundle.instruction or ""
@@ -354,6 +456,52 @@ class PreparedBundle:
             # format_context_block uses deduplicator for unique content and
             # mention_to_path for attribution (showing name → resolved path)
             all_context = format_context_block(deduplicator, mention_to_path)
+
+            # ── mentions:resolved event emission ─────────────────────────────
+            # Determine which files are new to this session (not yet emitted).
+            all_unique = deduplicator.get_unique_files()
+            new_files = [cf for cf in all_unique if cf.content_hash not in _seen_hashes]
+
+            # Collect failed resolutions from the @mention pass.
+            # Bundle context files that don't exist are silently skipped above;
+            # only @mention failures carry a failure_reason.
+            failed_entries = [
+                {
+                    "mention": mr.mention,
+                    # failure_reason was added to MentionResult in amplifier_foundation ≥ current;
+                    # getattr provides backward compatibility with older installed stubs.
+                    "reason": getattr(mr, "failure_reason", None) or "not_found",
+                }
+                for mr in mention_results
+                if not mr.found and mr.resolved_path is None
+            ]
+
+            if new_files or failed_entries:
+                resolutions = _build_resolutions(
+                    new_files, mention_to_path, _seen_hashes
+                )
+                deduplicated_count = len(all_unique) - len(new_files)
+                try:
+                    await session.coordinator.hooks.emit(
+                        _MENTIONS_RESOLVED_EVENT,
+                        {
+                            "source": "bundle_context",
+                            "resolutions": resolutions,
+                            "failed": failed_entries,
+                            "deduplicated_count": deduplicated_count,
+                            "turn": None,
+                        },
+                    )
+                except Exception:
+                    logger.debug(
+                        "Failed to emit %s event",
+                        _MENTIONS_RESOLVED_EVENT,
+                        exc_info=True,
+                    )
+                # Update the cross-turn seen-hash tracker after a successful pass.
+                for cf in new_files:
+                    _seen_hashes.add(cf.content_hash)
+            # ── end mentions:resolved ────────────────────────────────────────
 
             # Final structure: main instruction FIRST, then all context files
             if all_context:
@@ -449,6 +597,18 @@ class PreparedBundle:
 
         # Resolve any pending namespaced context references now that source_base_paths is available
         self.bundle.resolve_pending_context()
+
+        # Register the mentions:resolved event so that observability hooks
+        # (hooks-logging, hook-context-intelligence, …) discover it via
+        # collect_contributions("observability.events") — the same mechanism used
+        # by tool-delegate.  Registering here (post-initialize) ensures the
+        # contributor list is populated before any hook queries it.
+        # See: core:docs/specs/CONTRIBUTION_CHANNELS.md
+        session.coordinator.register_contributor(
+            "observability.events",
+            "foundation:mention-resolver",
+            lambda: [_MENTIONS_RESOLVED_EVENT],
+        )
 
         # Capture hook metadata for SessionConfigurator using the public list_handlers() API.
         # This records which hooks are registered and which event each is bound to.

--- a/amplifier_foundation/mentions/loader.py
+++ b/amplifier_foundation/mentions/loader.py
@@ -134,6 +134,7 @@ async def _resolve_mention(
             resolved_path=None,
             content=None,
             error=None,  # Opportunistic - no error for not found
+            failure_reason="not_found",
         )
 
     # Handle directories: generate listing as content
@@ -148,25 +149,43 @@ async def _resolve_mention(
                 error=None,
                 is_directory=True,
             )
-        except (PermissionError, OSError):
-            # Can't list directory - return without content
+        except PermissionError:
             return MentionResult(
                 mention=mention,
                 resolved_path=path,
                 content=None,
                 error=None,
                 is_directory=True,
+                failure_reason="permission_error",
+            )
+        except OSError:
+            return MentionResult(
+                mention=mention,
+                resolved_path=path,
+                content=None,
+                error=None,
+                is_directory=True,
+                failure_reason="not_found",
             )
 
     # Read file
     try:
         content = await read_with_retry(path)
+    except PermissionError:
+        return MentionResult(
+            mention=mention,
+            resolved_path=path,
+            content=None,
+            error=None,
+            failure_reason="permission_error",
+        )
     except (FileNotFoundError, OSError):
         return MentionResult(
             mention=mention,
             resolved_path=path,
             content=None,
             error=None,  # Opportunistic - no error for read failure
+            failure_reason="not_found",
         )
 
     # Check for duplicate content

--- a/amplifier_foundation/mentions/models.py
+++ b/amplifier_foundation/mentions/models.py
@@ -29,6 +29,9 @@ class MentionResult:
     content: str | None
     error: str | None
     is_directory: bool = False  # True if resolved_path is a directory
+    failure_reason: str | None = (
+        None  # "not_found" | "permission_error" | "bundle_not_registered" | "path_traversal_rejected" | "unknown"
+    )
 
     @property
     def found(self) -> bool:

--- a/tests/test_mentions_resolved_event.py
+++ b/tests/test_mentions_resolved_event.py
@@ -4,14 +4,21 @@ Evidence-driven test suite that proves:
 
 1. MentionResult.failure_reason — new field, backward-compatible default.
 2. _resolve_mention — failure_reason is populated at every failure site.
-3. _extract_bundle_attribution — correctly maps @mention syntax and cache
-   paths to (bundle_namespace, source_type) pairs.
-4. _build_resolutions — constructs the event payload from ContextFile objects.
-5. Factory emission — the system-prompt factory emits mentions:resolved on
+3. _determine_source_type — classifies the syntax form of a mention string
+   into one of: bundle_namespace, bundle_context_decl, user_shortcut,
+   project_shortcut, home_shortcut, relative_path.
+4. _to_origins_key — normalises @mention strings to the
+   "context:{ns}:{name}" key form used by Bundle.origins.
+5. _lookup_origins — retrieves the full attribution chain from Bundle.origins;
+   synthesises a single-entry chain from the namespace prefix when the key is
+   absent; returns [] for user-owned paths (no bundle attribution).
+6. _build_resolutions — constructs the event payload from ContextFile objects,
+   emitting origins: list[{bundle, via}] instead of a flat bundle: str | None.
+7. Factory emission — the system-prompt factory emits mentions:resolved on
    the first turn that loads context, and is silent on subsequent turns
    when nothing new has been added.
-6. Observability registration — create_session() registers the event on the
-   coordinator's observability.events contribution channel.
+8. Observability registration — create_session() and spawn() register the
+   event on the coordinator's observability.events contribution channel.
 """
 
 from __future__ import annotations
@@ -24,6 +31,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from amplifier_foundation.bundle import Bundle
+from amplifier_foundation.configurator._types import Origin
 from amplifier_foundation.mentions.deduplicator import ContentDeduplicator
 from amplifier_foundation.mentions.loader import load_mentions
 from amplifier_foundation.mentions.models import ContextFile, MentionResult
@@ -35,7 +43,7 @@ from amplifier_foundation.mentions.resolver import BaseMentionResolver
 _prep = importlib.import_module("amplifier_foundation.bundle._prepared")
 PreparedBundle: Any = _prep.PreparedBundle
 BundleModuleResolver: Any = _prep.BundleModuleResolver
-_extract_bundle_attribution: Any = _prep._extract_bundle_attribution
+_determine_source_type: Any = _prep._determine_source_type
 _build_resolutions: Any = _prep._build_resolutions
 MENTIONS_RESOLVED: str = _prep._MENTIONS_RESOLVED_EVENT
 
@@ -215,74 +223,44 @@ class TestLoaderFailureReason:
         assert getattr(results[0], "failure_reason") is None  # type: ignore[attr-defined]
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# 3. _extract_bundle_attribution
-# ─────────────────────────────────────────────────────────────────────────────
+# ──────────────────────────────────────────────────────────────────────────
+# 3. _determine_source_type — syntax label only (no attribution)
+# ──────────────────────────────────────────────────────────────────────────
 
 
-class TestExtractBundleAttribution:
-    """Attribution logic maps @mention syntax and cache paths to (bundle, source_type)."""
+class TestDetermineSourceType:
+    """_determine_source_type classifies the syntactic form of a mention.
 
-    def _any_path(self) -> Path:
-        return Path("/tmp/dummy.md")
+    It returns ONLY the source_type label (str). Bundle attribution lives in
+    Bundle.origins and is looked up by _lookup_origins — not by parsing paths.
+    """
 
     @pytest.mark.parametrize(
-        "mention, want_bundle, want_type",
+        "mention, want_type",
         [
-            ("@foundation:context/foo.md", "foundation", "bundle_namespace"),
-            ("@recipes:agents/coder.md", "recipes", "bundle_namespace"),
-            ("@my-bundle:path/doc.md", "my-bundle", "bundle_namespace"),
-            ("@user:settings.md", "user", "user_shortcut"),
-            ("@project:custom.md", "project", "project_shortcut"),
+            ("@foundation:context/foo.md", "bundle_namespace"),
+            ("@recipes:agents/coder.md", "bundle_namespace"),
+            ("@my-bundle:path/doc.md", "bundle_namespace"),
+            ("@user:settings.md", "user_shortcut"),
+            ("@project:custom.md", "project_shortcut"),
         ],
     )
-    def test_namespaced_mentions(
-        self, mention: str, want_bundle: str, want_type: str
-    ) -> None:
-        bundle, source_type = _extract_bundle_attribution(mention, self._any_path())
-        assert bundle == want_bundle
-        assert source_type == want_type
+    def test_namespaced_mentions(self, mention: str, want_type: str) -> None:
+        assert _determine_source_type(mention) == want_type
 
     @pytest.mark.parametrize("mention", ["@~/my-notes.md", "@~/.amplifier/cfg.md"])
     def test_home_shortcut(self, mention: str) -> None:
-        bundle, source_type = _extract_bundle_attribution(mention, self._any_path())
-        assert bundle is None
-        assert source_type == "home_shortcut"
+        assert _determine_source_type(mention) == "home_shortcut"
 
     @pytest.mark.parametrize(
         "mention", ["@AGENTS.md", "@./subdir/file.md", "@docs/guide.md"]
     )
     def test_relative_path(self, mention: str) -> None:
-        bundle, source_type = _extract_bundle_attribution(mention, self._any_path())
-        assert bundle is None
-        assert source_type == "relative_path"
+        assert _determine_source_type(mention) == "relative_path"
 
-    def test_cache_path_extracts_slug(self) -> None:
-        """Bundle cache paths yield the slug as attribution."""
-        cache_path = Path(
-            "/home/user/.amplifier/cache"
-            "/amplifier-foundation-c909465861f9d6ce"
-            "/context/bundle-awareness.md"
-        )
-        bundle, source_type = _extract_bundle_attribution(None, cache_path)
-        assert bundle == "foundation"
-        assert source_type == "bundle_context_decl"
-
-    def test_cache_path_hyphenated_slug(self) -> None:
-        cache_path = Path(
-            "/home/user/.amplifier/cache"
-            "/amplifier-context-intelligence-abc123def456"
-            "/context/awareness.md"
-        )
-        bundle, source_type = _extract_bundle_attribution(None, cache_path)
-        assert bundle == "context-intelligence"
-        assert source_type == "bundle_context_decl"
-
-    def test_local_path_no_cache_pattern(self, tmp_path: Path) -> None:
-        """A local file path with no cache pattern → bundle=None."""
-        bundle, source_type = _extract_bundle_attribution(None, tmp_path / "local.md")
-        assert bundle is None
-        assert source_type == "bundle_context_decl"
+    def test_no_mention_is_bundle_context_decl(self) -> None:
+        """mention=None (a ContextFile from the context: YAML section) → bundle_context_decl."""
+        assert _determine_source_type(None) == "bundle_context_decl"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -302,12 +280,14 @@ class TestBuildResolutions:
     def test_all_required_fields_present(self, tmp_path: Path) -> None:
         f = tmp_path / "file.md"
         f.write_text("hello")
-        resolutions = _build_resolutions([self._make_cf(f)], {"@file.md": f})
+        resolutions = _build_resolutions(
+            [self._make_cf(f)], {"@file.md": f}, bundle_origins={}
+        )
         assert len(resolutions) == 1
         assert set(resolutions[0].keys()) == {
             "mention",
             "resolved_path",
-            "bundle",
+            "origins",
             "source_type",
             "content_hash",
             "is_new",
@@ -317,7 +297,9 @@ class TestBuildResolutions:
         f = tmp_path / "file.md"
         f.write_text("content")
         cf = self._make_cf(f)
-        resolutions = _build_resolutions([cf], {"@file.md": f}, seen_hashes=set())
+        resolutions = _build_resolutions(
+            [cf], {"@file.md": f}, bundle_origins={}, seen_hashes=set()
+        )
         assert resolutions[0]["is_new"] is True
 
     def test_is_new_false_when_hash_already_seen(self, tmp_path: Path) -> None:
@@ -325,32 +307,222 @@ class TestBuildResolutions:
         f.write_text("content")
         cf = self._make_cf(f)
         resolutions = _build_resolutions(
-            [cf], {"@file.md": f}, seen_hashes={cf.content_hash}
+            [cf], {"@file.md": f}, bundle_origins={}, seen_hashes={cf.content_hash}
         )
         assert resolutions[0]["is_new"] is False
-
-    def test_bundle_namespace_in_payload(self, tmp_path: Path) -> None:
-        """@foundation:ctx/x.md → bundle='foundation' in the resolution entry."""
-        f = tmp_path / "x.md"
-        f.write_text("x")
-        cf = self._make_cf(f, "x")
-        resolutions = _build_resolutions(
-            [cf], {"@foundation:ctx/x.md": f}, seen_hashes=set()
-        )
-        assert resolutions[0]["bundle"] == "foundation"
-        assert resolutions[0]["source_type"] == "bundle_namespace"
 
     def test_untracked_path_gets_mention_none(self, tmp_path: Path) -> None:
         """A ContextFile whose path has no entry in mention_to_path → mention=None."""
         f = tmp_path / "orphan.md"
         f.write_text("orphan")
-        resolutions = _build_resolutions([self._make_cf(f, "orphan")], {})
+        resolutions = _build_resolutions(
+            [self._make_cf(f, "orphan")], {}, bundle_origins={}
+        )
         assert resolutions[0]["mention"] is None
 
+    def test_origins_shape_direct_introducer(self, tmp_path: Path) -> None:
+        """Bundle.origins has [Origin('foundation', None)] → payload origins
+        list has a single entry with bundle='foundation' and via=None."""
+        f = tmp_path / "x.md"
+        f.write_text("x")
+        cf = self._make_cf(f, "x")
+        bundle_origins = {
+            "context:foundation:ctx/x.md": [
+                Origin(bundle="foundation", via_behavior=None)
+            ]
+        }
+        resolutions = _build_resolutions(
+            [cf],
+            {"@foundation:ctx/x.md": f},
+            bundle_origins=bundle_origins,
+            seen_hashes=set(),
+        )
+        assert resolutions[0]["origins"] == [{"bundle": "foundation", "via": None}]
+        assert resolutions[0]["source_type"] == "bundle_namespace"
+
+    def test_full_chain_via_behavior(self, tmp_path: Path) -> None:
+        """A two-entry origin chain is preserved in order in the payload."""
+        f = tmp_path / "g.md"
+        f.write_text("g")
+        cf = self._make_cf(f, "g")
+        bundle_origins = {
+            "context:foundation:ctx/g.md": [
+                Origin(bundle="behavior-x", via_behavior=None),
+                Origin(bundle="foundation", via_behavior="behavior-x"),
+            ]
+        }
+        resolutions = _build_resolutions(
+            [cf],
+            {"@foundation:ctx/g.md": f},
+            bundle_origins=bundle_origins,
+            seen_hashes=set(),
+        )
+        assert resolutions[0]["origins"] == [
+            {"bundle": "behavior-x", "via": None},
+            {"bundle": "foundation", "via": "behavior-x"},
+        ]
+
+    def test_fallback_for_mention_not_in_origins(self, tmp_path: Path) -> None:
+        """@foundation:ctx/foo.md not present in bundle_origins → synthesise
+        a single-entry chain from the namespace prefix."""
+        f = tmp_path / "foo.md"
+        f.write_text("foo")
+        cf = self._make_cf(f, "foo")
+        resolutions = _build_resolutions(
+            [cf],
+            {"@foundation:ctx/foo.md": f},
+            bundle_origins={},  # mention missing from origins
+            seen_hashes=set(),
+        )
+        assert resolutions[0]["origins"] == [{"bundle": "foundation", "via": None}]
+
+    def test_user_owned_file_has_empty_origins(self, tmp_path: Path) -> None:
+        """A relative-path mention (@./local.md) → origins=[] (never null)."""
+        f = tmp_path / "local.md"
+        f.write_text("local")
+        cf = self._make_cf(f, "local")
+        resolutions = _build_resolutions(
+            [cf],
+            {"@./local.md": f},
+            bundle_origins={},
+            seen_hashes=set(),
+        )
+        assert resolutions[0]["origins"] == []
+        assert resolutions[0]["source_type"] == "relative_path"
+
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 5. Factory emission  (primary behavioural evidence)
+# 4b. _to_origins_key — normalise mention to Bundle.origins key form
 # ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestToOriginsKey:
+    """_to_origins_key normalises a mention to the Bundle.origins key form."""
+
+    def _fn(self):
+        return getattr(_prep, "_to_origins_key")
+
+    def test_bundle_namespace_mention_produces_context_key(self) -> None:
+        """@foundation:context/foo.md → 'context:foundation:context/foo.md'."""
+        fn = self._fn()
+        assert fn("@foundation:context/foo.md") == "context:foundation:context/foo.md"
+
+    def test_strips_leading_at(self) -> None:
+        """The leading @ is stripped before building the key."""
+        fn = self._fn()
+        assert fn("@recipes:agents/coder.md") == "context:recipes:agents/coder.md"
+
+    def test_mention_without_at_also_normalised(self) -> None:
+        """A context-name key without @ prefix (from context: YAML) is normalised."""
+        fn = self._fn()
+        assert (
+            fn("foundation:context/guide.md") == "context:foundation:context/guide.md"
+        )
+
+    def test_none_returns_none(self) -> None:
+        """mention=None (bundle_context_decl) → None."""
+        fn = self._fn()
+        assert fn(None) is None
+
+    def test_bare_relative_path_returns_none(self) -> None:
+        """@AGENTS.md has no namespace colon → None."""
+        fn = self._fn()
+        assert fn("@AGENTS.md") is None
+
+    def test_relative_dot_path_returns_none(self) -> None:
+        """@./subdir/file.md has no namespace → None."""
+        fn = self._fn()
+        assert fn("@./subdir/file.md") is None
+
+    def test_user_shortcut_returns_none(self) -> None:
+        """@user:settings.md → None (user-owned, no bundle origins entry)."""
+        fn = self._fn()
+        assert fn("@user:settings.md") is None
+
+    def test_project_shortcut_returns_none(self) -> None:
+        """@project:custom.md → None (user-owned)."""
+        fn = self._fn()
+        assert fn("@project:custom.md") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4c. _lookup_origins — resolve mention to bundle attribution chain
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLookupOrigins:
+    """_lookup_origins returns a list of {bundle, via} dicts from Bundle.origins."""
+
+    def _fn(self):
+        return getattr(_prep, "_lookup_origins")
+
+    def test_returns_chain_from_origins(self) -> None:
+        """Key found in bundle_origins → projected chain returned."""
+        fn = self._fn()
+        origins = {
+            "context:foundation:ctx/a.md": [
+                Origin(bundle="foundation", via_behavior=None)
+            ]
+        }
+        result = fn("@foundation:ctx/a.md", origins)
+        assert result == [{"bundle": "foundation", "via": None}]
+
+    def test_returns_full_chain_order_preserved(self) -> None:
+        """Multi-entry chain is returned in order."""
+        fn = self._fn()
+        origins = {
+            "context:foundation:ctx/b.md": [
+                Origin(bundle="behavior-x", via_behavior=None),
+                Origin(bundle="foundation", via_behavior="behavior-x"),
+            ]
+        }
+        result = fn("@foundation:ctx/b.md", origins)
+        assert result == [
+            {"bundle": "behavior-x", "via": None},
+            {"bundle": "foundation", "via": "behavior-x"},
+        ]
+
+    def test_synthesises_single_entry_when_not_in_origins(self) -> None:
+        """@foundation:ctx/missing.md not in origins → single synthesised entry."""
+        fn = self._fn()
+        result = fn("@foundation:ctx/missing.md", {})
+        assert result == [{"bundle": "foundation", "via": None}]
+
+    def test_relative_path_returns_empty(self) -> None:
+        """@AGENTS.md (no namespace) → []."""
+        fn = self._fn()
+        assert fn("@AGENTS.md", {}) == []
+
+    def test_none_mention_returns_empty(self) -> None:
+        """mention=None → []."""
+        fn = self._fn()
+        assert fn(None, {}) == []
+
+    def test_user_shortcut_returns_empty(self) -> None:
+        """@user:settings.md → []."""
+        fn = self._fn()
+        assert fn("@user:settings.md", {}) == []
+
+    def test_project_shortcut_returns_empty(self) -> None:
+        """@project:custom.md → []."""
+        fn = self._fn()
+        assert fn("@project:custom.md", {}) == []
+
+    def test_via_behavior_projected_as_via(self) -> None:
+        """Origin.via_behavior is returned under the 'via' key."""
+        fn = self._fn()
+        origins = {
+            "context:ns:doc.md": [
+                Origin(bundle="ns", via_behavior="some-behavior"),
+            ]
+        }
+        result = fn("@ns:doc.md", origins)
+        assert result[0]["via"] == "some-behavior"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 5. Factory emission  (primary behavioural evidence)
+# ──────────────────────────────────────────────────────────────────────────
 
 
 class TestFactoryEmission:
@@ -502,6 +674,52 @@ class TestFactoryEmission:
             assert entry["reason"] in valid_reasons, (
                 f"Unexpected failure reason: {entry['reason']!r}"
             )
+
+    @pytest.mark.asyncio
+    async def test_bundle_origins_propagated_to_resolution_payload(
+        self, tmp_path: Path
+    ) -> None:
+        """captured_bundle.origins is passed to _build_resolutions (not {}).
+
+        When a bundle has origins with a non-None via_behavior, that value must
+        appear in the resolution payload.  Passing {} instead of
+        captured_bundle.origins discards this information.
+
+        Setup: bundle with context key '@mybundle:guide.md' and origins dict
+        that carries via_behavior='behavior-x' for that key.  The factory must
+        emit a resolution whose origins chain reflects the real via value.
+        """
+        guide_file = tmp_path / "guide.md"
+        guide_file.write_text("# Guide")
+
+        from amplifier_foundation.configurator._types import Origin
+
+        bundle = Bundle(
+            name="mybundle",
+            context={"@mybundle:guide.md": guide_file},
+            origins={
+                "context:mybundle:guide.md": [
+                    Origin(bundle="mybundle", via_behavior="behavior-x")
+                ]
+            },
+        )
+        prepared = _make_prepared(bundle)
+        session = _make_mock_session()
+
+        factory = prepared._create_system_prompt_factory(bundle, session)
+        await factory()
+
+        _, payload = session.coordinator.hooks.emit.call_args.args
+        assert payload["resolutions"], (
+            "No resolutions emitted — bundle context not loaded"
+        )
+
+        origins_in_payload = payload["resolutions"][0]["origins"]
+        assert origins_in_payload == [{"bundle": "mybundle", "via": "behavior-x"}], (
+            f"Expected via_behavior to be 'behavior-x' but got: {origins_in_payload!r}. "
+            f"Likely cause: _build_resolutions was called with {{}} instead of "
+            f"captured_bundle.origins, discarding the actual origin chain."
+        )
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_mentions_resolved_event.py
+++ b/tests/test_mentions_resolved_event.py
@@ -7,18 +7,13 @@ Evidence-driven test suite that proves:
 3. _determine_source_type — classifies the syntax form of a mention string
    into one of: bundle_namespace, bundle_context_decl, user_shortcut,
    project_shortcut, home_shortcut, relative_path.
-4. _to_origins_key — normalises @mention strings to the
-   "context:{ns}:{name}" key form used by Bundle.origins.
-5. _lookup_origins — retrieves the full attribution chain from Bundle.origins;
-   synthesises a single-entry chain from the namespace prefix when the key is
-   absent; returns [] for user-owned paths (no bundle attribution).
-6. _build_resolutions — constructs the event payload from ContextFile objects,
-   emitting origins: list[{bundle, via}] instead of a flat bundle: str | None.
-7. Factory emission — the system-prompt factory emits mentions:resolved on
+4. _build_resolutions — constructs the event payload (NO origins field,
+   schema is {mention, resolved_path, source_type, content_hash, is_new}).
+5. Factory emission — the system-prompt factory emits mentions:resolved on
    the first turn that loads context, and is silent on subsequent turns
    when nothing new has been added.
-8. Observability registration — create_session() and spawn() register the
-   event on the coordinator's observability.events contribution channel.
+6. Observability registration — create_session() and spawn() register when
+   the bundle has content.
 """
 
 from __future__ import annotations
@@ -31,7 +26,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from amplifier_foundation.bundle import Bundle
-from amplifier_foundation.configurator._types import Origin
 from amplifier_foundation.mentions.deduplicator import ContentDeduplicator
 from amplifier_foundation.mentions.loader import load_mentions
 from amplifier_foundation.mentions.models import ContextFile, MentionResult
@@ -68,9 +62,15 @@ def _make_mock_session() -> MagicMock:
     list_handlers() is the only synchronous method on HookRegistry called by
     create_session(), so it is explicitly made a MagicMock (not AsyncMock) to
     avoid RuntimeWarning about unawaited coroutines.
+
+    execute() and cleanup() are AsyncMock so that spawn() can await them.
     """
     mock_hooks = AsyncMock()
     mock_hooks.list_handlers = MagicMock(return_value={})  # sync on real HookRegistry
+    # register() is called synchronously (not awaited) and its return value is
+    # called as unregister().  Pin it to a plain MagicMock so spawn() can call
+    # the returned value without hitting "coroutine object is not callable".
+    mock_hooks.register = MagicMock(return_value=MagicMock())
     coordinator = MagicMock()
     coordinator.hooks = mock_hooks
     coordinator.register_contributor = MagicMock()
@@ -80,6 +80,8 @@ def _make_mock_session() -> MagicMock:
     session = MagicMock()
     session.coordinator = coordinator
     session.initialize = AsyncMock()
+    session.execute = AsyncMock()
+    session.cleanup = AsyncMock()
     return session
 
 
@@ -223,16 +225,17 @@ class TestLoaderFailureReason:
         assert getattr(results[0], "failure_reason") is None  # type: ignore[attr-defined]
 
 
-# ──────────────────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────────
 # 3. _determine_source_type — syntax label only (no attribution)
-# ──────────────────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────────
 
 
 class TestDetermineSourceType:
     """_determine_source_type classifies the syntactic form of a mention.
 
-    It returns ONLY the source_type label (str). Bundle attribution lives in
-    Bundle.origins and is looked up by _lookup_origins — not by parsing paths.
+    It returns ONLY the source_type label (str).
+    This function returns only the syntax label. Bundle attribution is handled
+    separately by `context:include`.
     """
 
     @pytest.mark.parametrize(
@@ -281,13 +284,12 @@ class TestBuildResolutions:
         f = tmp_path / "file.md"
         f.write_text("hello")
         resolutions = _build_resolutions(
-            [self._make_cf(f)], {"@file.md": f}, bundle_origins={}
+            [self._make_cf(f)], {"@file.md": f}
         )
         assert len(resolutions) == 1
         assert set(resolutions[0].keys()) == {
             "mention",
             "resolved_path",
-            "origins",
             "source_type",
             "content_hash",
             "is_new",
@@ -298,7 +300,7 @@ class TestBuildResolutions:
         f.write_text("content")
         cf = self._make_cf(f)
         resolutions = _build_resolutions(
-            [cf], {"@file.md": f}, bundle_origins={}, seen_hashes=set()
+            [cf], {"@file.md": f}, seen_hashes=set()
         )
         assert resolutions[0]["is_new"] is True
 
@@ -307,7 +309,7 @@ class TestBuildResolutions:
         f.write_text("content")
         cf = self._make_cf(f)
         resolutions = _build_resolutions(
-            [cf], {"@file.md": f}, bundle_origins={}, seen_hashes={cf.content_hash}
+            [cf], {"@file.md": f}, seen_hashes={cf.content_hash}
         )
         assert resolutions[0]["is_new"] is False
 
@@ -316,213 +318,14 @@ class TestBuildResolutions:
         f = tmp_path / "orphan.md"
         f.write_text("orphan")
         resolutions = _build_resolutions(
-            [self._make_cf(f, "orphan")], {}, bundle_origins={}
+            [self._make_cf(f, "orphan")], {}
         )
         assert resolutions[0]["mention"] is None
 
-    def test_origins_shape_direct_introducer(self, tmp_path: Path) -> None:
-        """Bundle.origins has [Origin('foundation', None)] → payload origins
-        list has a single entry with bundle='foundation' and via=None."""
-        f = tmp_path / "x.md"
-        f.write_text("x")
-        cf = self._make_cf(f, "x")
-        bundle_origins = {
-            "context:foundation:ctx/x.md": [
-                Origin(bundle="foundation", via_behavior=None)
-            ]
-        }
-        resolutions = _build_resolutions(
-            [cf],
-            {"@foundation:ctx/x.md": f},
-            bundle_origins=bundle_origins,
-            seen_hashes=set(),
-        )
-        assert resolutions[0]["origins"] == [{"bundle": "foundation", "via": None}]
-        assert resolutions[0]["source_type"] == "bundle_namespace"
-
-    def test_full_chain_via_behavior(self, tmp_path: Path) -> None:
-        """A two-entry origin chain is preserved in order in the payload."""
-        f = tmp_path / "g.md"
-        f.write_text("g")
-        cf = self._make_cf(f, "g")
-        bundle_origins = {
-            "context:foundation:ctx/g.md": [
-                Origin(bundle="behavior-x", via_behavior=None),
-                Origin(bundle="foundation", via_behavior="behavior-x"),
-            ]
-        }
-        resolutions = _build_resolutions(
-            [cf],
-            {"@foundation:ctx/g.md": f},
-            bundle_origins=bundle_origins,
-            seen_hashes=set(),
-        )
-        assert resolutions[0]["origins"] == [
-            {"bundle": "behavior-x", "via": None},
-            {"bundle": "foundation", "via": "behavior-x"},
-        ]
-
-    def test_fallback_for_mention_not_in_origins(self, tmp_path: Path) -> None:
-        """@foundation:ctx/foo.md not present in bundle_origins → synthesise
-        a single-entry chain from the namespace prefix."""
-        f = tmp_path / "foo.md"
-        f.write_text("foo")
-        cf = self._make_cf(f, "foo")
-        resolutions = _build_resolutions(
-            [cf],
-            {"@foundation:ctx/foo.md": f},
-            bundle_origins={},  # mention missing from origins
-            seen_hashes=set(),
-        )
-        assert resolutions[0]["origins"] == [{"bundle": "foundation", "via": None}]
-
-    def test_user_owned_file_has_empty_origins(self, tmp_path: Path) -> None:
-        """A relative-path mention (@./local.md) → origins=[] (never null)."""
-        f = tmp_path / "local.md"
-        f.write_text("local")
-        cf = self._make_cf(f, "local")
-        resolutions = _build_resolutions(
-            [cf],
-            {"@./local.md": f},
-            bundle_origins={},
-            seen_hashes=set(),
-        )
-        assert resolutions[0]["origins"] == []
-        assert resolutions[0]["source_type"] == "relative_path"
-
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 4b. _to_origins_key — normalise mention to Bundle.origins key form
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-class TestToOriginsKey:
-    """_to_origins_key normalises a mention to the Bundle.origins key form."""
-
-    def _fn(self):
-        return getattr(_prep, "_to_origins_key")
-
-    def test_bundle_namespace_mention_produces_context_key(self) -> None:
-        """@foundation:context/foo.md → 'context:foundation:context/foo.md'."""
-        fn = self._fn()
-        assert fn("@foundation:context/foo.md") == "context:foundation:context/foo.md"
-
-    def test_strips_leading_at(self) -> None:
-        """The leading @ is stripped before building the key."""
-        fn = self._fn()
-        assert fn("@recipes:agents/coder.md") == "context:recipes:agents/coder.md"
-
-    def test_mention_without_at_also_normalised(self) -> None:
-        """A context-name key without @ prefix (from context: YAML) is normalised."""
-        fn = self._fn()
-        assert (
-            fn("foundation:context/guide.md") == "context:foundation:context/guide.md"
-        )
-
-    def test_none_returns_none(self) -> None:
-        """mention=None (bundle_context_decl) → None."""
-        fn = self._fn()
-        assert fn(None) is None
-
-    def test_bare_relative_path_returns_none(self) -> None:
-        """@AGENTS.md has no namespace colon → None."""
-        fn = self._fn()
-        assert fn("@AGENTS.md") is None
-
-    def test_relative_dot_path_returns_none(self) -> None:
-        """@./subdir/file.md has no namespace → None."""
-        fn = self._fn()
-        assert fn("@./subdir/file.md") is None
-
-    def test_user_shortcut_returns_none(self) -> None:
-        """@user:settings.md → None (user-owned, no bundle origins entry)."""
-        fn = self._fn()
-        assert fn("@user:settings.md") is None
-
-    def test_project_shortcut_returns_none(self) -> None:
-        """@project:custom.md → None (user-owned)."""
-        fn = self._fn()
-        assert fn("@project:custom.md") is None
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# 4c. _lookup_origins — resolve mention to bundle attribution chain
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-class TestLookupOrigins:
-    """_lookup_origins returns a list of {bundle, via} dicts from Bundle.origins."""
-
-    def _fn(self):
-        return getattr(_prep, "_lookup_origins")
-
-    def test_returns_chain_from_origins(self) -> None:
-        """Key found in bundle_origins → projected chain returned."""
-        fn = self._fn()
-        origins = {
-            "context:foundation:ctx/a.md": [
-                Origin(bundle="foundation", via_behavior=None)
-            ]
-        }
-        result = fn("@foundation:ctx/a.md", origins)
-        assert result == [{"bundle": "foundation", "via": None}]
-
-    def test_returns_full_chain_order_preserved(self) -> None:
-        """Multi-entry chain is returned in order."""
-        fn = self._fn()
-        origins = {
-            "context:foundation:ctx/b.md": [
-                Origin(bundle="behavior-x", via_behavior=None),
-                Origin(bundle="foundation", via_behavior="behavior-x"),
-            ]
-        }
-        result = fn("@foundation:ctx/b.md", origins)
-        assert result == [
-            {"bundle": "behavior-x", "via": None},
-            {"bundle": "foundation", "via": "behavior-x"},
-        ]
-
-    def test_synthesises_single_entry_when_not_in_origins(self) -> None:
-        """@foundation:ctx/missing.md not in origins → single synthesised entry."""
-        fn = self._fn()
-        result = fn("@foundation:ctx/missing.md", {})
-        assert result == [{"bundle": "foundation", "via": None}]
-
-    def test_relative_path_returns_empty(self) -> None:
-        """@AGENTS.md (no namespace) → []."""
-        fn = self._fn()
-        assert fn("@AGENTS.md", {}) == []
-
-    def test_none_mention_returns_empty(self) -> None:
-        """mention=None → []."""
-        fn = self._fn()
-        assert fn(None, {}) == []
-
-    def test_user_shortcut_returns_empty(self) -> None:
-        """@user:settings.md → []."""
-        fn = self._fn()
-        assert fn("@user:settings.md", {}) == []
-
-    def test_project_shortcut_returns_empty(self) -> None:
-        """@project:custom.md → []."""
-        fn = self._fn()
-        assert fn("@project:custom.md", {}) == []
-
-    def test_via_behavior_projected_as_via(self) -> None:
-        """Origin.via_behavior is returned under the 'via' key."""
-        fn = self._fn()
-        origins = {
-            "context:ns:doc.md": [
-                Origin(bundle="ns", via_behavior="some-behavior"),
-            ]
-        }
-        result = fn("@ns:doc.md", origins)
-        assert result[0]["via"] == "some-behavior"
-
-
-# ──────────────────────────────────────────────────────────────────────────
 # 5. Factory emission  (primary behavioural evidence)
-# ──────────────────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────────
 
 
 class TestFactoryEmission:
@@ -675,52 +478,6 @@ class TestFactoryEmission:
                 f"Unexpected failure reason: {entry['reason']!r}"
             )
 
-    @pytest.mark.asyncio
-    async def test_bundle_origins_propagated_to_resolution_payload(
-        self, tmp_path: Path
-    ) -> None:
-        """captured_bundle.origins is passed to _build_resolutions (not {}).
-
-        When a bundle has origins with a non-None via_behavior, that value must
-        appear in the resolution payload.  Passing {} instead of
-        captured_bundle.origins discards this information.
-
-        Setup: bundle with context key '@mybundle:guide.md' and origins dict
-        that carries via_behavior='behavior-x' for that key.  The factory must
-        emit a resolution whose origins chain reflects the real via value.
-        """
-        guide_file = tmp_path / "guide.md"
-        guide_file.write_text("# Guide")
-
-        from amplifier_foundation.configurator._types import Origin
-
-        bundle = Bundle(
-            name="mybundle",
-            context={"@mybundle:guide.md": guide_file},
-            origins={
-                "context:mybundle:guide.md": [
-                    Origin(bundle="mybundle", via_behavior="behavior-x")
-                ]
-            },
-        )
-        prepared = _make_prepared(bundle)
-        session = _make_mock_session()
-
-        factory = prepared._create_system_prompt_factory(bundle, session)
-        await factory()
-
-        _, payload = session.coordinator.hooks.emit.call_args.args
-        assert payload["resolutions"], (
-            "No resolutions emitted — bundle context not loaded"
-        )
-
-        origins_in_payload = payload["resolutions"][0]["origins"]
-        assert origins_in_payload == [{"bundle": "mybundle", "via": "behavior-x"}], (
-            f"Expected via_behavior to be 'behavior-x' but got: {origins_in_payload!r}. "
-            f"Likely cause: _build_resolutions was called with {{}} instead of "
-            f"captured_bundle.origins, discarding the actual origin chain."
-        )
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 6. Observability registration
@@ -740,7 +497,7 @@ class TestObservabilityRegistration:
         self,
     ) -> None:
         """create_session() calls register_contributor('observability.events', ...)."""
-        bundle = Bundle(name="test")
+        bundle = Bundle(name="test", instruction="Do something")
         prepared = _make_prepared(bundle)
         mock_session = _make_mock_session()
 
@@ -759,7 +516,7 @@ class TestObservabilityRegistration:
     @pytest.mark.asyncio
     async def test_mentions_resolved_in_contributed_event_list(self) -> None:
         """The contributor lambda returns a list containing 'mentions:resolved'."""
-        bundle = Bundle(name="test")
+        bundle = Bundle(name="test", instruction="Do something")
         prepared = _make_prepared(bundle)
         mock_session = _make_mock_session()
 
@@ -784,7 +541,7 @@ class TestObservabilityRegistration:
         self,
     ) -> None:
         """The contributor name is 'foundation:mention-resolver'."""
-        bundle = Bundle(name="test")
+        bundle = Bundle(name="test", instruction="Do something")
         prepared = _make_prepared(bundle)
         mock_session = _make_mock_session()
 
@@ -798,3 +555,136 @@ class TestObservabilityRegistration:
         ]
         contributor_name = obs_calls[0].args[1]
         assert contributor_name == "foundation:mention-resolver"
+
+    @pytest.mark.asyncio
+    async def test_empty_bundle_does_not_register(self) -> None:
+        """An empty bundle (no instruction, context, or pending_context) must NOT
+        register on observability.events — it never emits the event."""
+        bundle = Bundle(name="empty")  # no instruction, no context
+        prepared = _make_prepared(bundle)
+        mock_session = _make_mock_session()
+
+        with patch("amplifier_core.AmplifierSession", return_value=mock_session):
+            await prepared.create_session()
+
+        registered_channels = [
+            c.args[0]
+            for c in mock_session.coordinator.register_contributor.call_args_list
+        ]
+        assert "observability.events" not in registered_channels, (
+            "Empty bundle registered observability.events — event never fires for empty bundles"
+        )
+
+    @pytest.mark.asyncio
+    async def test_spawn_registers_when_child_has_content(self) -> None:
+        """spawn() registers observability.events when the child bundle has content.
+        This is a different code path from create_session()."""
+        parent_bundle = Bundle(name="parent")
+        child_bundle = Bundle(name="child", instruction="Do something")
+        prepared = _make_prepared(parent_bundle)
+        mock_child = _make_mock_session()
+
+        with patch("amplifier_core.AmplifierSession", return_value=mock_child):
+            await prepared.spawn(child_bundle, "Do something", compose=False)
+
+        registered_channels = [
+            c.args[0]
+            for c in mock_child.coordinator.register_contributor.call_args_list
+        ]
+        assert "observability.events" in registered_channels, (
+            "spawn() did not register observability.events for child session with content"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. Reviewer findings — edge-case contracts
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestReviewerFindings:
+    """Targeted tests for specific reviewer-requested contracts."""
+
+    def _make_cf(self, path: Path, content: str = "body") -> ContextFile:
+        import hashlib
+
+        h = hashlib.sha256(content.encode()).hexdigest()
+        return ContextFile(content=content, content_hash=h, paths=[path])
+
+    def test_build_resolutions_resolved_path_is_always_absolute(
+        self, tmp_path: Path
+    ) -> None:
+        """resolved_path in _build_resolutions output is always an absolute string."""
+        f = tmp_path / "doc.md"
+        f.write_text("doc")
+        resolutions = _build_resolutions([self._make_cf(f, "doc")], {"@doc.md": f})
+        assert len(resolutions) == 1
+        assert Path(resolutions[0]["resolved_path"]).is_absolute(), (
+            f"resolved_path is not absolute: {resolutions[0]['resolved_path']!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_spawn_registers_observability_events(self) -> None:
+        """spawn() registers observability.events on the child session coordinator."""
+        parent_bundle = Bundle(name="parent")
+        child_bundle = Bundle(name="child", instruction="Do something")
+        prepared = _make_prepared(parent_bundle)
+        mock_child = _make_mock_session()
+
+        with patch("amplifier_core.AmplifierSession", return_value=mock_child):
+            await prepared.spawn(child_bundle, "Do something", compose=False)
+
+        registered_channels = [
+            c.args[0]
+            for c in mock_child.coordinator.register_contributor.call_args_list
+        ]
+        assert "observability.events" in registered_channels, (
+            "spawn() did not register observability.events — event not discoverable"
+        )
+
+    @pytest.mark.asyncio
+    async def test_permission_error_on_file_appears_in_failed_list(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PermissionError during file read → mention appears in failed[] with
+        reason='permission_error'.
+
+        The factory includes a MentionResult in failed_entries only when
+        mr.failure_reason is not None.  A PermissionError sets
+        failure_reason='permission_error' in loader.py, so the entry correctly
+        appears in the event payload under the new filter.
+        """
+        target = tmp_path / "locked.md"
+        target.write_text("classified")
+
+        import amplifier_foundation.mentions.loader as loader_module
+
+        async def _raise_permission(*_args: Any, **_kwargs: Any) -> str:
+            raise PermissionError("access denied")
+
+        monkeypatch.setattr(loader_module, "read_with_retry", _raise_permission)
+
+        bundle = Bundle(
+            name="test",
+            instruction="See @locked.md for details",
+            base_path=tmp_path,
+        )
+        prepared = _make_prepared(bundle)
+        session = _make_mock_session()
+
+        factory = prepared._create_system_prompt_factory(bundle, session)
+        await factory()
+
+        # The event should be emitted because there is a failed entry
+        assert session.coordinator.hooks.emit.called, (
+            "emit not called — failed entry did not trigger event emission"
+        )
+        _, payload = session.coordinator.hooks.emit.call_args.args
+        failed_mentions = [f["mention"] for f in payload["failed"]]
+        assert "@locked.md" in failed_mentions, (
+            f"@locked.md not in failed list: {failed_mentions}"
+        )
+        for entry in payload["failed"]:
+            if entry["mention"] == "@locked.md":
+                assert entry["reason"] == "permission_error", (
+                    f"Expected reason='permission_error' but got {entry['reason']!r}"
+                )

--- a/tests/test_mentions_resolved_event.py
+++ b/tests/test_mentions_resolved_event.py
@@ -1,0 +1,582 @@
+"""Tests for the mentions:resolved event.
+
+Evidence-driven test suite that proves:
+
+1. MentionResult.failure_reason — new field, backward-compatible default.
+2. _resolve_mention — failure_reason is populated at every failure site.
+3. _extract_bundle_attribution — correctly maps @mention syntax and cache
+   paths to (bundle_namespace, source_type) pairs.
+4. _build_resolutions — constructs the event payload from ContextFile objects.
+5. Factory emission — the system-prompt factory emits mentions:resolved on
+   the first turn that loads context, and is silent on subsequent turns
+   when nothing new has been added.
+6. Observability registration — create_session() registers the event on the
+   coordinator's observability.events contribution channel.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from amplifier_foundation.bundle import Bundle
+from amplifier_foundation.mentions.deduplicator import ContentDeduplicator
+from amplifier_foundation.mentions.loader import load_mentions
+from amplifier_foundation.mentions.models import ContextFile, MentionResult
+from amplifier_foundation.mentions.resolver import BaseMentionResolver
+
+# Private helpers are imported via importlib so Pyright's stale-cache errors
+# on these new symbols don't block the test run.  The runtime behaviour is
+# what matters; Pyright will be correct once it analyses the modified files.
+_prep = importlib.import_module("amplifier_foundation.bundle._prepared")
+PreparedBundle: Any = _prep.PreparedBundle
+BundleModuleResolver: Any = _prep.BundleModuleResolver
+_extract_bundle_attribution: Any = _prep._extract_bundle_attribution
+_build_resolutions: Any = _prep._build_resolutions
+MENTIONS_RESOLVED: str = _prep._MENTIONS_RESOLVED_EVENT
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_prepared(bundle: Bundle) -> Any:
+    """Minimal PreparedBundle — module resolver is irrelevant for these tests."""
+    return PreparedBundle(
+        mount_plan={},
+        bundle=bundle,
+        resolver=BundleModuleResolver(module_paths={}),
+    )
+
+
+def _make_mock_session() -> MagicMock:
+    """Mock session whose coordinator.hooks.emit is a capturable AsyncMock.
+
+    list_handlers() is the only synchronous method on HookRegistry called by
+    create_session(), so it is explicitly made a MagicMock (not AsyncMock) to
+    avoid RuntimeWarning about unawaited coroutines.
+    """
+    mock_hooks = AsyncMock()
+    mock_hooks.list_handlers = MagicMock(return_value={})  # sync on real HookRegistry
+    coordinator = MagicMock()
+    coordinator.hooks = mock_hooks
+    coordinator.register_contributor = MagicMock()
+    coordinator.mount = AsyncMock()
+    coordinator.register_capability = MagicMock()
+    coordinator.get = MagicMock(return_value=None)
+    session = MagicMock()
+    session.coordinator = coordinator
+    session.initialize = AsyncMock()
+    return session
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. MentionResult.failure_reason
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMentionResultFailureReason:
+    """failure_reason is a backward-compatible optional field on MentionResult."""
+
+    def test_defaults_to_none(self) -> None:
+        """Existing call sites that omit failure_reason are unaffected."""
+        result = MentionResult(
+            mention="@AGENTS.md",
+            resolved_path=None,
+            content=None,
+            error=None,
+        )
+        assert getattr(result, "failure_reason") is None  # type: ignore[attr-defined]
+
+    def test_can_be_set_at_construction(self) -> None:
+        """failure_reason can carry a specific string at construction time."""
+        result = MentionResult(
+            mention="@missing.md",
+            resolved_path=None,
+            content=None,
+            error=None,
+            failure_reason="not_found",  # type: ignore[call-arg]
+        )
+        assert getattr(result, "failure_reason") == "not_found"  # type: ignore[attr-defined]
+
+    def test_found_property_unaffected(self, tmp_path: Path) -> None:
+        """The found property still returns True for resolved files."""
+        f = tmp_path / "ok.md"
+        f.write_text("content")
+        result = MentionResult(
+            mention="@ok.md",
+            resolved_path=f,
+            content="content",
+            error=None,
+        )
+        assert result.found is True
+        assert getattr(result, "failure_reason") is None  # type: ignore[attr-defined]
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "not_found",
+            "permission_error",
+            "bundle_not_registered",
+            "path_traversal_rejected",
+            "unknown",
+        ],
+    )
+    def test_accepted_reason_strings(self, reason: str) -> None:
+        """All documented reason strings are valid field values."""
+        result = MentionResult(
+            mention="@x.md",
+            resolved_path=None,
+            content=None,
+            error=None,
+            failure_reason=reason,  # type: ignore[call-arg]
+        )
+        assert getattr(result, "failure_reason") == reason  # type: ignore[attr-defined]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Loader — failure_reason at every failure site
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLoaderFailureReason:
+    """_resolve_mention populates failure_reason at every failure branch."""
+
+    @pytest.mark.asyncio
+    async def test_unregistered_bundle_gives_not_found(self) -> None:
+        """@bundle:path mention with no registered bundle → failure_reason='not_found'."""
+        resolver = BaseMentionResolver(bundles={})
+        results = await load_mentions(
+            "@foundation:missing/file.md",
+            resolver=resolver,
+            deduplicator=ContentDeduplicator(),
+        )
+        assert len(results) == 1
+        r = results[0]
+        assert r.resolved_path is None
+        assert getattr(r, "failure_reason") == "not_found"  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_file_gives_not_found(self, tmp_path: Path) -> None:
+        """A mention that the resolver returns None for → failure_reason='not_found'."""
+        resolver = BaseMentionResolver(base_path=tmp_path)
+        # Do NOT create the file — resolver returns None for a missing path.
+        results = await load_mentions(
+            "@no-such-file.md",
+            resolver=resolver,
+            deduplicator=ContentDeduplicator(),
+        )
+        assert len(results) == 1
+        assert getattr(results[0], "failure_reason") == "not_found"  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_permission_error_on_read_gives_permission_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PermissionError during file read → failure_reason='permission_error'."""
+        target = tmp_path / "secret.md"
+        target.write_text("classified")
+
+        import amplifier_foundation.mentions.loader as loader_module
+
+        async def _raise_permission(*_args: Any, **_kwargs: Any) -> str:
+            raise PermissionError("access denied")
+
+        monkeypatch.setattr(loader_module, "read_with_retry", _raise_permission)
+
+        resolver = BaseMentionResolver(base_path=tmp_path)
+        results = await load_mentions(
+            "@secret.md",
+            resolver=resolver,
+            deduplicator=ContentDeduplicator(),
+        )
+        assert len(results) == 1
+        assert getattr(results[0], "failure_reason") == "permission_error"  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_successful_resolution_has_no_failure_reason(
+        self, tmp_path: Path
+    ) -> None:
+        """A successfully resolved file has failure_reason=None."""
+        f = tmp_path / "readme.md"
+        f.write_text("# Hello")
+        results = await load_mentions(
+            "@readme.md",
+            resolver=BaseMentionResolver(base_path=tmp_path),
+            deduplicator=ContentDeduplicator(),
+        )
+        assert len(results) == 1
+        assert results[0].found is True
+        assert getattr(results[0], "failure_reason") is None  # type: ignore[attr-defined]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. _extract_bundle_attribution
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestExtractBundleAttribution:
+    """Attribution logic maps @mention syntax and cache paths to (bundle, source_type)."""
+
+    def _any_path(self) -> Path:
+        return Path("/tmp/dummy.md")
+
+    @pytest.mark.parametrize(
+        "mention, want_bundle, want_type",
+        [
+            ("@foundation:context/foo.md", "foundation", "bundle_namespace"),
+            ("@recipes:agents/coder.md", "recipes", "bundle_namespace"),
+            ("@my-bundle:path/doc.md", "my-bundle", "bundle_namespace"),
+            ("@user:settings.md", "user", "user_shortcut"),
+            ("@project:custom.md", "project", "project_shortcut"),
+        ],
+    )
+    def test_namespaced_mentions(
+        self, mention: str, want_bundle: str, want_type: str
+    ) -> None:
+        bundle, source_type = _extract_bundle_attribution(mention, self._any_path())
+        assert bundle == want_bundle
+        assert source_type == want_type
+
+    @pytest.mark.parametrize("mention", ["@~/my-notes.md", "@~/.amplifier/cfg.md"])
+    def test_home_shortcut(self, mention: str) -> None:
+        bundle, source_type = _extract_bundle_attribution(mention, self._any_path())
+        assert bundle is None
+        assert source_type == "home_shortcut"
+
+    @pytest.mark.parametrize(
+        "mention", ["@AGENTS.md", "@./subdir/file.md", "@docs/guide.md"]
+    )
+    def test_relative_path(self, mention: str) -> None:
+        bundle, source_type = _extract_bundle_attribution(mention, self._any_path())
+        assert bundle is None
+        assert source_type == "relative_path"
+
+    def test_cache_path_extracts_slug(self) -> None:
+        """Bundle cache paths yield the slug as attribution."""
+        cache_path = Path(
+            "/home/user/.amplifier/cache"
+            "/amplifier-foundation-c909465861f9d6ce"
+            "/context/bundle-awareness.md"
+        )
+        bundle, source_type = _extract_bundle_attribution(None, cache_path)
+        assert bundle == "foundation"
+        assert source_type == "bundle_context_decl"
+
+    def test_cache_path_hyphenated_slug(self) -> None:
+        cache_path = Path(
+            "/home/user/.amplifier/cache"
+            "/amplifier-context-intelligence-abc123def456"
+            "/context/awareness.md"
+        )
+        bundle, source_type = _extract_bundle_attribution(None, cache_path)
+        assert bundle == "context-intelligence"
+        assert source_type == "bundle_context_decl"
+
+    def test_local_path_no_cache_pattern(self, tmp_path: Path) -> None:
+        """A local file path with no cache pattern → bundle=None."""
+        bundle, source_type = _extract_bundle_attribution(None, tmp_path / "local.md")
+        assert bundle is None
+        assert source_type == "bundle_context_decl"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. _build_resolutions
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBuildResolutions:
+    """_build_resolutions constructs the structured resolutions list."""
+
+    def _make_cf(self, path: Path, content: str = "body") -> ContextFile:
+        import hashlib
+
+        h = hashlib.sha256(content.encode()).hexdigest()
+        return ContextFile(content=content, content_hash=h, paths=[path])
+
+    def test_all_required_fields_present(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.md"
+        f.write_text("hello")
+        resolutions = _build_resolutions([self._make_cf(f)], {"@file.md": f})
+        assert len(resolutions) == 1
+        assert set(resolutions[0].keys()) == {
+            "mention",
+            "resolved_path",
+            "bundle",
+            "source_type",
+            "content_hash",
+            "is_new",
+        }
+
+    def test_is_new_true_when_hash_not_in_seen(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.md"
+        f.write_text("content")
+        cf = self._make_cf(f)
+        resolutions = _build_resolutions([cf], {"@file.md": f}, seen_hashes=set())
+        assert resolutions[0]["is_new"] is True
+
+    def test_is_new_false_when_hash_already_seen(self, tmp_path: Path) -> None:
+        f = tmp_path / "file.md"
+        f.write_text("content")
+        cf = self._make_cf(f)
+        resolutions = _build_resolutions(
+            [cf], {"@file.md": f}, seen_hashes={cf.content_hash}
+        )
+        assert resolutions[0]["is_new"] is False
+
+    def test_bundle_namespace_in_payload(self, tmp_path: Path) -> None:
+        """@foundation:ctx/x.md → bundle='foundation' in the resolution entry."""
+        f = tmp_path / "x.md"
+        f.write_text("x")
+        cf = self._make_cf(f, "x")
+        resolutions = _build_resolutions(
+            [cf], {"@foundation:ctx/x.md": f}, seen_hashes=set()
+        )
+        assert resolutions[0]["bundle"] == "foundation"
+        assert resolutions[0]["source_type"] == "bundle_namespace"
+
+    def test_untracked_path_gets_mention_none(self, tmp_path: Path) -> None:
+        """A ContextFile whose path has no entry in mention_to_path → mention=None."""
+        f = tmp_path / "orphan.md"
+        f.write_text("orphan")
+        resolutions = _build_resolutions([self._make_cf(f, "orphan")], {})
+        assert resolutions[0]["mention"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Factory emission  (primary behavioural evidence)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestFactoryEmission:
+    """The system-prompt factory emits mentions:resolved with correct semantics.
+
+    These tests are the key evidence that the feature works end-to-end:
+
+    - Turn 1 with context files  → event emitted, payload is correct.
+    - Turn 2 (same files)        → event NOT emitted (deduplication guard).
+    - Turn 3 with a new file     → event emitted again for the new file only.
+    - Empty bundle               → event never emitted.
+    - Unresolvable @mention      → failed[] list in payload.
+    - resolved_path              → always an absolute string.
+    """
+
+    @pytest.mark.asyncio
+    async def test_emits_on_first_turn_with_context_files(self, tmp_path: Path) -> None:
+        """Turn 1: mentions:resolved is emitted with source=bundle_context."""
+        ctx_file = tmp_path / "guide.md"
+        ctx_file.write_text("# Guide content")
+
+        bundle = Bundle(name="test", context={"@guide": ctx_file})
+        prepared = _make_prepared(bundle)
+        session = _make_mock_session()
+
+        factory = prepared._create_system_prompt_factory(bundle, session)
+        await factory()
+
+        emit = session.coordinator.hooks.emit
+        emit.assert_called_once()
+        event_name, payload = emit.call_args.args
+
+        assert event_name == MENTIONS_RESOLVED
+        assert payload["source"] == "bundle_context"
+        assert payload["turn"] is None
+        assert len(payload["resolutions"]) == 1
+        assert payload["resolutions"][0]["is_new"] is True
+        assert payload["resolutions"][0]["content_hash"] != ""
+        assert payload["deduplicated_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_silent_on_second_turn_same_files(self, tmp_path: Path) -> None:
+        """Turn 2: no new files → emit is NOT called again."""
+        ctx_file = tmp_path / "ctx.md"
+        ctx_file.write_text("context body")
+
+        bundle = Bundle(name="test", context={"@ctx": ctx_file})
+        prepared = _make_prepared(bundle)
+        session = _make_mock_session()
+
+        factory = prepared._create_system_prompt_factory(bundle, session)
+        await factory()  # turn 1 — emits
+        call_count_after_turn1 = session.coordinator.hooks.emit.call_count
+        assert call_count_after_turn1 == 1
+
+        await factory()  # turn 2 — same files, must NOT emit
+        assert session.coordinator.hooks.emit.call_count == 1, (
+            "emit was called again on turn 2 — deduplication guard is broken"
+        )
+
+    @pytest.mark.asyncio
+    async def test_emits_again_when_new_file_appears(self, tmp_path: Path) -> None:
+        """A new context file added between turns triggers a second emission."""
+        file_a = tmp_path / "a.md"
+        file_a.write_text("AAA")
+        file_b = tmp_path / "b.md"
+        file_b.write_text("BBB")
+
+        bundle = Bundle(name="test", context={"@a": file_a})
+        prepared = _make_prepared(bundle)
+        session = _make_mock_session()
+
+        factory = prepared._create_system_prompt_factory(bundle, session)
+        await factory()  # turn 1 — emits for file_a
+
+        bundle.context["@b"] = file_b  # new file appears
+        await factory()  # turn 2 — file_b is new → must emit
+
+        emit = session.coordinator.hooks.emit
+        assert emit.call_count == 2
+
+        # Second emission covers only the new file
+        _, second_payload = emit.call_args_list[1].args
+        assert len(second_payload["resolutions"]) == 1
+        assert second_payload["resolutions"][0]["is_new"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_emit_for_empty_bundle(self) -> None:
+        """A bundle with no instruction and no context files emits nothing."""
+        bundle = Bundle(name="empty")
+        prepared = _make_prepared(bundle)
+        session = _make_mock_session()
+
+        factory = prepared._create_system_prompt_factory(bundle, session)
+        await factory()
+
+        session.coordinator.hooks.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resolved_path_is_absolute(self, tmp_path: Path) -> None:
+        """resolved_path in the payload is always an absolute string."""
+        ctx_file = tmp_path / "info.md"
+        ctx_file.write_text("info")
+
+        bundle = Bundle(name="test", context={"@info": ctx_file})
+        prepared = _make_prepared(bundle)
+        session = _make_mock_session()
+
+        factory = prepared._create_system_prompt_factory(bundle, session)
+        await factory()
+
+        _, payload = session.coordinator.hooks.emit.call_args.args
+        for r in payload["resolutions"]:
+            assert Path(r["resolved_path"]).is_absolute(), (
+                f"resolved_path is not absolute: {r['resolved_path']!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_mention_appears_in_failed_list(
+        self, tmp_path: Path
+    ) -> None:
+        """@mentions that cannot be resolved appear in failed[] with a reason."""
+        ctx_file = tmp_path / "real.md"
+        ctx_file.write_text("real content")
+
+        bundle = Bundle(
+            name="test",
+            instruction="See @no-such-bundle:nowhere.md for details",
+            context={"@real": ctx_file},
+        )
+        prepared = _make_prepared(bundle)
+        session = _make_mock_session()
+
+        factory = prepared._create_system_prompt_factory(bundle, session)
+        await factory()
+
+        _, payload = session.coordinator.hooks.emit.call_args.args
+        failed_mentions = [f["mention"] for f in payload["failed"]]
+        assert "@no-such-bundle:nowhere.md" in failed_mentions
+
+        valid_reasons = {
+            "not_found",
+            "permission_error",
+            "bundle_not_registered",
+            "path_traversal_rejected",
+            "unknown",
+        }
+        for entry in payload["failed"]:
+            assert entry["reason"] in valid_reasons, (
+                f"Unexpected failure reason: {entry['reason']!r}"
+            )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Observability registration
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestObservabilityRegistration:
+    """create_session() registers mentions:resolved on observability.events.
+
+    This is the mechanism that makes the event discoverable by hooks-logging
+    and hook-context-intelligence without any app-layer wiring — the same
+    pattern used by tool-delegate for its delegate:* events.
+    """
+
+    @pytest.mark.asyncio
+    async def test_register_contributor_called_for_observability_events(
+        self,
+    ) -> None:
+        """create_session() calls register_contributor('observability.events', ...)."""
+        bundle = Bundle(name="test")
+        prepared = _make_prepared(bundle)
+        mock_session = _make_mock_session()
+
+        with patch("amplifier_core.AmplifierSession", return_value=mock_session):
+            await prepared.create_session()
+
+        registered_channels = [
+            c.args[0]
+            for c in mock_session.coordinator.register_contributor.call_args_list
+        ]
+        assert "observability.events" in registered_channels, (
+            "observability.events channel not registered — "
+            "hooks-logging will not discover mentions:resolved"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mentions_resolved_in_contributed_event_list(self) -> None:
+        """The contributor lambda returns a list containing 'mentions:resolved'."""
+        bundle = Bundle(name="test")
+        prepared = _make_prepared(bundle)
+        mock_session = _make_mock_session()
+
+        with patch("amplifier_core.AmplifierSession", return_value=mock_session):
+            await prepared.create_session()
+
+        obs_calls = [
+            c
+            for c in mock_session.coordinator.register_contributor.call_args_list
+            if c.args[0] == "observability.events"
+        ]
+        assert obs_calls, "No observability.events registration found"
+
+        contributor_fn = obs_calls[0].args[2]
+        contributed = contributor_fn()
+        assert MENTIONS_RESOLVED in contributed, (
+            f"Expected {MENTIONS_RESOLVED!r} in contributed events: {contributed!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_contributor_registered_under_foundation_mention_resolver(
+        self,
+    ) -> None:
+        """The contributor name is 'foundation:mention-resolver'."""
+        bundle = Bundle(name="test")
+        prepared = _make_prepared(bundle)
+        mock_session = _make_mock_session()
+
+        with patch("amplifier_core.AmplifierSession", return_value=mock_session):
+            await prepared.create_session()
+
+        obs_calls = [
+            c
+            for c in mock_session.coordinator.register_contributor.call_args_list
+            if c.args[0] == "observability.events"
+        ]
+        contributor_name = obs_calls[0].args[1]
+        assert contributor_name == "foundation:mention-resolver"


### PR DESCRIPTION
## Problem

The `@mention` resolver is completely silent. When `PreparedBundle` loads context files declared in the `context:` YAML section, nothing observable happens. The resolved content lands inside multi-KB XML blobs in `session:start.data.raw` that are:

- Redacted in ~65% of sessions by `hooks-redaction`
- Absent entirely for runtime (per-turn) @mentions
- Fragile to parse — the XML format is a display convention, not a schema contract

This creates three concrete gaps:

| Gap | Impact |
|-----|--------|
| **No resolution visibility** | Cannot determine which @mentions resolved vs. failed, or which files were loaded |
| **Silent failures** | A bundle declares a context file that no longer exists — nobody finds out |
| **No turn-level tracking** | User types `@AGENTS.md` mid-session — invisible to hooks and observers |

---

## Two-layer event model

This PR introduces `mentions:resolved` as a **foundation-layer event** — the per-mention parse fact. Bundle attribution and content-inclusion facts belong at a different layer:

| Event | Layer | Fires when |
|---|---|---|
| `context:include` | kernel constant (added `fd1feeb`, *"Context file inclusions (for debugging context size)"*) | A context file is added to the system prompt — any source |
| `mentions:resolved` | foundation/mentions | An `@`-syntax token is parsed and resolved |

These are distinct events at distinct layers. A user typing `@AGENTS.md` produces both: `mentions:resolved` (the parse fact) and `context:include` (the inclusion fact). Consumers needing the joined view assemble it from both. This PR covers `mentions:resolved` only.

---

## Solution

A single new event, `mentions:resolved`, emitted after each resolution pass inside the system-prompt factory. The event carries the resolution manifest — what was asked for, what resolved, what failed, what was deduplicated.

### Event schema

```python
{
  "source": "bundle_context",     # or "user_prompt" (app-layer, follow-up PR)

  "resolutions": [
    {
      "mention":       str | None,  # "@foundation:context/foo.md" or None for context: decls
      "resolved_path": str,         # absolute path on disk
      "source_type":   str,         # how the path was referenced:
                                    # "bundle_namespace" | "bundle_context_decl" |
                                    # "user_shortcut" | "project_shortcut" |
                                    # "home_shortcut" | "relative_path"
      "content_hash":  str,         # SHA-256 matching the deduplicator
      "is_new":        bool,        # True = first time this file appears in the session
    }
  ],

  "failed": [{"mention": str, "reason": str}],
  "deduplicated_count": int,
  "turn": None,                     # null for bundle_context; int for user_prompt
}
```

### Silent-fail policy

The `@AGENTS.md`-in-many-locations pattern is intentional — those non-resolutions are not failures and do not appear in `failed[]`. Only entries with an explicit `failure_reason` (`"not_found"`, `"permission_error"`) surface. Two specific cases are deferred to follow-up PRs:

- Bundle `context:` YAML declaration → file missing: validate at load time, surface via `/config show context`. Separate PR.
- User-typed `@mention` → zero resolutions (typo): one-line UX warning. Separate PR.

### Where it fires

```
session:start
  ├─ [turn 1]
  │     execution:start
  │     mentions:resolved  ← source=bundle_context (all context files)
  │     provider:request
  │
  ├─ [turn 2, same files]
  │     execution:start
  │     (no event — deduplication guard)
  │     provider:request
  │
  └─ session:end
```

---

## How it works

### Hook subscription: two complementary mechanisms

| Mechanism | Path | Effect |
|---|---|---|
| `inject_additional_events(FOUNDATION_OBSERVABILITY_EVENTS)` | mount plan → hook `additional_events` config | hooks-logging and hook-context-intelligence subscribe at session init |
| `coordinator.register_contributor("observability.events", ...)` | coordinator contribution channel | event discoverable via `collect_contributions("observability.events")` at runtime |

Both are registered in `create_session()` and `spawn()`, guarded by `if bundle.instruction or bundle.context`. Empty-bundle sessions do not register — they never emit the event.

---

## Changes (4 files, no new dependencies, no kernel modifications)

### `amplifier_foundation/mentions/models.py`

Added `failure_reason: str | None = None` to `MentionResult`. Defaults to `None` — all existing call sites are unaffected.

### `amplifier_foundation/mentions/loader.py`

`_resolve_mention()` now sets `failure_reason` at each failure branch (`"not_found"` | `"permission_error"`).

### `amplifier_foundation/bundle/_observability.py`

Added `"mentions:resolved"` to `FOUNDATION_OBSERVABILITY_EVENTS`.

### `amplifier_foundation/bundle/_prepared.py`

**Added:**
- `_determine_source_type(mention) -> str` — classifies the syntax form of a mention string

**Updated:**
- `_build_resolutions` — emits `{mention, resolved_path, source_type, content_hash, is_new}` per entry
- `_create_system_prompt_factory` — emits event; `failed[]` filter uses `mr.failure_reason is not None` so PermissionError cases surface
- `create_session()` — registers on `observability.events` inside the bundle-content guard
- `spawn()` — same registration, same guard; `spawn()` bypasses `create_session()` so both sites are required

---

## Tests — 41 passing, 0 warnings

`tests/test_mentions_resolved_event.py`

| Group | Count | What it proves |
|---|---|---|
| `TestMentionResultFailureReason` | 5 | New field, backward-compatible |
| `TestLoaderFailureReason` | 4 | `failure_reason` set at every failure site |
| `TestDetermineSourceType` | 11 | Syntax-label classifier, all mention forms |
| `TestBuildResolutions` | 4 | Payload shape, `is_new`, `resolved_path` absolute |
| `TestFactoryEmission` | 6 | Turn 1 emits; turn 2 silent; new file re-emits; PermissionError in `failed[]` |
| `TestReviewerFindings` | 3 | `resolved_path` absolute, `spawn()` registers, PermissionError in `failed[]` |
| `TestObservabilityRegistration` | 5 | Both `create_session()` and `spawn()` register; empty bundle does not |

---

## What is NOT in this PR

- **`user_prompt` source (Path B)** — `amplifier_app_cli/main.py:_process_runtime_mentions()`. Schema and registration established here; app-layer emission is a follow-up PR
- **`context:include` emission** — emitting the kernel-layer inclusion fact is a separate PR; the constant and its semantics are now documented
- **Bundle `context:` YAML missing file** — surface via `/config show context` with a `[missing]` flag; separate PR
- **User-typed `@mention` typo warning** — one-line UX surface; separate PR
- **`ContextFile.origins` field** — tagging attribution on the dataclass itself; separate PR
