### PR TITLE
fix(hooks-session-naming): opt naming call out of extended thinking; restore model_role default

### DIFF
--- a/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
+++ b/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
@@ -537,7 +537,16 @@ class SessionNamingHook:
                 max_output_tokens=256,
             )
 
-            response = await provider.complete(request)
+            # extended_thinking=False: this is a mechanical classification chore,
+            # not a reasoning task. Without this explicit opt-out, a provider with
+            # a session-level reasoning effort configured (e.g. Anthropic
+            # `effort: medium`) force-enables extended thinking on this call and
+            # floors max_output_tokens up to the thinking budget (tens of
+            # thousands), which — combined with stream=False above — trips
+            # Anthropic's "streaming is required for operations that may take
+            # longer than 10 minutes" guard and makes naming fail every retry.
+            # Providers without a thinking concept ignore this kwarg.
+            response = await provider.complete(request, extended_thinking=False)
 
             if response and response.content:
                 # Extract text from content blocks
@@ -592,7 +601,7 @@ async def mount(
         max_name_length=config.get("max_name_length", 50),
         max_description_length=config.get("max_description_length", 200),
         max_retries=config.get("max_retries", 3),
-        model_role=config.get("model_role"),
+        model_role=config.get("model_role", "fast"),
     )
 
     hook = SessionNamingHook(coordinator, hook_config)

--- a/modules/hooks-session-naming/pyproject.toml
+++ b/modules/hooks-session-naming/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amplifier-module-hooks-session-naming"
-version = "0.1.1"
+version = "0.1.2"
 description = "Automatic session naming and description generation"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Problem

Automatic session naming silently fails for any user who has a reasoning `effort`
configured on their Anthropic provider. No session ever gets an auto-generated
name; the naming retries all fail identically.

## Root cause

Two independent caller-side defects in `hooks-session-naming`, both in
`_call_provider()` / `mount()`:

1. **Naming call did not opt out of extended thinking.** The hook builds a small
   non-streaming naming request (`max_output_tokens=256`, `metadata={"stream": False}`)
   and calls `provider.complete(request)`. When the provider has a session-level
   reasoning `effort` set, it force-enables extended thinking on *every* call and
   floors `max_tokens` up to `budget + buffer` (e.g. `32000 + 8192 = 40192`). That
   oversized **non-streaming** request trips the Anthropic SDK guard *"Streaming is
   required for operations that may take longer than 10 minutes"* — so every retry
   fails and naming never completes.

2. **`mount()` dropped the documented `model_role` default.** The config dataclass
   documents `model_role` defaulting to `"fast"`, but `mount()` read
   `config.get("model_role")` (no default → `None`), silently routing naming to the
   priority thinking-capable model instead of a cheap one.

## Fix

1. Pass `extended_thinking=False` on the naming call. This is the highest-precedence
   opt-out and wins even when an `effort` is configured. Naming is a mechanical
   classification chore, not a reasoning task. Providers without a thinking concept
   ignore the kwarg (absorbed by `**kwargs`), so the change is provider-agnostic. It
   mirrors the existing `metadata={"stream": False}` opt-out already on the same request.
2. Default `model_role` to `"fast"` in `mount()`, matching the documented dataclass default.

Defect 1 is the actual root cause (fixes the failure for any model + effort combo);
defect 2 is an independent routing-correctness fix.

## Testing

- Unit tests: 16/16 pass.
- Validated end-to-end in an isolated environment reproducing the failure config
  (thinking-capable priority model, `balanced` routing, provider `effort: medium`,
  naming hook with no explicit `model_role`):
  - **Before:** naming call logs `thinking: True`, `max_tokens=40192`, 5/5 streaming-guard
    retries fail, no name written.
  - **After:** naming call logs `thinking: False`, `max_tokens=256`, no retries, a real
    session name is written. Foreground conversation turns still honor the configured
    `effort` (extended thinking still active for the actual user conversation).