### PR TITLE
fix(activator): detect installs by distribution name, not guessed import (#326)

### DIFF
--- a/amplifier_foundation/modules/activator.py
+++ b/amplifier_foundation/modules/activator.py
@@ -16,7 +16,6 @@ import logging
 import site
 import subprocess
 import sys
-from importlib.util import find_spec
 from pathlib import Path
 from typing import Callable
 
@@ -25,6 +24,28 @@ from amplifier_foundation.paths.resolution import get_amplifier_home
 from amplifier_foundation.sources.resolver import SimpleSourceResolver
 
 logger = logging.getLogger(__name__)
+
+
+def _distribution_installed(pkg_name: str) -> bool:
+    """Return True if a distribution named ``pkg_name`` is installed.
+
+    Keys on the distribution name via ``importlib.metadata`` rather than guessing
+    an import name from ``pkg_name.replace("-", "_")``. Both editable and wheel
+    installs register a queryable ``.dist-info``, and ``uv sync`` removing an
+    editable install also removes that metadata. This correctly answers "is it
+    installed?" for bundles whose import package differs from their distribution
+    name (e.g. ``amplifier-bundle-evaluation`` -> ``amplifier_evaluation``) or
+    that ship no import package at all (``packages=[]``), both of which the old
+    import-name guess mis-detected as "not installed" and rebuilt on every
+    process. See issue #326.
+    """
+    from importlib.metadata import PackageNotFoundError, distribution
+
+    try:
+        distribution(pkg_name)
+        return True
+    except PackageNotFoundError:
+        return False
 
 
 class ModuleActivator:
@@ -212,22 +233,21 @@ class ModuleActivator:
             )
             return
 
-        # Skip packages that are already importable in the current environment.
+        # Skip packages that are already installed in the current environment.
         # This prevents editable-installing packages (like amplifier-core) that were
         # already installed from PyPI as prebuilt wheels. Without this check, a repo
         # cloned into the cache for its YAML/context files (via bundle includes) would
         # trigger a source build that may require native toolchains (Rust, protobuf, etc).
+        #
+        # Detection keys on the distribution name (importlib.metadata), NOT a guessed
+        # import name. See _distribution_installed() and issue #326.
         pkg_name = pyproject_data.get("project", {}).get("name", "")
-        if pkg_name:
-            import importlib.util
-
-            normalized = pkg_name.replace("-", "_")
-            if importlib.util.find_spec(normalized) is not None:
-                logger.debug(
-                    f"Package '{pkg_name}' already installed, "
-                    f"skipping editable install from {bundle_path}"
-                )
-                return
+        if pkg_name and _distribution_installed(pkg_name):
+            logger.debug(
+                f"Package '{pkg_name}' already installed, "
+                f"skipping editable install from {bundle_path}"
+            )
+            return
 
         if progress_callback:
             progress_callback("installing_package", pkg_name or bundle_path.name)
@@ -395,14 +415,12 @@ class ModuleActivator:
                     with open(pyproject, "rb") as f:
                         data = tomllib.load(f)
                     pkg_name = data.get("project", {}).get("name", "")
-                    if pkg_name:
-                        normalized = pkg_name.replace("-", "_")
-                        if find_spec(normalized) is not None:
-                            logger.debug(
-                                f"Package '{pkg_name}' already installed from wheels, "
-                                f"skipping editable install from {module_path}"
-                            )
-                            return
+                    if pkg_name and _distribution_installed(pkg_name):
+                        logger.debug(
+                            f"Package '{pkg_name}' already installed from wheels, "
+                            f"skipping editable install from {module_path}"
+                        )
+                        return
                 except Exception:
                     pass  # If we can't check, proceed with install
 
@@ -421,16 +439,14 @@ class ModuleActivator:
                     with open(_pyproject, "rb") as f:
                         _data = tomllib.load(f)
                     _pkg_name = _data.get("project", {}).get("name", "")
-                    if _pkg_name:
-                        _normalized = _pkg_name.replace("-", "_")
-                        if find_spec(_normalized) is None:
-                            logger.debug(
-                                f"Package '{_pkg_name}' no longer importable "
-                                f"(removed by uv sync?), invalidating cache "
-                                f"for {module_path.name}"
-                            )
-                            self._install_state.invalidate(module_path)
-                            _stale = True
+                    if _pkg_name and not _distribution_installed(_pkg_name):
+                        logger.debug(
+                            f"Package '{_pkg_name}' no longer installed "
+                            f"(removed by uv sync?), invalidating cache "
+                            f"for {module_path.name}"
+                        )
+                        self._install_state.invalidate(module_path)
+                        _stale = True
                 except Exception:
                     pass
             if not _stale:

