### PR TITLE
fix(spawn): resolve bare provider type names against multi-instance providers

### DIFF
--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -204,7 +204,7 @@ async def resolve_model_pattern(
     try:
         providers = coordinator.get("providers")
         if providers:
-            provider = _find_provider_instance(providers, provider_name)
+            provider = _find_provider_instance(providers, provider_name, coordinator)
             if provider and hasattr(provider, "list_models"):
                 models = await provider.list_models()
                 # Handle both list of strings and list of model objects
@@ -293,18 +293,79 @@ async def resolve_model_pattern(
     )
 
 
+def _get_provider_specs(coordinator: Any) -> list[dict[str, Any]]:
+    """Best-effort fetch of the mount plan's provider config list.
+
+    ``coordinator.config`` is a stable, documented property of
+    ``amplifier_core``'s Rust-backed coordinator (``RustCoordinator.config
+    -> dict[str, Any]``), already relied on elsewhere in this codebase
+    (e.g. ``configurator/_inspector.py``) to read back ``module``/``id``
+    metadata for mounted instances. This helper degrades gracefully to an
+    empty list for any coordinator-like object that doesn't expose it
+    (e.g. bare test doubles), rather than raising.
+    """
+    config = getattr(coordinator, "config", None)
+    if not isinstance(config, dict):
+        return []
+    specs = config.get("providers", [])
+    return specs if isinstance(specs, list) else []
+
+
+def _spec_for_instance(
+    provider_specs: list[dict[str, Any]], instance_id: str
+) -> dict[str, Any] | None:
+    """Find the mount plan config spec matching a runtime provider instance name."""
+    for spec in provider_specs:
+        if not isinstance(spec, dict):
+            continue
+        spec_id = spec.get("id") or spec.get("module", "")
+        if spec_id == instance_id:
+            return spec
+    return None
+
+
+def _module_type_of(spec: dict[str, Any] | None) -> str | None:
+    """Extract the bare module type (e.g. "anthropic") from a provider spec."""
+    if spec is None:
+        return None
+    module = spec.get("module", "")
+    if not module:
+        return None
+    return module.replace("provider-", "")
+
+
 def _find_provider_instance(
     providers: dict[str, Any],
     provider_name: str,
+    coordinator: Any = None,
 ) -> Any | None:
     """Find a provider instance by name with flexible matching.
 
     Args:
         providers: Dict of mounted providers by name.
         provider_name: Provider to find (e.g., "anthropic").
+        coordinator: Optional coordinator, used as a fallback source of
+            mount plan config (module/id/priority) when ``provider_name``
+            is a bare module type that doesn't match any dict key directly
+            (see fallback below).
 
     Returns:
         Provider instance or None if not found.
+
+    Matching strategy:
+        1. Exact key, "provider-" prefix stripped, or "provider-" prefix
+           added -- covers the single-instance case and any instance
+           explicitly keyed by the bare type.
+        2. Fallback: if ``provider_name`` is a bare module type (e.g.
+           "anthropic") and no provider is keyed by it directly, this
+           happens when 2+ instances of that module each have a distinct
+           explicit ``id:`` (needed for routing-matrix disambiguation) and
+           none of them is the bare type itself. Search the mount plan's
+           provider config list for every instance whose underlying
+           module type matches, and return the one configured with the
+           highest priority (lowest priority number) -- mirroring how the
+           default provider is selected elsewhere in this module (see
+           ``_apply_single_override``'s ``priority = 0`` promotion).
     """
     for name, provider in providers.items():
         if provider_name in (
@@ -313,7 +374,24 @@ def _find_provider_instance(
             f"provider-{provider_name}",
         ):
             return provider
-    return None
+
+    provider_specs = _get_provider_specs(coordinator)
+    if not provider_specs:
+        return None
+
+    candidates: list[tuple[int, str]] = []
+    for name in providers:
+        spec = _spec_for_instance(provider_specs, name)
+        if _module_type_of(spec) == provider_name:
+            assert spec is not None  # narrowed by _module_type_of returning non-None
+            priority = spec.get("config", {}).get("priority", 0)
+            candidates.append((priority, name))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda c: c[0])
+    return providers[candidates[0][1]]
 
 
 def _find_provider_index(

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -11,6 +11,7 @@ from amplifier_foundation.spawn_utils import ProviderPreference
 from amplifier_foundation.spawn_utils import _apply_single_override
 from amplifier_foundation.spawn_utils import _build_provider_lookup
 from amplifier_foundation.spawn_utils import _find_provider_index
+from amplifier_foundation.spawn_utils import _find_provider_instance
 from amplifier_foundation.spawn_utils import apply_provider_preferences
 from amplifier_foundation.spawn_utils import apply_provider_preferences_with_resolution
 from amplifier_foundation.spawn_utils import is_glob_pattern
@@ -357,6 +358,158 @@ class TestResolveModelPattern:
         assert result.resolved_model == "qwen3.6-35b-a3b-ud-q4_k_xl"
 
 
+class TestFindProviderInstanceMultiInstance:
+    """Regression tests for _find_provider_instance's bare-module-type fallback.
+
+    Live production bug: a user with 3 separately-configured Anthropic
+    instances (each with an explicit `id:` -- anthropic-sonnet,
+    anthropic-opus, anthropic-haiku -- none keyed bare "anthropic") hit
+    "provider has no models" for every matrix role candidate naming the
+    bare type "anthropic" (e.g. fast -> claude-haiku-*). The real Anthropic
+    API was independently confirmed to have real models available; the bug
+    is purely in provider lookup never falling back to "search all
+    instances of this module type" when no single provider is keyed by
+    the bare type.
+    """
+
+    @staticmethod
+    def _provider_specs() -> list[dict]:
+        return [
+            {
+                "module": "provider-anthropic",
+                "id": "anthropic-sonnet",
+                "config": {"priority": 1},
+            },
+            {
+                "module": "provider-anthropic",
+                "id": "anthropic-opus",
+                "config": {"priority": 2},
+            },
+            {
+                "module": "provider-anthropic",
+                "id": "anthropic-haiku",
+                "config": {"priority": 9},
+            },
+        ]
+
+    def test_bare_type_resolves_to_highest_priority_instance(self) -> None:
+        """No provider is keyed bare 'anthropic' -- must fall back to the
+        module-type search and pick the default (priority=1) instance,
+        not return None."""
+        sonnet = MagicMock(name="sonnet-instance")
+        opus = MagicMock(name="opus-instance")
+        haiku = MagicMock(name="haiku-instance")
+        providers = {
+            "anthropic-sonnet": sonnet,
+            "anthropic-opus": opus,
+            "anthropic-haiku": haiku,
+        }
+        coordinator = MagicMock()
+        coordinator.config = {"providers": self._provider_specs()}
+
+        result = _find_provider_instance(providers, "anthropic", coordinator)
+
+        assert result is sonnet, (
+            "Bare type 'anthropic' with no bare-keyed instance must resolve "
+            "to the highest-priority (lowest priority number) instance of "
+            f"that module type. Got: {result!r}"
+        )
+
+    def test_returns_none_without_coordinator(self) -> None:
+        """Without a coordinator, old exact-match-only behavior is preserved
+        (no crash, no fallback attempted)."""
+        providers = {"anthropic-sonnet": MagicMock()}
+        assert _find_provider_instance(providers, "anthropic") is None
+
+    def test_exact_match_still_wins_over_fallback(self) -> None:
+        """A provider keyed literally 'anthropic' is preferred immediately --
+        the fallback path is never even consulted."""
+        bare = MagicMock(name="bare-instance")
+        providers = {"anthropic": bare, "anthropic-haiku": MagicMock()}
+        coordinator = MagicMock()
+        coordinator.config = {
+            "providers": [
+                {
+                    "module": "provider-anthropic",
+                    "id": "anthropic-haiku",
+                    "config": {"priority": 1},
+                },
+                {
+                    "module": "provider-anthropic",
+                    "id": "anthropic",
+                    "config": {"priority": 5},
+                },
+            ]
+        }
+        assert _find_provider_instance(providers, "anthropic", coordinator) is bare
+
+    def test_no_matching_module_type_returns_none(self) -> None:
+        """Fallback search finds no instance of the requested module type ->
+        still returns None (no false positive)."""
+        providers = {"openai": MagicMock()}
+        coordinator = MagicMock()
+        coordinator.config = {
+            "providers": [
+                {"module": "provider-openai", "id": "openai", "config": {}},
+            ]
+        }
+        assert _find_provider_instance(providers, "anthropic", coordinator) is None
+
+
+class TestResolveModelPatternMultiInstanceProvider:
+    """End-to-end regression test (live prod bug, reproduced directly against
+    the real amplifier ecosystem): resolve_model_pattern() must resolve a
+    bare-type provider name + glob pattern against the default instance when
+    multiple named instances exist and none is keyed by the bare type.
+    """
+
+    @pytest.mark.asyncio
+    async def test_bare_type_glob_resolves_via_default_instance(self) -> None:
+        sonnet_provider = AsyncMock()
+        sonnet_provider.list_models = AsyncMock(
+            return_value=["claude-haiku-4-5-20251001", "claude-haiku-3-20240307"]
+        )
+        opus_provider = AsyncMock()
+        opus_provider.list_models = AsyncMock(return_value=["claude-opus-4-8"])
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.get.return_value = {
+            "anthropic-sonnet": sonnet_provider,
+            "anthropic-opus": opus_provider,
+        }
+        mock_coordinator.config = {
+            "providers": [
+                {
+                    "module": "provider-anthropic",
+                    "id": "anthropic-sonnet",
+                    "config": {"priority": 1},
+                },
+                {
+                    "module": "provider-anthropic",
+                    "id": "anthropic-opus",
+                    "config": {"priority": 2},
+                },
+            ]
+        }
+
+        result = await resolve_model_pattern(
+            "claude-haiku-*", "anthropic", mock_coordinator
+        )
+
+        assert result.resolved_model == "claude-haiku-4-5-20251001", (
+            "resolve_model_pattern() must resolve a bare-type provider name "
+            "against the default (highest-priority) instance when no single "
+            "instance is keyed by the bare type. Got: "
+            f"{result.resolved_model!r} (before the fix this returned None, "
+            "with 'provider has no models' logged -- even though the "
+            "provider genuinely has matching models)."
+        )
+        assert opus_provider.list_models.await_count == 0, (
+            "Only the resolved (highest-priority) instance's list_models() "
+            "should be queried, not every instance of the type."
+        )
+
+
 class TestApplyProviderPreferencesWithResolution:
     """Tests for apply_provider_preferences_with_resolution function."""
 
@@ -521,7 +674,9 @@ class TestApplyProviderPreferencesWithResolution:
         }
 
         mock_anthropic = AsyncMock()
-        mock_anthropic.list_models = AsyncMock(return_value=["claude-sonnet-4-20250514"])
+        mock_anthropic.list_models = AsyncMock(
+            return_value=["claude-sonnet-4-20250514"]
+        )
         mock_openai = AsyncMock()
         mock_openai.list_models = AsyncMock(return_value=["gpt-4o", "gpt-4o-mini"])
 
@@ -532,7 +687,9 @@ class TestApplyProviderPreferencesWithResolution:
         }
 
         prefs = [
-            ProviderPreference(provider="anthropic", model="claude-haiku-*"),  # no match
+            ProviderPreference(
+                provider="anthropic", model="claude-haiku-*"
+            ),  # no match
             ProviderPreference(provider="openai", model="claude-*"),  # no match either
         ]
 


