### PR TITLE
feat(ci): add resolver-priority-tripwire pre-commit check

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,12 @@
+- id: resolver-priority-tripwire
+  name: resolver priority tripwire
+  description: >-
+    Detects first-match-wins provider/module resolution with no
+    priority tie-break (the anti-pattern fixed in amplifier-foundation
+    PR #267, amplifier-bundle-routing-matrix PR #31, and amplifier-app-cli
+    PR #214/#215). See docs/PATTERNS.md#priority-based-provider-resolution
+    for the accepted fix pattern.
+  entry: python3 scripts/ci_checks/resolver_priority_tripwire.py --diff-only
+  language: system
+  types: [python]
+  pass_filenames: false

--- a/.resolver-priority-tripwire-baseline.json
+++ b/.resolver-priority-tripwire-baseline.json
@@ -1,0 +1,8 @@
+{
+  "baseline": [
+    "amplifier_foundation/spawn_utils.py:_find_provider_index:416"
+  ],
+  "notes": {
+    "amplifier_foundation/spawn_utils.py:_find_provider_index:416": "Triaged during tripwire rollout (see diff summary / PR description). NOT confirmed as a false positive: _find_provider_index() has the identical tuple-of-variants first-match-wins structure as the 4 confirmed historical bugs (amplifier-foundation PR #267, amplifier-bundle-routing-matrix PR #31, amplifier-app-cli PR #214/#215), with no priority tie-break. It currently has no production call site (only exercised by tests), so the ambiguous-multi-instance scenario may not be reachable today, but this should be tracked as a follow-up fix, not dismissed. Baselined only to let this rollout land with zero unbaselined findings; do not treat this entry as evidence the finding is spurious."
+  }
+}

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -171,6 +171,43 @@ test_bundle = Bundle(
 )
 ```
 
+### Priority-Based Provider Resolution
+
+When resolving a caller-supplied provider/module name against a collection of
+mounted instances, do **not** return on the first structural match. If 2+
+instances of the same module can share an id/type match (e.g. a bare type
+name like `"anthropic"` matching multiple `provider-anthropic` instances that
+each have a distinct `id:`), first-match-wins silently serves whichever
+instance happens to be first in list order -- not the one the caller
+actually wanted. This exact anti-pattern was independently found and fixed
+four times in one week: `_find_provider_instance()`
+(amplifier-foundation PR #267), `find_provider_by_type()`
+(amplifier-bundle-routing-matrix PR #31), and
+`get_provider_config()`/`_get_provider_config()`/`_find_provider_entry()`
+(amplifier-app-cli PR #214/#215).
+
+The accepted fix: collect **all** structural matches, then resolve
+deterministically to the highest-priority (lowest `priority` number,
+defaulting to 100 when absent) instance instead of the first one found:
+
+```python
+matches = [p for p in providers if _matches(p, name)]
+if not matches:
+    return None
+
+
+def _priority(p):
+    return p.get("config", {}).get("priority", 100)
+
+
+return min(matches, key=_priority)
+```
+
+A CI tripwire (`scripts/ci_checks/resolver_priority_tripwire.py`) detects
+new instances of this pattern via AST analysis -- see its module docstring
+for the exact detection rules, and `.pre-commit-hooks.yaml` for the
+`resolver-priority-tripwire` hook id.
+
 ## Session Patterns
 
 ### Basic Session

--- a/scripts/ci_checks/_ast_scan.py
+++ b/scripts/ci_checks/_ast_scan.py
@@ -1,0 +1,64 @@
+"""Generic AST scanning helpers shared by resolver_priority_tripwire.py.
+
+Kept in a companion module so the main tripwire script stays under its
+<300-line budget; these are pure tree-walking utilities with no knowledge
+of the resolver-priority detection rules themselves.
+"""
+
+from __future__ import annotations
+
+import ast
+
+
+def walk_own(node: ast.AST):
+    """Descendants of node, never crossing into nested function/lambda scopes."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        yield child
+        yield from walk_own(child)
+
+
+def iter_functions(node: ast.AST, prefix: str = ""):
+    """Yield (qualname, def) for every function at any nesting depth."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.ClassDef):
+            yield from iter_functions(child, f"{prefix}{child.name}.")
+        elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            qualname = f"{prefix}{child.name}"
+            yield qualname, child
+            yield from iter_functions(child, f"{qualname}.")
+        else:
+            yield from iter_functions(child, prefix)
+
+
+def const_str(node: ast.AST | None) -> str | None:
+    return (
+        node.value
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        else None
+    )
+
+
+def flatten_or(test: ast.expr) -> list[ast.expr]:
+    if isinstance(test, ast.BoolOp) and isinstance(test.op, ast.Or):
+        return [c for v in test.values for c in flatten_or(v)]
+    return [test]
+
+
+def has_return_or_break(stmts: list[ast.stmt]) -> bool:
+    return any(
+        isinstance(n, (ast.Return, ast.Break)) for s in stmts for n in ast.walk(s)
+    )
+
+
+def has_tiebreak_call(func: ast.AST, tiebreak_calls: set[str]) -> bool:
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Call):
+            continue
+        f = node.func
+        if (isinstance(f, ast.Name) and f.id in tiebreak_calls) or (
+            isinstance(f, ast.Attribute) and f.attr in tiebreak_calls
+        ):
+            return True
+    return False

--- a/scripts/ci_checks/_yaml_lite.py
+++ b/scripts/ci_checks/_yaml_lite.py
@@ -1,0 +1,41 @@
+"""Minimal stdlib-only YAML subset loader for resolver_priority_tripwire's
+config file: flat scalar/list keys only, no nested mappings. Avoids a
+third-party PyYAML dependency for a handful of simple override keys.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def load_simple_yaml(text: str) -> dict:
+    data: dict = {}
+    current: str | None = None
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        if line[:1].isspace() and current and line.strip().startswith("-"):
+            data.setdefault(current, []).append(line.strip()[1:].strip().strip("\"'"))
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = (p.strip() for p in line.partition(":"))
+        if not value:
+            current, data[key] = key, data.get(key, [])
+        elif value.startswith("[") and value.endswith("]"):
+            data[key] = [
+                v.strip().strip("\"'") for v in value[1:-1].split(",") if v.strip()
+            ]
+            current = None
+        else:
+            data[key], current = value.strip("\"'"), None
+    return data
+
+
+def load_config(repo_root: Path, config_filename: str, defaults: dict) -> dict:
+    cfg = {k: list(v) if isinstance(v, list) else v for k, v in defaults.items()}
+    path = repo_root / config_filename
+    if path.exists():
+        cfg.update(load_simple_yaml(path.read_text(encoding="utf-8")))
+    return cfg

--- a/scripts/ci_checks/resolver_priority_tripwire.py
+++ b/scripts/ci_checks/resolver_priority_tripwire.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""CI tripwire: detects first-match-wins provider/module resolution with no
+priority tie-break -- a function that iterates a collection, matches a
+caller-supplied name against id/type fields, and returns on first match with
+no min()/sorted()/max() tie-break among multiple structurally possible
+matches. This is the anti-pattern fixed in amplifier-foundation PR #267,
+amplifier-bundle-routing-matrix PR #31, and amplifier-app-cli PR #214/#215.
+Fix pattern: docs/PATTERNS.md#priority-based-provider-resolution.
+
+Stdlib-only: ast, argparse, pathlib, json, sys, re, fnmatch, subprocess.
+Companion modules _yaml_lite.py and _ast_scan.py hold generic, rule-agnostic
+helpers so this file stays under its <300-line budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from _ast_scan import (
+    const_str,
+    flatten_or,
+    has_return_or_break,
+    has_tiebreak_call,
+    iter_functions,
+    walk_own,
+)
+from _yaml_lite import load_config as _load_config
+
+ID_FIELD_NAMES = ["id", "instance_id", "name"]
+TYPE_FIELD_NAMES = ["module", "type", "provider_type", "kind"]
+TIEBREAK_FIELD_NAMES = ["priority", "rank", "precedence"]
+DEFAULT_EXCLUDE_GLOBS = [".venv/**", "**/tests/**", "**/test_*.py"]
+TIEBREAK_CALLS = {"min", "max", "sorted", "sort"}
+STR_TRANSFORMS = {
+    "replace",
+    "removeprefix",
+    "removesuffix",
+    "strip",
+    "lstrip",
+    "rstrip",
+    "lower",
+    "upper",
+}
+DOC_REFERENCE = "docs/PATTERNS.md#priority-based-provider-resolution"
+CONFIG_FILENAME = ".resolver-priority-tripwire.yaml"
+
+
+@dataclass
+class Finding:
+    file: str
+    function: str
+    line: int
+    tier: str  # "ERROR" | "WARN"
+    reason: str
+
+    @property
+    def key(self) -> str:
+        return f"{self.file}:{self.function}:{self.line}"
+
+
+def load_config(repo_root: Path) -> dict:
+    defaults = {
+        "id_field_names": ID_FIELD_NAMES,
+        "type_field_names": TYPE_FIELD_NAMES,
+        "tiebreak_field_names": TIEBREAK_FIELD_NAMES,
+        "exclude_globs": DEFAULT_EXCLUDE_GLOBS,
+    }
+    return _load_config(repo_root, CONFIG_FILENAME, defaults)
+
+
+def _analyze_function(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    qualname: str,
+    relpath: str,
+    id_fields: set[str],
+    type_fields: set[str],
+    file_has_tiebreak_vocab: bool,
+) -> list[Finding]:
+    """Apply the resolver-priority-tripwire detection algorithm to one function."""
+    params = {a.arg for a in func.args.args if a.arg not in ("self", "cls")} | {
+        a.arg for a in func.args.kwonlyargs
+    }
+    if not params:
+        return []
+    own = list(walk_own(func))
+    if not any(isinstance(n, (ast.For, ast.AsyncFor)) for n in own):
+        return []
+
+    all_fields = id_fields | type_fields
+    field_alias: dict[str, str] = {}
+    param_alias: set[str] = set(params)
+
+    def resolve_field(expr: ast.AST | None) -> str | None:
+        if expr is None:
+            return None
+        if isinstance(expr, ast.IfExp):
+            return resolve_field(expr.body) or resolve_field(expr.orelse)
+        if isinstance(expr, ast.Name):
+            return field_alias.get(expr.id)
+        if isinstance(expr, ast.Attribute):
+            return expr.attr if expr.attr in all_fields else resolve_field(expr.value)
+        if isinstance(expr, ast.Subscript):
+            key = const_str(expr.slice)
+            return key if key in all_fields else None
+        if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Attribute):
+            if expr.func.attr == "get" and expr.args:
+                key = const_str(expr.args[0])
+                return key if key in all_fields else None
+            if expr.func.attr in STR_TRANSFORMS:
+                return resolve_field(expr.func.value)
+            return next((r for a in expr.args if (r := resolve_field(a))), None)
+        return None
+
+    def resolve_param(expr: ast.AST) -> bool:
+        if isinstance(expr, ast.Name):
+            return expr.id in param_alias
+        if isinstance(expr, ast.JoinedStr):
+            return any(
+                isinstance(v, ast.FormattedValue) and resolve_param(v.value)
+                for v in expr.values
+            )
+        if isinstance(expr, ast.Call):
+            return any(resolve_param(a) for a in expr.args)
+        return False
+
+    for node in own:  # Build field/param alias maps (single-hop, source order).
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            target = node.targets[0].id
+            if field := resolve_field(node.value):
+                field_alias[target] = field
+            elif isinstance(node.value, ast.Name) and resolve_param(node.value):
+                param_alias.add(target)
+
+    def tier_of(field: str) -> str | None:
+        return "id" if field in id_fields else "type" if field in type_fields else None
+
+    def classify(clause: ast.expr) -> tuple[str, str] | None:
+        if not isinstance(clause, ast.Compare) or len(clause.ops) != 1:
+            return None
+        op, left, right = clause.ops[0], clause.left, clause.comparators[0]
+        if (
+            isinstance(op, ast.In)
+            and isinstance(right, (ast.Tuple, ast.List))
+            and resolve_param(left)
+        ):
+            elts = right.elts
+            loopish = any(
+                isinstance(e, ast.Name)
+                or (
+                    isinstance(e, ast.Call)
+                    and isinstance(e.func, ast.Attribute)
+                    and e.func.attr in STR_TRANSFORMS
+                )
+                for e in elts
+            )
+            if loopish and any(resolve_param(e) for e in elts):
+                return (
+                    "tuple_idiom",
+                    "dict-key tuple-of-variants idiom (key, key.replace(...), f'provider-{x}')",
+                )
+        if isinstance(op, (ast.In, ast.Eq)):
+            for field_side, param_side in ((left, right), (right, left)):
+                if (
+                    (f := resolve_field(field_side))
+                    and resolve_param(param_side)
+                    and (t := tier_of(f))
+                ):
+                    return (t, f)
+        return None
+
+    findings: list[Finding] = []
+    for node in own:
+        if not isinstance(node, ast.If):
+            continue
+        cats = [c for c in (classify(c) for c in flatten_or(node.test)) if c]
+        if not cats or not has_return_or_break(node.body):
+            continue
+        kinds, evidence = {c[0] for c in cats}, ", ".join(sorted({c[1] for c in cats}))
+        if "tuple_idiom" in kinds or ("id" in kinds and "type" in kinds):
+            findings.append(Finding(relpath, qualname, node.lineno, "ERROR", evidence))
+        elif kinds == {"type"}:
+            tier = "ERROR" if file_has_tiebreak_vocab else "WARN"
+            findings.append(
+                Finding(
+                    relpath,
+                    qualname,
+                    node.lineno,
+                    tier,
+                    f"type-only match on '{evidence}', first-match-wins",
+                )
+            )
+
+    return [] if findings and has_tiebreak_call(func, TIEBREAK_CALLS) else findings
+
+
+def analyze_file(path: Path, repo_root: Path, cfg: dict) -> list[Finding]:
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+    except (SyntaxError, UnicodeDecodeError, OSError):
+        return []
+    relpath = path.resolve().relative_to(repo_root.resolve()).as_posix()
+    id_fields, type_fields = set(cfg["id_field_names"]), set(cfg["type_field_names"])
+    has_vocab = any(
+        re.search(rf"\b{re.escape(w)}\b", source, re.IGNORECASE)
+        for w in cfg["tiebreak_field_names"]
+    )
+    return [
+        finding
+        for qualname, func in iter_functions(tree)
+        for finding in _analyze_function(
+            func, qualname, relpath, id_fields, type_fields, has_vocab
+        )
+    ]
+
+
+def _all_py_files(repo_root: Path, exclude_globs: list[str]) -> list[Path]:
+    return [
+        p
+        for p in repo_root.rglob("*.py")
+        if not any(
+            fnmatch.fnmatch(p.relative_to(repo_root).as_posix(), pat)
+            for pat in exclude_globs
+        )
+    ]
+
+
+def _diff_files(repo_root: Path, base: str) -> list[Path]:
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--name-only", f"{base}...HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError) as exc:
+        print(f"warning: git diff against {base!r} failed: {exc}", file=sys.stderr)
+        return []
+    return [
+        repo_root / line
+        for line in proc.stdout.splitlines()
+        if line.endswith(".py") and (repo_root / line).exists()
+    ]
+
+
+def render_report(findings: list[Finding], baseline: set[str]) -> tuple[str, dict]:
+    errors = [f for f in findings if f.tier == "ERROR" and f.key not in baseline]
+    warnings = [f for f in findings if f.tier == "WARN" and f.key not in baseline]
+    baselined = [f for f in findings if f.key in baseline]
+
+    lines = [
+        f"resolver-priority-tripwire: {len(errors)} error(s), {len(warnings)} warning(s), {len(baselined)} baselined"
+    ]
+    for f in errors + warnings + baselined:
+        status = "BASELINED" if f.key in baseline else f.tier
+        lines.append(f"[{status}] {f.key}: {f.reason}")
+        if status != "BASELINED":
+            lines.append(f"    Fix pattern: see {DOC_REFERENCE}")
+
+    payload = {
+        "summary": {
+            "errors": len(errors),
+            "warnings": len(warnings),
+            "baselined": len(baselined),
+        },
+        "doc_reference": DOC_REFERENCE,
+        "findings": [
+            {**asdict(f), "key": f.key, "baselined": f.key in baseline}
+            for f in findings
+        ],
+    }
+    return "\n".join(lines), payload
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        prog="resolver_priority_tripwire",
+        description="Detects first-match-wins provider/module resolution with no priority tie-break.",
+    )
+    ap.add_argument("--repo-root", default=".", help="Repository root (default: cwd)")
+    ap.add_argument(
+        "--all", action="store_true", help="Scan the full repo (default mode)"
+    )
+    ap.add_argument(
+        "--diff-only", action="store_true", help="Scope to files changed vs --base"
+    )
+    ap.add_argument("--base", default="origin/main", help="Base ref for --diff-only")
+    ap.add_argument(
+        "--baseline", help="Baseline JSON path suppressing pre-accepted findings"
+    )
+    ap.add_argument(
+        "--json-out", help="Path for the machine-readable JSON report ('-' for stdout)"
+    )
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    cfg = load_config(repo_root)
+    files = (
+        _diff_files(repo_root, args.base)
+        if args.diff_only
+        else _all_py_files(repo_root, cfg["exclude_globs"])
+    )
+
+    baseline: set[str] = set()
+    if args.baseline and (bp := Path(args.baseline).expanduser()).exists():
+        baseline = set(json.loads(bp.read_text(encoding="utf-8")).get("baseline", []))
+
+    findings = [f for file in files for f in analyze_file(file, repo_root, cfg)]
+    text, payload = render_report(findings, baseline)
+    print(text)
+    if args.json_out == "-":
+        print(json.dumps(payload, indent=2))
+    elif args.json_out:
+        Path(args.json_out).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    return (
+        1 if any(f.tier == "ERROR" and f.key not in baseline for f in findings) else 0
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_checks/tests/fixtures/fixture1_spawn_utils_post.py
+++ b/scripts/ci_checks/tests/fixtures/fixture1_spawn_utils_post.py
@@ -1,0 +1,78 @@
+# Provenance: amplifier-foundation amplifier_foundation/spawn_utils.py
+# at commit dec9828 (PR #267 merged, fixed).
+# https://github.com/microsoft/amplifier-foundation/pull/267
+from typing import Any
+
+
+def _get_provider_specs(coordinator: Any) -> list[dict[str, Any]]:
+    """Best-effort fetch of the mount plan's provider config list."""
+    config = getattr(coordinator, "config", None)
+    if not isinstance(config, dict):
+        return []
+    specs = config.get("providers", [])
+    return specs if isinstance(specs, list) else []
+
+
+def _spec_for_instance(
+    provider_specs: list[dict[str, Any]], instance_id: str
+) -> dict[str, Any] | None:
+    """Find the mount plan config spec matching a runtime provider instance name."""
+    for spec in provider_specs:
+        if not isinstance(spec, dict):
+            continue
+        spec_id = spec.get("id") or spec.get("module", "")
+        if spec_id == instance_id:
+            return spec
+    return None
+
+
+def _module_type_of(spec: dict[str, Any] | None) -> str | None:
+    """Extract the bare module type (e.g. "anthropic") from a provider spec."""
+    if spec is None:
+        return None
+    module = spec.get("module", "")
+    if not module:
+        return None
+    return module.replace("provider-", "")
+
+
+def _find_provider_instance(
+    providers: dict[str, Any],
+    provider_name: str,
+    coordinator: Any = None,
+) -> Any | None:
+    """Find a provider instance by name with flexible matching.
+
+    Matching strategy:
+        1. Exact key, "provider-" prefix stripped, or "provider-" prefix
+           added -- covers the single-instance case and any instance
+           explicitly keyed by the bare type.
+        2. Fallback: search the mount plan's provider config list for every
+           instance whose underlying module type matches, and return the
+           one configured with the highest priority (lowest priority number).
+    """
+    for name, provider in providers.items():
+        if provider_name in (
+            name,
+            name.replace("provider-", ""),
+            f"provider-{provider_name}",
+        ):
+            return provider
+
+    provider_specs = _get_provider_specs(coordinator)
+    if not provider_specs:
+        return None
+
+    candidates: list[tuple[int, str]] = []
+    for name in providers:
+        spec = _spec_for_instance(provider_specs, name)
+        if _module_type_of(spec) == provider_name:
+            assert spec is not None  # narrowed by _module_type_of returning non-None
+            priority = spec.get("config", {}).get("priority", 0)
+            candidates.append((priority, name))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda c: c[0])
+    return providers[candidates[0][1]]

--- a/scripts/ci_checks/tests/fixtures/fixture1_spawn_utils_pre.py
+++ b/scripts/ci_checks/tests/fixtures/fixture1_spawn_utils_pre.py
@@ -1,0 +1,27 @@
+# Provenance: amplifier-foundation amplifier_foundation/spawn_utils.py
+# at commit dec9828^ (immediately before PR #267 merged).
+# https://github.com/microsoft/amplifier-foundation/pull/267
+from typing import Any
+
+
+def _find_provider_instance(
+    providers: dict[str, Any],
+    provider_name: str,
+) -> Any | None:
+    """Find a provider instance by name with flexible matching.
+
+    Args:
+        providers: Dict of mounted providers by name.
+        provider_name: Provider to find (e.g., "anthropic").
+
+    Returns:
+        Provider instance or None if not found.
+    """
+    for name, provider in providers.items():
+        if provider_name in (
+            name,
+            name.replace("provider-", ""),
+            f"provider-{provider_name}",
+        ):
+            return provider
+    return None

--- a/scripts/ci_checks/tests/fixtures/fixture2_resolver_post.py
+++ b/scripts/ci_checks/tests/fixtures/fixture2_resolver_post.py
@@ -1,0 +1,80 @@
+# Provenance: amplifier-bundle-routing-matrix
+# modules/hooks-routing/amplifier_module_hooks_routing/resolver.py
+# at commit a88c1ff (PR #31 merged, fixed).
+# https://github.com/microsoft/amplifier-bundle-routing-matrix/pull/31
+from typing import Any
+
+
+def _get_provider_specs(coordinator: Any) -> list[dict[str, Any]]:
+    """Best-effort fetch of the mount plan's provider config list."""
+    config = getattr(coordinator, "config", None)
+    if not isinstance(config, dict):
+        return []
+    specs = config.get("providers", [])
+    return specs if isinstance(specs, list) else []
+
+
+def _spec_for_instance(
+    provider_specs: list[dict[str, Any]], instance_id: str
+) -> dict[str, Any] | None:
+    """Find the mount plan config spec matching a runtime provider instance name."""
+    for spec in provider_specs:
+        if not isinstance(spec, dict):
+            continue
+        spec_id = spec.get("id") or spec.get("module", "")
+        if spec_id == instance_id:
+            return spec
+    return None
+
+
+def _module_type_of(spec: dict[str, Any] | None) -> str | None:
+    """Extract the bare module type (e.g. "anthropic") from a provider spec."""
+    if spec is None:
+        return None
+    module = spec.get("module", "")
+    if not module:
+        return None
+    return module.replace("provider-", "")
+
+
+def find_provider_by_type(
+    providers: dict[str, Any],
+    type_name: str,
+    coordinator: Any = None,
+) -> tuple[str, Any] | None:
+    """Find an installed provider by module type name or instance ID.
+
+    Matching strategy:
+        1. Exact key, "provider-" prefix stripped, or "provider-" prefix
+           added -- covers the single-instance case and any instance
+           explicitly keyed by the bare type.
+        2. Fallback: search the mount plan's provider config list for every
+           instance whose underlying module type matches, and return the
+           one configured with the highest priority (lowest priority number).
+    """
+    for name, provider in providers.items():
+        if type_name in (
+            name,
+            name.replace("provider-", ""),
+            f"provider-{type_name}",
+        ):
+            return (name, provider)
+
+    provider_specs = _get_provider_specs(coordinator)
+    if not provider_specs:
+        return None
+
+    candidates: list[tuple[int, str]] = []
+    for name in providers:
+        spec = _spec_for_instance(provider_specs, name)
+        if _module_type_of(spec) == type_name:
+            assert spec is not None  # narrowed by _module_type_of returning non-None
+            priority = spec.get("config", {}).get("priority", 0)
+            candidates.append((priority, name))
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda c: c[0])
+    best_name = candidates[0][1]
+    return (best_name, providers[best_name])

--- a/scripts/ci_checks/tests/fixtures/fixture2_resolver_pre.py
+++ b/scripts/ci_checks/tests/fixtures/fixture2_resolver_pre.py
@@ -1,0 +1,29 @@
+# Provenance: amplifier-bundle-routing-matrix
+# modules/hooks-routing/amplifier_module_hooks_routing/resolver.py
+# at commit a88c1ff^ (immediately before PR #31 merged).
+# https://github.com/microsoft/amplifier-bundle-routing-matrix/pull/31
+from typing import Any
+
+
+def find_provider_by_type(
+    providers: dict[str, Any],
+    type_name: str,
+) -> tuple[str, Any] | None:
+    """Find an installed provider by module type name or instance ID.
+
+    Args:
+        providers: Dict of mounted providers keyed by module id or instance id.
+        type_name: Provider identifier from a matrix candidate's ``provider:``
+            field (short type name or multi-instance id).
+
+    Returns:
+        ``(module_id, provider_instance)`` or ``None``.
+    """
+    for name, provider in providers.items():
+        if type_name in (
+            name,
+            name.replace("provider-", ""),
+            f"provider-{type_name}",
+        ):
+            return (name, provider)
+    return None

--- a/scripts/ci_checks/tests/fixtures/fixture3a_provider_manager_post.py
+++ b/scripts/ci_checks/tests/fixtures/fixture3a_provider_manager_post.py
@@ -1,0 +1,53 @@
+# Provenance: amplifier-app-cli amplifier_app_cli/provider_manager.py
+# ProviderManager.get_provider_config(), at commit 3f3f425 (PR #214 merged, fixed).
+# https://github.com/microsoft/amplifier-app-cli/pull/214
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class ProviderManager:
+    def __init__(self, settings: Any) -> None:
+        self._settings = settings
+
+    def get_provider_config(
+        self, provider_id: str, scope: str | None = None
+    ) -> dict[str, Any] | None:
+        """Get configuration for a specific provider by module ID."""
+        if scope is not None:
+            providers = self._settings.get_scope_provider_overrides(scope)
+        else:
+            providers = self._settings.get_provider_overrides()
+
+        logger.debug(f"get_provider_config: found {len(providers)} providers")
+        matches: list[dict[str, Any]] = []
+        for provider in providers:
+            module = provider.get("module")
+            logger.debug(
+                f"get_provider_config: checking module '{module}' against '{provider_id}'"
+            )
+            if module == provider_id:
+                matches.append(provider)
+
+        if not matches:
+            logger.debug(
+                f"get_provider_config: no matching provider found for '{provider_id}'"
+            )
+            return None
+
+        # Multiple instances of the same module can be configured (distinct
+        # ids, different priorities). Matching on 'module' alone is
+        # ambiguous, so resolve deterministically to the highest-priority
+        # (lowest priority number) instance rather than the first in list
+        # order.
+        def _priority(p: dict[str, Any]) -> int:
+            config = p.get("config", {})
+            return config.get("priority", 100) if isinstance(config, dict) else 100
+
+        best = min(matches, key=_priority)
+        config = best.get("config", {})
+        logger.debug(
+            f"get_provider_config: found matching config with keys: {list(config.keys())}"
+        )
+        return config

--- a/scripts/ci_checks/tests/fixtures/fixture3a_provider_manager_pre.py
+++ b/scripts/ci_checks/tests/fixtures/fixture3a_provider_manager_pre.py
@@ -1,0 +1,38 @@
+# Provenance: amplifier-app-cli amplifier_app_cli/provider_manager.py
+# ProviderManager.get_provider_config(), at commit 3f3f425^ (before PR #214).
+# https://github.com/microsoft/amplifier-app-cli/pull/214
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class ProviderManager:
+    def __init__(self, settings: Any) -> None:
+        self._settings = settings
+
+    def get_provider_config(
+        self, provider_id: str, scope: str | None = None
+    ) -> dict[str, Any] | None:
+        """Get configuration for a specific provider by module ID."""
+        if scope is not None:
+            providers = self._settings.get_scope_provider_overrides(scope)
+        else:
+            providers = self._settings.get_provider_overrides()
+
+        logger.debug(f"get_provider_config: found {len(providers)} providers")
+        for provider in providers:
+            module = provider.get("module")
+            logger.debug(
+                f"get_provider_config: checking module '{module}' against '{provider_id}'"
+            )
+            if module == provider_id:
+                config = provider.get("config", {})
+                logger.debug(
+                    f"get_provider_config: found matching config with keys: {list(config.keys())}"
+                )
+                return config
+        logger.debug(
+            f"get_provider_config: no matching provider found for '{provider_id}'"
+        )
+        return None

--- a/scripts/ci_checks/tests/fixtures/fixture3b_routing_post.py
+++ b/scripts/ci_checks/tests/fixtures/fixture3b_routing_post.py
@@ -1,0 +1,38 @@
+# Provenance: amplifier-app-cli amplifier_app_cli/commands/routing.py
+# _get_provider_config(), at commit 3f3f425 (PR #214 merged, fixed).
+# https://github.com/microsoft/amplifier-app-cli/pull/214
+from typing import Any
+
+
+def _get_provider_config(provider_name: str, settings: Any) -> dict[str, Any] | None:
+    """Look up the stored config dict for a provider by type name, module name,
+    or instance id.
+    """
+    matches: list[dict[str, Any]] = []
+    for p in settings.get_provider_overrides():
+        p_module = p.get("module", "")
+        p_type = (
+            p_module.removeprefix("provider-")
+            if p_module.startswith("provider-")
+            else p_module
+        )
+        if (
+            p.get("id") == provider_name
+            or p_type == provider_name
+            or p_module == provider_name
+        ):
+            matches.append(p)
+
+    if not matches:
+        return None
+
+    # Multiple instances of the same module can share a bare type/module
+    # name match (matching by 'id' is already unambiguous). Resolve
+    # deterministically to the highest-priority (lowest config.priority
+    # number) instance instead of whichever is first in list order.
+    def _priority(p: dict[str, Any]) -> int:
+        config = p.get("config", {})
+        return config.get("priority", 100) if isinstance(config, dict) else 100
+
+    best = min(matches, key=_priority)
+    return best.get("config", {})

--- a/scripts/ci_checks/tests/fixtures/fixture3b_routing_pre.py
+++ b/scripts/ci_checks/tests/fixtures/fixture3b_routing_pre.py
@@ -1,0 +1,24 @@
+# Provenance: amplifier-app-cli amplifier_app_cli/commands/routing.py
+# _get_provider_config(), at commit 3f3f425^ (before PR #214).
+# https://github.com/microsoft/amplifier-app-cli/pull/214
+from typing import Any
+
+
+def _get_provider_config(provider_name: str, settings: Any) -> dict[str, Any] | None:
+    """Look up the stored config dict for a provider by type name, module name,
+    or instance id.
+    """
+    for p in settings.get_provider_overrides():
+        p_module = p.get("module", "")
+        p_type = (
+            p_module.removeprefix("provider-")
+            if p_module.startswith("provider-")
+            else p_module
+        )
+        if (
+            p.get("id") == provider_name
+            or p_type == provider_name
+            or p_module == provider_name
+        ):
+            return p.get("config", {})
+    return None

--- a/scripts/ci_checks/tests/fixtures/fixture4_provider_cmd_post.py
+++ b/scripts/ci_checks/tests/fixtures/fixture4_provider_cmd_post.py
@@ -1,0 +1,47 @@
+# Provenance: amplifier-app-cli amplifier_app_cli/commands/provider.py
+# _find_provider_entry(), at commit 6986ad8 (PR #215 merged, fixed).
+# https://github.com/microsoft/amplifier-app-cli/pull/215
+from typing import Any
+
+
+def _display_name(module: str) -> str:
+    return module.removeprefix("provider-")
+
+
+def _find_provider_entry(
+    providers: list[dict[str, Any]], name: str
+) -> dict[str, Any] | None:
+    """Find a provider entry by name/id.
+
+    Matches against:
+    - 'id' field (for multi-instance providers) -- unambiguous by definition,
+      so an id match is returned immediately.
+    - 'module' field stripped of 'provider-' prefix, or the full 'module'
+      field -- this can match 2+ instances of the same module. In that
+      ambiguous case, resolve deterministically to the highest-priority
+      (lowest `config.priority` value, defaulting to 100 when absent)
+      instance instead of whichever happens to be first in list order.
+    """
+    for p in providers:
+        if p.get("id") == name:
+            return p
+
+    matches: list[dict[str, Any]] = [
+        p
+        for p in providers
+        if (module := p.get("module", ""))
+        and (
+            module == name
+            or module == f"provider-{name}"
+            or _display_name(module) == name
+        )
+    ]
+
+    if not matches:
+        return None
+
+    def _priority(p: dict[str, Any]) -> int:
+        config = p.get("config", {})
+        return config.get("priority", 100) if isinstance(config, dict) else 100
+
+    return min(matches, key=_priority)

--- a/scripts/ci_checks/tests/fixtures/fixture4_provider_cmd_pre.py
+++ b/scripts/ci_checks/tests/fixtures/fixture4_provider_cmd_pre.py
@@ -1,0 +1,33 @@
+# Provenance: amplifier-app-cli amplifier_app_cli/commands/provider.py
+# _find_provider_entry(), at commit 6986ad8^ (before PR #215).
+# https://github.com/microsoft/amplifier-app-cli/pull/215
+from typing import Any
+
+
+def _display_name(module: str) -> str:
+    return module.removeprefix("provider-")
+
+
+def _find_provider_entry(
+    providers: list[dict[str, Any]], name: str
+) -> dict[str, Any] | None:
+    """Find a provider entry by name/id.
+
+    Matches against:
+    - 'id' field (for multi-instance providers)
+    - 'module' field stripped of 'provider-' prefix
+    - full 'module' field
+    """
+    for p in providers:
+        # Match by id field
+        if p.get("id") == name:
+            return p
+        # Match by module name (with or without prefix)
+        module = p.get("module", "")
+        if (
+            module == name
+            or module == f"provider-{name}"
+            or _display_name(module) == name
+        ):
+            return p
+    return None

--- a/scripts/ci_checks/tests/test_resolver_priority_tripwire.py
+++ b/scripts/ci_checks/tests/test_resolver_priority_tripwire.py
@@ -1,0 +1,348 @@
+"""Tests for resolver_priority_tripwire.py.
+
+The 4 "must fire pre-fix / must be silent post-fix" regression cases are the
+acceptance tests for this tool -- they use the literal, historically-real
+code blobs from the fixes each anti-pattern occurrence, copied into
+fixtures/ with provenance headers. See fixtures/*.py for source commits.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import resolver_priority_tripwire as tripwire  # noqa: E402
+import _yaml_lite  # noqa: E402
+
+FIXTURES = SCRIPT_DIR / "tests" / "fixtures"
+DEFAULT_CFG = {
+    "id_field_names": tripwire.ID_FIELD_NAMES,
+    "type_field_names": tripwire.TYPE_FIELD_NAMES,
+    "tiebreak_field_names": tripwire.TIEBREAK_FIELD_NAMES,
+    "exclude_globs": tripwire.DEFAULT_EXCLUDE_GLOBS,
+}
+
+
+def _findings(fixture_name: str) -> list[tripwire.Finding]:
+    return tripwire.analyze_file(FIXTURES / fixture_name, FIXTURES, DEFAULT_CFG)
+
+
+# --------------------------------------------------------------------------
+# The 4 mandatory historical regression fixtures.
+# --------------------------------------------------------------------------
+HISTORICAL_PAIRS = [
+    # (label, pre-fix fixture, post-fix fixture)
+    ("foundation-267", "fixture1_spawn_utils_pre.py", "fixture1_spawn_utils_post.py"),
+    ("routing-matrix-31", "fixture2_resolver_pre.py", "fixture2_resolver_post.py"),
+    (
+        "app-cli-214-provider-manager",
+        "fixture3a_provider_manager_pre.py",
+        "fixture3a_provider_manager_post.py",
+    ),
+    ("app-cli-214-routing", "fixture3b_routing_pre.py", "fixture3b_routing_post.py"),
+    (
+        "app-cli-215-provider-cmd",
+        "fixture4_provider_cmd_pre.py",
+        "fixture4_provider_cmd_post.py",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label,pre,post", HISTORICAL_PAIRS, ids=[p[0] for p in HISTORICAL_PAIRS]
+)
+def test_fires_on_prefix_silent_on_postfix(label, pre, post):
+    pre_findings = _findings(pre)
+    assert pre_findings, f"{label}: expected a finding on pre-fix blob {pre}, got none"
+
+    post_findings = _findings(post)
+    assert not post_findings, (
+        f"{label}: expected NO finding on post-fix blob {post} (tie-break present), got {post_findings}"
+    )
+
+
+def test_foundation_267_is_tier1_error_tuple_idiom():
+    findings = _findings("fixture1_spawn_utils_pre.py")
+    assert any(f.tier == "ERROR" for f in findings)
+
+
+def test_routing_matrix_31_is_tier1_error_id_and_type_chain():
+    findings = _findings("fixture2_resolver_pre.py")
+    assert any(f.tier == "ERROR" for f in findings)
+
+
+def test_app_cli_214_provider_manager_is_type_only_tier2():
+    """Single comparison on 'module' only (no id field in the same chain) ->
+    Tier 2, WARN unless escalated by tiebreak vocab elsewhere in the file."""
+    findings = _findings("fixture3a_provider_manager_pre.py")
+    assert findings
+    assert all(f.tier in ("WARN", "ERROR") for f in findings)
+
+
+def test_app_cli_214_routing_is_tier1_error_id_and_type_chain():
+    """id/type checks combined in one OR-chain -> Tier 1 ERROR."""
+    findings = _findings("fixture3b_routing_pre.py")
+    assert any(f.tier == "ERROR" for f in findings)
+
+
+# --------------------------------------------------------------------------
+# Unit-level detection behavior
+# --------------------------------------------------------------------------
+def test_id_only_comparison_does_not_fire():
+    src = """
+def find_by_id(items, item_id):
+    for item in items:
+        if item.get("id") == item_id:
+            return item
+    return None
+"""
+    tmp = FIXTURES / "_tmp_id_only.py"
+    tmp.write_text(src, encoding="utf-8")
+    try:
+        findings = tripwire.analyze_file(tmp, FIXTURES, DEFAULT_CFG)
+        assert findings == []
+    finally:
+        tmp.unlink()
+
+
+def test_min_tiebreak_suppresses_type_only_match():
+    src = """
+def find_by_type(items, type_name):
+    matches = []
+    for item in items:
+        if item.get("module") == type_name:
+            matches.append(item)
+    if not matches:
+        return None
+    return min(matches, key=lambda i: i.get("config", {}).get("priority", 100))
+"""
+    tmp = FIXTURES / "_tmp_min_suppressed.py"
+    tmp.write_text(src, encoding="utf-8")
+    try:
+        findings = tripwire.analyze_file(tmp, FIXTURES, DEFAULT_CFG)
+        assert findings == []
+    finally:
+        tmp.unlink()
+
+
+def test_type_only_escalates_to_error_when_tiebreak_vocab_present_elsewhere():
+    src = """
+def unrelated_priority_helper(x):
+    return x.get("priority", 100)
+
+
+def find_by_type(items, type_name):
+    for item in items:
+        if item.get("module") == type_name:
+            return item
+    return None
+"""
+    tmp = FIXTURES / "_tmp_escalate.py"
+    tmp.write_text(src, encoding="utf-8")
+    try:
+        findings = tripwire.analyze_file(tmp, FIXTURES, DEFAULT_CFG)
+        assert findings
+        assert all(f.tier == "ERROR" for f in findings if f.function == "find_by_type")
+    finally:
+        tmp.unlink()
+
+
+def test_type_only_stays_warn_without_tiebreak_vocab():
+    src = """
+def find_by_type(items, type_name):
+    for item in items:
+        if item.get("module") == type_name:
+            return item
+    return None
+"""
+    tmp = FIXTURES / "_tmp_warn.py"
+    tmp.write_text(src, encoding="utf-8")
+    try:
+        findings = tripwire.analyze_file(tmp, FIXTURES, DEFAULT_CFG)
+        assert findings
+        assert all(f.tier == "WARN" for f in findings)
+    finally:
+        tmp.unlink()
+
+
+def test_no_parameter_function_not_flagged():
+    src = """
+def process(items):
+    for item in items:
+        if item.get("module") == "anthropic":
+            return item
+    return None
+"""
+    tmp = FIXTURES / "_tmp_no_param.py"
+    tmp.write_text(src, encoding="utf-8")
+    try:
+        findings = tripwire.analyze_file(tmp, FIXTURES, DEFAULT_CFG)
+        assert findings == []
+    finally:
+        tmp.unlink()
+
+
+def test_no_for_loop_not_flagged():
+    src = """
+def check(item, name):
+    if item.get("module") == name:
+        return item
+    return None
+"""
+    tmp = FIXTURES / "_tmp_no_loop.py"
+    tmp.write_text(src, encoding="utf-8")
+    try:
+        findings = tripwire.analyze_file(tmp, FIXTURES, DEFAULT_CFG)
+        assert findings == []
+    finally:
+        tmp.unlink()
+
+
+# --------------------------------------------------------------------------
+# Config loading
+# --------------------------------------------------------------------------
+def test_load_simple_yaml_parses_lists_and_scalars():
+    text = """
+exclude_globs:
+  - ".venv/**"
+  - "**/tests/**"
+tiebreak_field_names: [priority, rank, precedence]
+"""
+    data = _yaml_lite.load_simple_yaml(text)
+    assert data["exclude_globs"] == [".venv/**", "**/tests/**"]
+    assert data["tiebreak_field_names"] == ["priority", "rank", "precedence"]
+
+
+def test_load_config_uses_defaults_when_no_override_file(tmp_path):
+    cfg = tripwire.load_config(tmp_path)
+    assert cfg["id_field_names"] == tripwire.ID_FIELD_NAMES
+    assert cfg["exclude_globs"] == tripwire.DEFAULT_EXCLUDE_GLOBS
+
+
+def test_load_config_applies_override(tmp_path):
+    (tmp_path / ".resolver-priority-tripwire.yaml").write_text(
+        'exclude_globs:\n  - "vendor/**"\n', encoding="utf-8"
+    )
+    cfg = tripwire.load_config(tmp_path)
+    assert cfg["exclude_globs"] == ["vendor/**"]
+
+
+# --------------------------------------------------------------------------
+# CLI end-to-end behavior (subprocess, so exit codes are exercised for real)
+# --------------------------------------------------------------------------
+SCRIPT_PATH = SCRIPT_DIR / "resolver_priority_tripwire.py"
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_all_mode_exits_1_on_unbaselined_error(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "bad.py").write_text(
+        (FIXTURES / "fixture1_spawn_utils_pre.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    result = _run_cli("--repo-root", str(repo), "--all")
+    assert result.returncode == 1
+    assert "ERROR" in result.stdout
+
+
+def test_cli_all_mode_exits_0_when_only_warnings(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "warn_only.py").write_text(
+        (FIXTURES / "fixture3a_provider_manager_pre.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    result = _run_cli("--repo-root", str(repo), "--all")
+    # This fixture is type-only (no id field in the same chain) and has no
+    # tiebreak vocabulary elsewhere in the standalone file -> WARN, non-blocking.
+    assert result.returncode == 0
+
+
+def test_cli_baseline_suppresses_error_exit(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "bad.py").write_text(
+        (FIXTURES / "fixture1_spawn_utils_pre.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    findings = tripwire.analyze_file(repo / "bad.py", repo, DEFAULT_CFG)
+    assert findings
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps({"baseline": [f.key for f in findings]}), encoding="utf-8"
+    )
+
+    result = _run_cli(
+        "--repo-root", str(repo), "--all", "--baseline", str(baseline_path)
+    )
+    assert result.returncode == 0
+    assert "BASELINED" in result.stdout
+
+
+def test_cli_diff_only_scopes_to_changed_files(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+
+    (repo / "clean.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, check=True)
+    subprocess.run(["git", "branch", "-m", "main"], cwd=repo, check=True)
+
+    (repo / "bad.py").write_text(
+        (FIXTURES / "fixture1_spawn_utils_pre.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add bad.py"], cwd=repo, check=True)
+
+    result = _run_cli("--repo-root", str(repo), "--diff-only", "--base", "main~1")
+    assert result.returncode == 1
+    assert "bad.py" in result.stdout
+
+
+def test_cli_json_out_writes_machine_readable_report(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "bad.py").write_text(
+        (FIXTURES / "fixture1_spawn_utils_pre.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    json_path = tmp_path / "report.json"
+    _run_cli("--repo-root", str(repo), "--all", "--json-out", str(json_path))
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["summary"]["errors"] >= 1
+    assert payload["findings"]
+    assert payload["doc_reference"] == tripwire.DOC_REFERENCE
+
+
+def test_exclude_globs_skip_tests_directory(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "tests").mkdir(parents=True)
+    (repo / "tests" / "test_something.py").write_text(
+        (FIXTURES / "fixture1_spawn_utils_pre.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    result = _run_cli("--repo-root", str(repo), "--all")
+    assert result.returncode == 0
+    assert "0 error(s)" in result.stdout


### PR DESCRIPTION
## Summary
- After the same anti-pattern (bare-type resolution against multi-instance providers, first-match-wins instead of priority-aware) was found and fixed independently 6 times across this session (amplifier-foundation, amplifier-bundle-routing-matrix, amplifier-app-cli x3, and now this self-scan's own finding), added an AST-based stdlib-only detection script as a pre-commit hook other repos can reference (`resolver-priority-tripwire`), rather than relying on manual sweeps.
- Detection validated against the actual pre-fix/post-fix code of all 4 originally-known historical fixes as literal regression-test fixtures (fires pre-fix, silent post-fix, verified against real git history).
- Self-scan of this repo (amplifier-foundation itself) found ONE additional occurrence: `_find_provider_index()` in `spawn_utils.py` — same structural anti-pattern, no confirmed live production caller found (only exercised in tests), honestly baselined (not dismissed) with a note recommending a follow-up fix. **Not fixed in this PR** — that's separate, tracked work.
- Policy: WARN-tier findings are non-blocking; ERROR-tier findings (high-confidence matches) block CI.

## Test plan
- [x] 24 passed, including 5 parametrized fixture tests proving fire-on-pre-fix/silent-on-post-fix against real historical commits (not synthetic examples)
- [x] CLI flags (`--all`, `--diff-only`, `--baseline`, `--json-out`) exercised end-to-end via subprocess tests
- [x] Self-scan against amplifier-foundation's own codebase in `--all` mode: 0 unbaselined findings (1 baselined, noted above)
- [x] `python_check` clean

Generated with [Amplifier](https://github.com/microsoft/amplifier)
