### PR TITLE
fix: merge duplicate depends_on YAML keys in validation recipes

### DIFF
--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -856,7 +856,6 @@ steps:
     agent: "foundation:zen-architect"
     mode: "REVIEW"
     condition: "{{quality_classification.requires_llm_analysis}} == true"
-    depends_on: ["set-default-quality-results"]
     prompt: |
       Analyze agent description quality for agents that need work in this repository.
 
@@ -965,7 +964,7 @@ steps:
     output: "quality_results"
     timeout: 600
     on_error: "continue"
-    depends_on: ["quality-classification"]
+    depends_on: ["set-default-quality-results", "quality-classification"]
 
   # ============================================================================
   # PHASE 5: Tool Access Analysis (Agent-Based, Conditional)
@@ -978,7 +977,6 @@ steps:
     agent: "foundation:zen-architect"
     mode: "ANALYZE"
     condition: "{{quality_classification.requires_llm_analysis}} == true"
-    depends_on: ["set-default-tool-analysis", "description-quality-check"]
     prompt: |
       Analyze tool access patterns for agents that need work in this repository.
 
@@ -1055,7 +1053,7 @@ steps:
     output: "tool_analysis"
     timeout: 600
     on_error: "continue"
-    depends_on: ["description-quality-check"]
+    depends_on: ["set-default-tool-analysis", "description-quality-check"]
 
   # ============================================================================
   # PHASE 6: Final Report Synthesis

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -3368,7 +3368,6 @@ steps:
     agent: "foundation:zen-architect"
     mode: "ANALYZE"
     condition: "{{quality_classification.requires_llm_analysis}} == true"
-    depends_on: ["set-default-composition-analysis"]
     prompt: |
       Analyze the composition of this bundle repository with focus on hygiene violations.
 
@@ -3468,7 +3467,7 @@ steps:
     output: "composition_analysis"
     timeout: 300
     on_error: "continue"
-    depends_on: ["quality-classification"]
+    depends_on: ["set-default-composition-analysis", "quality-classification"]
 
   # ============================================================================
   # PHASE 4.5: Convention Compliance (Conditional)
@@ -3478,7 +3477,6 @@ steps:
     agent: "foundation:zen-architect"
     mode: "REVIEW"
     condition: "{{quality_classification.requires_llm_analysis}} == true"
-    depends_on: ["set-default-repo-conventions", "composition-analysis"]
     prompt: |
       Review repository-wide convention compliance, incorporating v3.0.0 hygiene findings.
 
@@ -3528,7 +3526,7 @@ steps:
     output: "repo_conventions"
     timeout: 300
     on_error: "continue"
-    depends_on: ["composition-analysis"]
+    depends_on: ["set-default-repo-conventions", "composition-analysis"]
 
   # ============================================================================
   # PHASE 6: Bundle Doc Freshness Check (v3)