### PR DESCRIPTION
## Summary

`_find_provider_instance()` only matched a dict key by exact name, prefix-stripped, or prefix-added. When a user has 2+ instances of the same provider module, each with an explicit `id:` (e.g. `anthropic-sonnet` priority 1, `anthropic-opus` priority 2, `anthropic-haiku` priority 9 — no instance keyed bare `"anthropic"`), a matrix candidate naming the bare type `"anthropic"` could never be found. This is called from `resolve_model_pattern()` during glob resolution (e.g. role `fast` -> `claude-haiku-*`), so it silently reported "provider has no models" for every glob role naming a bare type that only has named instances — even though the provider and matching models genuinely exist.

Reproduced live: the exact production scenario (3 named Anthropic instances, no bare-keyed one) hit this; independently confirmed Anthropic's real API returns 9 real models (including haiku and opus variants) when queried directly with the same key, ruling out an API/account limitation.

**Fix:** `_find_provider_instance()` now accepts an optional `coordinator` param. When no dict-key match is found, it falls back to reading `coordinator.config["providers"]`, cross-references each mounted instance's config spec (id/module) to recover its module type, collects all instances matching the requested bare type, and returns the one with the highest priority (lowest priority number) — mirroring the "default provider" convention used elsewhere in this codebase. Exact-match still wins immediately; the fallback only runs when nothing matched directly.

Confirmed via grep that `resolve_model_pattern()` is the only caller, already updated to pass the coordinator through.

**Flagging (not fixing here, separate repo/PR):** `find_provider_by_type()` in the sibling `amplifier-bundle-routing-matrix` repo has the identical matching gap — same structure, same limitation — confirmed by direct comparison.

## Test plan

- [x] `uv run pytest tests/test_spawn_utils.py -q` — **53 passed** (48 existing + 5 new)
- [x] Full suite — **1510 passed**
- [x] Red-green regression verified: reverting only the `spawn_utils.py` fix (keeping new tests) makes the new tests fail, reproducing the exact production log line: `No available models from provider 'anthropic' for pattern 'claude-haiku-*' - cannot resolve (provider has no models)`. Restoring the fix makes them pass.
- [x] Type check: 0 errors (confirmed via a fresh, cache-cleared `uv run pyright` run, after an initial run through a different tool wrapper showed stale-cache false positives that did not reproduce)

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
