### PR TITLE
feat(hooks-deprecation): multi-tombstone + on_session_ready firing + observability event

### DIFF
--- a/modules/hooks-deprecation/amplifier_module_hooks_deprecation/__init__.py
+++ b/modules/hooks-deprecation/amplifier_module_hooks_deprecation/__init__.py
@@ -449,6 +449,26 @@ async def on_session_ready(coordinator: Any) -> None:
 
         configs = parse_deprecation_configs(own_config)
 
+        # Self-deprecate the legacy flat form under composition. When the merged
+        # config carries BOTH a scalar `bundle_name` AND a `deprecations:` list,
+        # we are provably in a multi-tombstone composition where at least one
+        # author is still on the flat form. That scalar is at risk: foundation's
+        # deep-merge keeps only ONE `bundle_name` (child-wins), so a second flat
+        # mount would silently clobber it. The hook can't see the tombstone that
+        # was already dropped (the merge discards it before we run) -- so we warn
+        # on the CAUSE (flat form present alongside a list), not the symptom. A
+        # lone flat consumer (no list) is safe and stays silent -- no nagging.
+        if own_config.get("bundle_name") and (own_config.get("deprecations") or []):
+            logger.warning(
+                "hooks-deprecation: a flat scalar 'bundle_name' tombstone (%r) is "
+                "composed alongside a 'deprecations:' list. Foundation's deep-merge "
+                "keeps only one scalar 'bundle_name' (child-wins), so a flat "
+                "tombstone can be silently clobbered when another behavior also "
+                "mounts this hook flat. Move it under the 'deprecations:' list so "
+                "every tombstone unions.",
+                own_config.get("bundle_name"),
+            )
+
         declared_ids: set[str] = set()
         for section in ("hooks", "tools", "providers"):
             for entry in coordinator.config.get(section, []) or []:

--- a/modules/hooks-deprecation/amplifier_module_hooks_deprecation/__init__.py
+++ b/modules/hooks-deprecation/amplifier_module_hooks_deprecation/__init__.py
@@ -3,6 +3,27 @@
 A reusable hook that any bundle can include to signal it's deprecated.
 Fires once per session on session:start, warns both AI and user,
 provides migration guidance, and emits a deprecation:warning event.
+
+Supports N tombstones per mount (see ``parse_deprecation_configs``): a
+legacy flat config (single tombstone, unchanged), a ``deprecations:`` list
+(N tombstones), or both at once. Both-at-once is what a composed bundle
+sees after foundation's deep_merge unions two behaviors that each mount
+this module with a different tombstone -- deep_merge replaces the scalar
+``bundle_name`` (child-wins, collapsing to one) but concatenates the
+``deprecations`` list, so moving per-tombstone data under a list key is
+what lets multiple tombstones survive the merge.
+
+Firing decisions are made in two phases:
+
+- ``mount()`` only validates config (fails fast on a malformed tombstone).
+- ``on_session_ready()`` -- the kernel's post-composition lifecycle
+  callback, run once every module has finished ``mount()`` -- is where the
+  session:start handler actually gets registered. At that point
+  ``coordinator.config`` reflects the ACTUAL composed module list, so a
+  tombstone whose deprecated bundle is genuinely present in this session
+  fires reliably, even with ``require_evidence=True`` and no filesystem
+  evidence (best-effort ``.amplifier/`` scanning remains the fallback
+  signal for anything not directly observable in the composed plan).
 """
 
 from __future__ import annotations
@@ -71,6 +92,42 @@ class DeprecationConfig:
             sunset_date=sunset_date,
             require_evidence=bool(raw.get("require_evidence", False)),
         )
+
+
+def parse_deprecation_configs(raw: dict[str, Any]) -> list[DeprecationConfig]:
+    """Parse one or more deprecation tombstones from a raw module config dict.
+
+    Supports three shapes:
+      - Legacy flat (unchanged): {bundle_name, message, ...} -> one tombstone.
+      - List form: {deprecations: [{bundle_name, message, ...}, ...]} -> N tombstones.
+      - Both at once: the flat fields form one tombstone AND each entry in
+        `deprecations` forms another. This is the shape a composed bundle sees
+        after foundation's deep_merge unions two behaviors that each mount this
+        module with a different tombstone (deep_merge replaces the scalar
+        `bundle_name` -- collapsing to one -- but concatenates the `deprecations`
+        list, so this is what lets both tombstones survive the merge).
+
+    `DeprecationConfig.from_dict` already ignores unknown keys (like
+    `deprecations`), so passing `raw` straight through for the flat branch is safe.
+
+    Raises:
+        ValueError: If neither a top-level `bundle_name` nor a non-empty
+            `deprecations` list is present.
+    """
+    tombstones: list[DeprecationConfig] = []
+
+    if raw.get("bundle_name"):
+        tombstones.append(DeprecationConfig.from_dict(raw))
+
+    for entry in raw.get("deprecations") or []:
+        tombstones.append(DeprecationConfig.from_dict(entry))
+
+    if not tombstones:
+        raise ValueError(
+            "hooks-deprecation requires a top-level 'bundle_name' or a non-empty 'deprecations' list"
+        )
+
+    return tombstones
 
 
 def find_source_files(bundle_name: str, search_dirs: list[Path]) -> list[str]:
@@ -186,10 +243,17 @@ class DeprecationHook:
         config: DeprecationConfig,
         hooks: Any,
         search_dirs: list[Path] | None = None,
+        composed: bool = False,
     ):
         self.config = config
         self.hooks = hooks
         self.search_dirs = search_dirs or []
+        # True when the kernel's fully-composed mount plan (read at
+        # on_session_ready time) confirms this tombstone's bundle_name is
+        # actually part of this session. Defaults to False so direct
+        # construction (all pre-existing tests) is byte-identical to
+        # today's behavior.
+        self.composed = composed
         self._fired = False
 
     async def on_session_start(self, event: str, data: dict[str, Any]) -> HookResult:
@@ -209,8 +273,12 @@ class DeprecationHook:
         # Scan for source files referencing this deprecated bundle
         source_files = find_source_files(self.config.bundle_name, self.search_dirs)
 
-        # Opt-in: when evidence is required and none was found, stay silent.
-        if self.config.require_evidence and not source_files:
+        # Opt-in: when evidence is required and none was found, stay silent --
+        # UNLESS this bundle is confirmed present in the ACTUAL composed
+        # module list (self.composed), which is a stronger, reliable signal
+        # that should never be overridden by the absence of best-effort
+        # filesystem evidence.
+        if self.config.require_evidence and not source_files and not self.composed:
             return HookResult(action="continue")
 
         # Build the AI context block and user message
@@ -246,50 +314,195 @@ class DeprecationHook:
         )
 
 
-async def mount(
-    coordinator: Any, config: dict[str, Any] | None = None
-) -> dict[str, Any]:
-    """Mount the deprecation hook into the coordinator.
+_SEVERITY_RANK = {"info": 0, "warning": 1, "error": 2}
+
+
+def combine_hook_results(results: list[HookResult]) -> HookResult:
+    """Combine the per-tombstone HookResults from one session:start dispatch.
+
+    Pass-through for the single-tombstone case (len(results) == 1): returns
+    that result unchanged, byte-for-byte, so the legacy single-config path is
+    observably identical to today's behavior -- including when the one result
+    is action="continue" (already fired, or require_evidence gated it silent).
+
+    For multiple tombstones, results with action="continue" (already fired or
+    evidence-gated silent) are dropped; the rest are concatenated into a
+    single inject_context result. If none remain active, returns "continue".
+    """
+    if len(results) == 1:
+        return results[0]
+
+    active = [r for r in results if r.action != "continue"]
+    if not active:
+        return HookResult(action="continue")
+
+    context_blocks = [r.context_injection for r in active if r.context_injection]
+    user_messages = [r.user_message for r in active if r.user_message]
+    levels = [r.user_message_level for r in active if r.user_message_level]
+    level = max(levels, key=lambda lvl: _SEVERITY_RANK.get(lvl, 0)) if levels else None
+
+    return HookResult(
+        action="inject_context",
+        context_injection="\n\n".join(context_blocks) if context_blocks else None,
+        context_injection_role="system",
+        user_message="\n".join(user_messages) if user_messages else None,
+        user_message_level=level,
+        user_message_source="deprecation",
+    )
+
+
+async def mount(coordinator: Any, config: dict[str, Any] | None = None) -> None:
+    """Validate deprecation hook config at mount time.
+
+    `mount()` runs mid-composition (kernel Phase 2-5): earlier-phase modules
+    are wired, but the full module list for this session isn't settled yet,
+    so "is bundle X actually part of this session?" can't be answered
+    reliably here. All this does now is validate `config` up front -- so a
+    misconfigured tombstone still fails fast with the same ValueError as
+    before -- and return. No hook is registered here.
+
+    Registering the actual `session:start` handler is deferred to
+    `on_session_ready()`, which the kernel calls once every module across
+    every phase has finished `mount()`. At that point `coordinator.config`
+    reflects the ACTUAL composed module list, which is what lets the
+    firing decision be based on ground truth instead of best-effort
+    filesystem scanning. See `on_session_ready` for the full mechanism.
 
     Args:
         coordinator: The Amplifier coordinator instance.
-        config: Module configuration dict with deprecation settings.
+        config: Module configuration dict with deprecation settings. Either
+            a legacy flat tombstone, a `deprecations:` list of tombstones,
+            or both (see `parse_deprecation_configs`).
 
     Returns:
-        Module metadata dict.
+        None. No cleanup is needed for this module.
 
     Raises:
         ValueError: If required config keys are missing or invalid.
     """
