### PR TITLE
feat: include amplifier-bundle-llm-wiki as default-on behavior

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -33,6 +33,7 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=behaviors/skills.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-browser-tester@main#subdirectory=behaviors/browser-tester.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-superpowers@main#subdirectory=behaviors/superpowers-methodology.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-llm-wiki@main#subdirectory=behaviors/llm-wiki.yaml
   - bundle: git+https://github.com/microsoft/amplifier-module-hook-shell@main#subdirectory=behaviors/hook-shell.yaml
   - bundle: git+https://github.com/microsoft/amplifier-module-tool-mcp@main#subdirectory=behaviors/mcp.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-filesystem@main#subdirectory=behaviors/apply-patch.yaml


### PR DESCRIPTION
## Summary

Adds [`microsoft/amplifier-bundle-llm-wiki`](https://github.com/microsoft/amplifier-bundle-llm-wiki) as a default-on behavior in the foundation bundle's External bundles section. Single-line addition; no other changes.

## What this provides

Five composable workflow modes implementing the [Karpathy LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f):

| Mode | Purpose |
|---|---|
| `/wiki-init` | Design and scaffold the project-specific policy (schema, publish target, viewer) |
| `/wiki-ingest` | Process raw content from `raw/` into the wiki |
| `/wiki-lint` | Read-only health check — orphans, stale refs, contradictions, broken cross-refs |
| `/wiki-publish` | Generate the shippable artifact via the project's publish script |
| `/wiki-query` | Read-only Q&A against the compiled wiki |

Plus one specialist agent (`wiki-policy-designer`) contributed by `/wiki-init` for scaffolding new wiki projects.

## Cost rationale — zero-cost-when-dormant

The bundle uses the per-mode `contributes.context` pattern (canonical reference implementation documented as [`amplifier-bundle-modes` schema reference §9.7](https://github.com/microsoft/amplifier-bundle-modes/blob/main/context/mode-schema-reference.md#97-workflow-modes-with-shared-orientation), landed earlier this session as PR #23):

| State | Token cost |
|---|---:|
| Persistent (no wiki mode active) | ~195 (bundle.md 74 + thin behavior 121) |
| With any one wiki mode active | +~500 orientation + mode body |
| `wiki-policy-designer` agent | only mounts when `/wiki-init` delegates |

Including this in foundation does NOT impose ongoing per-turn cost on users who never activate a wiki mode. The behavior file is a pure install anchor (no `context.include`); all heavy content is mode-gated or agent-gated.

## Placement

Inserted in the External bundles list immediately after `superpowers-methodology`, clustering with other workflow-mode bundles.

## Validation

Just ran `@foundation:recipes/validate-bundle-repo.yaml` v3.6.0 against the modified bundle:

- **Verdict: PASS WITH SUGGESTIONS** (no new findings from this change)
- 0 errors
- 3 warnings, ALL pre-existing and unrelated:
  - `agents` behavior context-tokens-high (~1000 tok)
  - `tasks` behavior context-tokens-high (~1000 tok)
  - `experiments/delegation-only` missing `exp-` prefix
- 41 bundles found, all hygiene checks clean
- Build succeeded
- Single-line behavior include passes structure lint

## Companion entries landed this session

- [microsoft/amplifier#300](https://github.com/microsoft/amplifier/pull/300) — MODULES.md catalog entry
- [microsoft/amplifier-bundle-modes#23](https://github.com/microsoft/amplifier-bundle-modes/pull/23) — §9.7 reference documentation
- [microsoft/amplifier-bundle-llm-wiki](https://github.com/microsoft/amplifier-bundle-llm-wiki) — full migration to microsoft namespace; `@amplifier:recipes/repo-audit` PASS; canonical ruleset active on main

## Test plan

- Single-line addition; no other files affected
- Pattern matches existing entries (`git+https://...#subdirectory=behaviors/...yaml`)
- Validator confirms no new findings
- The behavior file at the target URL has been audited and verified clean