### PR TITLE
fix(spawn): fail loud instead of silently using an unresolved model glob

### DIFF
--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -121,13 +121,18 @@ class ModelResolutionResult:
     """Result of model pattern resolution.
 
     Attributes:
-        resolved_model: The final model name to use.
+        resolved_model: The final model name to use, or None if the pattern
+            could not be resolved against the provider's available models.
+            None is an explicit failure signal -- callers must NOT treat it
+            as (or substitute in) the raw, unresolved pattern string, since
+            that string is not a real model name and would be sent literally
+            to the provider's API.
         pattern: Original pattern (None if input wasn't a pattern).
         available_models: All models available from the provider.
         matched_models: Models that matched the pattern.
     """
 
-    resolved_model: str
+    resolved_model: str | None
     pattern: str | None = None
     available_models: list[str] | None = None
     matched_models: list[str] | None = None
@@ -165,7 +170,11 @@ async def resolve_model_pattern(
         2. Query provider for available models
         3. Filter with fnmatch
         4. Sort descending (latest date/version wins)
-        5. Return first match, or original if no matches
+        5. Return the best match, or a failure signal (resolved_model=None)
+           if the provider has no models, or none of them match the pattern.
+           The raw, unresolved pattern string is never returned disguised as
+           a successful resolution -- callers must check for None and treat
+           it as "could not resolve", not substitute in the pattern itself.
     """
     # Not a pattern - return as-is
     if not is_glob_pattern(model_hint):
@@ -222,12 +231,13 @@ async def resolve_model_pattern(
 
     if not available_models:
         logger.warning(
-            "No available models from provider '%s' for pattern '%s' - using pattern as-is",
+            "No available models from provider '%s' for pattern '%s' - "
+            "cannot resolve (provider has no models)",
             provider_name,
             model_hint,
         )
         return ModelResolutionResult(
-            resolved_model=model_hint,
+            resolved_model=None,
             pattern=model_hint,
             available_models=[],
             matched_models=[],
@@ -248,14 +258,14 @@ async def resolve_model_pattern(
     if not matched:
         logger.warning(
             "Pattern '%s' matched no models from provider '%s'. "
-            "Available: %s. Using pattern as-is.",
+            "Available: %s. Cannot resolve.",
             model_hint,
             provider_name,
             ", ".join(available_models[:10])
             + ("..." if len(available_models) > 10 else ""),
         )
         return ModelResolutionResult(
-            resolved_model=model_hint,
+            resolved_model=None,
             pattern=model_hint,
             available_models=available_models,
             matched_models=[],
@@ -506,7 +516,13 @@ async def apply_provider_preferences_with_resolution(
     # Build lookup for efficient matching
     lookup = _build_provider_lookup(providers)
 
-    # Find first matching preference and resolve its model pattern
+    # Find first matching preference whose model actually resolves, and
+    # apply it. A preference whose provider is present but whose glob
+    # pattern fails to resolve (no matching models) is NOT applied with
+    # the raw, unresolved pattern -- that would send a literal glob string
+    # to the provider's API. Instead we advance to the next preference in
+    # the ordered list, mirroring resolve_model_role()'s `continue`
+    # behavior in the sibling routing-matrix resolver.
     for pref in preferences:
         if pref.provider in lookup:
             target_idx = lookup[pref.provider]
@@ -517,13 +533,24 @@ async def apply_provider_preferences_with_resolution(
                 result = await resolve_model_pattern(
                     pref.model, pref.provider, coordinator
                 )
+                if result.resolved_model is None:
+                    logger.warning(
+                        "Preference for provider '%s' failed to resolve model "
+                        "pattern '%s' - trying next preference",
+                        pref.provider,
+                        pref.model,
+                    )
+                    continue
                 resolved_model = result.resolved_model
 
             return _apply_single_override(
                 mount_plan, providers, target_idx, resolved_model, pref.config
             )
 
-    # No preferences matched
+    # No preferences matched -- either no preference's provider was present
+    # in the mount plan, or every candidate's model pattern failed to
+    # resolve. Either way, leave the mount plan unmodified rather than
+    # writing an unresolved pattern string into it.
     logger.warning(
         "No preferred providers found in mount plan. Preferences: %s, Available: %s",
         [p.provider for p in preferences],

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -250,8 +250,17 @@ class TestResolveModelPattern:
         assert len(result.matched_models or []) == 3
 
     @pytest.mark.asyncio
-    async def test_pattern_no_matches_returns_pattern(self) -> None:
-        """Test that unmatched patterns are returned as-is."""
+    async def test_pattern_no_matches_returns_none(self) -> None:
+        """Regression test (bug: silent-fallback design flaw): when a glob
+        pattern finds zero matches against a real, non-empty model list,
+        resolve_model_pattern() must NOT disguise this as a successful
+        resolution by returning the raw, unresolved pattern string as
+        resolved_model. That raw glob (e.g. "claude-*") would otherwise
+        flow straight into a mount plan and be sent literally to the
+        provider's API, producing a confusing 404 instead of a clear,
+        diagnosable "could not resolve a model" signal. Failure must be
+        explicit: resolved_model is None.
+        """
         mock_provider = AsyncMock()
         mock_provider.list_models = AsyncMock(return_value=["gpt-4o", "gpt-4o-mini"])
 
@@ -264,7 +273,35 @@ class TestResolveModelPattern:
             mock_coordinator,
         )
 
-        assert result.resolved_model == "claude-*"
+        assert result.resolved_model is None, (
+            "resolve_model_pattern() must signal failure (None) when a glob "
+            f"matches nothing, not disguise it as success. Got: {result.resolved_model!r}"
+        )
+        assert result.matched_models == []
+
+    @pytest.mark.asyncio
+    async def test_empty_model_list_returns_none(self) -> None:
+        """Regression test (bug: silent-fallback design flaw): when the
+        provider has no available models at all (empty list_models()
+        result), resolve_model_pattern() must NOT return the raw,
+        unresolved pattern string disguised as a successful resolution.
+        """
+        mock_provider = AsyncMock()
+        mock_provider.list_models = AsyncMock(return_value=[])
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.get.return_value = {"provider-openai": mock_provider}
+
+        result = await resolve_model_pattern(
+            "gpt-4o-*",
+            "openai",
+            mock_coordinator,
+        )
+
+        assert result.resolved_model is None, (
+            "resolve_model_pattern() must signal failure (None) when the "
+            f"provider has no models, not disguise it as success. Got: {result.resolved_model!r}"
+        )
         assert result.matched_models == []
 
     @pytest.mark.asyncio
@@ -410,6 +447,105 @@ class TestApplyProviderPreferencesWithResolution:
         assert result["providers"][0]["config"]["priority"] == 0
         # gpt-4o-mini > gpt-4o when sorted descending
         assert result["providers"][0]["config"]["default_model"] == "gpt-4o-mini"
+
+    @pytest.mark.asyncio
+    async def test_falls_through_to_next_preference_when_glob_fails(self) -> None:
+        """Regression test (bug: silent-fallback design flaw): when the
+        FIRST preference's glob pattern fails to resolve against its
+        provider's real model list (zero fnmatch matches), the function
+        must NOT apply that preference with the raw, unresolved glob
+        string as the "resolved" model. It must instead advance to the
+        NEXT preference in the ordered list -- mirroring
+        resolve_model_role()'s `continue` behavior in the sibling
+        routing-matrix resolver -- and apply ITS successfully resolved
+        model.
+        """
+        mount_plan = {
+            "providers": [
+                {"module": "provider-anthropic", "config": {}},
+                {"module": "provider-openai", "config": {}},
+            ]
+        }
+
+        # Anthropic is present but has no model matching the glob.
+        mock_anthropic = AsyncMock()
+        mock_anthropic.list_models = AsyncMock(
+            return_value=["claude-sonnet-4-20250514"]  # no "claude-haiku-*" match
+        )
+        # OpenAI is present and DOES have a matching model.
+        mock_openai = AsyncMock()
+        mock_openai.list_models = AsyncMock(return_value=["gpt-4o-mini"])
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.get.return_value = {
+            "provider-anthropic": mock_anthropic,
+            "provider-openai": mock_openai,
+        }
+
+        prefs = [
+            # First preference: provider present, but glob matches nothing.
+            ProviderPreference(provider="anthropic", model="claude-haiku-*"),
+            # Second preference: provider present, glob resolves cleanly.
+            ProviderPreference(provider="openai", model="gpt-4o-*"),
+        ]
+
+        result = await apply_provider_preferences_with_resolution(
+            mount_plan, prefs, mock_coordinator
+        )
+
+        # The SECOND preference (openai) must be the one promoted/applied,
+        # with its cleanly-resolved model -- NOT anthropic with the raw
+        # unresolved glob "claude-haiku-*".
+        assert result["providers"][1]["config"]["priority"] == 0, (
+            "Expected openai (second preference) to be promoted after "
+            "anthropic's glob failed to resolve."
+        )
+        assert result["providers"][1]["config"]["default_model"] == "gpt-4o-mini"
+        # Anthropic (first preference) must be left untouched -- specifically,
+        # it must never have been given the raw, unresolved glob as a model.
+        assert "default_model" not in result["providers"][0]["config"]
+        assert result["providers"][0]["config"].get("priority") != 0
+
+    @pytest.mark.asyncio
+    async def test_all_preferences_fail_leaves_mount_plan_unmodified(self) -> None:
+        """Regression test: when EVERY preference in the ordered list fails
+        to resolve its glob pattern, the mount plan must be returned
+        unmodified -- no unresolved pattern string may be written into it
+        anywhere, and no provider should be promoted.
+        """
+        mount_plan = {
+            "providers": [
+                {"module": "provider-anthropic", "config": {"priority": 10}},
+                {"module": "provider-openai", "config": {"priority": 20}},
+            ]
+        }
+
+        mock_anthropic = AsyncMock()
+        mock_anthropic.list_models = AsyncMock(return_value=["claude-sonnet-4-20250514"])
+        mock_openai = AsyncMock()
+        mock_openai.list_models = AsyncMock(return_value=["gpt-4o", "gpt-4o-mini"])
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.get.return_value = {
+            "provider-anthropic": mock_anthropic,
+            "provider-openai": mock_openai,
+        }
+
+        prefs = [
+            ProviderPreference(provider="anthropic", model="claude-haiku-*"),  # no match
+            ProviderPreference(provider="openai", model="claude-*"),  # no match either
+        ]
+
+        result = await apply_provider_preferences_with_resolution(
+            mount_plan, prefs, mock_coordinator
+        )
+
+        # Nothing should have been promoted or modified.
+        assert result["providers"][0]["config"] == {"priority": 10}
+        assert result["providers"][1]["config"] == {"priority": 20}
+        # No unresolved glob pattern string should appear anywhere in the result.
+        for p in result["providers"]:
+            assert "default_model" not in p["config"]
 
 
 class TestProviderPreferenceConfig:


### PR DESCRIPTION
## Summary
- `resolve_model_pattern()` treated "no matching model found" (empty model list, or zero fnmatch matches) as a **success**, returning the raw, unresolved glob pattern (e.g. `claude-haiku-*`) as the "resolved" model. `apply_provider_preferences_with_resolution()` then wrote that literal, unresolved string into the mount plan and returned immediately — sending it straight to the live provider API as a model name and producing a confusing 404 (e.g. Anthropic `NotFoundError: model: claude-haiku-*`) instead of a clear routing failure.
- Reproduced live: any agent whose declared `model_role` resolves, via a routing matrix, to a role backed by a glob candidate that fails to match now fails this exact way in production.
- **Fix:** `resolve_model_pattern()` now returns `None` (`ModelResolutionResult.resolved_model: str | None`) on failure instead of the raw pattern. `apply_provider_preferences_with_resolution()` now advances to the **next** preference in the ordered list when one fails to resolve (mirroring the already-correct pattern in the sibling `amplifier-bundle-routing-matrix` resolver's `resolve_model_role()`), and leaves the mount plan unmodified if every preference fails, rather than ever writing an unresolved pattern into it. Confirmed via grep that the only production caller of `resolve_model_pattern()` is `apply_provider_preferences_with_resolution()`, so this contract change is safe.

## Test plan
- [x] `uv run pytest tests/test_spawn_utils.py -q` — **48 passed** (44 existing + 4 new)
- [x] Full-suite stash comparison: **1502 passed** on pristine main, **1505 passed** with the fix applied — exactly the 3 net-new tests, zero regressions
- [x] Red-green regression verified: reverting only the `spawn_utils.py` fix (keeping the new tests) makes all 4 new tests **fail**, reproducing the exact bug — `{'default_model': 'claude-haiku-*'}` leaking into the mount plan with log `"Using pattern as-is."`; restoring the fix makes them pass with log `"Cannot resolve."`
- [x] ruff-lint / pyright / stub-check clean (one cosmetic ruff-format nit on the test file, non-blocking)
- [x] N/A — no provisioning/infra changes

Generated with [Amplifier](https://github.com/microsoft/amplifier)