-    parsed = DeprecationConfig.from_dict(config or {})
+    parse_deprecation_configs(config or {})
 
-    # Build search directories for source file scanning
-    working_dir_str = coordinator.get_capability("session.working_dir")
-    search_dirs: list[Path] = []
-    if working_dir_str:
-        search_dirs.append(Path(working_dir_str))
-    search_dirs.append(Path.cwd())
-    search_dirs.append(Path.home())
-
-    hook = DeprecationHook(parsed, coordinator.hooks, search_dirs=search_dirs)
-
-    coordinator.hooks.register(
-        "session:start",
-        hook.on_session_start,
-        priority=10,  # Run early so AI sees the warning from the start
-        name="deprecation",
+    # Declare the event we emit so the session capture hooks
+    # (hooks-logging + hook-context-intelligence) auto-discover and record it via
+    # the observability.events contribution channel. Module-owned declaration --
+    # see core:docs/specs/CONTRIBUTION_CHANNELS.md; template: tool-delegate.
+    coordinator.register_contributor(
+        "observability.events",
+        "hooks-deprecation",
+        lambda: ["deprecation:warning"],
     )
 
-    return {
-        "name": "hooks-deprecation",
-        "version": "0.1.0",
-        "description": f"Deprecation warning for {parsed.bundle_name}",
-        "config": {
-            "bundle_name": parsed.bundle_name,
-            "replacement": parsed.replacement,
-            "severity": parsed.severity,
-            "sunset_date": parsed.sunset_date.isoformat()
-            if parsed.sunset_date
-            else None,
-        },
-    }
+    return None
+
+
+async def on_session_ready(coordinator: Any) -> None:
+    """Register the deprecation session:start handler from the composed plan.
+
+    This is where firing is actually decided and wired up -- `mount()` only
+    validates config. `on_session_ready()` runs once every
+    orchestrator/context/provider/tool/hook module has finished `mount()`
+    (kernel Phase 6), strictly before `session:start` can fire, so
+    `coordinator.config` here reflects the ACTUAL composed module list for
+    this session rather than a best-effort filesystem guess made
+    mid-composition.
+
+    Steps:
+      1. Recover this module's own merged tombstone config: scan
+         `coordinator.config["hooks"]` for the entry whose
+         `module == "hooks-deprecation"` (after foundation's compose-merge
+         there is exactly one, with the unioned config) and take its
+         `config`. If no such entry exists, this module wasn't actually
+         mounted for this session -- return without registering anything.
+      2. Parse that config into N tombstones via `parse_deprecation_configs`
+         (unchanged helper -- handles flat / list / both shapes).
+      3. Compute the declared composed module-id set: the union of
+         `module` across `coordinator.config["hooks"]`, `["tools"]`, and
+         `["providers"]`. This is the reliable "is bundle X actually part
+         of this session?" signal `mount()` couldn't produce mid-composition.
+      4. Build one `DeprecationHook` per tombstone, passing
+         `composed=(tombstone.bundle_name in declared_ids)`.
+      5. Register ONE combined `session:start` handler, named
+         "deprecation", using the same `combine_hook_results` merge the
+         old `mount()`-time registration used.
+
+    Net effect (additive-only -- see `DeprecationHook.on_session_start`): a
+    tombstone fires if `require_evidence=False` (legacy, unchanged) OR its
+    bundle is composed (new, reliable signal) OR (`require_evidence=True`
+    and filesystem evidence was found, unchanged). Nothing that fired under
+    the old mount()-time-only gate stops firing.
+
+    Exceptions are caught and logged rather than propagated. The kernel
+    already isolates `on_session_ready` failures per-module (emitting
+    `module:on_session_ready_failed`), but a deprecation notice is
+    inherently best-effort and must never be the reason session
+    initialization fails.
+    """
+    try:
+        own_config: dict[str, Any] | None = None
+        for entry in coordinator.config.get("hooks", []) or []:
+            if entry.get("module") == "hooks-deprecation":
+                own_config = entry.get("config") or {}
+                break
+
+        if own_config is None:
+            return
+
+        configs = parse_deprecation_configs(own_config)
+
+        declared_ids: set[str] = set()
+        for section in ("hooks", "tools", "providers"):
+            for entry in coordinator.config.get(section, []) or []:
+                module_id = entry.get("module")
+                if module_id:
+                    declared_ids.add(module_id)
+
+        working_dir_str = coordinator.get_capability("session.working_dir")
+        search_dirs: list[Path] = []
+        if working_dir_str:
+            search_dirs.append(Path(working_dir_str))
+        search_dirs.append(Path.cwd())
+        search_dirs.append(Path.home())
+
+        tombstone_hooks = [
+            DeprecationHook(
+                cfg,
+                coordinator.hooks,
+                search_dirs=search_dirs,
+                composed=cfg.bundle_name in declared_ids,
+            )
+            for cfg in configs
+        ]
+
+        hooks_registry = coordinator.hooks
+
+        # Defensive guard: the kernel invokes on_session_ready() exactly
+        # once per session, but avoid double-registering the handler if
+        # this is ever invoked twice for the same coordinator (e.g. direct
+        # re-invocation in a test or a future kernel change).
+        if hasattr(hooks_registry, "list_handlers"):
+            try:
+                existing = hooks_registry.list_handlers("session:start") or {}
+                if "deprecation" in existing.get("session:start", []):
+                    return
+            except Exception:
+                logger.debug(
+                    "hooks-deprecation: list_handlers guard check failed; "
+                    "proceeding with registration",
+                    exc_info=True,
+                )
+
+        async def _on_session_start(event: str, data: dict[str, Any]) -> HookResult:
+            results = [await h.on_session_start(event, data) for h in tombstone_hooks]
+            return combine_hook_results(results)
+
+        hooks_registry.register(
+            "session:start",
+            _on_session_start,
+            priority=10,  # Run early so AI sees the warning from the start
+            name="deprecation",
+        )
+    except Exception:
+        logger.exception(
+            "hooks-deprecation: on_session_ready failed to register the "
+            "session:start handler"
+        )

--- a/modules/hooks-deprecation/pyproject.toml
+++ b/modules/hooks-deprecation/pyproject.toml
@@ -3,8 +3,10 @@ name = "amplifier-module-hooks-deprecation"
 version = "0.1.0"
 description = "Reusable deprecation warning hook for deprecated bundles"
 requires-python = ">=3.11"
-# No dependencies - amplifier-core is available at runtime via the host environment
-dependencies = []
+# on_session_ready() is dispatched by amplifier-core's module loader, which
+# gained that lifecycle callback in v1.4.0. Pinned at the module level (as
+# tool-delegate pins >=1.2.1) so foundation's own floor stays at >=1.0.10.
+dependencies = ["amplifier-core>=1.4.0"]
 
 [project.entry-points."amplifier.modules"]
 hooks-deprecation = "amplifier_module_hooks_deprecation:mount"

--- a/modules/hooks-deprecation/tests/test_deprecation_hook.py
+++ b/modules/hooks-deprecation/tests/test_deprecation_hook.py
@@ -2,6 +2,7 @@
 
 from datetime import date, timedelta
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -14,6 +15,8 @@ from amplifier_module_hooks_deprecation import (
     effective_severity,
     find_source_files,
     mount,
+    on_session_ready,
+    parse_deprecation_configs,
 )
 
 
@@ -560,14 +563,21 @@ class TestDeprecationHook:
 
 
 # — Mount Function Tests —
+#
+# mount() now ONLY validates config and registers nothing (see
+# on_session_ready() below for where firing actually gets wired up). These
+# tests were adapted from the pre-on_session_ready flow: the hook
+# registration and working-dir-capability assertions moved to
+# TestOnSessionReady, since that's the phase that now owns them.
 
 
 class TestMount:
     """Tests for the mount() entry point."""
 
     @pytest.mark.asyncio
-    async def test_registers_session_start_hook(self):
-        """mount() registers a handler on 'session:start'."""
+    async def test_does_not_register_any_hook(self):
+        """mount() no longer registers a session:start handler -- that is
+        deferred to on_session_ready()."""
         coordinator = MagicMock()
         coordinator.hooks = MagicMock()
         coordinator.hooks.register = MagicMock()
@@ -579,17 +589,13 @@ class TestMount:
         }
         await mount(coordinator, config)
 
