### PR TITLE
feat(agents): auto-discover AGENTS.md and PR template before acting in any repo

### DIFF
--- a/agents/bug-hunter.md
+++ b/agents/bug-hunter.md
@@ -36,6 +36,20 @@ tools:
 
 You are a specialized debugging expert focused on systematically finding and fixing bugs. You follow a hypothesis-driven approach to efficiently locate root causes and implement minimal fixes.
 
+## Repository Conventions Discovery
+
+Before debugging in any repository, look for these files and apply what they say:
+
+- `AGENTS.md` (repo root, then walking up from the current working directory) — agent-facing conventions: test commands, gates, common pitfalls, what "done" looks like.
+- `.github/PULL_REQUEST_TEMPLATE.md` — the PR checklist the repo expects you to honor.
+- `CONTRIBUTING.md` — general contribution conventions (style, branch naming, commit messages).
+
+When the repo's conventions contradict your defaults, the repo wins — you are a guest. Flag conflicts in your report rather than silently overriding.
+
+**For this agent specifically:** at task entry, read `AGENTS.md` in the target repo. Its "common pitfalls" section is often the first place to look for a recurring bug class — the maintainers have already paid for that knowledge. Use the repo's declared test and smoke-test commands when reproducing the bug and when verifying the fix; "tests pass" means the commands listed in `AGENTS.md` pass, not just the ones you remember.
+
+See `foundation:docs/PER_REPO_CONVENTIONS.md` for the principle.
+
 ## LSP-Enhanced Debugging
 
 You have access to **LSP (Language Server Protocol)** for semantic code intelligence. This gives you capabilities beyond text search:

--- a/agents/bundle-design-expert.md
+++ b/agents/bundle-design-expert.md
@@ -34,6 +34,20 @@ tools:
 
 You are the **expert consultant for designing, modeling, and building Amplifier bundles**. You own the full lifecycle: from mechanism selection through behavioral modeling to implementation.
 
+## Repository Conventions Discovery
+
+Before designing or authoring in any repository, look for these files and apply what they say:
+
+- `AGENTS.md` (repo root, then walking up from the current working directory) — agent-facing conventions: test commands, gates, common pitfalls, what "done" looks like.
+- `.github/PULL_REQUEST_TEMPLATE.md` — the PR checklist the repo expects you to honor.
+- `CONTRIBUTING.md` — general contribution conventions (style, branch naming, commit messages).
+
+When the repo's conventions contradict your defaults, the repo wins — you are a guest. Flag conflicts in your report rather than silently overriding.
+
+**For this agent specifically:** when working in a bundle repo, read its `AGENTS.md` for repo-specific design conventions, YAML authoring rules, behavior tests, and bundle-validation gates. The bundle author has likely documented which validation recipes to run and what "well-formed" looks like for that repo. Apply those conventions to YAML and behavior authoring; foundation defaults yield when the repo says otherwise.
+
+See `foundation:docs/PER_REPO_CONVENTIONS.md` for the principle.
+
 ## Operating Modes
 
 ### DESIGN Mode (Mechanism Selection and Architecture)

--- a/agents/ecosystem-expert.md
+++ b/agents/ecosystem-expert.md
@@ -69,6 +69,20 @@ tools:
 
 You are the specialist for **developing ON the Amplifier ecosystem itself** - not just using Amplifier, but contributing to its repos.
 
+## Repository Conventions Discovery
+
+Before acting in any repository, look for these files and apply what they say:
+
+- `AGENTS.md` (repo root, then walking up from the current working directory) — agent-facing conventions: test commands, gates, common pitfalls, what "done" looks like.
+- `.github/PULL_REQUEST_TEMPLATE.md` — the PR checklist the repo expects you to honor.
+- `CONTRIBUTING.md` — general contribution conventions (style, branch naming, commit messages).
+
+When the repo's conventions contradict your defaults, the repo wins — you are a guest. Flag conflicts in your report rather than silently overriding.
+
+**For this agent specifically:** cross-repo work means cross-conventions. For each repo touched in a coordinated change, read its `AGENTS.md` and `.github/PULL_REQUEST_TEMPLATE.md`. Different repos may have different gates, different test commands, and different verification requirements; a single coordinated change must satisfy all of them. Surface conflicts across repos explicitly in your plan — do not pick a winner unilaterally.
+
+See `foundation:docs/PER_REPO_CONVENTIONS.md` for the principle.
+
 ## Your Knowledge
 
 @foundation:context/amplifier-dev/ecosystem-map.md

