### PR TITLE
fix(modules): run uv installs async to stop freezing the event loop

### DIFF
--- a/amplifier_foundation/modules/activator.py
+++ b/amplifier_foundation/modules/activator.py
@@ -15,12 +15,104 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
+from weakref import WeakKeyDictionary
 
 from amplifier_foundation.modules.install_state import InstallStateManager
 from amplifier_foundation.paths.resolution import get_amplifier_home
 from amplifier_foundation.sources.resolver import SimpleSourceResolver
 
 logger = logging.getLogger(__name__)
+
+# Wall-clock bound (seconds) for a single ``uv`` install invocation. This is only
+# meaningful because installs are now run via a non-blocking async subprocess:
+# a timeout can never fire while the event loop is frozen inside a synchronous
+# subprocess.run(). Generous enough for a from-source editable build; can be
+# lifted into config later if this module grows a config surface.
+DEFAULT_INSTALL_TIMEOUT = 300
+
+
+class ModuleInstallTimeout(RuntimeError):
+    """Raised when a module install exceeds DEFAULT_INSTALL_TIMEOUT seconds.
+
+    Fails loud instead of hanging: the previous synchronous ``subprocess.run()``
+    had no timeout, so a wedged ``uv`` install would freeze the entire event loop
+    (and any liveness heartbeat) until the worker was reaped.
+    """
+
+
+# Per-event-loop install lock registry.
+#
+# Making installs non-blocking means activate_all()'s ``asyncio.gather()`` can,
+# for the first time, run multiple editable ``uv pip install`` invocations
+# *truly* concurrently into the SAME interpreter environment. Concurrent editable
+# installs race on site-packages metadata (.pth files, RECORD, dist-info), so we
+# serialize the install critical section with an ``asyncio.Lock``.
+#
+# The lock is created lazily *inside the running loop* and keyed by that loop, so
+# it never binds to a loop at import time and never triggers cross-loop
+# "bound to a different event loop" errors when foundation spawns child sessions
+# that each drive their own event loop. Entries are weakly held: when a loop is
+# garbage-collected its lock disappears automatically.
+_install_locks: WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+    WeakKeyDictionary()
+)
+
+
+def _get_install_lock() -> asyncio.Lock:
+    """Return the install lock bound to the currently running event loop.
+
+    Must be called from within a running coroutine (installs always are).
+    """
+    loop = asyncio.get_running_loop()
+    lock = _install_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _install_locks[loop] = lock
+    return lock
+
+
+async def _run_install(
+    cmd: list[str], *, timeout: float = DEFAULT_INSTALL_TIMEOUT
+) -> None:
+    """Run a ``uv`` install command without blocking the event loop.
+
+    Preserves the error surface of the previous synchronous
+    ``subprocess.run(..., check=True, capture_output=True, text=True)`` call:
+
+    * a non-zero exit raises ``subprocess.CalledProcessError`` carrying the
+      captured stdout/stderr, and
+    * a missing ``uv`` binary still raises ``FileNotFoundError``.
+
+    Adds a wall-clock ``timeout``: on expiry the child is killed, reaped, and a
+    typed :class:`ModuleInstallTimeout` is raised so the caller fails loud
+    instead of hanging.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        try:
+            await proc.wait()  # reap the killed child so we don't leak a zombie
+        except ProcessLookupError:
+            pass
+        raise ModuleInstallTimeout(
+            f"Install exceeded {timeout}s and was killed: {' '.join(cmd)}"
+        ) from None
+
+    if proc.returncode != 0:
+        # Match the old check=True behavior: surface a CalledProcessError whose
+        # stdout/stderr are decoded text, exactly as capture_output+text gave.
+        raise subprocess.CalledProcessError(
+            proc.returncode or -1,
+            cmd,
+            output=stdout_b.decode(errors="replace") if stdout_b else "",
+            stderr=stderr_b.decode(errors="replace") if stderr_b else "",
+        )
 
 
 class ModuleActivator:
@@ -224,24 +316,25 @@ class ModuleActivator:
         requirements = module_path / "requirements.txt"
 
         if pyproject.exists():
+            cmd = [
+                "uv",
+                "pip",
+                "install",
+                "-e",
+                str(module_path),
+                "--python",
+                sys.executable,
+                "--quiet",
+            ]
             try:
-                subprocess.run(
-                    [
-                        "uv",
-                        "pip",
-                        "install",
-                        "-e",
-                        str(module_path),
-                        "--python",
-                        sys.executable,
-                        "--quiet",
-                    ],
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-                # Mark as installed after successful install
-                self._install_state.mark_installed(module_path)
+                # Serialize the install + state-mark critical section per event
+                # loop so newly-concurrent gather() installs cannot corrupt shared
+                # site-packages metadata. The subprocess itself is non-blocking, so
+                # the loop (and any heartbeat) keeps running while uv works.
+                async with _get_install_lock():
+                    await _run_install(cmd)
+                    # Mark as installed after successful install
+                    self._install_state.mark_installed(module_path)
             except subprocess.CalledProcessError as e:
                 logger.error(
                     f"Failed to install module from {module_path}.\nstdout: {e.stdout}\nstderr: {e.stderr}"
@@ -253,24 +346,25 @@ class ModuleActivator:
                 )
                 raise
         elif requirements.exists():
+            cmd = [
+                "uv",
+                "pip",
+                "install",
+                "-r",
+                str(requirements),
+                "--python",
+                sys.executable,
+                "--quiet",
+            ]
             try:
-                subprocess.run(
-                    [
-                        "uv",
-                        "pip",
-                        "install",
-                        "-r",
-                        str(requirements),
-                        "--python",
-                        sys.executable,
-                        "--quiet",
-                    ],
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
-                # Mark as installed after successful install
-                self._install_state.mark_installed(module_path)
+                # Serialize the install + state-mark critical section per event
+                # loop so newly-concurrent gather() installs cannot corrupt shared
+                # site-packages metadata. The subprocess itself is non-blocking, so
+                # the loop (and any heartbeat) keeps running while uv works.
+                async with _get_install_lock():
+                    await _run_install(cmd)
+                    # Mark as installed after successful install
+                    self._install_state.mark_installed(module_path)
             except subprocess.CalledProcessError as e:
                 logger.error(
                     f"Failed to install requirements from {requirements}.\nstdout: {e.stdout}\nstderr: {e.stderr}"

--- a/tests/test_activator_install.py
+++ b/tests/test_activator_install.py
@@ -1,0 +1,238 @@
+"""Tests for the non-blocking install path in ModuleActivator.
+
+These cover the async subprocess install helper introduced to fix a defect where
+``_install_dependencies`` ran ``subprocess.run(...)`` synchronously on the event
+loop thread with no timeout, freezing the entire loop (and any liveness
+heartbeat) for the duration of a ``uv`` install.
+
+Coverage:
+  (a) mocked async success -> install runs, state marked installed
+  (b) non-zero return      -> subprocess.CalledProcessError with stderr preserved
+  (c) wait_for timeout     -> child killed + reaped, ModuleInstallTimeout raised
+  (d) loop-not-blocked     -> a concurrent task makes progress while install runs
+  plus: installs serialize under the per-loop lock, and a missing ``uv`` binary
+  still surfaces FileNotFoundError (error surface preserved).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from amplifier_foundation.modules.activator import (
+    DEFAULT_INSTALL_TIMEOUT,
+    ModuleActivator,
+    ModuleInstallTimeout,
+    _run_install,
+)
+
+
+class _FakeProc:
+    """Minimal stand-in for an asyncio subprocess.Process."""
+
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        hang: bool = False,
+        communicate_delay: float = 0.0,
+    ) -> None:
+        self._returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._hang = hang
+        self._communicate_delay = communicate_delay
+        self.killed = False
+        self.waited = False
+
+    @property
+    def returncode(self) -> int:
+        return self._returncode
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        if self._hang:
+            await asyncio.sleep(3600)  # never completes within a test timeout
+        if self._communicate_delay:
+            await asyncio.sleep(self._communicate_delay)
+        return self._stdout, self._stderr
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        self.waited = True
+        return self._returncode
+
+
+def _patch_exec(proc: _FakeProc):
+    """Patch asyncio.create_subprocess_exec to return the given fake proc."""
+
+    async def _fake_exec(*args, **kwargs):
+        _fake_exec.calls.append((args, kwargs))
+        return proc
+
+    _fake_exec.calls = []  # type: ignore[attr-defined]
+    return patch("asyncio.create_subprocess_exec", new=_fake_exec)
+
+
+# --------------------------------------------------------------------------- #
+# (a) success path                                                            #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_run_install_success_returns_none() -> None:
+    proc = _FakeProc(returncode=0, stdout=b"done", stderr=b"")
+    with _patch_exec(proc) as fake_exec:
+        result = await _run_install(["uv", "pip", "install", "-e", "."])
+    assert result is None
+    assert fake_exec.calls  # the subprocess was actually spawned
+
+
+@pytest.mark.asyncio
+async def test_install_dependencies_marks_installed_on_success(tmp_path: Path) -> None:
+    """A successful editable install marks the module installed (post-install refresh)."""
+    module_path = tmp_path / "mod"
+    module_path.mkdir()
+    (module_path / "pyproject.toml").write_text(
+        '[project]\nname = "mod"\nversion = "0.0.0"\n'
+    )
+
+    activator = ModuleActivator(cache_dir=tmp_path / "cache", install_deps=True)
+    activator._install_state = MagicMock()
+    activator._install_state.is_installed.return_value = False
+
+    with patch("amplifier_foundation.modules.activator._run_install") as run_install:
+
+        async def _ok(cmd, *, timeout=DEFAULT_INSTALL_TIMEOUT):
+            return None
+
+        run_install.side_effect = _ok
+        await activator._install_dependencies(module_path)
+
+    run_install.assert_called_once()
+    called_cmd = run_install.call_args.args[0]
+    assert called_cmd[:4] == ["uv", "pip", "install", "-e"]
+    activator._install_state.mark_installed.assert_called_once_with(module_path)
+
+
+# --------------------------------------------------------------------------- #
+# (b) non-zero return -> CalledProcessError with stderr preserved             #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_run_install_nonzero_raises_called_process_error() -> None:
+    proc = _FakeProc(returncode=2, stdout=b"some out", stderr=b"boom: build failed")
+    with _patch_exec(proc):
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            await _run_install(["uv", "pip", "install", "-e", "."])
+    err = exc_info.value
+    assert err.returncode == 2
+    assert err.stderr == "boom: build failed"
+    assert err.output == "some out"
+
+
+# --------------------------------------------------------------------------- #
+# (c) timeout -> child killed + reaped, typed error raised                     #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_run_install_timeout_kills_child_and_raises() -> None:
+    proc = _FakeProc(hang=True)
+    with _patch_exec(proc):
+        with pytest.raises(ModuleInstallTimeout) as exc_info:
+            await _run_install(["uv", "pip", "install", "-e", "."], timeout=0.05)
+    assert proc.killed is True
+    assert proc.waited is True  # reaped, no zombie
+    assert "0.05" in str(exc_info.value)
+
+
+# --------------------------------------------------------------------------- #
+# (d) loop-not-blocked regression guard                                        #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_event_loop_not_blocked_during_install() -> None:
+    """A concurrent task must make progress while a slow install runs.
+
+    With the old synchronous subprocess.run() the loop would be frozen and the
+    counter could not advance until the install returned. The async install
+    yields control, so the counter climbs concurrently.
+    """
+    proc = _FakeProc(returncode=0, communicate_delay=0.2)
+
+    counter = 0
+    stop = False
+
+    async def ticker() -> None:
+        nonlocal counter
+        while not stop:
+            counter += 1
+            await asyncio.sleep(0.001)
+
+    with _patch_exec(proc):
+        tick_task = asyncio.create_task(ticker())
+        await _run_install(["uv", "pip", "install", "-e", "."])
+        stop = True
+        await tick_task
+
+    # If the loop had been blocked, counter would be ~0. It should have ticked
+    # many times during the 0.2s install.
+    assert counter > 5
+
+
+# --------------------------------------------------------------------------- #
+# locking: concurrent installs serialize (no overlap into shared env)          #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_concurrent_installs_are_serialized(tmp_path: Path) -> None:
+    """gather() over two installs must not overlap the critical section."""
+    active = 0
+    max_active = 0
+
+    def make_module(name: str) -> Path:
+        p = tmp_path / name
+        p.mkdir()
+        (p / "pyproject.toml").write_text(
+            f'[project]\nname = "{name}"\nversion = "0.0.0"\n'
+        )
+        return p
+
+    m1 = make_module("m1")
+    m2 = make_module("m2")
+
+    activator = ModuleActivator(cache_dir=tmp_path / "cache", install_deps=True)
+    activator._install_state = MagicMock()
+    activator._install_state.is_installed.return_value = False
+
+    async def fake_run(cmd, *, timeout=DEFAULT_INSTALL_TIMEOUT):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.05)  # hold the critical section
+        active -= 1
+
+    with patch(
+        "amplifier_foundation.modules.activator._run_install", side_effect=fake_run
+    ):
+        await asyncio.gather(
+            activator._install_dependencies(m1),
+            activator._install_dependencies(m2),
+        )
+
+    # Serialized by the per-loop lock: never more than one install in flight.
+    assert max_active == 1
+
+
+# --------------------------------------------------------------------------- #
+# error surface: missing uv still raises FileNotFoundError                     #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_missing_uv_raises_file_not_found() -> None:
+    async def _boom(*args, **kwargs):
+        raise FileNotFoundError("uv not found")
+
+    with patch("asyncio.create_subprocess_exec", new=_boom):
+        with pytest.raises(FileNotFoundError):
+            await _run_install(["uv", "pip", "install", "-e", "."])


