### PR TITLE
docs(bundle-design): add structural invariants to bundle-design-expert review framework

### DIFF
--- a/agents/bundle-design-expert.md
+++ b/agents/bundle-design-expert.md
@@ -281,6 +281,78 @@ If you're just adding agents + maybe a tool, a behavior might be all you need.
 
 ---
 
+## Bundle Review Invariants
+
+When reviewing an existing bundle repo, run these checks mechanically **before forming any verdict**. A bundle that fails any of them is broken at the wiring layer regardless of how clean its design looks.
+
+### First, classify the file you're reviewing
+
+The classification is determined by the file's *shape*, not its location:
+
+- **Standalone bundle** — the file declares enough that a bundle loader can resolve it into a full/complete/useful mount plan. Typically the root `bundle.md`/`bundle.yaml` of a repo, but a repo may also ship additional standalones under `/bundles/`.
+- **Partial bundle** — the file contributes capability that composes onto a standalone. Most common: behavior bundles at `behaviors/<bundle-name>.yaml`. Other uses: provider partials, extension behaviors that include and extend another behavior.
+
+The **thin standalone** is the most common shape for bundle repos:
+
+```yaml
+includes:
+  - bundle: <another standalone — almost always foundation or a foundation-including bundle>
+  - bundle: <name>:behaviors/<name>
+```
+
+Anything more is fine but stops being "thin" — it's a richer standalone.
+
+### Invariant 1 — Every artifact in the repo has a runtime path from the standalone
+
+The standalone's `includes:` is the **only** runtime entry surface. For every file or declaration that exists in the repo, trace the path from the standalone to it. If no path exists, the artifact is **dead** — it loads silently and contributes nothing.
+
+| Artifact in repo | Required wiring |
+|---|---|
+| `context/*.md` | `@-mention` in standalone's body **or** `context.include:` in an included behavior partial |
+| `agents/*.md` | `agents:` block in standalone or included partial (no auto-discovery for agents) |
+| `modules/tool-*` | `tools:` block in standalone or included partial |
+| `modules/hook-*` | `hooks:` block in standalone or included partial |
+| `modes/*.md` | Auto-discovered by the modes bundle's hook *only if* the modes bundle is composed in. Verify the prerequisite. |
+| `recipes/*.yaml`, `skills/*` | Auto-discovered by their respective mechanisms — verify those mechanisms are composed in |
+
+### Invariant 2 — If a `behaviors/<name>.yaml` partial exists, the standalone MUST include it
+
+The behavior partial is inert until included. The convention is `- bundle: <name>:behaviors/<name>` in the standalone's `includes:` block. Without that line the behavior file is dead code.
+
+### Invariant 3 — If `context/` files exist, they must be reachable
+
+Two options:
+
+- `@-mention` in the standalone's body
+- `context.include:` entry in an included behavior partial
+
+Neither = dead context.
+
+**The two channels are independent and not deduplicated against each other.** Do not list the same file in both — it loads twice into every session prompt. The `ContentDeduplicator` only operates within recursive `@-mention` resolution; it does not bridge the body-instruction and `context.include` channels.
+
+### Invariant 4 — "Pure-mode bundle" exemption is rare and explicit
+
+Modes auto-discover from `modes/`. **Nothing else does.** A bundle that ships `modes/` *plus* `context/` still needs a behavior partial to wire the context. The "no behavior needed" exemption applies only when:
+
+- `ls context/ agents/ modules/ hooks/` is empty
+- The standalone has no top-level `context:`, `tools:`, `hooks:`, or `agents:` blocks
+
+If any of those exist, the behavior partial is required.
+
+### Invariant 5 — Validator gate-mode matters
+
+`validate-bundle-repo` and similar tools have multiple gate sets. When `amplifier_foundation` is not installed in the runner, the recipe runs in `hygiene_only` mode and skips the `BundleRegistry` resolution that would catch orphaned context, missing behaviors, and broken includes. **A PASS in `hygiene_only` is not a PASS on structural invariants.** Check which gates ran before citing the verdict.
+
+### Verdict policy
+
+- **CRITICAL** — Invariants 1, 2, or 3 fail. Do not issue any PASS verdict (including PASS-WITH-WARN).
+- **WARN** — Invariant 4 or 5 concerns, or stylistic concerns once structural invariants pass.
+- **PASS** — All five invariants pass and design-level concerns are addressed.
+
+Run the invariants first. Design judgment comes after.
+
+---
+
 ## Bundle Composition Patterns
 
 Key patterns (details in BUNDLE_GUIDE.md):

