### PR TITLE
fix(validate-bundle-repo): mode-validation reads from `mode:` block + ignores false positives

### DIFF
--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -2621,10 +2621,54 @@ steps:
       # Directories to scan for unadvertised-mode references
       SCAN_DIRS = ["context", "agents", "behaviors", "skills", "modes"]
 
-      def scan_for_mode_mentions(mode_name, own_file_path):
-          """Return list of relative paths where mode_name is mentioned."""
+      def collect_mode_internal_files(mode_file_path):
+          """Return resolved paths the mode body @-mentions directly.
+
+          These files are 'mode-internal' lazy context — the LLM sees them
+          only when the mode is already active. References to the mode within
+          them are self-references, not dead-end invocations from out-of-mode
+          context, so the advertising-rule check skips them.
+
+          Template placeholders like @bundle:context/<filename> are ignored
+          (they do not resolve to an actual file).
+          """
+          internal = set()
+          try:
+              content = mode_file_path.read_text(encoding="utf-8", errors="replace")
+          except Exception:
+              return internal
+          # Strip frontmatter; only look at the body where @-mentions live
+          body_match = re.search(r'^---\s*\n.*?\n---\s*\n(.*)', content, re.DOTALL)
+          body = body_match.group(1) if body_match else content
+          # Match @namespace:path/to/file.md — kebab/snake names, dots/dashes/slashes in path
+          for m in re.finditer(r'@[\w-]+:([\w/.\-]+\.md)', body):
+              rel = m.group(1)
+              candidate = path / rel
+              if candidate.exists():
+                  internal.add(candidate.resolve())
+          return internal
+
+      def scan_for_mode_mentions(mode_name, own_file_path, mode_internal_files):
+          """Return list of relative paths where mode_name is mentioned as a
+          slash-command invocation or by name= attribute.
+
+          Skips:
+          - The mode's own file
+          - Files in mode_internal_files (lazy-loaded by this mode — references
+            to mode_name within them are self-references, not dead-end invocations)
+
+          The slash regex requires word/slash boundaries to avoid false positives
+          from URL paths (https://.../langsmith/evaluation) and file paths
+          (modes/evaluation.md, /evaluations/ as a directory segment).
+          """
           mentions = []
-          slash_pat = re.compile(r'`?/' + re.escape(mode_name) + r'`?')
+          # /mode-name must NOT be preceded by an alphanumeric char or slash
+          # (that would make it a path component, not a slash command), and
+          # must NOT be followed by an alphanumeric char, dot, or slash
+          # (which would make it part of a larger word or path).
+          slash_pat = re.compile(
+              r'(?<![\w/])`?/' + re.escape(mode_name) + r'`?(?![\w./])'
+          )
           name_pat  = re.compile(r'name=["\']' + re.escape(mode_name) + r'["\']')
           own_resolved = Path(own_file_path).resolve()
           for dir_name in SCAN_DIRS:
@@ -2632,8 +2676,11 @@ steps:
               if not scan_dir.exists():
                   continue
               for md_file in scan_dir.rglob("*.md"):
-                  if md_file.resolve() == own_resolved:
+                  resolved = md_file.resolve()
+                  if resolved == own_resolved:
                       continue  # skip the mode's own file
+                  if resolved in mode_internal_files:
+                      continue  # mode-internal — LLM already in mode when it reads this
                   try:
                       file_content = md_file.read_text(encoding="utf-8", errors="replace")
                       if slash_pat.search(file_content) or name_pat.search(file_content):
@@ -2667,7 +2714,8 @@ steps:
           }
 
           # ── Check A: Description token budget ────────────────────────────
-          description = fm.get("description", "")
+          # NOTE: description lives under the `mode:` block per the schema; not at frontmatter top level.
+          description = mode_section.get("description", "")
           # Handle YAML block scalars that parse as None or non-string
           if not isinstance(description, str):
               description = str(description) if description else ""
@@ -2714,12 +2762,14 @@ steps:
               detail["issues"].append("mode_description_high")
 
           # ── Check B: Advertising rule ─────────────────────────────────────
-          # Default advertised: True if key absent (opt-in to non-advertising is explicit)
-          advertised = fm.get("advertised", True)
+          # NOTE: `advertised` lives under the `mode:` block per the schema; not at frontmatter top level.
+          # Default True if key absent (opt-in to non-advertising is explicit).
+          advertised = mode_section.get("advertised", True)
           detail["advertised"] = advertised
 
           if advertised is False:
-              mentions = scan_for_mode_mentions(mode_name, mode_file)
+              mode_internal = collect_mode_internal_files(mode_file)
+              mentions = scan_for_mode_mentions(mode_name, mode_file, mode_internal)
               if mentions:
                   results["errors"].append({
                       "type": "unadvertised_but_referenced",


### PR DESCRIPTION
## Summary

The v3.6.0 mode-advertising-rule check (in `recipes/validate-bundle-repo.yaml`) was silently disabled across the entire ecosystem due to a frontmatter-nesting bug, and once fixed produced URL/file-path false positives plus didn't account for mode-internal lazy-loaded files. This PR fixes all three.

## The bugs

### 1. `advertised` read at the wrong frontmatter level (silent rule disablement)

```python
advertised = fm.get("advertised", True)   # ← reads top level
```

But the schema places `advertised` under `mode:`:

```yaml
mode:
  name: evaluation
  advertised: false   # ← actual location
```

The default-True kicked in for every mode, so `advertised: false` modes registered as `advertised: true` and the advertising-rule check (which only runs when `advertised is False`) was effectively dead across the ecosystem.

### 2. `description` had the same nesting bug

`description = fm.get("description", "")` returned `""` silently, so the 500/800-token budget check passed by default. Same fix.

### 3. Slash-command regex was too loose

`r'`?/<mode_name>`?'` matches `/evaluation` anywhere — including `langsmith/evaluation` inside URL paths and `modes/evaluation.md` inside file paths. Once #1 was fixed, the check fired false positives on these non-invocation references.

### 4. No reachability awareness

The scan flagged any file in `context/`, `agents/`, `behaviors/`, `skills/`, `modes/` that named the mode. But files reachable only through the mode body's own `@-mentions` are mode-internal — the LLM sees them when the mode is already active, so a mention there is a self-reference, not a dead-end invocation from outside the mode.

## The fix (~58 lines)

Single file: `recipes/validate-bundle-repo.yaml`.

```python
# 1+2: read from the mode: block
description = mode_section.get("description", "")
advertised  = mode_section.get("advertised", True)

# 3: tightened regex with word/slash boundaries
slash_pat = re.compile(r'(?<![\w/])`?/' + re.escape(mode_name) + r'`?(?![\w./])')

# 4: new helper, called before each scan
def collect_mode_internal_files(mode_file_path):
    """Return resolved paths the mode body @-mentions directly.
    These are mode-internal lazy context — references to the mode
    within them are self-references, not dead-end invocations."""
    # ... regex search over mode body for @<ns>:<path>.md mentions ...

# scan loop now skips files in mode_internal_files
```

## Validation

**Full test suite**: 1498 passed, 1 skipped, 3 warnings in 9.60s — no regressions.

**Live re-run against `microsoft/amplifier-bundle-evaluation`**: this bundle has `advertised: false` and two files that previously surfaced as false positives once the underlying read bug was fixed:

| File | Why it matched (loose regex) | Why it shouldn't match |
|---|---|---|
| `context/deep_dives/demystifying-evals-for-ai-agents.md` | `https://docs.langchain.com/langsmith/evaluation` URL substring | URL path, not slash-command |
| `context/workflow/harness-automation.md` | `modes/evaluation.md` file-path reference (and `/evaluations/` path segments) | File path, not slash-command — and this file is `@`-mentioned by the eval mode body so it's mode-internal anyway |

After this PR: validator reports **PASS — 0 errors, 0 warnings, 0 suggestions**. The deep-dive file is cleared by the tightened regex; harness-automation.md is cleared by either the tightened regex or the mode-internal exclusion (both apply).

## Impact

- Every `advertised: false` mode in the ecosystem is now actually being checked by the v3.6.0 advertising rule. Existing bundles may surface previously-hidden violations on next validation run — those are real findings, not regressions from this PR.
- Validation reports against bundles with unadvertised modes will be more accurate going forward.

## Test plan

- ✅ Unit tests: `tests/test_recipes_yaml_hygiene.py`, `tests/test_load_mode_metadata.py`, `tests/test_validate_bundle_repo_integration.py`, `tests/test_bundle_prepare_modes_walk.py` all pass
- ✅ Full suite: 1498/1498 pass (+1 skipped, pre-existing)
- ✅ Live integration against eval bundle: clean PASS