### PR DESCRIPTION
## Summary

- **Durable root-cause fix** for a class of "synchronous subprocess freezes the resolver event loop" bugs. `ModuleActivator._install_dependencies` ran `subprocess.run(["uv","pip","install",...])` **synchronously on the asyncio event-loop thread, unbounded**, at both install sites (pyproject and requirements).
- A synchronous subprocess blocks the *entire* loop, so any slow install froze **all** coroutines on it — **including liveness heartbeats**. In the Amplifier Resolve understudy resolver this caused workers to be reaped mid-bring-up (**~25% of runs**) during heavy bundle/module installs. `asyncio.gather` in `activate_all` cannot parallelize a synchronous subprocess: the first coroutine to hit it stalls everything behind it.

## Root cause

Both install call sites used `subprocess.run(..., check=True, capture_output=True, text=True)` with **no timeout**. Running on the loop thread, a single wedged `uv` install:
1. blocks every other coroutine on the loop (heartbeats included), and
2. defeats `asyncio.gather` — installs that *look* concurrent are serialized behind the first blocking call, with no deadline to break a hang.

## The fix

**1. Non-blocking installs with a wall-clock bound.** Both `subprocess.run` sites are replaced by an async `_run_install` helper built on `asyncio.create_subprocess_exec` + `asyncio.wait_for(communicate(), timeout=DEFAULT_INSTALL_TIMEOUT=300s)`. On timeout the child is **killed and reaped** (no zombie) and a typed `ModuleInstallTimeout` is raised — fail loud, never hang. A timeout can now actually fire, because the loop is no longer frozen inside a synchronous `subprocess.run()`.