--- a/docs/BUNDLE_GUIDE.md
+++ b/docs/BUNDLE_GUIDE.md
@@ -345,9 +345,9 @@ Bundle repos follow **conventions** that enable maximum reusability and composit
 
 ### The Recommended Pattern
 
-1. **Put your main value in `/behaviors/`** - this is what others compose onto their bundles
-2. **Root bundle includes its own behavior** - DRY, root bundle stays thin
-3. **`/bundles/` offers pre-composed variants** - convenience for users who want ready-to-run combinations
+1. **Put your main value in `/behaviors/`** — this is what others compose onto their bundles (a "partial" bundle)
+2. **The standalone bundle MUST include its own behavior** — this is the wiring path that makes the behavior's `context:`, `tools:`, and `hooks:` reachable at runtime. The behavior file is inert until included. DRY is a secondary benefit; reachability is the primary one.
+3. **`/bundles/` offers pre-composed variants** — additional standalone bundles for users who want ready-to-run combinations
 
 ```yaml
 # bundle.md (root) - thin, includes own behavior
@@ -1611,6 +1611,7 @@ This fires when `mount()` returns `None` without calling `coordinator.mount()`. 
 
 ### Behavior not applying
 
+- Verify the standalone bundle's `includes:` list contains `- bundle: <name>:behaviors/<name>`. A behavior file on disk that is never included is silently inert — the most common cause of "my behavior isn't loading."
 - Verify behavior YAML syntax is correct
 - Check include path: `my-bundle:behaviors/name` (not `my-bundle:behaviors/name.yaml`)
 - Ensure behavior declares `agents:` and/or `context:` sections


### PR DESCRIPTION
## Summary

The `bundle-design-expert` agent missed a structural defect during review of a new bundle — a missing `behaviors/<name>.yaml` left the bundle's `context/` files orphaned with no runtime path. The agent rationalized the absence as "a legitimate design choice for a pure-mode bundle."

Root cause: the agent has the right knowledge but no enforcement structure. The current `BUNDLE_GUIDE.md` frames the self-include as DRY rather than a wiring requirement.

This PR adds the missing enforcement structure.

## Changes

### `agents/bundle-design-expert.md`

Adds a **Bundle Review Invariants** section that:

- Anchors reviews in the project's bundle taxonomy (standalone vs partial; thin standalone as the canonical pattern)
- Defines five invariants with a verdict policy
- Documents the two-channel non-deduplication rule (`context.include` and `@-mention` are independent loading paths)
- Requires invariant checks before any PASS verdict

### `docs/BUNDLE_GUIDE.md`

Two targeted edits:

- "The Recommended Pattern" — re-frame point 2 from "DRY, root bundle stays thin" to "the standalone bundle MUST include its own behavior" (wiring, not style)
- "Behavior not applying" troubleshooting — add the most common failure case (missing self-include) as the first bullet

## Source authority

Verified by reading the runtime composition behavior in `amplifier_foundation/bundle.py:_create_system_prompt_factory`. The `context.include` and `@-mention` channels are joined via `instruction_parts.append` with no cross-channel dedup; `ContentDeduplicator` operates only within `@-mention` recursive resolution.

## How the defect was caught

A user manually compared the broken bundle's directory structure against `amplifier-bundle-evaluation` and `amplifier-bundle-modes` — both shipped reference bundles that have the `behaviors/<name>.yaml` file. The bundle-design-expert review and `validate-bundle-repo` (running in `hygiene_only` mode without `amplifier_foundation` installed) both passed the bundle without catching it.

## Test plan

- Read the new invariants section end-to-end; verify each is concrete and actionable
- Verify the diff against `BUNDLE_GUIDE.md` doesn't change any other content
- Mental walk-through: would a future review of a missing-behavior bundle now fail Invariant 1, 2, or 3 mechanically before reaching subjective judgment? (Yes.)

## Out of scope

The `bundle-design-expert` self-review identified several adjacent failure modes (orphan agents, orphan modules, mechanism prerequisites without their bundles, etc.) that follow the same pattern. Those are not addressed in this PR — Invariant 1's artifact table covers them as a natural extension, but specific guidance for each can be added in a follow-up if patterns emerge.