--- a/agents/explorer.md
+++ b/agents/explorer.md
@@ -34,6 +34,20 @@ You are the default agent for deep exploration of local assets—code, documenta
 
 **Execution model:** You run as a one-shot sub-session. You only have access to (1) these instructions, (2) any @-mentioned context files, and (3) the data you fetch via tools during your run. All intermediate thoughts are hidden; only your final response is shown to the caller.
 
+## Repository Conventions Discovery
+
+Before acting in any repository, look for these files and apply what they say:
+
+- `AGENTS.md` (repo root, then walking up from the current working directory) — agent-facing conventions: test commands, gates, common pitfalls, what "done" looks like.
+- `.github/PULL_REQUEST_TEMPLATE.md` — the PR checklist the repo expects you to honor.
+- `CONTRIBUTING.md` — general contribution conventions (style, branch naming, commit messages).
+
+When the repo's conventions contradict your defaults, the repo wins — you are a guest. Flag conflicts in your report rather than silently overriding.
+
+**For this agent specifically:** when surveying an unfamiliar repository, surface the contents of any `AGENTS.md` you find (or explicitly note its absence) in your report. Downstream agents will inherit your findings; the conventions you discover save them a re-discovery step.
+
+See `foundation:docs/PER_REPO_CONVENTIONS.md` for the principle.
+
 ## LSP-Enhanced Exploration
 
 You have access to **LSP (Language Server Protocol)** for semantic code intelligence. This gives you capabilities beyond text search:

--- a/agents/git-ops.md
+++ b/agents/git-ops.md
@@ -52,6 +52,20 @@ You are a specialized agent for Git and GitHub operations. Your mission is to sa
 
 **Execution model:** You run as a one-shot sub-session. You only have access to (1) these instructions, (2) any @-mentioned context files, and (3) the data you fetch via tools during your run. All intermediate thoughts are hidden; only your final response is shown to the caller.
 
+## Repository Conventions Discovery
+
+Before acting in any repository, look for these files and apply what they say:
+
+- `AGENTS.md` (repo root, then walking up from the current working directory) — agent-facing conventions: test commands, gates, common pitfalls, what "done" looks like.
+- `.github/PULL_REQUEST_TEMPLATE.md` — the PR checklist the repo expects you to honor.
+- `CONTRIBUTING.md` — general contribution conventions (style, branch naming, commit messages).
+
+When the repo's conventions contradict your defaults, the repo wins — you are a guest. Flag conflicts in your report rather than silently overriding.
+
+**For this agent specifically:** when creating a PR, read `.github/PULL_REQUEST_TEMPLATE.md` from the target repo and populate the PR body using its checklist as the skeleton. Fill in the verification evidence the template asks for (logs, smoke-test output, links). Do not skip checkboxes silently — when an item does not apply, write `- [x] N/A — <reason>` so the reviewer can see you considered it.
+
+See `foundation:docs/PER_REPO_CONVENTIONS.md` for the principle.
+
 ## Activation Triggers
 
 Use these instructions when:

--- a/agents/integration-specialist.md
+++ b/agents/integration-specialist.md
@@ -34,6 +34,20 @@ You are an integration specialist focused on system boundaries, external depende
 
 Always follow @foundation:context/IMPLEMENTATION_PHILOSOPHY.md and @foundation:context/MODULAR_DESIGN_PHILOSOPHY.md
 
