### PR TITLE
docs(bundles): clarify foundation-vs-anchors roles; drop stale "experimental" framing from anchors

### DIFF
--- a/bundles/anchors/bundle.md
+++ b/bundles/anchors/bundle.md
@@ -3,7 +3,7 @@ bundle:
   name: anchors
   version: 0.1.0
   description: |
-    Experimental lean bundle driven by a small set of behavioral principles.
+    Lean bundle driven by a small set of behavioral principles.
     A minimal system prompt, thin purposeful agents, and a standard tool roster.
     Explores how far concise behavior-shaping -- principles loaded once at the
     head of the system prompt -- can carry an Amplifier session at a fraction of
@@ -130,7 +130,7 @@ agents:
 
 # Anchors
 
-A lean, principle-driven experimental bundle. Behavior is shaped by a short set
+A lean, principle-driven bundle. Behavior is shaped by a short set
 of named principles loaded once at the head of the system prompt, backed by thin
 purposeful agents and a standard tool roster.
 

--- a/docs/BUNDLE_GUIDE.md
+++ b/docs/BUNDLE_GUIDE.md
@@ -23,6 +23,17 @@ Bundles are the primary way to share and compose AI agent configurations.
 
 ---
 
+## Foundation vs. Anchors: Which Base?
+
+This repository publishes two bundles that serve **different** purposes, and it is easy to conflate them:
+
+- **`anchors`** is the CLI's **default runtime bundle** — the bundle a new session uses when none is specified. It is lean and self-contained: it pins all of its own module sources with full `git+https://…` URLs and does **not** inherit from `foundation`. Think of `anchors` as a bundle you *run*.
+- **`foundation`** is the **composition base you inherit from** when authoring your own bundle. Think of `foundation` as a bundle you *build on*.
+
+This guide covers the second case: creating a bundle by inheriting from `foundation` (the thin bundle pattern below). Making `anchors` the default runtime bundle does **not** change how you author bundles — you still build on `foundation`.
+
+---
+
 ## The Thin Bundle Pattern (Recommended)
 
 **Most bundles should be thin** - inheriting from foundation and adding only their unique capabilities.


### PR DESCRIPTION
## What

Two small, related documentation corrections.

1. **`docs/BUNDLE_GUIDE.md`** — add a short **"Foundation vs. Anchors: Which Base?"** section near the top. The guide currently never mentions `anchors`, even though `anchors` was promoted to a published bundle (#259) and is now the CLI's default runtime bundle for new sessions. That silence lets readers — and tools/agents that ground their answers in this doc — conflate *"anchors is the default"* with *"build your bundle on anchors."* The new section draws the distinction:
   - `anchors` is a lean, self-contained bundle you **run** by default (it pins all of its own module sources with full `git+https://…` URLs and does not inherit from `foundation`).
   - `foundation` is the composition base you **build on** when authoring your own bundle.

   The thin-bundle-on-foundation authoring guidance is **unchanged** and remains correct.

2. **`bundles/anchors/bundle.md`** — drop the **"experimental"** framing from the bundle description and body. `anchors` was promoted from an experiment to a published bundle in #259 and is the CLI default; describing it as "experimental" is stale and leads tools/agents to present it as early-stage.

## Why

`docs/BUNDLE_GUIDE.md` predates the `anchors` promotion (#259) and is silent on it, and the `anchors` bundle still self-describes as experimental. Together these cause confusion about which bundle is the base for **authoring** vs. the default at **runtime**.

## Scope / non-goals

- Does **not** change the recommended authoring pattern (thin bundle inheriting from `foundation`) — that remains correct.
- Does **not** bump the `anchors` bundle `version` (still `0.1.0`); the version number is a separate release decision for the maintainer.
