### PR TITLE
fix(behavioral-anchor): resolve agents.include path bug so agents load (descriptions + scoped tools)

### DIFF
--- a/experiments/behavioral-anchor/agents/architect.md
+++ b/experiments/behavioral-anchor/agents/architect.md
@@ -8,6 +8,12 @@ meta:
     DO NOT USE WHEN: a clear spec already exists and code just needs writing.
 
 model_role: [reasoning, general]
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
 ---
 
 # Architect

--- a/experiments/behavioral-anchor/agents/builder.md
+++ b/experiments/behavioral-anchor/agents/builder.md
@@ -7,6 +7,14 @@ meta:
     DO NOT USE WHEN: requirements are vague or design decisions are open -- use architect first.
 
 model_role: [coding, general]
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
 ---
 
 # Builder

--- a/experiments/behavioral-anchor/agents/debugger.md
+++ b/experiments/behavioral-anchor/agents/debugger.md
@@ -7,6 +7,14 @@ meta:
     DO NOT USE WHEN: the problem is already understood and just needs implementation.
 
 model_role: [coding, general]
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
 ---
 
 # Debugger

--- a/experiments/behavioral-anchor/agents/explorer.md
+++ b/experiments/behavioral-anchor/agents/explorer.md
@@ -8,6 +8,12 @@ meta:
     DO NOT USE WHEN: you need a single known file -- read it directly.
 
 model_role: [general, fast]
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
 ---
 
 # Explorer

--- a/experiments/behavioral-anchor/agents/git-ops.md
+++ b/experiments/behavioral-anchor/agents/git-ops.md
@@ -7,6 +7,12 @@ meta:
     DO NOT USE WHEN: the task is code exploration or implementation.
 
 model_role: [fast, general]
+
+tools:
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
 ---
 
 # Git Ops

--- a/experiments/behavioral-anchor/agents/researcher.md
+++ b/experiments/behavioral-anchor/agents/researcher.md
@@ -7,6 +7,10 @@ meta:
     DO NOT USE WHEN: the answer is in the local codebase.
 
 model_role: [research, general]
+
+tools:
+  - module: tool-web
+    source: git+https://github.com/microsoft/amplifier-module-tool-web@main
 ---
 
 # Researcher

--- a/experiments/behavioral-anchor/behavioral-anchor.md
+++ b/experiments/behavioral-anchor/behavioral-anchor.md
@@ -119,12 +119,12 @@ hooks:
 
 agents:
   include:
-    - behavioral-anchor:agents/explorer
-    - behavioral-anchor:agents/architect
-    - behavioral-anchor:agents/builder
-    - behavioral-anchor:agents/debugger
-    - behavioral-anchor:agents/git-ops
-    - behavioral-anchor:agents/researcher
+    - behavioral-anchor:explorer
+    - behavioral-anchor:architect
+    - behavioral-anchor:builder
+    - behavioral-anchor:debugger
+    - behavioral-anchor:git-ops
+    - behavioral-anchor:researcher
 ---
 
 # Behavioral Anchor


### PR DESCRIPTION
## What this fixes

The behavioral-anchor experiment's six agents were registering **name-only**: the
delegate catalog showed `agents/architect`, `agents/builder`, etc. with **"No
description"** and no tools. This is exactly what Brian observed.

### Root cause

`agents.include` listed agents as `behavioral-anchor:agents/<name>`, but
`Bundle.resolve_agent_path` already hardcodes the `agents/` path segment. The
stray prefix produced a doubled, non-existent path
(`.../agents/agents/<name>.md`), so `resolve_agent_path` returned `None` and
`load_agent_metadata` silently skipped every agent — no description, no tools, no
`model_role`, no body. The displayed names also carried the stray `agents/`
prefix.

## Changes

- **Path fix (the actual bug):** dropped the `agents/` prefix on all six
  `agents.include` lines (`behavioral-anchor:agents/explorer` →
  `behavioral-anchor:explorer`). This is what makes the metadata load.
- **Scoped tools (kept):** explicit per-agent `tools:` blocks mirroring the
  foundation source agents with least authority — explorer/architect =
  filesystem+search; builder/debugger = filesystem+search+bash; git-ops =
  bash+filesystem; researcher = web. LSP intentionally excluded (this bundle
  deliberately omits it). Verified that foundation's real agents each declare
  their own scoped tools, so per-agent blocks — not parent inheritance — is the
  faithful pattern.
- **Descriptions (kept original, reverted the rewrite):** the bundle's purpose is
  behavior-shaping at a fraction of the usual context cost, and descriptions live
  in the per-turn delegate catalog, so terseness is on-thesis. The original
  `role + USE WHEN + DO NOT USE WHEN` descriptions are effective for a 6-agent
  roster; importing foundation's heavyweight description style would contradict
  the experiment the same way adding LSP or examples would.

## Verification (empirical, against the real foundation loader)

- `resolve_agent_path` now returns the real `.md` path for all six agents (was
  `None`).
- `load_agent_metadata` populates all six with clean names, the original
  descriptions, and scoped tools (counts 2/2/3/3/2/1).
