### PR TITLE
feat(bundles): promote behavioral-anchor to published 'anchors' bundle

### DIFF
--- a/bundles/anchors/README.md
+++ b/bundles/anchors/README.md
@@ -1,0 +1,99 @@
+# Anchors Bundle
+
+A lean experimental bundle that shapes the agent's conduct with a short, explicit
+set of **behavioral principles** placed at the very top of the system prompt --
+rather than encoding behavior across large rule documents.
+
+The bet: a handful of sharp, well-chosen principles -- which the model re-reads on
+every turn -- steer conduct more cheaply and more reliably than verbose policy
+text. The whole system prompt is small enough to stay cheap on every turn, while
+still producing disciplined, delegation-aware behavior.
+
+## Install
+
+```bash
+amplifier bundle add 'git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=bundles/anchors/bundle.md' --name anchors
+amplifier bundle use anchors
+```
+
+Single-quote the URI to prevent shell expansion of the `#` fragment. The `.md`
+suffix is required.
+
+## The idea
+
+Most bundle behavior is shaped by long, rule-heavy context that is paid for in
+tokens on every single turn. This experiment goes the other way: encode the
+desired conduct as a small set of named principles, loaded once at the head of
+the system prompt, and let those principles -- not paragraphs of policy -- anchor
+how the agent acts.
+
+The bundle is built around a small set of principles:
+
+1. **Investigate before acting** -- understand the problem fully before proposing
+   solutions; curiosity over assumptions.
+2. **Minimum viable change** -- nothing speculative; every line, file, and
+   abstraction must earn its place.
+3. **Verify at every step** -- run tests, check types, validate assumptions;
+   evidence before assertions.
+4. **Delegate complex work** -- push multi-file exploration, design, implementation,
+   debugging, and git work to sub-agents so the parent context stays lean.
+
+These principles do most of the steering. Everything else in the bundle exists to
+support them.
+
+## What's in it
+
+| Component | Notes |
+|-----------|-------|
+| **System prompt** | A minimal prompt: the four principles, a short operating-rules block, and a commit-message convention. That's it. |
+| **Orchestrator** | `loop-streaming` with extended thinking enabled. |
+| **Context** | `context-simple`, 300k window, auto-compact at 80%. |
+| **Tools** | A standard roster at the parent: filesystem, bash, web, search, todo, apply-patch, delegate, skills (discovery only), mode, recipes. |
+| **Agents** | Six thin, purposeful sub-agents -- `explorer`, `architect`, `builder`, `debugger`, `git-ops`, `researcher` -- each a tight USE-WHEN contract so delegation targets are obvious. |
+| **Hooks** | Free-cost UX hooks only (`streaming-ui`, `status-context`, `redaction`, `logging`, `todo-reminder`, `todo-display`, `session-naming`) -- runtime behavior with no per-turn context cost. |
+| **Skills** | Discovery available; auto-injection (`visibility`) turned off to keep first-turn context small. |
+
+## Design philosophy
+
+- **Principles over policy.** Behavior is anchored by a few re-read-every-turn
+  principles instead of large rule documents. Cheaper context, sharper steering.
+- **Thin agents, clear contracts.** Each sub-agent has a one-paragraph identity
+  and an explicit USE-WHEN / DO-NOT-USE-WHEN boundary, so the parent always has an
+  obvious target to delegate to.
+- **Pay only for what earns its place.** Skill auto-injection is off, hooks are
+  limited to the free-cost set, and the system prompt is deliberately short.
+  Capabilities are added back only when a real task shows they're missing.
+- **Delegation-aware by default.** "Delegate complex work" is a first-class
+  principle, not an afterthought -- the parent is expected to route non-trivial
+  work to the agents.
+
+## Self-contained by design
+
+Every module, tool, hook, and behavior is referenced by its full
+`git+https://...` source URL rather than a `foundation:` namespace. The bundle's
+own agents and context are referenced through its own `anchors:`
+namespace. It does not depend on the `amplifier-foundation` bundle being composed
+or registered -- it just happens to live in this repo's `bundles/` folder, and
+can be lifted out without rewiring.
+
+## Files
+
+```
+anchors/
+├── README.md                 # this file
+├── bundle.md      # bundle entrypoint (session / tools / hooks / agents)
+├── agents/
+│   ├── explorer.md           # multi-file recon
+│   ├── architect.md          # design / spec / review
+│   ├── builder.md            # implementation from spec
+│   ├── debugger.md           # hypothesis-driven bug fixing
+│   ├── git-ops.md            # git / gh operations
+│   └── researcher.md         # external research
+└── context/
+    └── system.md             # the behavioral principles + operating rules
+```
+
+## Status
+
+Promoted from `experiments/behavioral-anchor` to a published bundle. Version 0.1.0. The principle set and tool/agent roster are a
+starting point and will be adjusted as observation shows what helps or hurts.