-        coordinator.hooks.register.assert_called_once()
-        call_args = coordinator.hooks.register.call_args
-        assert call_args[0][0] == "session:start"
-        assert call_args[1]["name"] == "deprecation"
+        coordinator.hooks.register.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_returns_module_metadata(self):
-        """mount() returns proper module metadata dict."""
+    async def test_returns_none(self):
+        """mount() returns None -- no cleanup callable is needed."""
         coordinator = MagicMock()
         coordinator.hooks = MagicMock()
-        coordinator.hooks.register = MagicMock()
         coordinator.get_capability = MagicMock(return_value=None)
 
         config = {
@@ -599,16 +605,14 @@ class TestMount:
         }
         result = await mount(coordinator, config)
 
-        assert result["name"] == "hooks-deprecation"
-        assert "version" in result
-        assert result["config"]["bundle_name"] == "lsp-python"
+        assert result is None
 
     @pytest.mark.asyncio
-    async def test_uses_working_dir_capability(self):
-        """mount() uses session.working_dir capability for source scanning."""
+    async def test_does_not_use_working_dir_capability(self):
+        """mount() no longer builds search_dirs -- that's on_session_ready's
+        job, once the composed plan is available."""
         coordinator = MagicMock()
         coordinator.hooks = MagicMock()
