### PR TITLE
experiment(minimal-delegate): refactor to mirror build-up structure, fix harness compatibility

### DIFF
--- a/experiments/minimal-delegate/behaviors/minimal-delegate-foundation.yaml
+++ b/experiments/minimal-delegate/behaviors/minimal-delegate-foundation.yaml
@@ -1,0 +1,141 @@
+---
+bundle:
+  # Namespace: agents and context registered via this bundle resolve under
+  # `minimal-delegate:` (e.g. `minimal-delegate:context/...`).
+  # This YAML lives in experiments/minimal-delegate/behaviors/ but the context/
+  # directory lives one level up at experiments/minimal-delegate/.
+  # namespace_root: .. tells the registry to set
+  #   source_base_paths['minimal-delegate'] = experiments/minimal-delegate/
+  # rather than the default (this file's own behaviors/ directory).
+  name: minimal-delegate
+  version: 0.2.0
+  namespace_root: ..
+  description: |
+    Minimal-delegate foundation behavior. The parent session is a pure
+    orchestrator — it has ONLY `delegate`, `todo`, and `load_skill`.
+    NO direct tools (no filesystem, bash, web, search, LSP, etc.).
+    Every concrete action goes through a specialized sub-agent.
+    Token budget: 64k (context-simple max_tokens).
+
+    History:
+      0.1.0 — Self-contained .md, no foundation behavior includes, no
+              session.raw, no events.jsonl. Run #1 of optimize_bundle
+              produced HARNESS_BROKEN on all 6 runs — amplifier ran
+              successfully but wrote no events.jsonl for harness metrics.
+      0.2.0 — Refactored to mirror build-up v3 structure: thin pointer +
+              behavior YAML + foundation behavior includes. Added session.raw,
+              logging.yaml (events.jsonl writer), redaction, streaming-ui,
+              status-context, and productivity hooks. Experimental "minimal"
+              stays at the policy level; platform scaffolding is now correct.
+
+# Session configuration
+session:
+  raw: true
+  orchestrator:
+    module: loop-streaming
+    source: git+https://github.com/microsoft/amplifier-module-loop-streaming@main
+    # NOTE: extended_thinking intentionally omitted. Under a 64k token budget,
+    # extended thinking competes with context. Sub-agents can still use it
+    # independently inside their own sessions.
+  context:
+    module: context-simple
+    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
+    config:
+      max_tokens: 64000
+
+# ONLY meta-tools — these gate access to other capabilities.
+# CRITICAL: NO direct tools. Specifically absent:
+#   tool-filesystem (read_file, write_file, edit_file, glob)
+#   tool-bash
+#   tool-web (web_fetch, web_search)
+#   tool-search (grep)
+#   tool-lsp
+#   tool-python-check
+#   Any other tool that performs real work directly.
+tools:
+  - module: tool-delegate
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/tool-delegate
+    config:
+      features:
+        self_delegation:
+          # Disabled at the parent level: orchestrator with only
+          # todo + delegate + skills spawning itself produces a sub-instance
+          # with no real tools (no bash/filesystem/search/etc.) that can only
+          # thrash mode/todo until context overflows.
+          enabled: false
+        session_resume:
+          enabled: true
+        context_inheritance:
+          enabled: true
+          max_turns: 10
+        provider_selection:
+          enabled: true
+      settings:
+        exclude_tools: [tool-delegate]
+  - module: tool-todo
+    source: git+https://github.com/microsoft/amplifier-module-tool-todo@main
+  - module: tool-skills
+    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
+
+# Foundation behaviors — provide essential platform infrastructure.
+# logging.yaml is the critical one: it registers hooks-logging which writes
+# events.jsonl to ~/.amplifier/projects/{project}/sessions/{session_id}/events.jsonl
+# Without it the eval harness cannot extract metrics (tokens, requests, wall_clock).
+includes:
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/streaming-ui.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/status-context.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/redaction.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/logging.yaml
+
+# Productivity hooks (no per-turn context cost)
+hooks:
+  - module: hooks-todo-reminder
+    source: git+https://github.com/microsoft/amplifier-module-hooks-todo-reminder@main
+    config:
+      inject_role: user
+      priority: 10
+  - module: hooks-todo-display
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/hooks-todo-display
+    config:
+      show_progress_bar: true
+      show_border: true
+  - module: hooks-session-naming
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/hooks-session-naming
+    config:
+      initial_trigger_turn: 2
+      update_interval_turns: 5
+
+# Agents available for delegation: broader pool than build-up (which ships
+# 4 custom agents). Foundation specialists cover the full task surface;
+# python-dev specialists handle code-heavy scenarios.
+agents:
+  include:
+    - foundation:explorer          # multi-file read-only reconnaissance
+    - foundation:file-ops          # read, write, edit, search files
+    - foundation:web-research      # web search and fetch
+    - foundation:git-ops           # git, GitHub CLI, PRs
+    - foundation:bug-hunter        # root-cause analysis, debugging
+    - foundation:modular-builder   # implementation from spec
+    - foundation:zen-architect     # design, architecture, spec writing
+    - foundation:session-analyst   # review session history and outcomes
+    - foundation:test-coverage     # tests, coverage, verification
+    - foundation:security-guardian # security review and audit
+    - foundation:ecosystem-expert  # Amplifier ecosystem knowledge
+    - foundation:integration-specialist  # cross-repo integration work
+  # Python-specific specialists (for code-heavy scenarios):
+  code-intel:
+    name: code-intel
+    description: >
+      Code intelligence specialist. LSP operations: go-to-definition,
+      find-references, symbol lookup, call hierarchies, diagnostics.
+      Use for: finding where something is defined, tracing all callers,
+      understanding type signatures, cross-file semantic navigation.
+    source: git+https://github.com/microsoft/amplifier-bundle-python-dev@main
+  python-dev:
+    name: python-dev
+    description: >
+      Python development specialist. Implementation, debugging, testing,
+      type-checked code, packaging, and Python ecosystem patterns.
+      Use for: writing Python code, fixing Python bugs, reviewing Python
+      implementations, pyright/ruff compliance, pytest authoring.
+    source: git+https://github.com/microsoft/amplifier-bundle-python-dev@main

