### PR TITLE
chore(tests): eliminate warnings + remove developer-local hardcoded path

### DIFF
--- a/tests/test_session_repair.py
+++ b/tests/test_session_repair.py
@@ -5,18 +5,25 @@ import json
 import os
 import subprocess
 import sys
+import warnings
 from pathlib import Path
 
 import pytest
 
-# Load session-repair.py as a module (it's a script, not a package)
+# Load session-repair.py as a module (it's a script, not a package).
+# The script emits a DeprecationWarning on import (it has been superseded by
+# scripts/amplifier-session.py). The test file deliberately keeps the old
+# script under test, so we suppress that warning at load to keep test output
+# clean. If the script itself is ever removed, this whole test file goes too.
 _script_path = Path(__file__).resolve().parent.parent / "scripts" / "session-repair.py"
 _project_root = Path(__file__).resolve().parent.parent
 _spec = importlib.util.spec_from_file_location("session_repair", _script_path)
 if _spec is None or _spec.loader is None:
     raise ImportError(f"Could not load {_script_path}")
 _mod = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_mod)
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    _spec.loader.exec_module(_mod)
 
 parse_transcript = _mod.parse_transcript
 build_tool_index = _mod.build_tool_index

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -578,6 +578,7 @@ class TestRunSessionInSubprocess:
         mock_process.wait.assert_called_once()
 
     @pytest.mark.asyncio
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     async def test_timeout_wait_guarded_logs_warning_if_wait_hangs(
         self, tmp_path: Any, caplog: Any
     ) -> None:
@@ -586,6 +587,11 @@ class TestRunSessionInSubprocess:
         If the process doesn't exit after SIGKILL (zombie, kernel hang), the
         code should log a warning and still raise TimeoutError rather than
         blocking indefinitely.
+
+        filterwarnings: the patched asyncio.wait_for raises TimeoutError before
+        any awaitable returned by AsyncMock-patched asyncio.create_subprocess_exec
+        is consumed. That's the intended test path — the un-awaited coroutine
+        is an artifact of mock plumbing, not a defect.
         """
         import logging
 
@@ -597,7 +603,11 @@ class TestRunSessionInSubprocess:
         mock_process = MagicMock()
         mock_process.pid = 12345
         mock_process.kill = MagicMock()
-        mock_process.wait = AsyncMock()
+        # MagicMock (not AsyncMock) intentional: the patched asyncio.wait_for
+        # raises TimeoutError before any await happens, so the wait() return
+        # value is never consumed. AsyncMock here would leak an un-awaited
+        # coroutine and emit RuntimeWarning.
+        mock_process.wait = MagicMock()
 
         # First asyncio.wait_for call (process.communicate) times out.
         # Second asyncio.wait_for call (process.wait guard) also times out,
@@ -1307,7 +1317,9 @@ class TestBundleModuleResolverExceptionClass:
         The amplifier_core loader checks isinstance(e, core.ModuleNotFoundError), so the
         entry-point fallback never fires when the wrong exception class is raised.
         """
-        from amplifier_core.module_sources import ModuleNotFoundError as CoreModuleNotFoundError
+        from amplifier_core.module_sources import (
+            ModuleNotFoundError as CoreModuleNotFoundError,
+        )
 
         from amplifier_foundation.bundle import BundleModuleResolver
 
@@ -1320,7 +1332,9 @@ class TestBundleModuleResolverExceptionClass:
         self,
     ) -> None:
         """BundleModuleResolver.async_resolve() raises CoreModuleNotFoundError when no activator."""
-        from amplifier_core.module_sources import ModuleNotFoundError as CoreModuleNotFoundError
+        from amplifier_core.module_sources import (
+            ModuleNotFoundError as CoreModuleNotFoundError,
+        )
 
         from amplifier_foundation.bundle import BundleModuleResolver
 

--- a/tests/test_tool_schema.py
+++ b/tests/test_tool_schema.py
@@ -169,19 +169,10 @@ class TestEstimateModuleToolTokens:
         assert result["tool_count"] == 1
         assert result["tools"][0]["name"] == "my-tool"
 
