### PR TITLE
fix(spawn): expand @-mentions in runtime delegation instruction

### DIFF
--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -899,6 +899,43 @@ class PreparedBundle:
             name="_spawn_completion_capture",
         )
 
+        # Expand @-mentions in the delegation instruction and inject resolved content as
+        # developer messages before executing.  The agent body is already handled by the
+        # system prompt factory above; this covers the runtime task text sent by
+        # tool-delegate or any other caller of spawn().
+        if instruction:
+            from amplifier_foundation.mentions import BaseMentionResolver
+            from amplifier_foundation.mentions import ContentDeduplicator
+            from amplifier_foundation.mentions import load_mentions
+            from amplifier_foundation.mentions import parse_mentions
+
+            if parse_mentions(instruction):
+                _instr_bundles = self._build_bundles_for_resolver(effective_bundle)
+                _instr_resolver = BaseMentionResolver(
+                    bundles=_instr_bundles,
+                    base_path=effective_child_cwd,
+                )
+                _instr_dedup = ContentDeduplicator()
+                _mention_results = await load_mentions(
+                    instruction,
+                    resolver=_instr_resolver,
+                    deduplicator=_instr_dedup,
+                    relative_to=effective_child_cwd,
+                )
+                _instr_ctx = child_session.coordinator.get("context")
+                if _instr_ctx and hasattr(_instr_ctx, "add_message"):
+                    for _mr in _mention_results:
+                        if _mr.content is not None:
+                            _paths_str = (
+                                f"{_mr.mention} → {_mr.resolved_path}"
+                                if _mr.resolved_path
+                                else _mr.mention
+                            )
+                            _content = f"[Context from {_paths_str}]\n\n{_mr.content}"
+                            await _instr_ctx.add_message(
+                                {"role": "developer", "content": _content}
+                            )
+
         # Execute instruction and cleanup
         try:
             response = await child_session.execute(instruction)


### PR DESCRIPTION
## Summary

Subagents whose runtime delegation instruction contained `@bundle:path/to/file.md` markers were receiving those markers as **literal strings** in their LLM requests — the referenced files were never loaded.

## Root Cause

When `PreparedBundle.spawn()` creates a child session with a runtime delegation instruction, the instruction is passed verbatim to `child_session.execute(instruction)` without expanding `@-mention` file references. The agent body is already expanded via `_create_system_prompt_factory()`, but the runtime instruction was missed.

The `mention_resolver` and `mention_deduplicator` capabilities were already being propagated to the child session but never invoked on the runtime instruction.

## Fix

After creating the child session with propagated capabilities, call `load_mentions()` on the runtime instruction and inject resolved content as developer messages before calling `child_session.execute()`. This mirrors the reference implementation in `_process_runtime_mentions()` and the companion CLI-layer fix in amplifier-app-cli.

## Verification

- **Unit tests:** 1488/1489 passing (1 pre-existing failure unrelated to this fix)
- **Live subagent inspection:** foundation:explorer subagent's LLM request now contains file content from `@foundation:context/...` mentions instead of bare `@` strings
- **DTU clean-room test:** Behavior verified in isolated install from Gitea mirror snapshot; Amplifier binary version string confirmed patched code was running

## Companion PR

See amplifier-app-cli#<TBD> for the CLI-layer spawner fix.