### PR TITLE
feat: include amplifier-bundle-evaluation as default-on behavior

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -34,6 +34,7 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-bundle-browser-tester@main#subdirectory=behaviors/browser-tester.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-superpowers@main#subdirectory=behaviors/superpowers-methodology.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-llm-wiki@main#subdirectory=behaviors/llm-wiki.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-evaluation@main#subdirectory=behaviors/evaluation.yaml
   - bundle: git+https://github.com/microsoft/amplifier-module-hook-shell@main#subdirectory=behaviors/hook-shell.yaml
   - bundle: git+https://github.com/microsoft/amplifier-module-tool-mcp@main#subdirectory=behaviors/mcp.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-filesystem@main#subdirectory=behaviors/apply-patch.yaml


### PR DESCRIPTION
## Summary

Adds [amplifier-bundle-evaluation](https://github.com/microsoft/amplifier-bundle-evaluation) as a default-on behavior in the foundation bundle's External bundles section, immediately after `amplifier-bundle-llm-wiki`. Single-line addition; no other changes.

## What this provides

A single workflow mode `/mode evaluation` (advertised: false) implementing the evaluation methodology for Amplifier ecosystem work — scenario design, harness automation, rubric design, comparison-based eval, and case-study deep dives. Invoked explicitly via `/mode evaluation "<their ask>"` or when the LLM detects the user is asking about evaluation work.

## Cost rationale — zero-cost-when-dormant

Companion refactor at `microsoft/amplifier-bundle-evaluation` just converted the bundle to a true zero-cost install anchor (matching the [llm-wiki pattern](https://github.com/microsoft/amplifier-bundle-llm-wiki) and documented as the §9.7 reference implementation in [amplifier-bundle-modes](https://github.com/microsoft/amplifier-bundle-modes/blob/main/context/mode-schema-reference.md)).

| State | Tokens contributed to LLM context |
|---|---:|
| Bundle composed, no mode active | **0** |
| `/mode evaluation` active | + mode body + lazy-loaded `@`-mention context files |

Including this in foundation does NOT impose ongoing per-turn cost on users who never invoke the mode. The behavior file is a pure install anchor (no `context.include`); all heavy content (scenario patterns, harness automation, methodology, deep dives) lives behind the mode and lazy-loads via `@mention` only on activation.

## Placement

Inserted in the External bundles list immediately after `amplifier-bundle-llm-wiki`, clustering with other workflow-mode bundles.

## Companion PR

[microsoft/amplifier-bundle-evaluation — PR #14 — refactor: zero-cost install anchor](https://github.com/microsoft/amplifier-bundle-evaluation/pull/14) — merged 2026-05-29 09:49:50Z. Commit: `9f231f6cf994fe01a23207165cf4c2bb1db1f52e`