-    # ── 10. Real tool-recipes module (@property name) ─────────────────────────
-
-    def test_real_recipes_tool_module(self) -> None:
-        """Real tool-recipes module (uses @property name) should produce results."""
-        import pytest  # noqa: PLC0415
-
-        recipes_mod = Path(
-            "/home/bkrabach/dev/recipe-dot-docs"
-            "/amplifier-bundle-recipes/modules/tool-recipes"
-        )
-        if not recipes_mod.exists():
-            pytest.skip("recipes repo not available")
-        result = estimate_module_tool_tokens(recipes_mod)
-        assert result is not None
-        assert result["tool_count"] >= 1
-        assert any("recipes" in t["name"] for t in result["tools"])
+    # Note: a former test 10 hardcoded an absolute path to a specific
+    # developer's local clone of amplifier-bundle-recipes to exercise
+    # `estimate_module_tool_tokens` against a "real" tool-recipes module.
+    # It always skipped on CI and on every other machine. The @property-name
+    # extraction path is fully covered by test 9 (test_property_name_extraction)
+    # which uses a tmp_path-based inline stub of the same shape. Test 10
+    # was redundant in any environment where it actually ran.


### PR DESCRIPTION
## Summary

Three independent test-hygiene fixes that collectively take the test suite from `1498 passed, 1 skipped, 3 warnings` to `1498 passed, 0 skipped, 0 warnings`.

## Fix 1 — Delete hardcoded-path test in `tests/test_tool_schema.py`

`test_real_recipes_tool_module` hardcoded `/home/bkrabach/dev/recipe-dot-docs/amplifier-bundle-recipes/modules/tool-recipes` and skipped via `pytest.skip("recipes repo not available")` when the path didn't exist. It **always** skipped on CI and on every other contributor's machine — pretending to cover the regression case (tools with `name` declared as `@property` instead of class attribute) while running for one specific developer only.

The `@property name` extraction path is already fully covered by `test_property_name_extraction` (the test immediately preceding the deletion) which uses a `tmp_path`-based inline stub of the same shape. Replaced the deleted method with a comment block explaining the deletion and pointing at the surviving coverage.

## Fix 2 — Cleanup async-mock warnings in `tests/test_subprocess_runner.py`

`test_timeout_wait_guarded_logs_warning_if_wait_hangs` emitted `RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited` because the patched `asyncio.wait_for` raised `TimeoutError` before any await happened, so coroutines created by AsyncMock-flavored mocks were never consumed.

Two-part fix:
- Changed `mock_process.wait = AsyncMock()` → `mock_process.wait = MagicMock()` (MagicMock already imported). The wait return value is never awaited in this test path, so AsyncMock was the wrong choice.
- Added `@pytest.mark.filterwarnings("ignore::RuntimeWarning")` on the test method. The outer `patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=mock_process))` MUST stay AsyncMock (production code awaits the create call), and the second `TimeoutError`-on-wait_for short-circuit causes a small internal mock-plumbing coroutine to never be consumed. That's intentional in the test's structure; the filterwarnings makes the intent explicit.

## Fix 3 — Suppress deprecation warning in `tests/test_session_repair.py`

`scripts/session-repair.py` is deprecated and emits `DeprecationWarning` at import, pointing users at the replacement `scripts/amplifier-session.py`. `tests/test_session_repair.py` still loads it for backward-compat coverage.

Wrapped the script's `exec_module` call in `warnings.catch_warnings()` + `simplefilter("ignore", DeprecationWarning)` so test runs don't pollute output. Coverage of the production code (now living in `amplifier_foundation.session` and exposed via `scripts/amplifier-session.py`) is independently maintained by `tests/test_amplifier_session_cli.py`, `tests/test_session_diagnosis.py`, `tests/test_session_store.py`, and `tests/test_session_init_exports.py`. When the deprecated script is ultimately removed, this whole test file goes with it (noted in an inline comment).

## Local-path scrub

Broader grep across the repo for hardcoded developer-local paths in tests and source — `grep -E '"/home/[a-z]+/(dev|src|repo|code|work|projects)/[a-zA-Z0-9._/-]+"' --include="*.py" tests/ modules/ amplifier_foundation/ scripts/` — returned only the `test_real_recipes_tool_module` instance fixed in this PR. All other `/home/user/...` strings in the test suite are deliberate fixture data, not real paths.

## Validation

```
uv run python -m pytest -ra --no-header

1498 passed in 9.12s
```

No regressions, no warnings, no skips.

## Test plan

- Local: `uv run python -m pytest` — clean
- CI: should also be clean once merged