### PR TITLE
feat: add PyPI publish workflow (OIDC trusted publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish to PyPI
+
+# Publishes amplifier-foundation to PyPI via OIDC trusted publishing.
+# No API token secret required — auth is short-lived, exchanged at publish time.
+#
+# Bootstrap: before the first release, a PyPI pending trusted publisher must be
+# configured at pypi.org for project `amplifier-foundation`:
+#   Repository: microsoft/amplifier-foundation
+#   Workflow:   publish.yml
+#   Environment: pypi
+# See RELEASING.md for the full first-time setup checklist.
+#
+# Subsequent tag pushes use this workflow automatically.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
+    # id-token:write is required for OIDC trusted publishing.
+    # contents:read is required for actions/checkout.
+    permissions:
+      contents: read
+      id-token: write
+    environment: pypi
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Verify tag matches pyproject.toml version
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          PKG_VERSION="$(python3 -c "import tomllib; data=tomllib.load(open('pyproject.toml','rb')); print(data['project']['version'])")"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match pyproject.toml version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Publishing amplifier-foundation@$PKG_VERSION"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,80 @@
+# Releasing amplifier-foundation
+
+## How publishing works
+
+Releases are fully automated via OIDC trusted publishing — no API tokens or secrets are
+needed after one-time setup. The workflow (`.github/workflows/publish.yml`) fires when a
+`v<version>` git tag is pushed to `main` and publishes both the sdist and wheel to PyPI.
+
+## Release steps (per release)
+
+```bash
+# 1. Bump the version in pyproject.toml
+#    Edit [project] version = "X.Y.Z"
+
+# 2. Commit and merge to main
+git add pyproject.toml
+git commit -m "chore: bump version to X.Y.Z"
+# Open a PR and merge, or push directly if you have access
+
+# 3. Push the release tag from the tip of main
+git fetch origin
+git checkout main && git pull
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Pushing the tag triggers `.github/workflows/publish.yml`, which:
+1. Verifies the tag version matches `pyproject.toml`.
+2. Runs `uv build` to produce the sdist and wheel (pure-Python, `py3-none-any`).
+3. Publishes both artifacts to PyPI via `pypa/gh-action-pypi-publish` using OIDC.
+
+## One-time setup: PyPI trusted publisher
+
+Before the **first** release, a *pending trusted publisher* must be configured on PyPI.
+This only needs to be done once.
+
+1. Go to <https://pypi.org/manage/account/publishing/> (or the project page if it already
+   exists) and add a **pending publisher** (for a new project) with:
+
+   | Field | Value |
+   |---|---|
+   | PyPI project name | `amplifier-foundation` |
+   | GitHub repository owner | `microsoft` |
+   | GitHub repository name | `amplifier-foundation` |
+   | Workflow filename | `publish.yml` |
+   | Environment name | `pypi` |
+
+2. Create a GitHub Actions environment named `pypi` in the repo settings
+   (`Settings → Environments → New environment`). No secrets are needed; the environment
+   just scopes the OIDC token exchange. Adding a required reviewer is optional but
+   recommended for production releases.
+
+3. Push a test tag (e.g. `v0.0.1.dev0`) against the pending publisher to confirm the
+   handshake works end-to-end. Delete the test release on PyPI afterward if desired.
+
+> **Note:** The OIDC trusted-publisher handshake can only be proven by a real tag-triggered
+> run after PyPI-side configuration. No local test can verify this step.
+
+## Pre-release versions
+
+Append a pre-release suffix to signal non-final releases:
+
+```
+v1.1.0a1   →  alpha 1
+v1.1.0b2   →  beta 2
+v1.1.0rc1  →  release candidate 1
+```
+
+PyPI treats these correctly; `pip install amplifier-foundation` won't pull them unless
+`--pre` is passed.
+
+## Verifying a release
+
+After the workflow completes:
+
+```bash
+pip install --dry-run amplifier-foundation==X.Y.Z  # confirm on PyPI
+pip install amplifier-foundation==X.Y.Z
+python -c "import amplifier_foundation; print(amplifier_foundation.__version__)"
+```


### PR DESCRIPTION
## Summary

Adds a tag-driven GitHub Actions workflow for building and publishing the pure-Python sdist+wheel to PyPI via OIDC trusted publishing. Mirrors amplifier-core's proven pattern: push a `v*` git tag, CI builds and publishes automatically with no tokens in-repo.

Also adds `RELEASING.md` with version/tag conventions and publishing steps.

## What this does

- **publish.yml**: GitHub Actions workflow that triggers on `v*` tags
  - Builds pure-Python sdist + wheel
  - Publishes to PyPI via OIDC trusted publishing (no hardcoded tokens)
  - Includes a tag-vs-pyproject version-match guard so a mistagged release fails loudly instead of publishing the wrong version
  - Identical pattern to amplifier-core's proven automation

- **RELEASING.md**: Documents version/tag conventions and the publish flow for future maintainers

## Before this can publish

**PyPI side setup (one-time):**
1. Configure a PyPI pending trusted publisher:
   - Project name: `amplifier-foundation`
   - Repository owner: `microsoft`
   - Repository name: `amplifier-foundation`
   - Workflow filename: `publish.yml`
   - Environment name: `pypi`
2. Create a `pypi` environment in the GitHub repo (Settings → Environments)

**Tagging and publishing:**
- To publish version X.Y.Z: git tag `vX.Y.Z` && git push --tags
- CI detects the tag, validates version match, builds, and publishes

## Validation

Locally validated via `uv build`:
- Builds clean pure-Python sdist + wheel
- No platform-specific code or build artifacts
- Ready to push to PyPI

**Note:** The OIDC handshake itself (confirming the trusted publisher works) can only be validated by the first real tagged run after the trusted publisher is set up at PyPI.