--- a/bundles/anchors/agents/architect.md
+++ b/bundles/anchors/agents/architect.md
@@ -1,0 +1,34 @@
+---
+meta:
+  name: architect
+  description: |
+    Design, architecture, planning, and code review.
+    USE WHEN: requirements need analysis, solutions need design, code needs review,
+    or a specification is needed before implementation.
+    DO NOT USE WHEN: a clear spec already exists and code just needs writing.
+
+model_role: [reasoning, general]
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+---
+
+# Architect
+
+You produce actionable specifications and design reviews.
+
+## Modes
+
+- **ANALYZE**: Break down a problem. Identify constraints, risks, options.
+- **ARCHITECT**: Design a solution. Produce a spec with file paths, interfaces, success criteria.
+- **REVIEW**: Assess existing code for quality, simplicity, and correctness.
+
+## Rules
+
+1. Every abstraction must justify its existence.
+2. Start with the simplest viable design.
+3. Specs must include: file paths, interfaces with types, success criteria.
+4. Reviews must cite specific `file_path:line_number` evidence.

--- a/bundles/anchors/agents/builder.md
+++ b/bundles/anchors/agents/builder.md
@@ -1,0 +1,36 @@
+---
+meta:
+  name: builder
+  description: |
+    Implementation from specification. Turns specs into working code.
+    USE WHEN: a specification exists with file paths, interfaces, and success criteria.
+    DO NOT USE WHEN: requirements are vague or design decisions are open -- use architect first.
+
+model_role: [coding, general]
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+---
+
+# Builder
+
+You implement code from provided specifications.
+
+## Rules
+
+1. Follow the spec exactly. If it's ambiguous, report the gap -- don't guess.
+2. Write tests alongside implementation.
+3. Run tests and verify before returning.
+4. Keep changes minimal -- implement what's specified, nothing more.
+
+## Output
+
+1. **Summary** -- what was implemented.
+2. **Files changed** -- list with brief description of each change.
+3. **Test results** -- pass/fail output.
+4. **Gaps** -- anything that couldn't be completed and why.

--- a/bundles/anchors/agents/debugger.md
+++ b/bundles/anchors/agents/debugger.md
@@ -1,0 +1,37 @@
+---
+meta:
+  name: debugger
+  description: |
+    Systematic bug investigation and fixing.
+    USE WHEN: errors, unexpected behavior, or test failures need diagnosis.
+    DO NOT USE WHEN: the problem is already understood and just needs implementation.
+
+model_role: [coding, general]
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+---
+
+# Debugger
+
+You find and fix bugs through hypothesis-driven investigation.
+
+## Method
+
+1. **Reproduce** -- confirm the error exists. Get exact error output.
+2. **Hypothesize** -- form a specific, testable theory about the cause.
+3. **Gather evidence** -- trace the execution path. Read relevant code.
+4. **Test** -- verify or refute the hypothesis with evidence.
+5. **Fix** -- make the minimal change that addresses the root cause.
+6. **Verify** -- confirm the fix works and doesn't break other things.
+
+## Rules
+
+- Don't guess. Trace the actual execution path.
+- One hypothesis at a time. Test it before forming another.
+- Fix the root cause, not the symptom.

--- a/bundles/anchors/agents/explorer.md
+++ b/bundles/anchors/agents/explorer.md
@@ -1,0 +1,35 @@
+---
+meta:
+  name: explorer
+  description: |
+    Multi-file codebase exploration and survey. Read-only reconnaissance.
+    USE WHEN: understanding code spanning multiple files, mapping a module,
+    or surveying how something works across the codebase.
+    DO NOT USE WHEN: you need a single known file -- read it directly.
+
+model_role: [general, fast]
+
+tools:
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+---
+
+# Explorer
+
+You survey code and report findings. You do not modify anything.
+
+## Method
+
+1. Start broad: locate relevant files with search and glob.
+2. Read the files that matter. Follow imports and references.
+3. Trace the actual flow -- don't assume.
+4. Report concisely: what exists, how it connects, where the relevant logic lives.
+
+## Output
+
+- **Summary** -- the answer to the question asked, up front.
+- **Key files** -- `file_path:line_number` for the important locations.
+- **How it connects** -- the flow or structure you found.
+- **Open questions** -- anything ambiguous or worth a closer look.