The prior error surface is **preserved**:
- non-zero exit → `subprocess.CalledProcessError` carrying decoded stdout/stderr (as `capture_output=True, text=True` gave), and
- missing `uv` binary → `FileNotFoundError`.

**2. Serialize installs with a per-event-loop lock (and why it avoids a *new* race).** Making installs non-blocking means `activate_all()`'s `asyncio.gather()` can, for the first time, run multiple editable `uv pip install` invocations **truly concurrently into the same interpreter environment**. Concurrent editable installs race on shared site-packages metadata (`.pth`, `RECORD`, `dist-info`). To close that newly-opened race, the install + state-mark critical section is serialized with an `asyncio.Lock` that is:
- created **lazily inside the running loop** (never binds a loop at import time), and
- held in a `WeakKeyDictionary` **keyed by the running loop** — so each child-session loop foundation spawns gets its own lock, avoiding "bound to a different event loop" errors, and entries disappear when a loop is GC'd.

## Test plan

- [x] New `tests/test_activator_install.py` (7 tests): success path, non-zero-exit error surface, timeout kill+reap, and a **loop-not-blocked regression guard** proving a concurrent task makes progress while a slow install runs.
  ```
  $ uv run pytest tests/test_activator_install.py -q
  7 passed in 0.42s
  ```
- [x] Full suite: **301 passed, 9 failed**.
  ```
  $ uv run pytest -q
  9 failed, 301 passed in 0.77s
  ```
  The 9 failures are **pre-existing and unrelated** to this change: macOS `/var` → `/private/var` symlink assertions in `test_paths.py`, `test_registry.py`, and `test_sources.py` (none touch the activator). They reproduce identically on the clean base.

## Scope / rollout note

This is the **durable root-cause fix** for the "sync subprocess freezes the resolver loop" bug class. It is defense-in-depth alongside two other mitigations already in place for the Amplifier Resolve go-live:
- a **stack-level pre-bake** that removes the install trigger at bring-up time (removes the *trigger*), and
- the **backend liveness watchdog** as the safety net.

This PR removes the *mechanism* so the failure mode cannot recur through this code path.

Generated with [Amplifier](https://github.com/microsoft/amplifier)
