### PR TITLE
fix(hooks-session-naming): salvage truncated naming responses

### DIFF
--- a/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
+++ b/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
@@ -564,7 +564,18 @@ class SessionNamingHook:
         return None
 
     def _parse_response(self, response: str) -> dict | None:
-        """Parse JSON response from LLM."""
+        """Parse the JSON naming response from the LLM.
+
+        The response is a small JSON object of the form
+        ``{"action": ..., "name": ..., "description": ...}``. Because the
+        provider call caps output tokens, a long ``description`` (the last,
+        free-text field) can push the response past the cap and truncate it
+        mid-string, leaving invalid JSON. Rather than discard the whole
+        response, salvage the fields that completed: ``action`` and ``name``
+        both precede ``description``, so they are intact whenever truncation
+        lands inside the description. Naming then still succeeds and the
+        description is refreshed on a later update pass.
+        """
         try:
             # Try to extract JSON from response (may have markdown wrapper)
             json_match = re.search(r"\{[^{}]*\}", response, re.DOTALL)
@@ -572,9 +583,54 @@ class SessionNamingHook:
                 return json.loads(json_match.group())
             return json.loads(response)
         except json.JSONDecodeError as e:
-            logger.warning(f"Failed to parse naming response: {e}")
-            logger.debug(f"Response was: {response[:200]}")
+            salvaged = self._salvage_partial(response)
+            if salvaged:
+                logger.debug(
+                    "Naming response truncated; salvaged fields: %s",
+                    ", ".join(salvaged),
+                )
+                return salvaged
+            # Best-effort background chore: a genuinely unparseable response is
+            # not worth a user-facing warning. Log quietly, like every other
+            # non-fatal naming outcome in this module.
+            logger.debug("Could not parse naming response: %s", e)
+            logger.debug("Response was: %s", response[:200])
             return None
+
+    @staticmethod
+    def _salvage_partial(response: str) -> dict | None:
+        """Recover completed fields from a truncated naming JSON response.
+
+        Only ``action`` and ``name`` are recovered: they precede the free-text
+        ``description`` that overflows the token cap, so they are complete
+        whenever truncation happens inside ``description``. Returns None when
+        nothing actionable can be read (e.g. truncation landed inside ``name``
+        itself), letting the caller treat it as a clean miss and retry on a
+        later turn.
+        """
+        # A complete JSON string value: opening quote, any escaped or
+        # non-quote characters, closing quote.
+        string_val = r'"((?:[^"\\]|\\.)*)"'
+        name_match = re.search(r'"name"\s*:\s*' + string_val, response)
+        action_match = re.search(r'"action"\s*:\s*' + string_val, response)
+        action = action_match.group(1) if action_match else None
+
+        if name_match:
+            raw = name_match.group(1)
+            try:
+                # Round-trip through json to unescape \", \\, etc.
+                name = json.loads(f'"{raw}"')
+            except json.JSONDecodeError:
+                name = raw
+            # A recovered name is only meaningful for the "set" action.
+            return {"action": action or "set", "name": name}
+
+        # No name recovered, but a short action-only response (defer/keep)
+        # may still have completed its action field.
+        if action in ("defer", "keep"):
+            return {"action": action}
+
+        return None
 
 
 async def mount(

--- a/modules/hooks-session-naming/tests/test_session_naming.py
+++ b/modules/hooks-session-naming/tests/test_session_naming.py
@@ -502,3 +502,60 @@ class TestNoStreamingEvents:
             "The naming call returns a tiny JSON object; cap it at <= 1024 "
             "(256 is the recommended value)."
         )
+
+
+# =============================================================================
+# Truncated-response parsing (token-cap resilience)
+# =============================================================================
+
+
+class TestParseResponseTruncation:
+    """_parse_response must survive a naming response truncated at the token cap.
+
+    The naming call caps output tokens. The requested JSON is
+    ``{"action", "name", "description"}`` with ``description`` last and
+    free-text, so an over-long description truncates the response mid-string
+    and yields invalid JSON. The parser salvages the completed ``action`` and
+    ``name`` fields instead of discarding the whole response, and never emits
+    a user-facing warning for a best-effort background chore.
+    """
+
+    def test_full_valid_response_parses(self) -> None:
+        hook = _make_hook()
+        result = hook._parse_response(
+            '{"action": "set", "name": "My Session", "description": "A test."}'
+        )
+        assert result == {
+            "action": "set",
+            "name": "My Session",
+            "description": "A test.",
+        }
+
+    def test_truncated_in_description_salvages_name(self) -> None:
+        hook = _make_hook()
+        result = hook._parse_response(
+            '{"action": "set", "name": "My Session", '
+            '"description": "A very long description that ran past the token c'
+        )
+        assert result == {"action": "set", "name": "My Session"}
+
+    def test_truncated_in_name_is_clean_miss(self) -> None:
+        hook = _make_hook()
+        result = hook._parse_response('{"action": "set", "name": "My Sess')
+        assert result is None
+
+    def test_truncation_emits_no_warning(self, caplog) -> None:
+        hook = _make_hook()
+        with caplog.at_level("DEBUG"):
+            hook._parse_response(
+                '{"action": "set", "name": "My Session", "description": "trunc'
+            )
+        warnings = [r for r in caplog.records if r.levelno >= 30]  # WARNING+
+        assert not warnings, f"unexpected warning(s): {[r.getMessage() for r in warnings]}"
+
+    def test_markdown_wrapped_response_parses(self) -> None:
+        hook = _make_hook()
+        result = hook._parse_response(
+            '```json\n{"action": "set", "name": "X Y", "description": "z"}\n```'
+        )
+        assert result == {"action": "set", "name": "X Y", "description": "z"}


### PR DESCRIPTION
## Problem

The session-naming hook caps its provider call at 256 output tokens. The model is asked to return a small JSON object — `{"action", "name", "description"}` — where `description` is a free-text field and comes last. When the description runs long, the response hits the token cap and truncates mid-string, leaving invalid JSON.

`_parse_response` then raised `JSONDecodeError`, discarded the entire response, and logged the failure at `warning` level, e.g.:

    Failed to parse naming response: Unterminated string starting at: line 1 column N (char N)

Two consequences:

1. The session got no name that pass, even though the `name` field had already completed.
2. A best-effort background chore surfaced a scary-looking warning on the user's console — inconsistent with every other non-fatal naming outcome in this module, which logs at `debug`.

## Fix

Make `_parse_response` tolerant of truncation rather than fragile to it. No change to the 256-token cap.

1. **Salvage completed fields.** On `JSONDecodeError`, recover `action` and `name` from the partial text. Both precede `description`, so they are intact whenever truncation lands inside the description. Naming still succeeds; the description is refreshed on a later update pass (`DESCRIPTION_UPDATE_PROMPT`). If truncation landed inside `name` itself, return `None` — a clean miss that retries on a later turn.
2. **Log quietly.** Downgrade the genuinely-unparseable case from `warning` to `debug`, matching the module's best-effort convention (the drain-timeout, defer, keep, and no-context paths all log at `debug`).

## Tests

Added `TestParseResponseTruncation` covering: a full valid response, truncation inside the description (salvages the name), truncation inside the name (clean miss returning `None`), no warning emitted on truncation, and markdown-wrapped responses. Full module suite passes (21 tests).