--- a/experiments/minimal-delegate/context/system-base.md
+++ b/experiments/minimal-delegate/context/system-base.md
@@ -1,0 +1,8 @@
+You are a session orchestrator. You have NO direct tools for file access, command execution, web access, or any real work. Your only capabilities:
+
+- `delegate` — spawn a specialized agent for any task
+- `todo` — track multi-step plans
+- `mode` — switch to a workflow mode (some modes grant gated tool access)
+- `load_skill` — load knowledge packages for context
+
+For all real work, delegate to an agent. Use `todo` to plan multi-step tasks before delegating. Use `mode` or `load_skill` when a workflow or knowledge package fits the task.

--- a/experiments/minimal-delegate/minimal-delegate-foundation.md
+++ b/experiments/minimal-delegate/minimal-delegate-foundation.md
@@ -1,109 +1,27 @@
 ---
 bundle:
   name: minimal-delegate-foundation
-  version: 0.1.0
+  version: 0.2.0
   description: |
-    Constrained orchestrator experimental bundle. Token budget 64k.
+    EXPERIMENTAL minimal-delegate bundle — constrained orchestrator with only
+    meta-tools (delegate, todo, load_skill) and a rich agent pool. No direct
+    file/bash/web access. Token budget 64k.
 
-    Has ONLY meta-tools: delegate, todo, load_skill (mode is platform-native).
-    No direct tools — every real action must route through a specialized agent.
+    Where build-up uses 4 purpose-built agents (explorer/planner/coder/tester),
+    minimal-delegate exposes the full foundation specialist pool (12 agents) plus
+    2 python-dev specialists. The hypothesis: a minimal system prompt + rich
+    agent menu, under 64k token budget, with no direct tools forces the
+    orchestrator to learn clean delegation discipline.
+
     Use this bundle to study how a minimum-instruction orchestrator performs
     under tight tooling constraints when it can only orchestrate other agents.
-
-    Baseline for the optimize_bundle experimental campaign:
-    - Hypothesis: constrained orchestrator achieves comparable outcomes with
-      less token consumption (never reads files itself) and more reliable
-      behavior (each agent has specialized context).
 
     To use this bundle:
       amplifier bundle add 'git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=experiments/minimal-delegate/minimal-delegate-foundation.md' --name minimal-delegate-foundation
       amplifier bundle use minimal-delegate-foundation
 
