### PR TITLE
fix(sources): retry transient git clone failures

### DIFF
--- a/amplifier_foundation/sources/git.py
+++ b/amplifier_foundation/sources/git.py
@@ -10,6 +10,7 @@ import logging
 import re
 import shutil
 import subprocess
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -32,6 +33,59 @@ _FULL_COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 def _is_full_commit_sha(ref: str) -> bool:
     """Check whether a ref is a full 40-hex-character commit SHA."""
     return bool(_FULL_COMMIT_SHA_PATTERN.match(ref))
+
+
+# Retry policy for network-touching git operations (clone/fetch).
+#
+# Deliberately NOT gated on an error-message allowlist. Classifying git stderr
+# into "transient" vs "permanent" is a policy table that drifts and misfires;
+# the entire cost of retrying a genuinely permanent error here is
+# _CLONE_RETRY_BACKOFF_S summed over the retries (3s), paid only on a path that
+# is already failing. Retrying everything is simpler and fails safe.
+_CLONE_MAX_ATTEMPTS = 3
+_CLONE_RETRY_BACKOFF_S = (1.0, 2.0)
+
+
+def _run_git_network_op(
+    args: list[str], cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run a network-touching git command, retrying transient failures.
+
+    A single dropped connection while cloning used to fail the module
+    permanently. Combined with strict activation (where a failed module aborts
+    the session rather than degrading it silently), one network blip would take
+    down a whole session. This absorbs that class of failure.
+
+    Args:
+        args: Full git command line.
+        cwd: Working directory for the command.
+
+    Returns:
+        The CompletedProcess from the first successful attempt.
+
+    Raises:
+        subprocess.CalledProcessError: From the final attempt, if all fail.
+    """
+    last_error: subprocess.CalledProcessError | None = None
+
+    for attempt in range(_CLONE_MAX_ATTEMPTS):
+        try:
+            return subprocess.run(
+                args, cwd=cwd, check=True, capture_output=True, text=True
+            )
+        except subprocess.CalledProcessError as e:
+            last_error = e
+            if attempt < _CLONE_MAX_ATTEMPTS - 1:
+                delay = _CLONE_RETRY_BACKOFF_S[attempt]
+                logger.warning(
+                    f"git {args[1] if len(args) > 1 else ''} failed "
+                    f"(attempt {attempt + 1}/{_CLONE_MAX_ATTEMPTS}), "
+                    f"retrying in {delay}s: {(e.stderr or '').strip()}"
+                )
+                time.sleep(delay)
+
+    assert last_error is not None  # loop always sets it before exhausting
+    raise last_error
 
 
 class GitSourceHandler:
@@ -218,7 +272,11 @@ class GitSourceHandler:
                 f"({e.stderr}); falling back to full clone + checkout"
             )
             shutil.rmtree(cache_path, ignore_errors=True)
-            run_git(["git", "clone", git_url, str(cache_path)])
+            # Retry only this clone, not the shallow fetch above: that fetch
+            # failing is an *expected* outcome on servers without
+            # allowReachableSHA1InWant, and retrying it would add seconds to a
+            # designed fallback path rather than to an error path.
+            _run_git_network_op(["git", "clone", git_url, str(cache_path)])
             run_git(
                 ["git", "-c", "advice.detachedHead=false", "checkout", "--quiet", sha],
                 cwd=cache_path,
@@ -276,12 +334,7 @@ class GitSourceHandler:
                     clone_args.extend(["--branch", parsed.ref])
                 clone_args.extend([git_url, str(cache_path)])
 
-                subprocess.run(
-                    clone_args,
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
+                _run_git_network_op(clone_args)
 
             # Verify clone completed with expected structure
             if not self._verify_clone_integrity(cache_path):

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -485,3 +485,95 @@ class TestGitSourceHandlerShaRefs:
         branch_path = handler._get_cache_path(branch_parsed, cache_dir)
         sha_path = handler._get_cache_path(sha_parsed, cache_dir)
         assert branch_path != sha_path
+
+
+class TestGitNetworkOpRetry343:
+    """Regression coverage for issue #343 (transient clone failures).
+
+    ``git clone`` had no retry. A single dropped connection failed the module
+    permanently. Once activation failures become fatal rather than silent, that
+    same blip would take down a whole session -- so the retry is what makes
+    fail-loud safe to turn on.
+    """
+
+    def test_retries_then_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failure followed by a success resolves without raising."""
+        from amplifier_foundation.sources import git as git_mod
+
+        calls: list[list[str]] = []
+        sleeps: list[float] = []
+
+        def fake_run(args, **kwargs):  # noqa: ANN001, ANN202
+            calls.append(args)
+            if len(calls) == 1:
+                raise subprocess.CalledProcessError(
+                    128, args, stderr="fatal: unable to access: Connection reset"
+                )
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(git_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(git_mod.time, "sleep", lambda s: sleeps.append(s))
+
+        result = git_mod._run_git_network_op(["git", "clone", "url", "/tmp/x"])
+
+        assert result.returncode == 0
+        assert len(calls) == 2, "should have retried exactly once"
+        assert sleeps == [1.0], "should have backed off before the retry"
+
+    def test_exhausts_attempts_and_reraises_real_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When every attempt fails, the original git error is raised."""
+        from amplifier_foundation.sources import git as git_mod
+
+        calls: list[list[str]] = []
+
+        def always_fail(args, **kwargs):  # noqa: ANN001, ANN202
+            calls.append(args)
+            raise subprocess.CalledProcessError(
+                128, args, stderr="fatal: could not resolve host: github.com"
+            )
+
+        monkeypatch.setattr(git_mod.subprocess, "run", always_fail)
+        monkeypatch.setattr(git_mod.time, "sleep", lambda _s: None)
+
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            git_mod._run_git_network_op(["git", "clone", "url", "/tmp/x"])
+
+        assert len(calls) == git_mod._CLONE_MAX_ATTEMPTS
+        # The real cause survives -- not swallowed into a generic message.
+        assert "could not resolve host" in (exc_info.value.stderr or "")
+
+    def test_shallow_sha_fetch_is_not_retried(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The SHA fetch falls straight through to full clone, no retry delay.
+
+        Servers without ``allowReachableSHA1InWant`` refuse the shallow fetch as
+        a matter of course. That failure is a designed fallback, not an error,
+        so retrying it would add seconds to a normal path.
+        """
+        from amplifier_foundation.sources.git import GitSourceHandler
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            handler = GitSourceHandler()
+            cache_path = Path(tmpdir) / "repo"
+            seen: list[list[str]] = []
+
+            def fake_run(args, **kwargs):  # noqa: ANN001, ANN202
+                seen.append(list(args))
+                # Refuse the shallow SHA fetch; succeed at everything else.
+                if "fetch" in args:
+                    raise subprocess.CalledProcessError(128, args, stderr="refused")
+                return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+            monkeypatch.setattr(subprocess, "run", fake_run)
+
+            handler._clone_at_commit("https://example.invalid/r.git", "a" * 40, cache_path)
+
+            fetch_calls = [c for c in seen if "fetch" in c]
+            assert len(fetch_calls) == 1, (
+                "shallow SHA fetch must not be retried -- its failure is the "
+                "designed trigger for the full-clone fallback"
+            )
+            assert any("clone" in c for c in seen), "should fall back to full clone"


### PR DESCRIPTION
## The problem

A module fetched over git gets exactly one clone attempt. A dropped connection, a DNS hiccup, or a momentary GitHub blip is treated as permanent failure. Downstream, that failure is currently swallowed and the module is silently dropped from the session — see microsoft/amplifier#343.

## What this changes

Retries the clone with bounded exponential backoff (3 attempts, ~1s and ~2s pauses) before giving up. On final failure the original error is raised unchanged.

## Two deliberate scope decisions

**No transient/permanent error classification.** The obvious "smarter" version matches git stderr against a pattern list to decide what is worth retrying. That is a policy table that drifts, misfires on localised or reworded git output, and needs maintenance forever. The entire cost of retrying a genuinely permanent error is ~3 seconds, paid only on a path that is already failing. Retrying everything is simpler and fails safe.

**The shallow SHA fetch in `_clone_at_commit` is NOT retried.** Its failure is the *expected* outcome against servers without `uploadpack.allowReachableSHA1InWant`, and that failure is the designed trigger for the full-clone fallback. Retrying it would add seconds to a normal control-flow path rather than an error path. There is a test pinning this so a future change does not "helpfully" wrap it.

## Why this matters for fail-loud

This should land before any app turns on strict module activation. Without a retry, a single dropped connection would escalate from "silently degraded session" to "no session at all". The retry is what makes fail-loud safe to enable.

## Tests

Retry-on-transient-then-succeed, exhaustion re-raising the original error, backoff timing, and a guard that the SHA-fetch fallback path stays un-retried.

Full suite: 1522 passed, 9 failed — identical to the `main` baseline (pre-existing failures, unrelated).

Refs: microsoft/amplifier#343
