### PR TITLE
Handle Windows absolute paths as file URIs

### DIFF
--- a/amplifier_foundation/paths/resolution.py
+++ b/amplifier_foundation/paths/resolution.py
@@ -128,6 +128,10 @@ def parse_uri(uri: str) -> ParsedURI:
         path, subpath = _extract_fragment_subpath(uri[7:])
         return ParsedURI(scheme="file", host="", path=path, ref="", subpath=subpath)
 
+    # Handle Windows absolute paths
+    if re.match(r"^[A-Za-z]:[\\/]", uri) or uri.startswith("\\\\"):
+        return ParsedURI(scheme="file", host="", path=uri, ref="", subpath="")
+
     # Handle absolute paths
     if uri.startswith("/"):
         return ParsedURI(scheme="file", host="", path=uri, ref="", subpath="")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -116,6 +116,20 @@ class TestParseUri:
         assert result.scheme == "file"
         assert result.path == "/home/user/bundle"
 
+    def test_parse_windows_absolute_path(self) -> None:
+        """Parses Windows absolute paths as file URIs."""
+        result = parse_uri(r"C:\Users\test\.amplifier\cache\module")
+        assert result.scheme == "file"
+        assert result.path == r"C:\Users\test\.amplifier\cache\module"
+        assert result.host == ""
+        assert result.subpath == ""
+
+    def test_parse_windows_unc_path(self) -> None:
+        """Parses Windows UNC paths as file URIs."""
+        result = parse_uri(r"\\server\share\module")
+        assert result.scheme == "file"
+        assert result.path == r"\\server\share\module"
+
     def test_https_uri(self) -> None:
         """Parses https:// URIs."""
         result = parse_uri("https://example.com/bundle.yaml")


### PR DESCRIPTION
## Problem
On Windows, a relative bundle module source can resolve to a drive-letter absolute path, but the source resolver does not treat `C:\...` as a local file path, causing module activation to fail.

```text
PS D:\projects\sample-repo> amplifier
Failed to activate tool-apply-patch: No handler for URI: C:\Users\jane.doe\.amplifier\cache\amplifier-bundle-filesystem-abc123def456\modules\tool-apply-patch
```

## Summary
- Treat Windows drive-letter absolute paths as file URIs in `parse_uri()`
- Treat UNC paths as file URIs
- Add regression tests for both path forms

## Tests
- `uv --directory C:\git\amplifier-foundation run pytest tests/test_paths.py::TestParseUri tests/test_sources.py`