--- a/tests/test_activator.py
+++ b/tests/test_activator.py
@@ -1,7 +1,10 @@
 """Tests for ModuleActivator._install_dependencies guard.
 
-Specifically tests the find_spec guard that prevents editable source builds
-for packages already installed from PyPI wheels (e.g. amplifier-core).
+Specifically tests the _distribution_installed guard that prevents editable
+source builds for packages already installed (e.g. amplifier-core), and the
+regression coverage for issue #326 (name-guessing via find_spec produced
+false "not installed" results for bundles whose distribution name differs
+from their import name, or that ship no import package at all).
 """
 
 from __future__ import annotations
@@ -11,25 +14,32 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from amplifier_foundation.modules.activator import ModuleActivator
+from amplifier_foundation.modules.activator import (
+    ModuleActivator,
+    _distribution_installed,
+)
 
 
 class TestInstallDependenciesWheelGuard:
-    """Tests for the 'already installed from wheels' guard in _install_dependencies.
+    """Tests for the 'already installed' guard in _install_dependencies.
 
     The guard prevents uv pip install -e (editable source build) for packages
-    that are already importable in the current environment.  This matters because
+    that are already installed in the current environment.  This matters because
     bundles like amplifier-core use maturin/Rust as their build backend, so an
     editable install would trigger a multi-minute Rust compilation even though
     the pre-built PyPI wheel is already present.