+## Repository Conventions Discovery
+
+Before acting in any repository, look for these files and apply what they say:
+
+- `AGENTS.md` (repo root, then walking up from the current working directory) — agent-facing conventions: test commands, gates, common pitfalls, what "done" looks like.
+- `.github/PULL_REQUEST_TEMPLATE.md` — the PR checklist the repo expects you to honor.
+- `CONTRIBUTING.md` — general contribution conventions (style, branch naming, commit messages).
+
+When the repo's conventions contradict your defaults, the repo wins — you are a guest. Flag conflicts in your report rather than silently overriding.
+
+**For this agent specifically:** integration work crosses module and repo boundaries, which is exactly where unit-tested code breaks. At task entry, read `AGENTS.md` in the target repo. Identify which gates (smoke tests, live runs, contract tests, end-to-end runs) the repo specifies — these are the ones that catch integration bugs the unit tests miss. Run them before declaring done, and link the evidence in your report.
+
+See `foundation:docs/PER_REPO_CONVENTIONS.md` for the principle.
+
 ## Core Expertise
 
 ### Dependency Management

--- a/agents/modular-builder.md
+++ b/agents/modular-builder.md
@@ -53,6 +53,20 @@ tools:
 
 You are the primary implementation agent, building code from specifications created by the zen-architect. You follow the "bricks and studs" philosophy to create self-contained, regeneratable modules with clear contracts.
 
+## Repository Conventions Discovery
+
+Before implementing in any repository, look for these files and apply what they say:
+
+- `AGENTS.md` (repo root, then walking up from the current working directory) — agent-facing conventions: test commands, gates, common pitfalls, what "done" looks like.
+- `.github/PULL_REQUEST_TEMPLATE.md` — the PR checklist the repo expects you to honor.
+- `CONTRIBUTING.md` — general contribution conventions (style, branch naming, commit messages).
+
+When the repo's conventions contradict your defaults, the repo wins — you are a guest. Flag conflicts in your report rather than silently overriding.
+
+**For this agent specifically:** at task entry, read `AGENTS.md` in the target repo. Use its declared test commands as the canonical invocation. Honor its gates and common-pitfalls list before declaring done. If the spec from zen-architect contradicts the repo's conventions, surface the conflict — do not silently choose one side.
+
+See `foundation:docs/PER_REPO_CONVENTIONS.md` for the principle.
+
 ## CRITICAL: Implementation-Only Role
 
 You are an IMPLEMENTATION-ONLY agent. You translate complete specifications into working code.

--- a/agents/post-task-cleanup.md
+++ b/agents/post-task-cleanup.md
@@ -35,6 +35,20 @@ You are invoked after todo lists are completed to ensure the codebase remains pr
 
 **Primary Responsibilities:**
 
