### PR TITLE
fix(hooks-session-naming): suppress background naming stream from leaking into interactive UI

### DIFF
--- a/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
+++ b/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
@@ -515,12 +515,18 @@ class SessionNamingHook:
                 logger.warning("No provider available for session naming")
                 return None
 
-            # Make the request — model=None means use provider default
+            # Make the request — model=None means use provider default.
+            # metadata={"stream": False} signals to the provider that this is
+            # a background utility call and must NOT take the streaming branch.
+            # The streaming branch emits llm:stream_block_start/delta/end events
+            # on the hook bus; without a session_id those events are indistinguishable
+            # from foreground output and leak into the streaming-UI overlay.
             from amplifier_core import ChatRequest, Message
 
             request = ChatRequest(
                 messages=[Message(role="user", content=prompt)],
                 model=model_override,
+                metadata={"stream": False},
             )
 
             response = await provider.complete(request)

--- a/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
+++ b/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
@@ -523,10 +523,18 @@ class SessionNamingHook:
             # from foreground output and leak into the streaming-UI overlay.
             from amplifier_core import ChatRequest, Message
 
+            # max_output_tokens: the naming response is a tiny JSON object
+            # ({"action": "set"|"defer", "name": "...", "description": "..."}).
+            # Without an explicit cap, the request inherits the provider's large
+            # default, which trips Anthropic's "streaming is required for operations
+            # that may take longer than 10 minutes" guard when stream=False.
+            # 256 tokens is a generous budget for the expected output and well
+            # below the threshold that triggers the guard.
             request = ChatRequest(
                 messages=[Message(role="user", content=prompt)],
                 model=model_override,
                 metadata={"stream": False},
+                max_output_tokens=256,
             )
 
             response = await provider.complete(request)

--- a/modules/hooks-session-naming/tests/test_session_naming.py
+++ b/modules/hooks-session-naming/tests/test_session_naming.py
@@ -473,3 +473,32 @@ class TestNoStreamingEvents:
         assert stream_events, (
             "DISCRIMINATOR BROKEN: expected stream events for request without flag"
         )
+
+    @pytest.mark.asyncio
+    async def test_call_provider_sets_small_max_output_tokens(self) -> None:
+        """ChatRequest must carry a small max_output_tokens to avoid Anthropic's
+        'streaming required for long operations' guard.
+
+        The naming call returns only a tiny JSON object; it has no need for a large
+        token budget.  Without an explicit cap the request inherits the provider's
+        large default, which trips Anthropic's guard when stream=False.
+
+        The cap must be set and must be <= 1024 (well below the threshold).
+        """
+        provider = _make_mock_provider()
+        hook = _make_hook(providers={"p": provider})
+
+        await hook._call_provider("name this session")
+
+        assert provider.complete.called
+        request = provider.complete.call_args[0][0]
+        assert request.max_output_tokens is not None, (
+            "ChatRequest.max_output_tokens must be explicitly set for the naming call. "
+            "Without it the request inherits the provider's large default, which trips "
+            "Anthropic's 'streaming required for long operations' guard when stream=False."
+        )
+        assert request.max_output_tokens <= 1024, (
+            f"max_output_tokens={request.max_output_tokens} is too large. "
+            "The naming call returns a tiny JSON object; cap it at <= 1024 "
+            "(256 is the recommended value)."
+        )

--- a/modules/hooks-session-naming/tests/test_session_naming.py
+++ b/modules/hooks-session-naming/tests/test_session_naming.py
@@ -375,3 +375,101 @@ class TestModelRoleResolution:
         call_kwargs = priority_provider.complete.call_args
         request = call_kwargs[0][0]
         assert request.model is None, "No model override without model_role"
