### PR TITLE
feat: support full commit SHA refs in bundle git sources (enables reproducible eval)

### DIFF
--- a/amplifier_foundation/sources/git.py
+++ b/amplifier_foundation/sources/git.py
@@ -7,6 +7,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import re
 import shutil
 import subprocess
 from datetime import datetime
@@ -21,6 +22,16 @@ logger = logging.getLogger(__name__)
 
 # Metadata file name for tracking cache info
 CACHE_METADATA_FILE = ".amplifier_cache_meta.json"
+
+# Full 40-character hex commit SHA (case-insensitive, matching SourceStatus.is_pinned).
+# Short/abbreviated SHAs are intentionally NOT matched: they are ambiguous as refs
+# and fall through to the existing --branch clone path (and its clear error).
+_FULL_COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def _is_full_commit_sha(ref: str) -> bool:
+    """Check whether a ref is a full 40-hex-character commit SHA."""
+    return bool(_FULL_COMMIT_SHA_PATTERN.match(ref))
 
 
 class GitSourceHandler:
@@ -152,6 +163,67 @@ class GitSourceHandler:
 
         return True
 
+    def _clone_at_commit(self, git_url: str, sha: str, cache_path: Path) -> None:
+        """Clone a repository pinned to a specific commit SHA.
+
+        ``git clone --branch`` only accepts branch/tag names, so commit SHAs
+        need a fetch + checkout sequence instead. Tries the cheapest form
+        first: shallow-fetch exactly the requested commit (supported by
+        GitHub and any server with ``uploadpack.allowReachableSHA1InWant``).
+        Falls back to a full clone + checkout when the server refuses to
+        serve the SHA directly.
+
+        Args:
+            git_url: Repository URL (without git+ prefix).
+            sha: Full 40-character commit SHA to pin.
+            cache_path: Destination directory for the clone.
+
+        Raises:
+            subprocess.CalledProcessError: If both strategies fail (converted
+                to BundleNotFoundError by the caller).
+        """
+
+        def run_git(args: list[str], cwd: Path | None = None) -> None:
+            subprocess.run(
+                args,
+                cwd=cwd,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        try:
+            # Cheap path: init + shallow fetch of the exact commit.
+            cache_path.mkdir(parents=True, exist_ok=True)
+            run_git(["git", "init", "--quiet", str(cache_path)])
+            run_git(["git", "remote", "add", "origin", git_url], cwd=cache_path)
+            run_git(["git", "fetch", "--depth", "1", "origin", sha], cwd=cache_path)
+            run_git(
+                [
+                    "git",
+                    "-c",
+                    "advice.detachedHead=false",
+                    "checkout",
+                    "--quiet",
+                    "FETCH_HEAD",
+                ],
+                cwd=cache_path,
+            )
+        except subprocess.CalledProcessError as e:
+            # Server refused direct SHA fetch (e.g., unadvertised object on a
+            # server without allowReachableSHA1InWant). Fall back to a full
+            # clone + checkout. Errors here propagate to the caller.
+            logger.debug(
+                f"Shallow fetch of commit {sha} from {git_url} failed "
+                f"({e.stderr}); falling back to full clone + checkout"
+            )
+            shutil.rmtree(cache_path, ignore_errors=True)
+            run_git(["git", "clone", git_url, str(cache_path)])
+            run_git(
+                ["git", "-c", "advice.detachedHead=false", "checkout", "--quiet", sha],
+                cwd=cache_path,
+            )
+
     async def resolve(self, parsed: ParsedURI, cache_dir: Path) -> ResolvedSource:
         """Resolve git URI to local cached path.
 
@@ -192,20 +264,24 @@ class GitSourceHandler:
             shutil.rmtree(cache_path)
 
         try:
-            # Shallow clone with specific ref
-            # Note: "HEAD" is not a valid --branch argument; it's a symbolic reference.
-            # When ref is HEAD (or not specified), let git clone use the repo's default branch.
-            clone_args = ["git", "clone", "--depth", "1"]
-            if parsed.ref and parsed.ref != "HEAD":
-                clone_args.extend(["--branch", parsed.ref])
-            clone_args.extend([git_url, str(cache_path)])
+            if parsed.ref and _is_full_commit_sha(parsed.ref):
+                # Commit SHAs are not valid --branch arguments; use fetch + checkout.
+                self._clone_at_commit(git_url, parsed.ref, cache_path)
+            else:
+                # Shallow clone with specific ref
+                # Note: "HEAD" is not a valid --branch argument; it's a symbolic reference.
+                # When ref is HEAD (or not specified), let git clone use the repo's default branch.
+                clone_args = ["git", "clone", "--depth", "1"]
+                if parsed.ref and parsed.ref != "HEAD":
+                    clone_args.extend(["--branch", parsed.ref])
+                clone_args.extend([git_url, str(cache_path)])
 
-            subprocess.run(
-                clone_args,
-                check=True,
-                capture_output=True,
-                text=True,
-            )
+                subprocess.run(
+                    clone_args,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
 
             # Verify clone completed with expected structure
             if not self._verify_clone_integrity(cache_path):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,13 +1,16 @@
 """Tests for source handlers."""
 
+import subprocess
 import tempfile
 import zipfile
 from pathlib import Path
 
 import pytest
+from amplifier_foundation.exceptions import BundleNotFoundError
 from amplifier_foundation.paths.resolution import ParsedURI
 from amplifier_foundation.sources.file import FileSourceHandler
 from amplifier_foundation.sources.git import GitSourceHandler
+from amplifier_foundation.sources.git import _is_full_commit_sha
 from amplifier_foundation.sources.http import HttpSourceHandler
 from amplifier_foundation.sources.zip import ZipSourceHandler
 
@@ -300,3 +303,185 @@ class TestGitSourceHandlerCloneIntegrity:
             )
             handler = GitSourceHandler()
             assert handler._verify_clone_integrity(clone_path) is False
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    """Run a git command in a fixture repo and return stdout."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _make_fixture_repo(base: Path) -> tuple[Path, list[str]]:
+    """Create a local git repo with two commits.
+
+    Returns:
+        (repo_path, [first_commit_sha, second_commit_sha])
+    """
+    repo = base / "fixture-repo"
+    repo.mkdir()
+    _git(["init", "--quiet", "-b", "main"], cwd=repo)
+    _git(["config", "user.email", "test@example.com"], cwd=repo)
+    _git(["config", "user.name", "Test"], cwd=repo)
+
+    (repo / "bundle.md").write_text("# Fixture Bundle\n")
+    (repo / "data.txt").write_text("version one\n")
+    _git(["add", "-A"], cwd=repo)
+    _git(["commit", "--quiet", "-m", "first"], cwd=repo)
+    first_sha = _git(["rev-parse", "HEAD"], cwd=repo)
+
+    (repo / "data.txt").write_text("version two\n")
+    _git(["add", "-A"], cwd=repo)
+    _git(["commit", "--quiet", "-m", "second"], cwd=repo)
+    second_sha = _git(["rev-parse", "HEAD"], cwd=repo)
+
+    return repo, [first_sha, second_sha]
+
+
+def _parsed_git_file_uri(repo: Path, ref: str) -> ParsedURI:
+    """Build a ParsedURI for a git+file:// URI pointing at a local fixture repo."""
+    return ParsedURI(scheme="git+file", host="", path=str(repo), ref=ref, subpath="")
+
+
+class TestIsFullCommitSha:
+    """Tests for _is_full_commit_sha ref classification."""
+
+    def test_accepts_full_lowercase_sha(self) -> None:
+        assert _is_full_commit_sha("32d4052dad46016f91ce698646580473e4121344") is True
+
+    def test_accepts_uppercase_sha(self) -> None:
+        assert _is_full_commit_sha("32D4052DAD46016F91CE698646580473E4121344") is True
+
+    def test_rejects_short_sha(self) -> None:
+        assert _is_full_commit_sha("32d4052") is False
+
+    def test_rejects_39_chars(self) -> None:
+        assert _is_full_commit_sha("3" * 39) is False
+
+    def test_rejects_41_chars(self) -> None:
+        assert _is_full_commit_sha("3" * 41) is False
+
+    def test_rejects_non_hex_chars(self) -> None:
+        assert _is_full_commit_sha("g" + "3" * 39) is False
+
+    def test_rejects_branch_names(self) -> None:
+        assert _is_full_commit_sha("main") is False
+        assert _is_full_commit_sha("feat/some-branch") is False
+        assert _is_full_commit_sha("v1.0.0") is False
+
+
+class TestGitSourceHandlerShaRefs:
+    """Tests for resolving git refs pinned to a commit SHA."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_full_sha_ref_pins_non_tip_commit(self) -> None:
+        """Full-SHA ref resolves to exactly that commit (not the branch tip).
+
+        The pinned commit is NOT the branch tip and the fixture remote does
+        not enable uploadpack.allowReachableSHA1InWant, so this also exercises
+        the full-clone + checkout fallback.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            repo, shas = _make_fixture_repo(base)
+            pinned_sha = shas[0]  # older, non-tip commit
+
+            handler = GitSourceHandler()
+            parsed = _parsed_git_file_uri(repo, ref=pinned_sha)
+            result = await handler.resolve(parsed, base / "cache")
+
+            assert result.active_path.exists()
+            assert (result.active_path / "data.txt").read_text() == "version one\n"
+            head = _git(["rev-parse", "HEAD"], cwd=result.source_root)
+            assert head == pinned_sha
+
+    @pytest.mark.asyncio
+    async def test_resolve_full_sha_ref_shallow_fetch(self) -> None:
+        """When the server allows SHA fetches, the shallow fast path is used."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            repo, shas = _make_fixture_repo(base)
+            # GitHub enables this; mirror it on the fixture remote.
+            _git(["config", "uploadpack.allowReachableSHA1InWant", "true"], cwd=repo)
+            pinned_sha = shas[0]
+
+            handler = GitSourceHandler()
+            parsed = _parsed_git_file_uri(repo, ref=pinned_sha)
+            result = await handler.resolve(parsed, base / "cache")
+
+            head = _git(["rev-parse", "HEAD"], cwd=result.source_root)
+            assert head == pinned_sha
+            # Shallow marker proves the depth-1 fetch path was taken
+            # (the fallback does a full clone, which is not shallow).
+            assert (result.source_root / ".git" / "shallow").exists()
+
+    @pytest.mark.asyncio
+    async def test_resolve_branch_ref_still_works(self) -> None:
+        """Branch refs continue to use the existing --branch clone path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            repo, shas = _make_fixture_repo(base)
+
+            handler = GitSourceHandler()
+            parsed = _parsed_git_file_uri(repo, ref="main")
+            result = await handler.resolve(parsed, base / "cache")
+
+            assert result.active_path.exists()
+            head = _git(["rev-parse", "HEAD"], cwd=result.source_root)
+            assert head == shas[1]  # branch tip
+
+    @pytest.mark.asyncio
+    async def test_short_sha_ref_raises_clear_error(self) -> None:
+        """Short/abbreviated SHAs are not special-cased and fail clearly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            repo, shas = _make_fixture_repo(base)
+            short_sha = shas[0][:7]
+
+            handler = GitSourceHandler()
+            parsed = _parsed_git_file_uri(repo, ref=short_sha)
+            with pytest.raises(BundleNotFoundError, match="Failed to clone"):
+                await handler.resolve(parsed, base / "cache")
+
+    @pytest.mark.asyncio
+    async def test_unknown_sha_raises_clear_error(self) -> None:
+        """A well-formed SHA that doesn't exist in the repo fails clearly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            repo, _shas = _make_fixture_repo(base)
+            bogus_sha = "deadbeef" * 5  # 40 hex chars, not in the repo
+
+            handler = GitSourceHandler()
+            parsed = _parsed_git_file_uri(repo, ref=bogus_sha)
+            with pytest.raises(BundleNotFoundError, match="Failed to clone"):
+                await handler.resolve(parsed, base / "cache")
+
+    def test_sha_and_branch_refs_get_distinct_cache_paths(self) -> None:
+        """A SHA ref must not collide with a branch ref cache entry."""
+        handler = GitSourceHandler()
+        cache_dir = Path("/tmp/cache")
+        sha = "32d4052dad46016f91ce698646580473e4121344"
+
+        branch_parsed = ParsedURI(
+            scheme="git+https",
+            host="github.com",
+            path="/org/repo",
+            ref="main",
+            subpath="",
+        )
+        sha_parsed = ParsedURI(
+            scheme="git+https",
+            host="github.com",
+            path="/org/repo",
+            ref=sha,
+            subpath="",
+        )
+
+        branch_path = handler._get_cache_path(branch_parsed, cache_dir)
+        sha_path = handler._get_cache_path(sha_parsed, cache_dir)
+        assert branch_path != sha_path


### PR DESCRIPTION
## Summary

This PR enables reproducible evaluation runs by supporting full commit SHA refs in bundle git sources. Currently, bundle sources can only resolve branches and tags — not exact commits — which blocks pinning the precise code under test.

## The Problem

Bundle git sources use `git clone --depth 1 --branch <ref>` to resolve refs. This works for branches/tags, but fails for commit SHAs:

```bash
# Branch/tag — works
git clone --depth 1 --branch main <url>

# Commit SHA — fails
git clone --depth 1 --branch a1b2c3d4e5... <url>
# fatal: reference is not a tree: a1b2c3d4e5...
```

**Impact:** Reproducible CI/eval runs cannot pin the exact code versions being tested. We can't say "these results are from commits X, Y, Z" — only "from the current main branch (which has changed)." For any automated measurement system (eval harnesses, benchmarks, A/B test harnesses), this is a blocker.

Meanwhile, the same SHA syntax works fine in uv:
```bash
uv pip install git+https://github.com/owner/repo@a1b2c3d4e5#egg=pkg
```

## The Fix

**Three-path git ref resolution:**

1. **Full 40-hex commit SHA** — use fetch-then-checkout:
   ```bash
   git init
   git fetch --depth 1 origin <sha>
   git checkout FETCH_HEAD
   ```
   (GitHub's `uploadpack.allowReachableSHA1InWant` makes this cheap — one commit's worth of objects)

2. **Branch/tag refs** — existing path unchanged:
   ```bash
   git clone --depth 1 --branch <ref> <url>
   ```

3. **Fallback for servers refusing SHA fetch** — full clone + checkout (tested and documented)

## Implementation

- New `_is_full_commit_sha()` helper (40-hex, case-insensitive, per `SourceStatus.is_pinned` semantics)
- New `_clone_at_commit()` method implementing the fetch-then-checkout strategy
- `resolve()` branches on ref type; branch/tag path is byte-for-byte untouched
- Cache keys already collision-free; regression-tested

## Tests

- **13 new tests** covering full-SHA resolution, short-SHA rejection (intentional — ambiguous), branch/tag passthrough, fallback behavior, cache interactions
- **Full suite:** 1,528 tests passing

## Verified Compatibility

- Matches uv's SHA ref syntax — same input format works in both ecosystems
- Handles both reachable commits (shallow fetch) and unreachable ones (full clone fallback)
- Short SHAs intentionally unsupported (ambiguous)

---

**Related:** This fix unblocks the eval harness (PR microsoft/amplifier-eval-harness) from pinning exact repo versions during measurement. See also issue microsoft/amplifier-foundation#[F6] (bundle refs blocking reproducibility).