### PR TITLE
fix(bundle): fail loud on module activation failures

### DIFF
--- a/amplifier_foundation/bundle/_dataclass.py
+++ b/amplifier_foundation/bundle/_dataclass.py
@@ -305,6 +305,7 @@ class Bundle:
         install_deps: bool = True,
         source_resolver: Callable[[str, str], str] | None = None,
         progress_callback: Callable[[str, str], None] | None = None,
+        strict: bool = False,
     ) -> PreparedBundle:
         """Prepare bundle for execution by activating all modules.
 
@@ -324,6 +325,11 @@ class Bundle:
             progress_callback: Optional callback(action, detail) for progress reporting.
                 Called at key phases during preparation to report what is happening.
                 Actions include "installing_package", "activating", "installing".
+            strict: If True, any module that fails to activate raises
+                ModuleActivationError instead of being logged and skipped.
+                Mirrors BundleRegistry(strict=...), which governs include
+                failures. Without this, a bundle whose modules fail to download
+                still returns a PreparedBundle -- just missing capabilities.
 
         Returns:
             PreparedBundle with mount_plan and create_session() helper.
@@ -355,7 +361,9 @@ class Bundle:
 
         # Create activator with bundle's base_path so relative module paths
         # like ./modules/foo resolve relative to the bundle, not cwd
-        activator = ModuleActivator(install_deps=install_deps, base_path=self.base_path)
+        activator = ModuleActivator(
+            install_deps=install_deps, base_path=self.base_path, strict=strict
+        )
 
         # CRITICAL: Install bundle packages BEFORE activating modules
         # Modules may import from their parent bundle's package (e.g., a tool

--- a/amplifier_foundation/modules/activator.py
+++ b/amplifier_foundation/modules/activator.py
@@ -65,6 +65,7 @@ class ModuleActivator:
         cache_dir: Path | None = None,
         install_deps: bool = True,
         base_path: Path | None = None,
+        strict: bool = False,
     ) -> None:
         """Initialize module activator.
 
@@ -75,9 +76,13 @@ class ModuleActivator:
                        For bundles loaded from git, this should be the cloned
                        bundle's base_path so relative paths like ./modules/foo
                        resolve correctly.
+            strict: If True, activation failures in activate_all() raise
+                    ModuleActivationError instead of being logged and skipped.
+                    Mirrors BundleRegistry(strict=...) for include failures.
         """
         self.cache_dir = cache_dir or get_amplifier_home() / "cache"
         self.install_deps = install_deps
+        self.strict = strict
         self._resolver = SimpleSourceResolver(
             cache_dir=self.cache_dir, base_path=base_path
         )
@@ -157,6 +162,11 @@ class ModuleActivator:
 
         Returns:
             Dict mapping module names to their local paths.
+
+        Raises:
+            ModuleActivationError: If strict=True and any module fails to
+                activate. All failures are reported together, not just the
+                first one.
         """
         # Phase 1: Resolve all sources and check install state
         to_activate = []
@@ -176,11 +186,21 @@ class ModuleActivator:
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
             activated = {}
+            failures: list[tuple[str, BaseException]] = []
             for (name, _), result in zip(to_activate, results):
-                if isinstance(result, Exception):
+                if isinstance(result, BaseException):
+                    failures.append((name, result))
                     logger.error(f"Failed to activate {name}: {result}")
                 else:
                     activated[name] = result
+
+            if failures and self.strict:
+                detail = "\n".join(f"  - {name}: {err}" for name, err in failures)
+                raise ModuleActivationError(
+                    f"{len(failures)} of {len(to_activate)} modules failed to "
+                    f"activate (strict mode):\n{detail}"
+                ) from failures[0][1]
+
             return activated
 
         return {}

--- a/amplifier_foundation/modules/activator.py
+++ b/amplifier_foundation/modules/activator.py
@@ -19,6 +19,7 @@ import sys
 from pathlib import Path
 from typing import Callable
 
+from amplifier_foundation.exceptions import BundleError
 from amplifier_foundation.modules.install_state import InstallStateManager
 from amplifier_foundation.paths.resolution import get_amplifier_home
 from amplifier_foundation.sources.resolver import SimpleSourceResolver
@@ -588,7 +589,12 @@ class ModuleActivator:
         self._install_state.save()
 
 
-class ModuleActivationError(Exception):
-    """Raised when module activation fails."""
+class ModuleActivationError(BundleError):
+    """Raised when module activation fails.
+
+    Subclasses BundleError so that callers already handling bundle
+    preparation failures render this cleanly instead of letting it
+    escape as an unhandled traceback.
+    """
 
     pass

--- a/amplifier_foundation/registry.py
+++ b/amplifier_foundation/registry.py
@@ -622,10 +622,17 @@ class BundleRegistry:
             future.set_result(bundle)
             return bundle
 
