### PR TITLE
fix(anchors): register skills-bundle source in anchors + anchors-amp-dev so /command skills are callable

### DIFF
--- a/bundles/anchors-amp-dev/bundle.md
+++ b/bundles/anchors-amp-dev/bundle.md
@@ -71,6 +71,7 @@ tools:
     config:
       skills:
         - "git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=skills"
+        - "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=skills"
       visibility:
         enabled: false
 

--- a/bundles/anchors/bundle.md
+++ b/bundles/anchors/bundle.md
@@ -63,12 +63,13 @@ tools:
       settings:
         exclude_tools: [tool-delegate]
 
-  # Skills (discovery available, auto-injection disabled to save tokens)
+  # Skills (user-invocable skills callable via /command + load_skill; auto-injection off to save tokens)
   - module: tool-skills
     source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
     config:
       skills:
         - "git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=skills"
+        - "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=skills"
       visibility:
         enabled: false
 


### PR DESCRIPTION
## Problem

The `anchors` and `anchors-amp-dev` bundles load the `tool-skills` module from `amplifier-bundle-skills`, but their `tool-skills` config registered only foundation's `skills/` directory as a skill **source**. The user-invocable `/command` skills shipped by `amplifier-bundle-skills` — `council`, `council-here`, `code-review`, `mass-change`, `session-debug` — were therefore undiscoverable in both profiles. `/council` and friends simply didn't exist in an `anchors` session.

## Fix

Register `amplifier-bundle-skills#subdirectory=skills` as a second skill source in each bundle's `tool-skills` config, alongside foundation's:

```yaml
config:
  skills:
    - "git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=skills"
    - "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=skills"
  visibility:
    enabled: false
```

`visibility.enabled` stays `false`: `/command` shortcut registration gates on `user-invocable`, **not** on `visibility`, so the skills become callable via `/command` and `load_skill` without being added to the auto-injected context list — no resting token cost, consistent with these profiles' lean intent.

`bundles/anchors/bundle.md` and `bundles/anchors-amp-dev/bundle.md` are both standalone bundles that independently declare `tool-skills` (neither inherits the other), so both needed the one-line change.

## Validation

Ran the deterministic path that feeds both skill discovery and `/command` shortcut registration in a clean environment on current `main`, before and after (no LLM):

```
amplifier tool invoke load_skill list=true -b anchors
```

| `/command` skill | Before | After |
|---|---|---|
| `council` | absent | present |
| `council-here` | absent | present |
| `code-review` | absent | present |
| `mass-change` | absent | present |
| `session-debug` | absent | present |

Before: only the three foundation skills (`bundle-to-dot`, `creating-amplifier-modules`, `per-repo-conventions`) resolved. After: all five skills-bundle `/command` skills resolve and `/council` is callable.
