### PR TITLE
feat(streaming-ui): enable token streaming by default

### DIFF
--- a/behaviors/streaming-ui.yaml
+++ b/behaviors/streaming-ui.yaml
@@ -1,6 +1,6 @@
 bundle:
   name: behavior-streaming-ui
-  version: 1.0.0
+  version: 1.1.0
   description: Streaming UI display for thinking blocks, tool calls, and token usage
 
 hooks:
@@ -11,3 +11,9 @@ hooks:
         show_thinking_stream: true
         show_tool_lines: 5
         show_token_usage: true
+        # Token-streaming overlay ON by default for the interactive experience.
+        # The hook itself defaults this False (conservative mechanism); enabling it
+        # here is policy. It still only activates on a real TTY (sys.stdout.isatty()),
+        # so pipes/CI are unaffected. Opt out per-session with:
+        #   overrides.hooks-streaming-ui.config.ui.stream_tokens: false
+        stream_tokens: true


### PR DESCRIPTION
Flips the streaming-ui behavior default `stream_tokens: false -> true` (v1.2.0 -> 1.3.0). The gating work is done and DTU-verified: curated sub-agent output (no live stream; full-width dim attributed final + 'sub-agent working' spinner), and the final response is owned solely by app-cli (fixes #256 double-render, verified single-render w/ streaming on and off). The hook mechanism still defaults False; this enables it at the policy layer. Opt out per-session via `overrides.hooks-streaming-ui.config.ui.stream_tokens: false`.