-        coordinator.hooks.register = MagicMock()
         coordinator.get_capability = MagicMock(return_value="/some/project")
 
         config = {
@@ -617,7 +621,7 @@ class TestMount:
         }
         await mount(coordinator, config)
 
-        coordinator.get_capability.assert_called_with("session.working_dir")
+        coordinator.get_capability.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_raises_on_invalid_config(self):
@@ -628,3 +632,598 @@ class TestMount:
 
         with pytest.raises(ValueError, match="bundle_name"):
             await mount(coordinator, {"message": "deprecated"})
+
+
+# — Multi-Tombstone Tests —
+#
+# Foundation composition deep-merges module mounts by module-id: deep_merge
+# REPLACES scalars (child-wins) but CONCATENATES lists. Two behaviors that each
+# mount hooks-deprecation with a different legacy flat `bundle_name` collapse
+# to ONE and a tombstone is silently lost. The `deprecations:` list form fixes
+# this by unioning instead of colliding. These tests exercise that fix through
+# the public `parse_deprecation_configs` + `mount` + `on_session_ready` surfaces.
+#
+# Firing is now decided in on_session_ready(), not mount(). mount() is still
+# called in these tests (it validates config and must keep raising the same
+# ValueErrors), but the handler only gets registered -- and can be dispatched
+# -- once on_session_ready() runs against a coordinator whose `.config`
+# mirrors the composed mount plan.
+
+
+def _make_coordinator(
+    working_dir: str | None = None,
+    hooks_config: dict[str, Any] | None = None,
+    declared_hooks: list[str] | None = None,
+    declared_tools: list[str] | None = None,
+    declared_providers: list[str] | None = None,
+):
+    """Build a coordinator mock whose `.config` mirrors a composed mount plan.
+
+    `hooks_config`, if given, becomes THIS module's own merged config --
+    embedded as the `{"module": "hooks-deprecation", "config": ...}` entry
+    in `coordinator.config["hooks"]`, exactly as on_session_ready() expects
+    to find it post-compose-merge.
+
+    `declared_hooks` / `declared_tools` / `declared_providers` are OTHER
+    module ids present in the composed plan (alongside hooks-deprecation
+    itself), used to exercise the composed-detection gate: a tombstone
+    fires without filesystem evidence iff its `bundle_name` is among these.
+    """
+    coordinator = MagicMock()
+    coordinator.hooks = MagicMock()
+    coordinator.hooks.register = MagicMock()
+    coordinator.hooks.emit = AsyncMock()
+    coordinator.hooks.list_handlers = MagicMock(return_value={})
+    coordinator.get_capability = MagicMock(return_value=working_dir)
+
+    # Records (channel, name, callback) tuples passed to register_contributor()
+    # so tests can assert on the observability.events declaration mount() makes
+    # for "deprecation:warning" (see TestObservabilityRegistration below).
+    register_contributor_calls: list[tuple[str, str, Any]] = []
+    coordinator.register_contributor_calls = register_contributor_calls
+
+    def _record_contributor(channel: str, name: str, callback: Any) -> None:
+        register_contributor_calls.append((channel, name, callback))
+
+    coordinator.register_contributor = _record_contributor
+
+    hooks_entries: list[dict[str, Any]] = [
+        {"module": name} for name in (declared_hooks or [])
+    ]
+    if hooks_config is not None:
+        hooks_entries.append({"module": "hooks-deprecation", "config": hooks_config})
+
+    coordinator.config = {
+        "hooks": hooks_entries,
+        "tools": [{"module": name} for name in (declared_tools or [])],
+        "providers": [{"module": name} for name in (declared_providers or [])],
+    }
+    return coordinator
+
+
+async def _register_and_dispatch(coordinator):
+    """Run on_session_ready() (registers the handler), then invoke it.
+
+    Replaces the old `_dispatch_session_start`, which invoked the handler
+    mount() used to register directly. Registration now happens in
+    on_session_ready() instead.
+    """
+    await on_session_ready(coordinator)
+    call_args = coordinator.hooks.register.call_args
+    handler = call_args[0][1]
+    return await handler("session:start", {})
+
+
+class TestParseDeprecationConfigs:
+    """Tests for the parse_deprecation_configs() normalizer."""
+
+    def test_legacy_flat_produces_one_tombstone(self):
+        """Legacy flat form (unchanged) produces exactly one tombstone."""
+        configs = parse_deprecation_configs(
+            {"bundle_name": "hooks-redaction", "message": "retired"}
+        )
+        assert len(configs) == 1
+        assert configs[0].bundle_name == "hooks-redaction"
+
+    def test_list_form_produces_n_tombstones(self):
+        """`deprecations:` list form produces one tombstone per entry."""
+        configs = parse_deprecation_configs(
+            {
+                "deprecations": [
+                    {"bundle_name": "a", "message": "m1"},
+                    {"bundle_name": "b", "message": "m2"},
+                ]
+            }
+        )
+        assert [c.bundle_name for c in configs] == ["a", "b"]
+
+    def test_both_present_produces_flat_plus_list_tombstones(self):
+        """Flat fields AND `deprecations:` entries both become tombstones.
+
+        This is the shape a composed bundle sees after deep_merge unions two
+        behaviors that each mount this module with a different tombstone.
+        """
+        configs = parse_deprecation_configs(
+            {
+                "bundle_name": "hooks-redaction",
+                "message": "r",
+                "deprecations": [{"bundle_name": "hooks-logging", "message": "l"}],
+            }
+        )
+        assert [c.bundle_name for c in configs] == ["hooks-redaction", "hooks-logging"]
+
+    def test_empty_config_raises_value_error(self):
+        """Neither bundle_name nor a non-empty deprecations list -> ValueError."""
+        with pytest.raises(ValueError, match="bundle_name.*deprecations"):
+            parse_deprecation_configs({})
+
+    def test_empty_deprecations_list_raises_value_error(self):
+        """An empty `deprecations: []` list (and no flat bundle_name) still raises."""
+        with pytest.raises(ValueError):
+            parse_deprecation_configs({"deprecations": []})
+
+
+class TestMultiTombstoneMount:
+    """Tests for mount() + on_session_ready() with multiple tombstones
+    (list form and union)."""
+
+    @pytest.mark.asyncio
+    async def test_list_form_both_fire(self):
+        """Two tombstones in `deprecations:` both fire in one combined dispatch."""
+        config = {
+            "deprecations": [
+                {"bundle_name": "a", "message": "message-a", "require_evidence": False},
+                {"bundle_name": "b", "message": "message-b", "require_evidence": False},
+            ]
+        }
+        coordinator = _make_coordinator(hooks_config=config)
+        await mount(coordinator, config)  # validates only; registers nothing
+
+        result = await _register_and_dispatch(coordinator)
+
+        assert result.action == "inject_context"
+        assert result.context_injection is not None
+        assert "DEPRECATION WARNING: a" in result.context_injection
+        assert "DEPRECATION WARNING: b" in result.context_injection
+        assert result.user_message is not None
+        assert "a" in result.user_message
+        assert "b" in result.user_message
+
+        assert coordinator.hooks.emit.await_count == 2
+        emitted_bundles = {
+            call.args[1]["bundle_name"]
+            for call in coordinator.hooks.emit.await_args_list
+        }
+        assert emitted_bundles == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_union_of_flat_and_list_both_fire(self):
+        """Flat bundle_name + deprecations list (the post-merge shape) both fire.
+
+        Mirrors what deep_merge produces when redaction.yaml's legacy flat
+        tombstone and logging.yaml's `deprecations:` tombstone are unioned.
+        """
+        config = {
+            "bundle_name": "hooks-redaction",
+            "message": "hooks-redaction is retired",
+            "require_evidence": False,
+            "deprecations": [
+                {
+                    "bundle_name": "hooks-logging",
+                    "message": "hooks-logging is demoted",
+                    "require_evidence": False,
+                }
+            ],
+        }
+        coordinator = _make_coordinator(hooks_config=config)
+        await mount(coordinator, config)
+
+        result = await _register_and_dispatch(coordinator)
+
+        assert result.action == "inject_context"
+        assert "hooks-redaction" in result.context_injection
+        assert "hooks-logging" in result.context_injection
+
+        assert coordinator.hooks.emit.await_count == 2
+        emitted_bundles = {
+            call.args[1]["bundle_name"]
+            for call in coordinator.hooks.emit.await_args_list
+        }
+        assert emitted_bundles == {"hooks-redaction", "hooks-logging"}
+
+    @pytest.mark.asyncio
+    async def test_require_evidence_gates_independently_per_tombstone(
+        self, tmp_path, monkeypatch
+    ):
+        """Each tombstone's require_evidence gate is evaluated independently.
+
+        Evidence is authored for only ONE of the two bundle_names, and
+        neither bundle is present in the composed plan (no declared_hooks
+        given); only the evidenced tombstone should fire, and only its
+        event should be emitted.
+
+        on_session_ready() always adds Path.cwd() and Path.home() to
+        search_dirs in addition to the working_dir capability, so both are
+        pinned to the same isolated tmp_path here -- otherwise real files
+        in the actual cwd/home (outside this test's control) could
+        coincidentally reference one of these bundle names and make the
+        gating non-deterministic.
+        """
+        amp_dir = tmp_path / ".amplifier"
+        amp_dir.mkdir()
+        (amp_dir / "settings.yaml").write_text(
+            "includes: hooks-redaction\n", encoding="utf-8"
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        config = {
+            "bundle_name": "hooks-redaction",
+            "message": "hooks-redaction is retired",
+            "require_evidence": True,
+            "deprecations": [
+                {
+                    "bundle_name": "hooks-logging",
+                    "message": "hooks-logging is demoted",
+                    "require_evidence": True,
+                }
+            ],
+        }
+        coordinator = _make_coordinator(working_dir=str(tmp_path), hooks_config=config)
+        await mount(coordinator, config)
+
+        result = await _register_and_dispatch(coordinator)
+
+        assert result.action == "inject_context"
+        assert "hooks-redaction" in result.context_injection
+        assert "hooks-logging" not in result.context_injection
+
+        coordinator.hooks.emit.assert_called_once()
+        call_args = coordinator.hooks.emit.call_args
+        assert call_args[0][1]["bundle_name"] == "hooks-redaction"
+
+    @pytest.mark.asyncio
+    async def test_single_flat_config_is_pass_through_identical_to_direct_hook(self):
+        """Backward compat: mount() + on_session_ready() with ONE flat
+        tombstone must be observably identical to using DeprecationHook
+        directly (today's legacy behavior).
+
+        Both paths use the same search dirs (Path.cwd() + Path.home(), since
+        get_capability returns None in both) so the source-file scan -- and
+        therefore the full result -- is deterministically identical. Neither
+        path declares any other composed module, so `composed` stays False
+        on both sides too.
+        """
+        cfg_dict = {"bundle_name": "lsp-python", "message": "lsp-python is deprecated"}
+        same_search_dirs = [Path.cwd(), Path.home()]
+
+        direct_hooks_mock = MagicMock()
+        direct_hooks_mock.emit = AsyncMock()
+        direct_hook = DeprecationHook(
+            DeprecationConfig.from_dict(cfg_dict),
+            direct_hooks_mock,
+            search_dirs=same_search_dirs,
+        )
+        direct_result = await direct_hook.on_session_start("session:start", {})
+
+        coordinator = _make_coordinator(working_dir=None, hooks_config=cfg_dict)
+        await mount(coordinator, cfg_dict)
+        mounted_result = await _register_and_dispatch(coordinator)
+
+        assert mounted_result.action == direct_result.action
+        assert mounted_result.context_injection == direct_result.context_injection
+        assert mounted_result.user_message == direct_result.user_message
+        assert mounted_result.user_message_level == direct_result.user_message_level
+        assert mounted_result.user_message_source == direct_result.user_message_source
+
+    @pytest.mark.asyncio
+    async def test_single_flat_config_fires_once_per_session_through_mount(self):
+        """Backward compat: single-tombstone mount() + on_session_ready()
+        still fires once per session (mirrors
+        TestDeprecationHook.test_fires_once_per_session, but through the
+        full mount() + on_session_ready() + combine_hook_results() path)."""
+        config = {"bundle_name": "lsp-python", "message": "lsp-python is deprecated"}
+        coordinator = _make_coordinator(hooks_config=config)
+        await mount(coordinator, config)
+        await on_session_ready(coordinator)
+
+        call_args = coordinator.hooks.register.call_args
+        handler = call_args[0][1]
+
+        result1 = await handler("session:start", {})
+        assert result1.action == "inject_context"
+
+        result2 = await handler("session:start", {})
+        assert result2.action == "continue"
+
+    @pytest.mark.asyncio
+    async def test_empty_config_raises_value_error_through_mount(self):
+        """mount() propagates parse_deprecation_configs' ValueError for {}."""
+        coordinator = _make_coordinator()
+
+        with pytest.raises(ValueError, match="bundle_name"):
+            await mount(coordinator, {})
+
+
+# — on_session_ready() Tests —
+#
+# Covers the registration mechanics on_session_ready() now owns: recovering
+# this module's own merged config from the composed plan, the defensive
+# no-op paths (no own entry, already registered, registration raises), and
+# the composed-detection gate itself (the additive bypass of
+# require_evidence when a tombstone's bundle is confirmed present in the
+# composed plan).
+
+
+class TestOnSessionReady:
+    """Tests for on_session_ready()'s registration mechanics."""
+
+    @pytest.mark.asyncio
+    async def test_no_own_config_entry_registers_nothing(self):
+        """If coordinator.config['hooks'] has no hooks-deprecation entry,
+        this module wasn't actually mounted for this session -- return
+        without registering anything."""
+        coordinator = _make_coordinator()  # no hooks_config -> no own entry
+
+        await on_session_ready(coordinator)
+
+        coordinator.hooks.register.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_registration_if_already_registered(self):
+        """Defensive guard: if list_handlers() already reports a
+        'deprecation' handler on session:start, on_session_ready() does not
+        register again."""
+        config = {"bundle_name": "lsp-python", "message": "deprecated"}
+        coordinator = _make_coordinator(hooks_config=config)
+        coordinator.hooks.list_handlers = MagicMock(
+            return_value={"session:start": ["deprecation"]}
+        )
+
+        await on_session_ready(coordinator)
+
+        coordinator.hooks.register.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_registration_exception_is_caught_not_propagated(self):
+        """An exception raised while registering the handler is caught and
+        logged, not propagated -- a deprecation notice must never be the
+        reason session initialization fails."""
+        config = {"bundle_name": "lsp-python", "message": "deprecated"}
+        coordinator = _make_coordinator(hooks_config=config)
+        coordinator.hooks.register = MagicMock(side_effect=RuntimeError("boom"))
+
+        await on_session_ready(coordinator)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_registers_session_start_handler_named_deprecation(self):
+        """on_session_ready() registers exactly one 'session:start' handler
+        named 'deprecation', same contract mount() used to fulfill."""
+        config = {"bundle_name": "lsp-python", "message": "deprecated"}
+        coordinator = _make_coordinator(hooks_config=config)
+
+        await on_session_ready(coordinator)
+
+        coordinator.hooks.register.assert_called_once()
+        call_args = coordinator.hooks.register.call_args
+        assert call_args[0][0] == "session:start"
+        assert call_args[1]["name"] == "deprecation"
+        assert call_args[1]["priority"] == 10
+
+
+class TestComposedDetection:
+    """Tests for the additive composed-detection gate: a tombstone whose
+    bundle_name is confirmed present in the ACTUAL composed mount plan
+    fires even with zero filesystem evidence. Nothing that fired under the
+    old evidence-only gate stops firing (see the (c) legacy case below)."""
+
+    @pytest.mark.asyncio
+    async def test_composed_bundle_in_hooks_fires_without_evidence(
+        self, tmp_path, monkeypatch
+    ):
+        """(a) require_evidence=True + bundle IS in coordinator.config['hooks']
+        -> fires even with NO filesystem source_files."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = {
+            "bundle_name": "lsp-python",
+            "message": "lsp-python is deprecated",
+            "require_evidence": True,
+        }
+        coordinator = _make_coordinator(
+            working_dir=str(tmp_path),
+            hooks_config=config,
+            declared_hooks=["lsp-python"],
+        )
+
+        result = await _register_and_dispatch(coordinator)
+
+        assert result.action == "inject_context"
+        assert "lsp-python" in result.context_injection
+        coordinator.hooks.emit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_composed_bundle_in_tools_fires_without_evidence(
+        self, tmp_path, monkeypatch
+    ):
+        """(a) variant: the composed signal also comes from `tools`, not
+        just `hooks`."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = {
+            "bundle_name": "tool-legacy",
+            "message": "tool-legacy is deprecated",
+            "require_evidence": True,
+        }
+        coordinator = _make_coordinator(
+            working_dir=str(tmp_path),
+            hooks_config=config,
+            declared_tools=["tool-legacy"],
+        )
+
+        result = await _register_and_dispatch(coordinator)
+
+        assert result.action == "inject_context"
+        coordinator.hooks.emit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_composed_bundle_in_providers_fires_without_evidence(
+        self, tmp_path, monkeypatch
+    ):
+        """(a) variant: the composed signal also comes from `providers`."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = {
+            "bundle_name": "provider-legacy",
+            "message": "provider-legacy is deprecated",
+            "require_evidence": True,
+        }
+        coordinator = _make_coordinator(
+            working_dir=str(tmp_path),
+            hooks_config=config,
+            declared_providers=["provider-legacy"],
+        )
+
+        result = await _register_and_dispatch(coordinator)
+
+        assert result.action == "inject_context"
+        coordinator.hooks.emit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_not_composed_and_no_evidence_stays_silent(
+        self, tmp_path, monkeypatch
+    ):
+        """(b) require_evidence=True + module NOT composed + NO source
+        files -> stays silent."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = {
+            "bundle_name": "lsp-python",
+            "message": "lsp-python is deprecated",
+            "require_evidence": True,
+        }
+        coordinator = _make_coordinator(working_dir=str(tmp_path), hooks_config=config)
+
+        result = await _register_and_dispatch(coordinator)
+
+        assert result.action == "continue"
+        assert result.context_injection is None
+        assert result.user_message is None
+        coordinator.hooks.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_require_evidence_false_fires_regardless(self, tmp_path, monkeypatch):
+        """(c) require_evidence=False fires regardless of composed status
+        or filesystem evidence (legacy, always-fire behavior)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = {
+            "bundle_name": "lsp-python",
+            "message": "lsp-python is deprecated",
+            "require_evidence": False,
+        }
+        coordinator = _make_coordinator(working_dir=str(tmp_path), hooks_config=config)
+
+        result = await _register_and_dispatch(coordinator)
+
+        assert result.action == "inject_context"
+        coordinator.hooks.emit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_union_only_composed_tombstone_fires(self, tmp_path, monkeypatch):
+        """(d) P2 union case: a merged config carries a flat tombstone
+        (hooks-redaction, require_evidence=True) AND a `deprecations:` list
+        tombstone (hooks-logging, require_evidence=True). Only
+        hooks-logging is present in the composed plan's `hooks` list; only
+        it should fire."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = {
+            "bundle_name": "hooks-redaction",
+            "message": "hooks-redaction is retired",
+            "require_evidence": True,
+            "deprecations": [
+                {
+                    "bundle_name": "hooks-logging",
+                    "message": "hooks-logging is demoted",
+                    "require_evidence": True,
+                }
+            ],
+        }
+        coordinator = _make_coordinator(
+            working_dir=str(tmp_path),
+            hooks_config=config,
+            declared_hooks=["hooks-logging"],  # hooks-redaction NOT declared
+        )
+
+        result = await _register_and_dispatch(coordinator)
+
+        assert result.action == "inject_context"
+        assert "hooks-logging" in result.context_injection
+        assert "hooks-redaction" not in result.context_injection
+
+        coordinator.hooks.emit.assert_called_once()
+        call_args = coordinator.hooks.emit.call_args
+        assert call_args[0][1]["bundle_name"] == "hooks-logging"
+
+
+# — Observability Contribution Channel Tests —
+#
+# hooks-deprecation EMITS "deprecation:warning" via self.hooks.emit(...) but
+# must also DECLARE it on the "observability.events" contribution channel so
+# the session capture hooks (hooks-logging + hook-context-intelligence), which
+# auto-discover recordable events via coordinator.collect_contributions(
+# "observability.events") at their own on_session_ready(), know to record it.
+# This is a module-owned declaration (template: tool-delegate's mount()); see
+# core:docs/specs/CONTRIBUTION_CHANNELS.md.
+
+
+class TestObservabilityRegistration:
+    """Tests for mount()'s observability.events contribution registration."""
+
+    @pytest.mark.asyncio
+    async def test_mount_registers_deprecation_warning_event(self):
+        """mount() registers exactly one observability.events contributor,
+        named 'hooks-deprecation', whose callback returns
+        ['deprecation:warning']."""
+        config = {"bundle_name": "lsp-python", "message": "lsp-python is deprecated"}
+        coordinator = _make_coordinator(hooks_config=config)
+
+        await mount(coordinator, config)
+
+        assert len(coordinator.register_contributor_calls) == 1
+        channel, name, callback = coordinator.register_contributor_calls[0]
+        assert channel == "observability.events"
+        assert name == "hooks-deprecation"
+        assert callback() == ["deprecation:warning"]
+
+    @pytest.mark.asyncio
+    async def test_registration_happens_even_without_evidence_requirement(self):
+        """The registration is unconditional -- it does not depend on any
+        tombstone's require_evidence setting or on multi-tombstone shape."""
+        config = {
+            "deprecations": [
+                {"bundle_name": "a", "message": "message-a"},
+                {"bundle_name": "b", "message": "message-b"},
+            ]
+        }
+        coordinator = _make_coordinator(hooks_config=config)
+
+        await mount(coordinator, config)
+
+        assert len(coordinator.register_contributor_calls) == 1
+        channel, name, callback = coordinator.register_contributor_calls[0]
+        assert channel == "observability.events"
+        assert name == "hooks-deprecation"
+        assert callback() == ["deprecation:warning"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_config_does_not_register_contributor(self):
+        """mount() raises before registering the contributor when config is
+        invalid -- validation still happens first, unchanged."""
+        coordinator = _make_coordinator()
+
+        with pytest.raises(ValueError, match="bundle_name"):
+            await mount(coordinator, {})
+
+        assert coordinator.register_contributor_calls == []

--- a/modules/hooks-deprecation/tests/test_deprecation_hook.py
+++ b/modules/hooks-deprecation/tests/test_deprecation_hook.py
@@ -1,5 +1,6 @@
 """Tests for the deprecation hook module."""
 
+import logging
 from datetime import date, timedelta
 from pathlib import Path
 from typing import Any
@@ -830,6 +831,79 @@ class TestMultiTombstoneMount:
             for call in coordinator.hooks.emit.await_args_list
         }
         assert emitted_bundles == {"hooks-redaction", "hooks-logging"}