+
+
+# =============================================================================
+# Task 7: Background naming call must not leak llm:stream_* events
+# =============================================================================
+
+
+class TestNoStreamingEvents:
+    """_call_provider must set metadata={'stream': False} so the provider takes
+    the non-streaming branch and emits no llm:stream_block_* events.
+
+    Root cause: without this flag the shared Anthropic provider uses
+    use_streaming=True, emitting llm:stream_block_start/delta/end on the hook
+    bus.  Those events carry no session_id, so the streaming-UI overlay treats
+    them as foreground output and renders the naming JSON to the terminal.
+    """
+
+    _STREAM_EVENTS = frozenset({
+        "llm:stream_block_start",
+        "llm:stream_block_delta",
+        "llm:stream_block_end",
+    })
+
+    def _make_streaming_simulator(self, emitted: list) -> MagicMock:
+        """Mock provider that conditionally emits stream events.
+
+        Mirrors the real AnthropicProvider's logic after the fix:
+          - metadata={'stream': False}  → non-streaming path, NO events
+          - anything else               → streaming path, emits llm:stream_*
+
+        This lets the test discriminate: before the fix the naming hook sends
+        no metadata flag so events fire; after the fix the flag suppresses them.
+        """
+        from amplifier_core import ChatRequest
+
+        async def _complete(request: ChatRequest) -> MagicMock:
+            force_no_stream = (
+                request.metadata is not None
+                and request.metadata.get("stream") is False
+            )
+            if not force_no_stream:
+                emitted.append("llm:stream_block_start")
+                emitted.append("llm:stream_block_delta")
+                emitted.append("llm:stream_block_end")
+            return _make_mock_provider().complete.return_value
+
+        provider = MagicMock()
+        provider.complete = _complete
+        return provider
+
+    @pytest.mark.asyncio
+    async def test_call_provider_sets_stream_false_in_metadata(self) -> None:
+        """ChatRequest passed to provider.complete() must have metadata['stream']=False."""
+        provider = _make_mock_provider()
+        hook = _make_hook(providers={"p": provider})
+
+        await hook._call_provider("name this session")
+
+        assert provider.complete.called
+        request = provider.complete.call_args[0][0]
+        assert request.metadata is not None, (
+            "ChatRequest.metadata must not be None — fix: pass metadata={'stream': False}"
+        )
+        assert request.metadata.get("stream") is False, (
+            f"Expected metadata['stream']=False, got metadata={request.metadata!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_naming_call_emits_no_stream_events(self) -> None:
+        """No llm:stream_* events on the hook bus during the naming call."""
+        emitted: list = []
+        provider = self._make_streaming_simulator(emitted)
+        hook = _make_hook(providers={"p": provider})
+
+        await hook._call_provider("name this session")
+
+        stream_events = [e for e in emitted if e in self._STREAM_EVENTS]
+        assert not stream_events, (
+            f"Naming call leaked llm:stream_* events: {stream_events}. "
+            "Fix: set metadata={'stream': False} in _call_provider()."
+        )
+
+    @pytest.mark.asyncio
+    async def test_discriminator_detects_streaming_without_flag(self) -> None:
+        """Control group: without the metadata flag, stream events ARE detected."""
+        from amplifier_core import ChatRequest
+
+        emitted: list = []
+        provider = self._make_streaming_simulator(emitted)
+
+        # Call directly with no metadata flag (pre-fix scenario)
+        request_no_flag = ChatRequest(messages=[])
+        await provider.complete(request_no_flag)
+
+        stream_events = [e for e in emitted if e in self._STREAM_EVENTS]
+        assert stream_events, (
+            "DISCRIMINATOR BROKEN: expected stream events for request without flag"
+        )

--- a/modules/hooks-session-naming/uv.lock
+++ b/modules/hooks-session-naming/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "amplifier-module-hooks-session-naming"
+version = "0.1.1"
+source = { editable = "." }


### PR DESCRIPTION
## Summary

Fixes two related issues in the session-naming hook that occur when the background naming LLM call streams events into the interactive CLI:

1. **Stream event leak into UI**: The background naming call used the shared streaming provider, emitting `llm:stream_*` events with no session_id. In the interactive CLI, these events were captured by the streaming UI overlay and rendered raw JSON (`{"action":"defer",...}`) plus stray ANSI escape sequences to the user's terminal after the prompt.

2. **Streaming-required guard failure**: Once streaming is suppressed, the naming call inherited a large default `max_output_tokens`, which trips Anthropic's "streaming required for operations that may take longer than 10 minutes" guard, causing retries and timeouts.

## Changes

- **054fb72**: `fix(hooks-session-naming): suppress streaming events from background naming call` — Sets `metadata={"stream": False}` on the naming ChatRequest so the provider takes the non-streaming path for this single call. This is forward-compatible (inert until a provider honors per-request stream override) and doesn't affect the shared provider's default behavior for foreground calls.

- **e5e954a**: `fix(hooks-session-naming): cap max_output_tokens=256 on naming ChatRequest` — Independently correct: naming responses are tiny JSON objects and should not budget thousands of tokens. This cap satisfies Anthropic's non-streaming guard and is a strict improvement regardless of streaming.

## Tests

- 3 new tests in `TestNoStreamingEvents` (tests/test_session_naming.py)
- Assertion that `max_output_tokens` is capped on naming requests
- 16/16 module tests pass
- 14/14 integration tests pass

## Backward Compatibility

Both fixes are backward-compatible:
- The `metadata={"stream": False}` flag is safely ignored by providers that don't yet honor per-request overrides (no-op until provider support lands).
- The `max_output_tokens` cap is a strict improvement with no behavioral downside.

## Generated with Amplifier

[Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>