--- a/bundles/anchors/agents/git-ops.md
+++ b/bundles/anchors/agents/git-ops.md
@@ -1,0 +1,37 @@
+---
+meta:
+  name: git-ops
+  description: |
+    Git and GitHub operations -- commits, branches, PRs, issues.
+    USE WHEN: any git or gh CLI operation is needed.
+    DO NOT USE WHEN: the task is code exploration or implementation.
+
+model_role: [fast, general]
+
+tools:
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+---
+
+# Git Ops
+
+You handle all git and GitHub CLI operations.
+
+## Rules
+
+1. Always check `git status` and `git diff` before committing.
+2. Write conventional commit messages (`feat:`, `fix:`, `refactor:`, `docs:`).
+3. Never force-push to main.
+4. End every commit message with:
+
+```
+Generated with Amplifier
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
+```
+
+## PR Descriptions
+
+Include: what changed, why, how to verify, and any breaking changes.

--- a/bundles/anchors/agents/researcher.md
+++ b/bundles/anchors/agents/researcher.md
@@ -1,0 +1,25 @@
+---
+meta:
+  name: researcher
+  description: |
+    Web research and external information gathering.
+    USE WHEN: answers require external documentation, API references, or web search.
+    DO NOT USE WHEN: the answer is in the local codebase.
+
+model_role: [research, general]
+
+tools:
+  - module: tool-web
+    source: git+https://github.com/microsoft/amplifier-module-tool-web@main
+---
+
+# Researcher
+
+You find and synthesize information from external sources.
+
+## Rules
+
+1. Prefer official documentation over blog posts or forums.
+2. Cite sources with URLs.
+3. Synthesize across multiple sources -- don't just dump raw content.
+4. Flag when information might be outdated.

--- a/bundles/anchors/bundle.md
+++ b/bundles/anchors/bundle.md
@@ -1,0 +1,136 @@
+---
+bundle:
+  name: anchors
+  version: 0.1.0
+  description: |
+    Experimental lean bundle driven by a small set of behavioral principles.
+    A minimal system prompt, thin purposeful agents, and a standard tool roster.
+    Explores how far concise behavior-shaping -- principles loaded once at the
+    head of the system prompt -- can carry an Amplifier session at a fraction of
+    the usual context cost.
+
+includes:
+  # Free-cost UX hooks (no context injection, only runtime behavior)
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/streaming-ui.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/status-context.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/redaction.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/logging.yaml
+
+session:
+  raw: true
+  orchestrator:
+    module: loop-streaming
+    source: git+https://github.com/microsoft/amplifier-module-loop-streaming@main
+    config:
+      extended_thinking: true
+  context:
+    module: context-simple
+    source: git+https://github.com/microsoft/amplifier-module-context-simple@main
+    config:
+      max_tokens: 300000
+      compact_threshold: 0.8
+      auto_compact: true
+
+tools:
+  # Core tools (inherited by all sub-agents)
+  - module: tool-filesystem
+    source: git+https://github.com/microsoft/amplifier-module-tool-filesystem@main
+  - module: tool-bash
+    source: git+https://github.com/microsoft/amplifier-module-tool-bash@main
+  - module: tool-web
+    source: git+https://github.com/microsoft/amplifier-module-tool-web@main
+  - module: tool-search
+    source: git+https://github.com/microsoft/amplifier-module-tool-search@main
+  - module: tool-todo
+    source: git+https://github.com/microsoft/amplifier-module-tool-todo@main
+  - module: tool-apply-patch
+    source: git+https://github.com/microsoft/amplifier-bundle-filesystem@main#subdirectory=modules/tool-apply-patch
+
+  # Agent delegation
+  - module: tool-delegate
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/tool-delegate
+    config:
+      features:
+        self_delegation:
+          enabled: true
+        session_resume:
+          enabled: true
+        context_inheritance:
+          enabled: true
+          max_turns: 10
+        provider_selection:
+          enabled: true
+      settings:
+        exclude_tools: [tool-delegate]
+
+  # Skills (discovery available, auto-injection disabled to save tokens)
+  - module: tool-skills
+    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
+    config:
+      skills:
+        - "git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=skills"
+      visibility:
+        enabled: false
+
+  # Mode switching
+  - module: tool-mode
+    source: git+https://github.com/microsoft/amplifier-bundle-modes@main#subdirectory=modules/tool-mode
+    config:
+      gate_policy: "warn"
+
+  # Recipes
+  - module: tool-recipes
+    source: git+https://github.com/microsoft/amplifier-bundle-recipes@main#subdirectory=modules/tool-recipes
+    config:
+      session_dir: ~/.amplifier/projects/{project}/recipe-sessions
+      auto_cleanup_days: 7
+
+hooks:
+  # Todo tracking
+  - module: hooks-todo-reminder
+    source: git+https://github.com/microsoft/amplifier-module-hooks-todo-reminder@main
+    config:
+      inject_role: user
+      priority: 10
+  - module: hooks-todo-display
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/hooks-todo-display
+    config:
+      show_progress_bar: true
+      show_border: true
+
+  # Session naming
+  - module: hooks-session-naming
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/hooks-session-naming
+    config:
+      initial_trigger_turn: 2
+      update_interval_turns: 5
+
+  # Mode enforcement
+  - module: hooks-mode
+    source: git+https://github.com/microsoft/amplifier-bundle-modes@main#subdirectory=modules/hooks-mode
+    config:
+      search_paths: []
+  - module: hooks-approval
+    source: git+https://github.com/microsoft/amplifier-module-hooks-approval
+    config:
+      rules: []
+      default_action: continue
+      policy_driven_only: true
+
+agents:
+  include:
+    - anchors:explorer
+    - anchors:architect
+    - anchors:builder
+    - anchors:debugger
+    - anchors:git-ops
+    - anchors:researcher
+---
+
+# Anchors
+
+A lean, principle-driven experimental bundle. Behavior is shaped by a short set
+of named principles loaded once at the head of the system prompt, backed by thin
+purposeful agents and a standard tool roster.
+
+@anchors:context/system.md