+
+    Detection is keyed on the distribution name via
+    ``amplifier_foundation.modules.activator._distribution_installed``
+    (importlib.metadata), not a guessed import name. See issue #326.
     """
 
     @pytest.mark.asyncio
     async def test_skips_install_when_package_already_importable(self) -> None:
-        """_install_dependencies returns early if the package is already importable.
+        """_install_dependencies returns early if the distribution is already installed.
 
-        When importlib.util.find_spec returns a non-None result for the package
-        named in pyproject.toml, uv pip install must NOT be called.
+        When _distribution_installed returns True for the package named in
+        pyproject.toml, uv pip install must NOT be called.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             module_path = Path(tmpdir)
@@ -38,27 +48,25 @@ class TestInstallDependenciesWheelGuard:
 
             activator = ModuleActivator(cache_dir=module_path / "cache")
 
-            # Pretend the package is already importable (wheel is installed).
-            fake_spec = MagicMock()
+            # Pretend the package is already installed (wheel or editable install present).
             with (
                 patch(
-                    "amplifier_foundation.modules.activator.find_spec",
-                    return_value=fake_spec,
-                ) as mock_find_spec,
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=True,
+                ) as mock_dist_installed,
                 patch("subprocess.run") as mock_subprocess,
             ):
                 await activator._install_dependencies(module_path)
 
-                # find_spec was called with the normalised package name
-                mock_find_spec.assert_called_once_with("my_test_pkg")
+                mock_dist_installed.assert_called_once()
                 # subprocess.run (i.e. uv pip install) must NOT have been called
                 mock_subprocess.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_proceeds_when_package_not_importable(self) -> None:
-        """_install_dependencies runs uv pip install when find_spec returns None.
+        """_install_dependencies runs uv pip install when the distribution isn't installed.
 
-        If the package is not yet importable (fresh environment, first install),
+        If the package is not yet installed (fresh environment, first install),
         the editable install should proceed as normal.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -71,8 +79,8 @@ class TestInstallDependenciesWheelGuard:
             mock_completed = MagicMock(returncode=0)
             with (
                 patch(
-                    "amplifier_foundation.modules.activator.find_spec",
-                    return_value=None,  # package NOT importable yet
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=False,  # distribution NOT installed yet
                 ),
                 patch("subprocess.run", return_value=mock_completed) as mock_subprocess,
             ):
@@ -87,9 +95,9 @@ class TestInstallDependenciesWheelGuard:
 
     @pytest.mark.asyncio
     async def test_force_bypasses_wheel_guard(self) -> None:
-        """force=True skips the find_spec check and always runs uv pip install.
+        """force=True skips the distribution check and always runs uv pip install.
 
-        Even when the package is already importable, force=True should trigger
+        Even when the package is already installed, force=True should trigger
         a reinstall from source — e.g. to pick up local dev changes.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -99,27 +107,32 @@ class TestInstallDependenciesWheelGuard:
 
             activator = ModuleActivator(cache_dir=module_path / "cache")
 
-            fake_spec = MagicMock()
             mock_completed = MagicMock(returncode=0)
             with (
                 patch(
-                    "amplifier_foundation.modules.activator.find_spec",
-                    return_value=fake_spec,  # package IS importable ...
-                ) as mock_find_spec,
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=True,  # package IS installed ...
+                ) as mock_dist_installed,
                 patch("subprocess.run", return_value=mock_completed) as mock_subprocess,
             ):
                 await activator._install_dependencies(module_path, force=True)
 
-                # find_spec should NOT have been consulted (guard bypassed)
-                mock_find_spec.assert_not_called()
+                # _distribution_installed should NOT have been consulted (guard bypassed)
+                mock_dist_installed.assert_not_called()
                 # uv pip install should still have been called
                 mock_subprocess.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_hyphen_to_underscore_normalisation(self) -> None:
-        """Package names with hyphens are normalised to underscores for find_spec.
+    async def test_guard_uses_raw_distribution_name(self) -> None:
+        """The guard checks the RAW distribution name — no import-name guessing.
 
-        PyPI name 'amplifier-core' → importable as 'amplifier_core'.
+        Prior to issue #326's fix, the guard normalised the name via
+        ``pkg_name.replace("-", "_")`` and called ``importlib.util.find_spec``,
+        which mis-detected bundles whose distribution name differs from their
+        import name (e.g. ``amplifier-bundle-evaluation`` -> ``amplifier_evaluation``)
+        as "not installed". The fix keys on the distribution name directly via
+        ``importlib.metadata``, so the guard must receive the hyphenated name
+        unmodified.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             module_path = Path(tmpdir)
@@ -130,18 +143,17 @@ class TestInstallDependenciesWheelGuard:
 
             activator = ModuleActivator(cache_dir=module_path / "cache")
 
-            fake_spec = MagicMock()
             with (
                 patch(
-                    "amplifier_foundation.modules.activator.find_spec",
-                    return_value=fake_spec,
-                ) as mock_find_spec,
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=True,
+                ) as mock_dist_installed,
                 patch("subprocess.run") as mock_subprocess,
             ):
                 await activator._install_dependencies(module_path)
 
-                # Must use underscore form when calling find_spec
-                mock_find_spec.assert_called_once_with("amplifier_core")
+                # Must use the RAW hyphenated name — no name-guessing.
+                mock_dist_installed.assert_called_once_with("amplifier-core")
                 mock_subprocess.assert_not_called()
 
     @pytest.mark.asyncio
@@ -161,15 +173,15 @@ class TestInstallDependenciesWheelGuard:
             mock_completed = MagicMock(returncode=0)
             with (
                 patch(
-                    "amplifier_foundation.modules.activator.find_spec",
-                    return_value=MagicMock(),  # would skip if name were found
-                ) as mock_find_spec,
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=True,  # would skip if name were found
+                ) as mock_dist_installed,
                 patch("subprocess.run", return_value=mock_completed) as mock_subprocess,
             ):
                 await activator._install_dependencies(module_path)
 
-                # find_spec should NOT have been called (no package name to check)
-                mock_find_spec.assert_not_called()
+                # _distribution_installed should NOT have been called (no package name to check)
+                mock_dist_installed.assert_not_called()
                 # install should proceed (requirements/pyproject still processed)
                 mock_subprocess.assert_called_once()
 
@@ -187,14 +199,14 @@ class TestInstallDependenciesWheelGuard:
             mock_completed = MagicMock(returncode=0)
             with (
                 patch(
-                    "amplifier_foundation.modules.activator.find_spec",
-                    return_value=MagicMock(),
-                ) as mock_find_spec,
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=True,
+                ) as mock_dist_installed,
                 patch("subprocess.run", return_value=mock_completed) as mock_subprocess,
             ):
                 await activator._install_dependencies(module_path)
 
-                mock_find_spec.assert_not_called()
+                mock_dist_installed.assert_not_called()
                 mock_subprocess.assert_called_once()
 
 
@@ -256,8 +268,8 @@ class TestPolyglotTransportSkip:
             mock_completed = MagicMock(returncode=0)
             with (
                 patch(
-                    "amplifier_foundation.modules.activator.find_spec",
-                    return_value=None,  # package not yet importable
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=False,  # distribution not yet installed
                 ),
                 patch("subprocess.run", return_value=mock_completed) as mock_subprocess,
             ):
@@ -285,11 +297,168 @@ class TestPolyglotTransportSkip:
             mock_completed = MagicMock(returncode=0)
             with (
                 patch(
-                    "amplifier_foundation.modules.activator.find_spec",
-                    return_value=None,  # package not yet importable
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=False,  # distribution not yet installed
                 ),
                 patch("subprocess.run", return_value=mock_completed) as mock_subprocess,
             ):
                 await activator._install_dependencies(module_path)
 
                 mock_subprocess.assert_called_once()
+
+
+class TestDistributionGuard326:
+    """Regression tests for issue #326.
+
+    #326: three guard sites guessed a package's import name via
+    ``pkg_name.replace("-", "_")`` and called ``importlib.util.find_spec(...)``.
+    When the distribution name and import name differ (e.g. dist
+    ``amplifier-bundle-evaluation`` -> import ``amplifier_evaluation``) or the
+    bundle ships no import package (``packages=[]``), the guess never resolved,
+    so a valid install was treated as missing and reinstalled on every process.
+
+    The fix replaces the guess with ``_distribution_installed()``, which keys
+    on the distribution name via ``importlib.metadata`` — the same metadata
+    that ``uv sync`` removes when it uninstalls an editable install, which is
+    what keeps the pre-existing #147 stale-cache cross-check correct.
+    """
+
+    def test_distribution_installed_true_for_real_dist(self) -> None:
+        """_distribution_installed reflects real importlib.metadata state.
+
+        Direct unit test of the helper — no mocking. ``pytest`` is guaranteed
+        to be installed in the test environment; a nonsense distribution name
+        is guaranteed not to be.
+        """
+        assert _distribution_installed("pytest") is True
+        assert _distribution_installed("no-such-distribution-xyz") is False
+
+    @pytest.mark.asyncio
+    async def test_name_mismatch_bundle_skips_reinstall(self) -> None:
+        """A bundle whose import name differs from its distribution name is not reinstalled.
+
+        Core #326 scenario: pyproject declares ``amplifier-bundle-evaluation``,
+        whose import package would be guessed as ``amplifier_evaluation`` — a
+        name that never matches what's actually importable. With the fix,
+        the guard keys on the distribution name directly, so an installed
+        distribution is correctly detected and the reinstall is skipped.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir)
+            pyproject = module_path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "amplifier-bundle-evaluation"\nversion = "1.0.0"\n'
+            )
+
+            activator = ModuleActivator(cache_dir=module_path / "cache")
+
+            with (
+                patch(
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=True,
+                ),
+                patch("subprocess.run") as mock_subprocess,
+            ):
+                await activator._install_dependencies(module_path)
+
+                mock_subprocess.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_packageless_bundle_skips_reinstall(self) -> None:
+        """A bundle that ships no import package (packages=[]) is not reinstalled.
+
+        Same #326 mechanic as the name-mismatch case: a bundle with
+        ``packages=[]`` has no importable module at all, so the old
+        find_spec-based guess could never succeed. The distribution-based
+        guard correctly detects the install regardless.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir)
+            pyproject = module_path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "amplifier-bundle-attractor"\nversion = "1.0.0"\n'
+            )
+
+            activator = ModuleActivator(cache_dir=module_path / "cache")
+
+            with (
+                patch(
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=True,
+                ),
+                patch("subprocess.run") as mock_subprocess,
+            ):
+                await activator._install_dependencies(module_path)
+
+                mock_subprocess.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_147_not_regressed_stale_state_triggers_reinstall(self) -> None:
+        """Stale install-state cache (issue #147) still triggers a reinstall.
+
+        Simulates ``uv sync`` removing an editable install without touching the
+        install-state fingerprint: ``is_installed()`` reports True (the cache
+        believes it's installed) but ``_distribution_installed()`` reports
+        False (the distribution metadata is actually gone). The stale-state
+        cross-check in ``_install_dependencies`` must invalidate the cache
+        entry and proceed with the reinstall — the #326 fix must not regress
+        this #147 behavior.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir)
+            pyproject = module_path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "amplifier-bundle-evaluation"\nversion = "1.0.0"\n'
+            )
+
+            activator = ModuleActivator(cache_dir=module_path / "cache")
+
+            mock_completed = MagicMock(returncode=0)
+            with (
+                patch.object(
+                    activator._install_state, "is_installed", return_value=True
+                ),
+                patch.object(activator._install_state, "invalidate") as mock_invalidate,
+                patch(
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=False,
+                ),
+                patch("subprocess.run", return_value=mock_completed) as mock_subprocess,
+            ):
+                await activator._install_dependencies(module_path)
+
+                mock_invalidate.assert_called_once_with(module_path)
+                mock_subprocess.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_147_healthy_state_skips(self) -> None:
+        """A healthy cached install state, confirmed by real metadata, is not invalidated.
+
+        ``is_installed()`` reports True and ``_distribution_installed()``
+        confirms the distribution is genuinely present — no invalidation and
+        no reinstall should occur.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir)
+            pyproject = module_path / "pyproject.toml"
+            pyproject.write_text(
+                '[project]\nname = "amplifier-bundle-evaluation"\nversion = "1.0.0"\n'
+            )
+
+            activator = ModuleActivator(cache_dir=module_path / "cache")
+
+            with (
+                patch.object(
+                    activator._install_state, "is_installed", return_value=True
+                ),
+                patch.object(activator._install_state, "invalidate") as mock_invalidate,
+                patch(
+                    "amplifier_foundation.modules.activator._distribution_installed",
+                    return_value=True,
+                ),
+                patch("subprocess.run") as mock_subprocess,
+            ):
+                await activator._install_dependencies(module_path)
+
+                mock_invalidate.assert_not_called()
+                mock_subprocess.assert_not_called()


### PR DESCRIPTION
## Problem

Editable bundle packages are reinstalled on every fresh `amplifier` process when
a package's distribution name does not match its import name. Reported in
microsoft/amplifier#326: one workstation logged ~1,287 redundant rebuilds and
`~/.cache/uv` grew to ~118 GiB over five days, driving the disk to 99%.

## Root cause

`activator.py` had three guards that decided whether a package was "already
installed" by guessing its import name from the distribution name
(`dist_name.replace("-", "_")`) and calling `importlib.util.find_spec()`:

1. the wheel-skip guard in `activate_bundle_package()`,
2. the authoritative wheel-skip guard in `_install_dependencies()`,
3. the stale-state cross-check in `_install_dependencies()` (added to detect
   editable installs removed by `uv sync`).

The guess only holds when the distribution name and import name match. It breaks
for bundles whose import package differs from the distribution name
(`amplifier-bundle-evaluation` -> `amplifier_evaluation`) and for bundles that
ship no import package at all (`packages=[]`). In those cases `find_spec()`
returns `None`, a valid install is treated as missing, and guard 3 invalidates
the fingerprint cache and triggers `uv pip install -e` on every process.

## Fix

Replace the guessed-import check in all three guards with a distribution-name
lookup via `importlib.metadata.distribution()`, added as a small helper
`_distribution_installed()`. This asks the correct question — "is this
distribution installed?" — using the real name, no guessing.

This preserves the intent of both prior guards and fixes the loop:

| Case | Behavior |
|------|----------|
| `amplifier-core` present as a PyPI wheel | distribution resolves -> skip (preserves the wheel-skip guard) |
| editable install removed by `uv sync` | `PackageNotFoundError` -> reinstall (preserves the stale-state cross-check) |
| `amplifier-bundle-evaluation` (name mismatch) | distribution resolves -> skip (fixes #326) |
| `packages=[]` bundle | distribution resolves -> skip (fixes package-less rebuilds) |

## Tests

`tests/test_activator.py`:
- Migrated the existing wheel-guard tests from patching `find_spec` to
  `_distribution_installed`, and added a test asserting the guard is called with
  the raw (hyphenated) distribution name — proving no name-guessing.
- New `TestDistributionGuard326`: real-distribution unit check, name-mismatch
  bundle skips reinstall, package-less bundle skips reinstall, and two tests
  confirming the `uv sync` stale-state path is not regressed (invalidate +
  reinstall when the distribution is genuinely gone; skip when healthy).

All 16 tests in `tests/test_activator.py` pass; `python_check` (ruff + pyright)
is clean on the changed module.

## Scope

This is the surgical core fix. Install-state write concurrency and making
behavior-root installation opt-in are tracked separately as follow-up hardening.

Fixes microsoft/amplifier#326