--- a/tests/test_recipes_yaml_hygiene.py
+++ b/tests/test_recipes_yaml_hygiene.py
@@ -1,0 +1,151 @@
+"""Tests for YAML hygiene in recipe files.
+
+Detects duplicate mapping keys in recipe YAML files.
+PyYAML silently resolves duplicate mapping keys to the last value,
+causing silent data loss. This test uses a strict loader that raises
+an error when a duplicate key is encountered.
+
+Bug class: duplicate `depends_on:` keys in a single step mapping.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Strict loader — raises on duplicate mapping keys
+# ---------------------------------------------------------------------------
+
+
+class _DuplicateKeyError(yaml.YAMLError):
+    """Raised when a YAML mapping contains a duplicate key."""
+
+
+class _StrictLoader(yaml.SafeLoader):
+    """PyYAML loader that raises _DuplicateKeyError on duplicate mapping keys.
+
+    PyYAML's default SafeLoader silently overwrites the first value when a
+    mapping contains duplicate keys.  This subclass overrides
+    ``construct_mapping`` to detect and reject such mappings before the
+    default resolution occurs.
+    """
+
+    def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> dict:  # type: ignore[override]
+        # Resolve keys first so we can compare them properly.
+        seen: dict[object, yaml.Node] = {}
+        for key_node, _value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if key in seen:
+                mark = key_node.start_mark
+                raise _DuplicateKeyError(
+                    f"Duplicate YAML key {key!r} at "
+                    f"line {mark.line + 1}, column {mark.column + 1}"
+                    f" in {mark.name!r}"
+                )
+            seen[key] = key_node
+        return super().construct_mapping(node, deep=deep)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+RECIPE_DIR = Path(__file__).parent.parent / "recipes"
+
+
+def _load_strict(path: Path) -> None:
+    """Load *path* with the strict loader; raises _DuplicateKeyError on dups."""
+    with path.open(encoding="utf-8") as fh:
+        yaml.load(fh, Loader=_StrictLoader)  # noqa: S506 — intentional custom loader
+
+
+def _recipe_paths() -> list[Path]:
+    """Return all *.yaml files under the recipes directory."""
+    return sorted(RECIPE_DIR.glob("*.yaml"))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the strict loader itself
+# ---------------------------------------------------------------------------
+
+
+class TestStrictLoader:
+    """Verify the strict loader correctly detects duplicate keys."""
+
+    def test_clean_yaml_loads_without_error(self) -> None:
+        """A YAML file with no duplicate keys must load cleanly."""
+        clean = """
+        name: example
+        version: "1.0.0"
+        steps:
+          - id: step-one
+            depends_on: ["setup"]
+          - id: step-two
+            depends_on: ["step-one"]
+        """
+        yaml.load(clean, Loader=_StrictLoader)  # must not raise
+
+    def test_duplicate_top_level_key_raises(self) -> None:
+        """A duplicate top-level key must raise _DuplicateKeyError."""
+        dup = """
+        name: first
+        name: second
+        """
+        with pytest.raises(_DuplicateKeyError, match="Duplicate YAML key 'name'"):
+            yaml.load(dup, Loader=_StrictLoader)
+
+    def test_duplicate_nested_key_raises(self) -> None:
+        """A duplicate key inside a nested mapping must raise _DuplicateKeyError."""
+        dup = """
+        steps:
+          - id: my-step
+            depends_on: ["setup"]
+            prompt: "do something"
+            depends_on: ["quality-classification"]
+        """
+        with pytest.raises(_DuplicateKeyError, match="Duplicate YAML key 'depends_on'"):
+            yaml.load(dup, Loader=_StrictLoader)
+
+    def test_duplicate_depends_on_in_list_item_raises(self) -> None:
+        """Duplicate depends_on inside a list-item mapping must be caught."""
+        dup = """
+        - id: composition-analysis
+          depends_on: ["set-default-composition-analysis"]
+          output: composition_analysis
+          depends_on: ["quality-classification"]
+        """
+        with pytest.raises(_DuplicateKeyError, match="Duplicate YAML key 'depends_on'"):
+            yaml.load(dup, Loader=_StrictLoader)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: all recipe YAML files must be duplicate-key-free
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "recipe_path",
+    _recipe_paths(),
+    ids=lambda p: p.name,
+)
+def test_recipe_has_no_duplicate_yaml_keys(recipe_path: Path) -> None:
+    """Every recipe YAML file must contain no duplicate mapping keys.
+
+    PyYAML silently discards the first of any duplicate keys, causing
+    silent data loss.  The canonical example is two ``depends_on:`` keys
+    in a single step: the first is silently dropped, leaving the step
+    with an incorrect dependency list.
+    """
+    try:
+        _load_strict(recipe_path)
+    except _DuplicateKeyError as exc:
+        pytest.fail(
+            f"{recipe_path.name} contains a duplicate YAML mapping key.\n"
+            f"PyYAML silently resolves duplicates to the last value, "
+            f"causing silent data loss.\n\n"
+            f"Detail: {exc}"
+        )


### PR DESCRIPTION
Two validation recipes had duplicate `depends_on:` mapping keys in the same step.
PyYAML silently resolves duplicate keys to the last value, so the first declared
dependency was lost from the parsed model in each case.

Affected steps:
- `recipes/validate-bundle-repo.yaml`:
  - `composition-analysis`: lost `set-default-composition-analysis`, kept only
    `quality-classification`. Merged: `[set-default-composition-analysis, quality-classification]`.
  - `repo-conventions`: lost `set-default-repo-conventions, composition-analysis`,
    kept only `composition-analysis`. Merged: `[set-default-repo-conventions, composition-analysis]`.
- `recipes/validate-agents.yaml`:
  - `description-quality-check`: lost `set-default-quality-results`, kept only
    `quality-classification`. Merged: `[set-default-quality-results, quality-classification]`.
  - `tool-access-analysis`: lost `set-default-tool-analysis, description-quality-check`,
    kept only `description-quality-check`. Merged: `[set-default-tool-analysis, description-quality-check]`.

No runtime regression exists today — the recipe engine in amplifier-bundle-recipes
currently runs steps in strict declaration order and ignores `depends_on` at runtime,
so the existing declaration order satisfies the lost dependencies coincidentally.
The intent encoded in the YAML, however, was silently corrupted.

Adds `tests/test_recipes_yaml_hygiene.py` — a parametrized test over every recipe
YAML using a strict PyYAML loader that raises on duplicate mapping keys. Catches
this class of bug at the YAML layer (where the engine's validator does not).

The fourth duplicate-key site in `validate-agents.yaml` was discovered by the new
hygiene test during development — same bug class, included for completeness.

## Verification

- New hygiene test: `pytest tests/test_recipes_yaml_hygiene.py -q` → 13 passed
- Full test suite (per implementation session): 1488 passed, 1 skipped, 0 regressions
  - 1 pre-existing failure in test_subprocess_runner unrelated to this change
- End-to-end: `validate-bundle-repo.yaml` was executed inside a Digital Twin Universe
  environment with this branch installed. Recipe completed all 31 steps and produced
  a valid validation report. Confirmed the YAML loads cleanly under strict parsing.

## Notes for reviewers

- The strict-loader test is parametrized over `recipes/*.yaml`, so adding the
  test naturally guards future recipes against the same class of bug.
- This change pairs with a companion fix in `amplifier-bundle-recipes`
  (`fix/depends-on-warning-storm`) that collapses the per-step depends_on warning
  to one warning per recipe. The two PRs are independent — either can land first.