### PR TITLE
feat(mentions): unify @mention expansion with expand_mentions_in_instruction helper

### DIFF
--- a/amplifier_foundation/__init__.py
+++ b/amplifier_foundation/__init__.py
@@ -59,6 +59,7 @@ from amplifier_foundation.io.yaml import write_yaml
 
 # Mention utilities
 from amplifier_foundation.mentions.deduplicator import ContentDeduplicator
+from amplifier_foundation.mentions.loader import expand_mentions_in_instruction
 from amplifier_foundation.mentions.loader import load_mentions
 from amplifier_foundation.mentions.models import ContextFile
 from amplifier_foundation.mentions.models import MentionResult
@@ -165,6 +166,7 @@ __all__ = [
     # Mentions
     "parse_mentions",
     "load_mentions",
+    "expand_mentions_in_instruction",
     "ContentDeduplicator",
     "ContextFile",
     "MentionResult",

--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -899,42 +899,29 @@ class PreparedBundle:
             name="_spawn_completion_capture",
         )
 
-        # Expand @-mentions in the delegation instruction and inject resolved content as
-        # developer messages before executing.  The agent body is already handled by the
-        # system prompt factory above; this covers the runtime task text sent by
-        # tool-delegate or any other caller of spawn().
+        # Expand @-mentions in the delegation instruction as XML context_file blocks
+        # prepended inline.  The agent body is already handled by the system prompt
+        # factory above; this covers the runtime task text sent by tool-delegate or
+        # any other caller of spawn().
         if instruction:
-            from amplifier_foundation.mentions import BaseMentionResolver
-            from amplifier_foundation.mentions import ContentDeduplicator
-            from amplifier_foundation.mentions import load_mentions
             from amplifier_foundation.mentions import parse_mentions
 
             if parse_mentions(instruction):
+                from amplifier_foundation.mentions import BaseMentionResolver
+                from amplifier_foundation.mentions import ContentDeduplicator
+                from amplifier_foundation.mentions import expand_mentions_in_instruction
+
                 _instr_bundles = self._build_bundles_for_resolver(effective_bundle)
                 _instr_resolver = BaseMentionResolver(
                     bundles=_instr_bundles,
                     base_path=effective_child_cwd,
                 )