-session:
-  orchestrator:
-    module: loop-streaming
-    source: git+https://github.com/microsoft/amplifier-module-loop-streaming@main
-  context:
-    module: context-simple
-    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
-    config:
-      max_tokens: 64000
-
-providers:
-  - module: provider-anthropic
-    source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
-
-# ONLY meta-tools — these gate access to other capabilities.
-# CRITICAL: NO direct tools. Specifically absent:
-#   tool-filesystem (read_file, write_file, edit_file, glob)
-#   tool-bash
-#   tool-web (web_fetch, web_search)
-#   tool-search (grep)
-#   tool-lsp
-#   tool-python-check
-#   Any other tool that performs real work directly.
-tools:
-  - module: tool-delegate
-    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/tool-delegate
-    config:
-      features:
-        self_delegation:
-          # Disabled at parent level: orchestrator with only todo+delegate
-          # spawning itself produces a sub-instance with no real tools.
-          enabled: false
-        session_resume:
-          enabled: true
-        context_inheritance:
-          enabled: true
-          max_turns: 10
-        provider_selection:
-          enabled: true
-      settings:
-        exclude_tools: [tool-delegate]
-  - module: tool-todo
-    source: git+https://github.com/microsoft/amplifier-module-tool-todo@main
-  - module: tool-skills
-    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
-
-agents:
-  include:
-    # Foundation core agents — cover the full task surface:
-    - foundation:explorer          # multi-file read-only reconnaissance
-    - foundation:file-ops          # read, write, edit, search files
-    - foundation:web-research      # web search and fetch
-    - foundation:git-ops           # git, GitHub CLI, PRs
-    - foundation:bug-hunter        # root-cause analysis, debugging
-    - foundation:modular-builder   # implementation from spec
-    - foundation:zen-architect     # design, architecture, spec writing
-    - foundation:session-analyst   # review session history and outcomes
-    - foundation:test-coverage     # tests, coverage, verification
-    - foundation:security-guardian # security review and audit
-    - foundation:ecosystem-expert  # Amplifier ecosystem knowledge
-    - foundation:integration-specialist  # cross-repo integration work
-  # Python-specific specialists (for code-heavy scenarios):
-  code-intel:
-    name: code-intel
-    description: >
-      Code intelligence specialist. LSP operations: go-to-definition,
-      find-references, symbol lookup, call hierarchies, diagnostics.
-      Use for: finding where something is defined, tracing all callers,
-      understanding type signatures, cross-file semantic navigation.
-    source: git+https://github.com/microsoft/amplifier-bundle-python-dev@main
-  python-dev:
-    name: python-dev
-    description: >
-      Python development specialist. Implementation, debugging, testing,
-      type-checked code, packaging, and Python ecosystem patterns.
-      Use for: writing Python code, fixing Python bugs, reviewing Python
-      implementations, pyright/ruff compliance, pytest authoring.
-    source: git+https://github.com/microsoft/amplifier-bundle-python-dev@main
+includes:
+  - bundle: foundation:experiments/minimal-delegate/behaviors/minimal-delegate-foundation
 ---
 
-You are a session orchestrator. You have NO direct tools for file access, command execution, web access, or any real work. Your only capabilities:
-
-- `delegate` — spawn a specialized agent for any task
-- `todo` — track multi-step plans
-- `mode` — switch to a workflow mode (some modes grant gated tool access)
-- `load_skill` — load knowledge packages for context
-
-For all real work, delegate to an agent. Use `todo` to plan multi-step tasks before delegating. Use `mode` or `load_skill` when a workflow or knowledge package fits the task.
+@foundation:experiments/minimal-delegate/context/system-base.md


### PR DESCRIPTION
## Problem

Run #1 of optimize_bundle on minimal-delegate-foundation produced HARNESS_BROKEN on all 6 paired runs. The amplifier process ran successfully (architecture summary in run.stdout) but exited code 1 and wrote no `events.jsonl`. Without events, the harness couldn't extract metrics.

## Root cause

The bundle was self-contained (all config inline in the .md), missing essential platform infrastructure:

| Missing | Impact |
|---|---|
| `session.raw: true` | Harness expects raw session mode |
| `behaviors/logging.yaml` | **hooks-logging** writes `events.jsonl` — without it, no metrics |
| `behaviors/streaming-ui.yaml` | UI feedback |
| `behaviors/status-context.yaml` | Environment context injection |
| `behaviors/redaction.yaml` | Log safety |
| Productivity hooks | todo-reminder, todo-display, session-naming |
| Explicit `providers:` | Likely conflicted with inheritance |

## Fix

Refactored to mirror build-up-foundation's v3 structure: thin pointer + behavior YAML + foundation behavior includes.

The 'minimal' aspect is preserved at the **policy** level (delegate+todo+skills only, no direct tools, minimal 5-line system prompt). Platform scaffolding (event logging, redaction, streaming UI) is now correctly inherited.

## Files changed

- `experiments/minimal-delegate/minimal-delegate-foundation.md` — thin pointer (was self-contained 109-line bundle)
- `experiments/minimal-delegate/behaviors/minimal-delegate-foundation.yaml` — full config with `session.raw: true`, foundation behavior includes, productivity hooks, 14-agent pool
- `experiments/minimal-delegate/context/system-base.md` — 5-line system prompt extracted from inline

## Verification

- YAML syntax: valid
- `session.raw: true`: present
- Tools: 3 (tool-delegate, tool-todo, tool-skills — no direct tools)
- Foundation behavior includes: 4 (streaming-ui, status-context, redaction, **logging**)
- Productivity hooks: 3 (todo-reminder, todo-display, session-naming)
- Agents: 14 (12 foundation specialists + code-intel + python-dev)
- Tests: 1498 passed, 1 skipped

Note: BundleValidator with `file://` cannot resolve new files against the `foundation:` namespace locally (it resolves from git cache); validator will work correctly post-merge when cache is updated.