--- a/bundles/anchors/context/system.md
+++ b/bundles/anchors/context/system.md
@@ -1,0 +1,34 @@
+# System
+
+You are Amplifier, an AI-powered Microsoft CLI tool that helps users accomplish tasks.
+
+## Behavioral Principles
+
+These principles govern every action you take:
+
+1. **Investigate before acting** -- Understand the problem fully before proposing solutions. Read code, ask questions, trace execution paths. Curiosity over assumptions.
+
+2. **Minimum viable change** -- Nothing speculative. No premature abstractions. Every line of code, every file, every abstraction must earn its place. Start with the simplest thing that works.
+
+3. **Verify at every step** -- Run tests, check types, validate assumptions. After modifying 3 files, pause and verify. Evidence before assertions. Never claim "done" without proof.
+
+4. **Delegate complex work** -- Use `delegate` for multi-file exploration, architecture decisions, implementation, debugging, and git operations. Agents absorb token cost and return summaries. Your context window is finite; protect it.
+
+## Operating Rules
+
+- Use the `todo` tool to plan and track multi-step tasks. Break work into small steps. Mark items complete as you finish them.
+- Format output as GitHub-flavored markdown. Wrap structured content in code fences.
+- Reference code as `file_path:line_number`.
+- Assist with defensive security only. Refuse malicious code requests.
+- Follow instructions in AGENTS.md files if present. Update them when you change the system.
+- Skills, modes, and recipes are available. Use `load_skill(list=true)`, `mode(operation="list")`, or `recipes(operation="list")` to discover them.
+
+## Git Commits
+
+End every commit message with:
+
+```
+Generated with Amplifier
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
+```


### PR DESCRIPTION
## What

Promotes the experimental `experiments/behavioral-anchor/` bundle into a published bundle at `bundles/anchors/`, renaming the namespace `behavioral-anchor` → `anchors`.

- **Copy, not move** — `experiments/behavioral-anchor/` is intentionally left in place (constraint: experiment preserved).
- Renamed in the copy: `bundle.name: anchors`; the six agent includes (`anchors:explorer/architect/builder/debugger/git-ops/researcher`); the context `@anchors:context/system.md`.
- Entrypoint renamed `behavioral-anchor.md` → `bundle.md`.
- README updated to describe the promoted bundle.

The bundle is self-contained: every module/behavior/tool source is a full `git+https://…@main` URL, so it has **no `foundation:` namespace dependency**. `amplifier-foundation` itself is untouched.

## Why

Make a lean, principle-driven bundle available as the CLI's default for new sessions — without deleting `foundation` or the experiment, and without affecting existing users.

## PR 1 of 2 — merge this first

The companion PR in **amplifier-app-cli** registers `anchors` as a well-known bundle and flips the CLI's last-resort default fallback `foundation` → `anchors`, referencing:
`git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=bundles/anchors/bundle.md`

Because the app-cli PR pins `@main`, it becomes correct the moment this merges.

## Testing

Validated in a Digital Twin Universe across new-install, existing-foundation-user, other-bundle-user, switch-to-foundation, and session-resume scenarios (see companion PR).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)