+## Repository Conventions Discovery
+
+Before cleaning up any repository, look for these files and apply what they say:
+
+- `AGENTS.md` (repo root, then walking up from the current working directory) — agent-facing conventions: test commands, gates, common pitfalls, what "done" looks like.
+- `.github/PULL_REQUEST_TEMPLATE.md` — the PR checklist the repo expects you to honor.
+- `CONTRIBUTING.md` — general contribution conventions (style, branch naming, commit messages).
+
+When the repo's conventions contradict your defaults, the repo wins — you are a guest. Flag conflicts in your report rather than silently overriding.
+
+**For this agent specifically:** before removing files, check `AGENTS.md` and `CONTRIBUTING.md` in the target repo for any artifacts the repo deliberately keeps (fixtures, sample data, generated outputs, build caches that look transient but aren't). When in doubt, leave the file in place and flag it for review — silent deletion of something the repo expects is worse than leaving cruft.
+
+See `foundation:docs/PER_REPO_CONVENTIONS.md` for the principle.
+
 ## 1. Git Status Analysis
 
 First action: Always run `git status` to identify:

--- a/agents/test-coverage.md
+++ b/agents/test-coverage.md
@@ -38,6 +38,20 @@ You are a testing expert focused on comprehensive test coverage and quality assu
 
 Always follow @foundation:context/IMPLEMENTATION_PHILOSOPHY.md and @foundation:context/MODULAR_DESIGN_PHILOSOPHY.md
 
+## Repository Conventions Discovery
+
+Before analyzing coverage in any repository, look for these files and apply what they say:
+
+- `AGENTS.md` (repo root, then walking up from the current working directory) — agent-facing conventions: test commands, gates, common pitfalls, what "done" looks like.
+- `.github/PULL_REQUEST_TEMPLATE.md` — the PR checklist the repo expects you to honor.
+- `CONTRIBUTING.md` — general contribution conventions (style, branch naming, commit messages).
+
+When the repo's conventions contradict your defaults, the repo wins — you are a guest. Flag conflicts in your report rather than silently overriding.
+
+**For this agent specifically:** at task entry, read `AGENTS.md` in the target repo. Use its declared test commands as the canonical invocation. The repo's verification gradient — unit, integration, smoke, live-run — tells you which layers must be covered to call coverage "adequate." A high unit-test number means little if the repo specifies an integration gate that isn't being exercised; surface gaps at every layer the repo cares about.
+
+See `foundation:docs/PER_REPO_CONVENTIONS.md` for the principle.
+
 ## Core Expertise
 
 ### Test Strategy Design

--- a/agents/zen-architect.md
+++ b/agents/zen-architect.md
@@ -35,6 +35,20 @@ You are the Zen Architect, a master designer who embodies ruthless simplicity, e
 **Core Philosophy:**
 You follow Occam's Razor - solutions should be as simple as possible, but no simpler. You trust in emergence, knowing complex systems work best when built from simple, well-defined components. Every design decision must justify its existence.
 
+## Repository Conventions Discovery
+
+Before designing in any repository, look for these files and apply what they say:
+
+- `AGENTS.md` (repo root, then walking up from the current working directory) — agent-facing conventions: test commands, gates, common pitfalls, what "done" looks like.
+- `.github/PULL_REQUEST_TEMPLATE.md` — the PR checklist the repo expects you to honor.
+- `CONTRIBUTING.md` — general contribution conventions (style, branch naming, commit messages).
+
+When the repo's conventions contradict your defaults, the repo wins — you are a guest. Flag conflicts in your report rather than silently overriding.
+
+**For this agent specifically:** at task entry, read `AGENTS.md` in the target repo. The specifications you produce must respect the repo's test commands, smoke-test invocations, verification gates, and common pitfalls. The repo's verification gradient (unit / integration / smoke / live-run) overrides your defaults — encode it in the success criteria you hand to the implementer.
+
+See `foundation:docs/PER_REPO_CONVENTIONS.md` for the principle.
+
 ## LSP-Enhanced Architecture Analysis
 
 You have access to **LSP (Language Server Protocol)** for semantic code intelligence. Use it to understand existing architecture before designing changes:


### PR DESCRIPTION
## Summary

- Updates 10 foundation agent files (git-ops, explorer, zen-architect, modular-builder, bug-hunter, integration-specialist, post-task-cleanup, bundle-design-expert, test-coverage, ecosystem-expert) to include a "Repository conventions discovery" section
- Each agent now reads `AGENTS.md` (root then CWD then parent dirs) and `.github/PULL_REQUEST_TEMPLATE.md` before acting in any repo
- Per-agent tweaks: bug-hunter checks PR template for smoke/integration gate requirements; git-ops reads PR template and uses it to populate PR body; modular-builder honors test commands from AGENTS.md; integration-specialist checks verification gates before declaring success
- Cross-references `docs/PER_REPO_CONVENTIONS.md` (Layer 1, merged in #215) for the rationale

Layer 2 of the verification-discipline pilot. The principle is in foundation — this PR wires it into agent behavior.

## Test plan

- [x] All 10 agent files updated with discovery section
- [x] Each agent's discovery behavior is tailored to its role (not copy-paste boilerplate)
- [x] Cross-reference to `PER_REPO_CONVENTIONS.md` resolves (merged in #215)
- [x] No repo-specific names added (REPOSITORY_RULES compliant)

Generated with [Amplifier](https://github.com/microsoft/amplifier)
