### PR TITLE
docs: cross-reference PER_REPO_CONVENTIONS.md from AGENT_AUTHORING.md

### DIFF
--- a/docs/AGENT_AUTHORING.md
+++ b/docs/AGENT_AUTHORING.md
@@ -6,6 +6,7 @@ Agents are specialized AI configurations that run as sub-sessions for focused ta
 
 → For file format, tool/provider configuration, @mentions, and composition, see **[BUNDLE_GUIDE.md](BUNDLE_GUIDE.md)**
 → For agent spawning and resolution patterns, see **[PATTERNS.md](PATTERNS.md)**
+→ For how the agent discovers and applies per-repo conventions *once it is spawned* (the other half of the delegation loop), see **[PER_REPO_CONVENTIONS.md](PER_REPO_CONVENTIONS.md)**
 
 This guide covers only what's **unique to agents**.
 
@@ -425,3 +426,4 @@ Put heavy @mentions in agent files (context sink), not in behavior context.inclu
 | Agent spawning patterns | [PATTERNS.md](PATTERNS.md) |
 | Agent resolution | [PATTERNS.md](PATTERNS.md) |
 | Bundle composition | [CONCEPTS.md](CONCEPTS.md) |
+| Per-repo conventions an agent reads at runtime | [PER_REPO_CONVENTIONS.md](PER_REPO_CONVENTIONS.md) |


### PR DESCRIPTION
## What

Adds two cross-references from `docs/AGENT_AUTHORING.md` to `docs/PER_REPO_CONVENTIONS.md`.

## Why

The two documents describe a single loop:

- **`meta.description`** (AGENT_AUTHORING.md) tells the root session when to spawn the agent.
- **Per-repo conventions** (PER_REPO_CONVENTIONS.md) tell the spawned agent what the target repo expects.

Both apply, but they currently live in separate docs with no link between them. PER_REPO_CONVENTIONS.md already cross-references AGENT_AUTHORING.md; this restores the symmetry.

## Changes

- 1 arrow-link in the top-of-file links block (alongside the existing BUNDLE_GUIDE.md and PATTERNS.md arrows).
- 1 row in the reference table at the bottom.