+
+    @pytest.mark.asyncio
+    async def test_flat_plus_list_logs_coexistence_warning(self, caplog):
+        """Scalar bundle_name composed alongside a deprecations: list warns.
+
+        The flat form under composition is at clobber risk (deep-merge keeps
+        only one scalar bundle_name), so on_session_ready() logs a migration
+        warning naming the at-risk flat tombstone -- warning on the CAUSE
+        (flat form present with a list), since the dropped tombstone from an
+        actual collision is already gone before the hook runs.
+        """
+        config = {
+            "bundle_name": "hooks-redaction",
+            "message": "hooks-redaction is retired",
+            "require_evidence": False,
+            "deprecations": [
+                {
+                    "bundle_name": "hooks-logging",
+                    "message": "demoted",
+                    "require_evidence": False,
+                }
+            ],
+        }
+        coordinator = _make_coordinator(hooks_config=config)
+        with caplog.at_level(
+            logging.WARNING, logger="amplifier_module_hooks_deprecation"
+        ):
+            await on_session_ready(coordinator)
+        warnings = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("composed alongside a 'deprecations:' list" in m for m in warnings)
+        assert any("hooks-redaction" in m for m in warnings)
+
+    @pytest.mark.asyncio
+    async def test_lone_flat_form_does_not_warn(self, caplog):
+        """A single flat tombstone (no list) is safe -> no coexistence warning."""
+        config = {
+            "bundle_name": "hooks-redaction",
+            "message": "retired",
+            "require_evidence": False,
+        }
+        coordinator = _make_coordinator(hooks_config=config)
+        with caplog.at_level(
+            logging.WARNING, logger="amplifier_module_hooks_deprecation"
+        ):
+            await on_session_ready(coordinator)
+        warnings = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert not any(
+            "composed alongside a 'deprecations:' list" in m for m in warnings
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_only_form_does_not_warn(self, caplog):
+        """List form with no flat scalar -> no coexistence warning."""
+        config = {
+            "deprecations": [
+                {"bundle_name": "a", "message": "m", "require_evidence": False}
+            ]
+        }
+        coordinator = _make_coordinator(hooks_config=config)
+        with caplog.at_level(
+            logging.WARNING, logger="amplifier_module_hooks_deprecation"
+        ):
+            await on_session_ready(coordinator)
+        warnings = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert not any(
+            "composed alongside a 'deprecations:' list" in m for m in warnings
+        )
 
     @pytest.mark.asyncio
     async def test_require_evidence_gates_independently_per_tombstone(


### PR DESCRIPTION
## TL;DR

`hooks-deprecation` records "this module is deprecated" tombstones, declared **at composition** — a behavior's YAML mounts the hook with a tombstone for the module it's retiring. Today each mount holds **one** flat tombstone. Foundation already ships one such registration (`behaviors/redaction.yaml`, from #274). So when a **second** behavior mounts the hook with the flat scalar form, foundation's deep-merge collapses the two `bundle_name` scalars into one and the second registration is **silently dropped** (the F8 collision).

Fix: add a `deprecations:` **list** form. Deep-merge **concatenates lists** (while it replaces scalars), so tombstones under the list key **survive composition and union** — and the hook now **warns** when a flat tombstone is composed alongside a list, so the collision-prone shape is caught. Additive and backward-compatible; base module already shipped in #274, so the net diff is exactly these enhancements. **72 module tests green.**

## Why this surfaced — composition-time registration + an existing consumer

- Deprecation is declared **at composition, not at the source.** The retired module (`hooks-logging`) doesn't deprecate itself; the behavior that used to mount it (`behaviors/logging.yaml`) declares the tombstone. Any number of behaviors can therefore each register a tombstone at composition.
- **Foundation already had one registered:** `behaviors/redaction.yaml` mounts `hooks-deprecation` (also from #274).
- When `logging.yaml` added a **second** flat-form registration for `hooks-logging`, foundation deep-merged the two module configs. Deep-merge **replaces the scalar** `bundle_name` (child wins), so redaction's tombstone won and **the logging hook's deprecation was never registered.** It looked like "the deprecation didn't fire" — but it was a merge collision, not a firing bug.

## The fix — a list the merge unions

| Config key | Deep-merge rule | Two behaviors → |
|---|---|---|
| `bundle_name:` — scalar (old flat form) | **replace** (child wins) | collide → **one tombstone lost** |
| `deprecations:` — list (new form) | **concatenate** | both survive → **union** |

Not new merge logic — just moving per-tombstone data under a list key so the *existing* deep-merge unions instead of clobbers.

**Before** — collides when a second behavior also mounts the hook:
```yaml
hooks-deprecation:
  bundle_name: hooks-logging      # scalar → deep-merge replaces it
```
**After** — survives composition:
```yaml
hooks-deprecation:
  deprecations:
    - bundle_name: hooks-logging  # list entry → deep-merge concatenates
```

## Backward compatibility — nothing to migrate

- **Old flat YAML is unchanged.** A single consumer's `{ bundle_name, message, … }` still parses to exactly one tombstone and fires identically. No config edits required.
- **Flat and list interoperate.** A merged config carrying flat fields *and* a `deprecations:` list yields one tombstone from the flat fields plus one per list entry — exactly the shape "one flat behavior + one list behavior" produces. So mixed old/new consumers compose cleanly.
- **`behaviors/redaction.yaml` needs no change** — it keeps its flat tombstone and keeps working. In this PR it's the live second consumer proving back-compat; once `logging.yaml` adopts the list form, both coexist.

## Guardrail — the flat form warns under composition (shipped in this PR)

Two behaviors that **both** keep the flat scalar `bundle_name` still collapse to one — inherent to deep-merging a scalar, and the hook can't see the tombstone the merge already dropped. So this PR warns on the **cause, not the symptom**: at `on_session_ready`, when the merged config carries a flat scalar `bundle_name` **and** a non-empty `deprecations:` list (the provable multi-tombstone composition), the hook logs a **once-per-session, non-blocking** warning naming the at-risk flat tombstone and telling the author to move it under `deprecations:`.

- **Narrow by design:** a lone flat consumer (no list) stays **silent** — no nagging, back-compat preserved.
- **Covered by 3 new tests:** flat+list → warns; lone flat → silent; list-only → silent.
- **Deliberately *not* taken here** (open for discussion): warning whenever the flat scalar is used *at all* (would also nudge safe single-consumers), or a foundation-level deep-merge diagnostic on scalar clobber (broader — every module). Those broad options are the only way to catch the two-behaviors-both-flat collapse, which leaves no list behind to signal it.

## Two supporting fixes

- **Fire at `on_session_ready` from the composed module list.** Decide "is the deprecated module actually composed?" from the kernel's post-composition module list — once per session, non-blocking — instead of guessing at mount time. More correct, more general.
- **Declare `deprecation:warning` on `observability.events` (F9a).** So any capture hook records the deprecation as a real event, not just an ephemeral notice.

## Testing

Module unit tests: **72 passed** (69 + 3 for the new coexistence warning). Reviewable with zero migration context — the base module already ships upstream (#274), so the diff vs `main` is exactly these enhancements.