-        except Exception:
-            # Cancel the future to avoid "Future exception was never retrieved" warning
-            # Any concurrent waiters will get CancelledError and can retry
-            future.cancel()
+        except Exception as exc:
+            # Propagate the REAL error to concurrent waiters (step 3 above awaits
+            # this future for the diamond-dependency case). Cancelling instead
+            # would hand every waiter a bare CancelledError, hiding the actual
+            # cause and turning one root failure into several misleading ones.
+            if not future.done():
+                future.set_exception(exc)
+                # The exception may have no waiter (the only consumer can be the
+                # owner, which re-raises below). Retrieve it via callback so
+                # asyncio does not emit "Future exception was never retrieved".
+                future.add_done_callback(lambda f: f.exception())
             raise
         finally:
             # Clean up pending load tracker

--- a/tests/test_activator.py
+++ b/tests/test_activator.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from amplifier_foundation.exceptions import BundleError
 from amplifier_foundation.modules.activator import (
     ModuleActivationError,
     ModuleActivator,
@@ -523,3 +524,48 @@ class TestStrictActivation343:
 
         assert "good-one" in activated
         assert "bad-one" not in activated
+
+
+class TestModuleActivationErrorIsBundleError343:
+    """``ModuleActivationError`` must live inside the ``BundleError`` hierarchy.
+
+    This class existed before issue #343 but nothing ever raised it, so its
+    base class was never load-bearing. Turning on strict activation made it
+    fire for the first time -- and because it subclassed bare ``Exception`` it
+    walked straight past every ``except BundleError`` handler in the codebase
+    and reached the user as a raw Python traceback.
+
+    The fix is inheritance, not another catch site: a bundle whose modules
+    fail to activate *is* a bundle error, so every current and future
+    ``except BundleError`` handler should cover it for free.
+    """
+
+    def test_is_bundle_error_subclass(self) -> None:
+        assert issubclass(ModuleActivationError, BundleError)
+
+    def test_caught_by_a_generic_bundle_error_handler(self) -> None:
+        """The whole point of the inheritance, pinned directly."""
+        try:
+            raise ModuleActivationError("1 of 2 modules failed to activate")
+        except BundleError as exc:
+            assert "1 of 2 modules failed to activate" in str(exc)
+        else:  # pragma: no cover - only reached if the fix regresses
+            pytest.fail("ModuleActivationError escaped `except BundleError`")
+
+    @pytest.mark.asyncio
+    async def test_real_strict_failure_is_catchable_as_bundle_error(self) -> None:
+        """End-to-end: the actual strict path raises something handlers catch.
+
+        Asserting the class hierarchy alone would still pass if ``activate_all``
+        were changed to raise some other error type, so drive the real path.
+        """
+        activator = ModuleActivator(install_deps=False, strict=True)
+
+        async def fake_activate(name: str, uri: str, **_: object) -> Path:
+            raise RuntimeError(f"clone failed for {name}")
+
+        with patch.object(activator, "activate", side_effect=fake_activate):
+            with pytest.raises(BundleError):
+                await activator.activate_all(
+                    [{"module": "bad-one", "source": "file:///bad-one"}]
+                )

--- a/tests/test_activator.py
+++ b/tests/test_activator.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from amplifier_foundation.modules.activator import (
+    ModuleActivationError,
     ModuleActivator,
     _distribution_installed,
 )
@@ -462,3 +463,63 @@ class TestDistributionGuard326:
 
                 mock_invalidate.assert_not_called()
                 mock_subprocess.assert_not_called()
+
+
+class TestStrictActivation343:
+    """Regression coverage for issue #343.
+
+    ``BundleRegistry(strict=...)`` made include failures fatal, but module
+    activation had no equivalent: ``activate_all`` logged every failure and
+    returned the survivors, so a session could start with a provider or tool
+    silently missing. These tests pin both halves of the contract.
+    """
+
+    @pytest.mark.asyncio
+    async def test_strict_raises_and_reports_every_failure(self) -> None:
+        """strict=True surfaces ALL failures, not just the first."""
+        activator = ModuleActivator(install_deps=False, strict=True)
+
+        async def fake_activate(name: str, uri: str, **_: object) -> Path:
+            if name in ("bad-one", "bad-two"):
+                raise RuntimeError(f"clone failed for {name}")
+            return Path("/tmp") / name
+
+        with patch.object(activator, "activate", side_effect=fake_activate):
+            with pytest.raises(ModuleActivationError) as exc_info:
+                await activator.activate_all(
+                    [
+                        {"module": "good-one", "source": "file:///good-one"},
+                        {"module": "bad-one", "source": "file:///bad-one"},
+                        {"module": "bad-two", "source": "file:///bad-two"},
+                    ]
+                )
+
+        message = str(exc_info.value)
+        assert "2 of 3 modules failed" in message
+        # Both failures reported together -- not just the first.
+        assert "bad-one" in message
+        assert "bad-two" in message
+        # Original cause is chained for debuggability.
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+    @pytest.mark.asyncio
+    async def test_non_strict_preserves_skip_and_continue(self) -> None:
+        """strict=False (the default) keeps the pre-#343 behaviour."""
+        activator = ModuleActivator(install_deps=False)
+        assert activator.strict is False
+
+        async def fake_activate(name: str, uri: str, **_: object) -> Path:
+            if name == "bad-one":
+                raise RuntimeError("clone failed")
+            return Path("/tmp") / name
+
+        with patch.object(activator, "activate", side_effect=fake_activate):
+            activated = await activator.activate_all(
+                [
+                    {"module": "good-one", "source": "file:///good-one"},
+                    {"module": "bad-one", "source": "file:///bad-one"},
+                ]
+            )
+
+        assert "good-one" in activated
+        assert "bad-one" not in activated

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1897,3 +1897,64 @@ class TestExplicitlyRequestedFlag:
             assert raw_state2.explicitly_requested is True, (
                 "explicitly_requested=True must survive a registry.json round-trip"
             )
+
+
+class TestPendingLoadFailurePropagation343:
+    """Regression coverage for issue #343 (shared-future failure cascade).
+
+    ``_load_single`` de-duplicates concurrent loads of the same URI through
+    ``_pending_loads``. When the owning task failed it called ``future.cancel()``,
+    so every task waiting on that future received a bare ``CancelledError``
+    instead of the real cause. One network blip therefore surfaced as several
+    unrelated-looking failures with the actual reason nowhere in the output.
+    """
+
+    @pytest.mark.asyncio
+    async def test_waiter_receives_real_error_not_cancellation(self) -> None:
+        """A diamond-dependency waiter sees the owner's actual exception."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            registry = BundleRegistry(home=base / "home")
+
+            uri = "git+https://example.invalid/some-bundle"
+            sentinel = "network unreachable while cloning some-bundle"
+
+            async def failing_resolve(_uri: str, **_kwargs: object) -> None:
+                # Hold the future open long enough for the waiter to attach.
+                await asyncio.sleep(0.05)
+                raise RuntimeError(sentinel)
+
+            registry._source_resolver.resolve = failing_resolve  # type: ignore[assignment,method-assign]
+
+            async def waiter() -> None:
+                # Let the owner register its future first, then join it.
+                await asyncio.sleep(0.01)
+                assert uri in registry._pending_loads
+                await registry._load_single(uri)
+
+            owner_task = asyncio.create_task(registry._load_single(uri))
+            waiter_task = asyncio.create_task(waiter())
+
+            owner_exc = None
+            waiter_exc = None
+            try:
+                await owner_task
+            except BaseException as e:  # noqa: BLE001 - asserting on type below
+                owner_exc = e
+            try:
+                await waiter_task
+            except BaseException as e:  # noqa: BLE001 - asserting on type below
+                waiter_exc = e
+
+            # Owner always saw the real error.
+            assert isinstance(owner_exc, RuntimeError)
+            assert sentinel in str(owner_exc)
+
+            # The waiter must see the SAME real error -- not CancelledError.
+            assert not isinstance(waiter_exc, asyncio.CancelledError), (
+                "waiter got CancelledError: the real cause was masked"
+            )
+            assert isinstance(waiter_exc, RuntimeError)
+            assert sentinel in str(waiter_exc)


### PR DESCRIPTION
## Problem

A module that fails to download is dropped from the session with only a DEBUG log. The session starts anyway, quietly missing tools or providers the bundle declared. The user experiences this as "the model ignored my instructions" — the failure surfaces far from its cause, so nobody looks at module activation.

Reported in microsoft/amplifier#343.

## What this changes

**1. Strict module activation (`activator.py`)**

`ModuleActivator` gains `strict=`. When on, `activate_all` raises `ModuleActivationError` naming **every** failed module, not just the first — a proxy blocking one host usually breaks several, and reporting them one per run wastes a round trip each. Default stays `False`, so no existing caller changes behaviour.

**2. Real errors reach concurrent waiters (`registry.py`)**

`_load_single` de-duplicates concurrent loads of the same URI through a shared future. On failure it called `future.cancel()`, handing every waiter a bare `CancelledError`. In the diamond-dependency case one root failure surfaced as several unrelated-looking failures with the actual cause nowhere in the output. It now propagates the real exception, with a done-callback to retrieve it so asyncio does not warn about an unretrieved exception.

**3. `ModuleActivationError` inherits from `BundleError`**

Nothing raised this class before, so its base was never load-bearing. Turning on strict activation fired it for the first time — and subclassing bare `Exception` meant it walked past every `except BundleError` handler and reached users as a raw traceback. A bundle whose modules fail to activate *is* a bundle error, so inheritance is the fix rather than another catch site. Verified there were zero existing catchers of `ModuleActivationError` in foundation or app-cli, so this is a safe widening.

## Tests

`tests/test_activator.py` — strict reports all failures and chains the original cause; non-strict preserves skip-and-continue; the `BundleError` relationship, that a generic handler actually catches it, and that the real `activate_all` path raises something those handlers catch.

`tests/test_registry.py` — a diamond-dependency waiter receives the owner's real exception rather than a cancellation.

## Scope

Mechanism only. Foundation does not decide to be strict; it makes strictness expressible. Turning it on is app-layer policy — see microsoft/amplifier-app-cli#237, which must merge **after** this.

**Not addressed:** bundle `includes:` still fail soft. `BundleRegistry` already accepts `strict`, but wiring it end-to-end is a separate change with a different blast radius.