-                _instr_dedup = ContentDeduplicator()
-                _mention_results = await load_mentions(
+                instruction = await expand_mentions_in_instruction(
                     instruction,
                     resolver=_instr_resolver,
-                    deduplicator=_instr_dedup,
+                    deduplicator=ContentDeduplicator(),
                     relative_to=effective_child_cwd,
                 )
-                _instr_ctx = child_session.coordinator.get("context")
-                if _instr_ctx and hasattr(_instr_ctx, "add_message"):
-                    for _mr in _mention_results:
-                        if _mr.content is not None:
-                            _paths_str = (
-                                f"{_mr.mention} → {_mr.resolved_path}"
-                                if _mr.resolved_path
-                                else _mr.mention
-                            )
-                            _content = f"[Context from {_paths_str}]\n\n{_mr.content}"
-                            await _instr_ctx.add_message(
-                                {"role": "developer", "content": _content}
-                            )
 
         # Execute instruction and cleanup
         try:

--- a/amplifier_foundation/mentions/__init__.py
+++ b/amplifier_foundation/mentions/__init__.py
@@ -1,6 +1,7 @@
 """@mention parsing and loading utilities."""
 
 from .deduplicator import ContentDeduplicator
+from .loader import expand_mentions_in_instruction
 from .loader import format_context_block
 from .loader import load_mentions
 from .models import ContextFile
@@ -13,6 +14,7 @@ from .utils import format_directory_listing
 __all__ = [
     "parse_mentions",
     "load_mentions",
+    "expand_mentions_in_instruction",
     "format_context_block",
     "format_directory_listing",
     "ContentDeduplicator",

--- a/amplifier_foundation/mentions/loader.py
+++ b/amplifier_foundation/mentions/loader.py
@@ -117,6 +117,61 @@ async def load_mentions(
     return results
 
 
+async def expand_mentions_in_instruction(
+    instruction: str,
+    *,
+    resolver: MentionResolverProtocol,
+    deduplicator: ContentDeduplicator | None = None,
+    relative_to: Path | None = None,
+) -> str:
+    """Return instruction with <context_file> XML blocks prepended for any @mentions.
+
+    The @mentions in the instruction body are preserved verbatim as semantic references.
+    Resolved file contents are formatted as XML <context_file> blocks and prepended.
+
+    Returns instruction unchanged if it is empty, contains no @mentions, or no @mentions
+    resolve to readable content.
+
+    This is the single source of truth for @mention expansion of LLM-bound text strings.
+
+    Args:
+        instruction: The text to expand. May contain @mention tokens.
+        resolver: Resolver to convert @mentions to file paths.
+        deduplicator: Optional deduplicator for content. If None, creates a fresh one.
+        relative_to: Base path for relative mentions (defaults to cwd).
+
+    Returns:
+        Instruction with <context_file> blocks prepended, or the original instruction
+        unchanged when no mentions resolve to readable content.
+
+    Example:
+        >>> result = await expand_mentions_in_instruction(
+        ...     "Check @AGENTS.md and proceed.",
+        ...     resolver=resolver,
+        ... )
+        >>> # result starts with <context_file paths="@AGENTS.md -> /abs/path">
+    """
+    if not instruction:
+        return instruction
+    if deduplicator is None:
+        deduplicator = ContentDeduplicator()
+    results = await load_mentions(
+        instruction,
+        resolver=resolver,
+        deduplicator=deduplicator,
+        relative_to=relative_to,
+    )
+    if not results:
+        return instruction
+    mention_to_path = {
+        r.mention: r.resolved_path for r in results if r.resolved_path is not None
+    }
+    block = format_context_block(deduplicator, mention_to_path)
+    if not block:
+        return instruction
+    return f"{block}\n\n{instruction}"
+
+
 async def _resolve_mention(
     mention: str,
     resolver: MentionResolverProtocol,

--- a/amplifier_foundation/subprocess_runner.py
+++ b/amplifier_foundation/subprocess_runner.py
@@ -592,7 +592,22 @@ async def _run_child_session(config_path: str) -> str:
 
     logger.debug("Subprocess child session initialized, capabilities registered")
 
-    # (7) Wrap execute/cleanup in try/finally
+    # (7) Expand @mentions in the prompt before execute. Mirrors PreparedBundle.spawn.
+    from amplifier_foundation.mentions import expand_mentions_in_instruction
+
+    _mention_resolver = session.coordinator.get_capability("mention_resolver")
+    _mention_dedup = session.coordinator.get_capability("mention_deduplicator")
+    _working_dir = session.coordinator.get_capability("session.working_dir")
+    _relative_to = Path(_working_dir) if _working_dir else None
+    if _mention_resolver is not None:
+        prompt = await expand_mentions_in_instruction(
+            prompt,
+            resolver=_mention_resolver,
+            deduplicator=_mention_dedup,
+            relative_to=_relative_to,
+        )
+
+    # (8) Wrap execute/cleanup in try/finally
     try:
         result: str = await session.execute(prompt)
         return result

--- a/tests/test_expand_mentions.py
+++ b/tests/test_expand_mentions.py
@@ -1,0 +1,196 @@
+"""Tests for expand_mentions_in_instruction helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+from amplifier_foundation.mentions.deduplicator import ContentDeduplicator
+from amplifier_foundation.mentions.loader import expand_mentions_in_instruction
+from amplifier_foundation.mentions.protocol import MentionResolverProtocol
+
+
+# ---------------------------------------------------------------------------
+# Stub resolver
+# ---------------------------------------------------------------------------
+
+
+class StubResolver:
+    """MentionResolverProtocol implementation backed by a dict."""
+
+    def __init__(self, mapping: dict[str, Path | None]) -> None:
+        self._mapping = mapping
+        self.calls: list[str] = []
+
+    def resolve(self, mention: str) -> Path | None:
+        self.calls.append(mention)
+        return self._mapping.get(mention)
+
+
+# Confirm StubResolver satisfies the protocol (static check via assignment)
+_: MentionResolverProtocol = StubResolver({})
+
+
+# ---------------------------------------------------------------------------
+# TestExpandMentionsInInstruction
+# ---------------------------------------------------------------------------
+
+
+class TestExpandMentionsInInstruction:
+    """Unit tests for expand_mentions_in_instruction."""
+
+    @pytest.mark.asyncio
+    async def test_empty_instruction_returns_unchanged(self) -> None:
+        """Empty string is returned unchanged (no resolver calls)."""
+        resolver = StubResolver({})
+        result = await expand_mentions_in_instruction("", resolver=resolver)
+        assert result == ""
+        assert resolver.calls == []
+
+    @pytest.mark.asyncio
+    async def test_no_mentions_returns_unchanged(self) -> None:
+        """Instruction with no @mentions is returned unchanged."""
+        resolver = StubResolver({})
+        instruction = "Do the thing and make it work."
+        result = await expand_mentions_in_instruction(instruction, resolver=resolver)
+        assert result == instruction
+
+    @pytest.mark.asyncio
+    async def test_one_resolvable_mention_prepends_block(self, tmp_path: Path) -> None:
+        """Single resolvable @mention prepends an XML context_file block.
+
+        The original @mention is preserved verbatim in the body.
+        """
+        content = "# Hello from file"
+        file = tmp_path / "notes.md"
+        file.write_text(content, encoding="utf-8")
+
+        resolver = StubResolver({"@notes.md": file})
+        instruction = "Read @notes.md carefully."
+
+        result = await expand_mentions_in_instruction(
+            instruction, resolver=resolver, relative_to=tmp_path
+        )
+
+        # Block comes first
+        assert result.startswith("<context_file")
+        # File content is in the block
+        assert content in result
+        # Original instruction is preserved (with @mention verbatim)
+        assert "Read @notes.md carefully." in result
+        # Block and instruction separated by double newline
+        parts = result.split("\n\n", 1)
+        assert len(parts) == 2
+        assert parts[1] == instruction
+
+    @pytest.mark.asyncio
+    async def test_one_unresolvable_mention_returns_unchanged(self) -> None:
+        """@mention that resolves to None leaves the instruction unchanged."""
+        resolver = StubResolver({"@missing.md": None})
+        instruction = "Check @missing.md please."
+        result = await expand_mentions_in_instruction(instruction, resolver=resolver)
+        assert result == instruction
+
+    @pytest.mark.asyncio
+    async def test_multiple_mentions_same_content_single_block(
+        self, tmp_path: Path
+    ) -> None:
+        """Two @mentions pointing to the same file produce one block (dedup).
+
+        The paths attribute lists both @mentions for attribution.
+        """
+        content = "Shared content"
+        file = tmp_path / "shared.md"
+        file.write_text(content, encoding="utf-8")
+
+        # Both @a.md and @b.md map to the same file
+        resolver = StubResolver({"@a.md": file, "@b.md": file})
+        instruction = "See @a.md and also @b.md."
+
+        result = await expand_mentions_in_instruction(instruction, resolver=resolver)
+
+        # Exactly one context_file block
+        assert result.count("<context_file") == 1
+        assert result.count("</context_file>") == 1
+        # Shared content appears once
+        assert result.count(content) == 1
+        # Original instruction preserved
+        assert instruction in result
+
+    @pytest.mark.asyncio
+    async def test_resolver_is_actually_called(self, tmp_path: Path) -> None:
+        """The resolver's resolve() method is called for each @mention found."""
+        file = tmp_path / "doc.md"
+        file.write_text("content", encoding="utf-8")
+
+        resolver = StubResolver({"@doc.md": file})
+        instruction = "Look at @doc.md carefully"
+
+        await expand_mentions_in_instruction(instruction, resolver=resolver)
+
+        assert "@doc.md" in resolver.calls
+
+    @pytest.mark.asyncio
+    async def test_external_deduplicator_respected(self, tmp_path: Path) -> None:
+        """When a deduplicator is supplied, it is used (not a fresh one).
+
+        Two @mentions in the same instruction that resolve to the same file
+        content produce only one context_file block (the deduplicator tracks
+        the first and suppresses the second from the unique-files listing).
+        """
+        shared_content = "Shared content across both mentions"
+        file = tmp_path / "shared.md"
+        file.write_text(shared_content, encoding="utf-8")
+
+        # Both mentions resolve to the same file — the deduplicator should
+        # track the content after the first and mark the second as duplicate.
+        dedup = ContentDeduplicator()
+        resolver = StubResolver({"@shared.md": file, "@alias.md": file})
+        instruction = "Check @shared.md and @alias.md here"
+
+        result = await expand_mentions_in_instruction(
+            instruction, resolver=resolver, deduplicator=dedup
+        )
+
+        # Only one block should be emitted (dedup merged them)
+        assert result.count("<context_file") == 1
+        # The content appears once
+        assert result.count(shared_content) == 1
+        # The deduplicator was used (its state reflects the file)
+        assert dedup.is_seen(shared_content)
+
+    @pytest.mark.asyncio
+    async def test_xml_format_has_paths_attribute(self, tmp_path: Path) -> None:
+        """The context_file block has a paths attribute showing @mention → path."""
+        content = "file content"
+        file = tmp_path / "ctx.md"
+        file.write_text(content, encoding="utf-8")
+
+        resolver = StubResolver({"@ctx.md": file})
+        instruction = "Use @ctx.md for reference"
+
+        result = await expand_mentions_in_instruction(instruction, resolver=resolver)
+
+        assert 'paths="' in result
+        assert "@ctx.md" in result
+        assert str(file.resolve()) in result
+
+    @pytest.mark.asyncio
+    async def test_multiple_different_files_produce_multiple_blocks(
+        self, tmp_path: Path
+    ) -> None:
+        """Each distinct resolvable @mention produces its own context_file block."""
+        file_a = tmp_path / "alpha.md"
+        file_b = tmp_path / "beta.md"
+        file_a.write_text("alpha content", encoding="utf-8")
+        file_b.write_text("beta content", encoding="utf-8")
+
+        resolver = StubResolver({"@alpha.md": file_a, "@beta.md": file_b})
+        instruction = "Read @alpha.md and @beta.md please"
+
+        result = await expand_mentions_in_instruction(instruction, resolver=resolver)
+
+        assert result.count("<context_file") == 2
+        assert "alpha content" in result
+        assert "beta content" in result
+        assert instruction in result


### PR DESCRIPTION
## Problem Statement

At-mention (`@file.md`) expansion before LLM execution was implemented as **inline copy-paste code at five separate call sites** across `amplifier-foundation` and `amplifier-app-cli`. This duplication caused:

- **Two output formats coexisted**: XML `<context_file>` blocks for the system-prompt path; developer-role messages for runtime instructions
- **Two loader implementations existed**: foundation's async `load_mentions()`, the CLI's sync `MentionLoader`  
- **Duplication bred bugs**: A bug at one site (`spawn_sub_session`) was patched yesterday by adding the inline block at two more places; two other sites (`resume_sub_session`, `subprocess_runner._run_child_session`) remained broken

Continuing to copy-paste was guaranteeing more bugs of the same shape.

## This PR's Scope (Foundation Only — Part 1 of 2)

**What's added:**
- Single source-of-truth helper: `expand_mentions_in_instruction(instruction, *, resolver, deduplicator, relative_to) → str` in `amplifier_foundation.mentions`
  - Returns instruction with `<context_file>` XML blocks prepended for any resolved `@mentions`
  - The `@mentions` in the instruction body are preserved verbatim as semantic references

**What's changed:**
- Replaced the existing developer-message-injection code in `PreparedBundle.spawn()` (lines 919-937 in `_prepared.py`) with a call to the helper
- **Deliberate format change**: file content now lands inline as XML blocks instead of as separate developer messages
- **User direction**: XML is the better LLM-input format; aligns with the system-prompt path's existing XML approach
- Added expansion to `subprocess_runner._run_child_session`, which was previously missing it (subprocess-spawned agents received raw `@file.md` strings)

**What's left alone (intentionally):**
- The system-prompt-factory path (`_prepared.py:~382-443`) is unchanged — it handles bundle context files in addition to `@mentions`, which is broader than this helper's scope

**Test coverage:**
- 9 new unit tests for the helper with comprehensive edge cases
- Test results: 1498 passed, 1 skipped (pre-existing), 0 regressions

**Design doc:**
- `/home/bkrabach/dev/agent-at-mention/docs/designs/at-mention-unify-xml-helper.md` (in parent workspace) documents the full unified plan

## The Companion PR (Coming in `microsoft/amplifier-app-cli`)

Part 2 will fix the remaining **three sites** in the CLI app:
- `spawn_sub_session`: system_instruction path (~line 635) and delegation instruction path (~line 749)
- `resume_sub_session`: instruction path (~line 1115)
- `main.py` REPL: `_process_runtime_mentions` (~line 2477)

The CLI PR will NOT change the CLI's mention-loading implementation (`MentionLoader`); it will focus on call sites only.

**Sequencing:** This PR (foundation) merges first. The CLI PR follows once this lands, then both repos will have a unified source of truth.

## Behaviour Change Callout

**Before this PR:** `PreparedBundle.spawn()` injected file content as developer-role messages (created by the old inline block).

**After this PR:** `PreparedBundle.spawn()` will inject file content as inline XML `<context_file>` blocks in the instruction body itself.

This is safe and intentional:
- Aligns the foundation's runtime-instruction path with its system-prompt path (both now use XML)
- Matches the design used in the REPL and upcoming CLI changes
- XML format is more reliable for LLM consumption than separate message injection

## Diff Summary

```
amplifier_foundation/__init__.py          |  2 ++
amplifier_foundation/bundle/_prepared.py  | 33 ++++++-------------
amplifier_foundation/mentions/__init__.py |  2 ++
amplifier_foundation/mentions/loader.py   | 55 +++++++++++++++++++++++++++++++
amplifier_foundation/subprocess_runner.py | 17 +++++++++-
5 files changed, 85 insertions(+), 24 deletions(-)
+ tests/test_expand_mentions.py (new, 9 tests)
```

## Verification

- [x] All tests pass (1498 passed, 1 skipped)
- [x] New helper function is properly exported at top-level `amplifier_foundation`
- [x] Both foundation call sites updated to use the helper
- [x] Design doc reviewed and linked
- [x] Commit message includes semantic context and co-author attribution