### PR TITLE
fix(tool-delegate): constrain model_role to the roles the session can actually resolve

### DIFF
--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -288,7 +288,39 @@ Agent usage notes:
                 " Use a registered agent name or bundle path instead."
             )
         schema["properties"]["agent"]["description"] += note
+
+        # Constrain `model_role` to the roles the active routing matrix
+        # actually defines. Left as an open string, models have been observed
+        # to invent values -- notably the literal "default" -- which resolve
+        # to no candidates and silently bypass routing rather than failing
+        # loudly. When no routing matrix is registered the parameter cannot be
+        # honoured at all, so it is dropped from the schema instead of being
+        # advertised as if it worked.
+        roles = self._available_model_roles()
+        if roles:
+            schema["properties"]["model_role"]["enum"] = roles
+        else:
+            schema["properties"].pop("model_role", None)
         return schema
+
+    def _available_model_roles(self) -> list[str]:
+        """Return role names published by the active routing matrix, if any.
+
+        A routing bundle stores its composed matrix on the coordinator's
+        session state as ``{"name": ..., "roles": {<role>: ...}}``. Without a
+        routing bundle the key is absent entirely and model-role routing is
+        unavailable for the session.
+        """
+        session_state = getattr(self.coordinator, "session_state", None)
+        if not isinstance(session_state, dict):
+            return []
+        matrix = session_state.get("routing_matrix")
+        if not isinstance(matrix, dict):
+            return []
+        roles = matrix.get("roles")
+        if not isinstance(roles, dict):
+            return []
+        return sorted(str(role) for role in roles)
 
     def _static_input_schema(self) -> dict:
         """Return a fresh literal copy of the input schema dict.

--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -289,38 +289,57 @@ Agent usage notes:
             )
         schema["properties"]["agent"]["description"] += note
 
-        # Constrain `model_role` to the roles the active routing matrix
-        # actually defines. Left as an open string, models have been observed
-        # to invent values -- notably the literal "default" -- which resolve
-        # to no candidates and silently bypass routing rather than failing
-        # loudly. When no routing matrix is registered the parameter cannot be
-        # honoured at all, so it is dropped from the schema instead of being
-        # advertised as if it worked.
-        roles = self._available_model_roles()
-        if roles:
-            schema["properties"]["model_role"]["enum"] = roles
-        else:
+        # Shape `model_role` to what the session can actually honour. Left as
+        # an open string, models have been observed to invent values -- notably
+        # the literal "default" -- which resolve to no candidates, log a
+        # warning, and let the spawn proceed on the agent's default model. The
+        # role names belong in the parameter the model is filling, not only in
+        # prose it may not weight.
+        #
+        # Three distinct states, and collapsing any two of them is a bug:
+        #   None -> no resolver registered at all. execute() can do nothing but
+        #           warn, so the parameter is inert: drop it.
+        #   ()   -> a resolver is registered but cannot enumerate its roles
+        #           (older routing bundle, or a strategy that has no fixed role
+        #           set). Routing works; we just cannot constrain it. Keep the
+        #           parameter as an open string -- dropping it here would break
+        #           working routing.
+        #   (..) -> constrain to those roles.
+        known_roles = self._resolver_known_roles()
+        if known_roles is None:
             schema["properties"].pop("model_role", None)
+        elif known_roles:
+            schema["properties"]["model_role"]["enum"] = list(known_roles)
         return schema
 
-    def _available_model_roles(self) -> list[str]:
-        """Return role names published by the active routing matrix, if any.
+    def _resolver_known_roles(self) -> tuple[str, ...] | None:
+        """Roles the active ``model_role_resolver`` can enumerate.
 
-        A routing bundle stores its composed matrix on the coordinator's
-        session state as ``{"name": ..., "roles": {<role>: ...}}``. Without a
-        routing bundle the key is absent entirely and model-role routing is
-        unavailable for the session.
+        Returns ``None`` when no resolver capability is registered, and an
+        empty tuple when a resolver is registered but does not expose the
+        optional ``known_roles`` member. Those two states are different and
+        callers must treat them differently -- see ``input_schema``.
+
+        The capability is the contract, and it is the same source ``execute()``
+        resolves against. Note that ``known_roles`` is advisory: a listed role
+        can still resolve to no candidates when no installed provider serves
+        it, which is why the miss-path warning in ``execute()`` stays.
         """
-        session_state = getattr(self.coordinator, "session_state", None)
-        if not isinstance(session_state, dict):
-            return []
-        matrix = session_state.get("routing_matrix")
-        if not isinstance(matrix, dict):
-            return []
-        roles = matrix.get("roles")
-        if not isinstance(roles, dict):
-            return []
-        return sorted(str(role) for role in roles)
+        if not hasattr(self.coordinator, "get_capability"):
+            return None
+        resolver = self.coordinator.get_capability("model_role_resolver")
+        if resolver is None:
+            return None
+        # Optional member of a duck-typed contract, so it may be absent, and a
+        # third-party resolver may return something unusable. A bad value must
+        # degrade to "cannot enumerate" -- never leak into the schema, and
+        # never raise, since this runs on every request.
+        roles = getattr(resolver, "known_roles", None)
+        if not isinstance(roles, (list, tuple)):
+            return ()
+        if not all(isinstance(role, str) for role in roles):
+            return ()
+        return tuple(roles)
 
     def _static_input_schema(self) -> dict:
         """Return a fresh literal copy of the input schema dict.

--- a/modules/tool-delegate/tests/test_delegate_model_role.py
+++ b/modules/tool-delegate/tests/test_delegate_model_role.py
@@ -604,3 +604,116 @@ class TestAgentSpawnedEventIncludesRouting:
         )
         assert len(payload["provider_preferences"]) >= 1
         assert payload["provider_preferences"][0]["provider"] == "anthropic"
+
+# =============================================================================
+# Tests: input_schema shaping of the model_role parameter
+#
+# Three states, and collapsing any two of them is a bug:
+#   no resolver registered   -> drop model_role (it is inert)
+#   resolver, no known_roles -> keep model_role open (routing still works)
+#   resolver with roles      -> constrain to those roles
+# =============================================================================
+
+
+class TestModelRoleSchemaShaping:
+    @staticmethod
+    def _model_role_prop(tool) -> dict | None:
+        return tool.input_schema["properties"].get("model_role")
+
+    def test_enum_matches_resolver_known_roles(self):
+        """Roles come from the capability -- the same source execute() resolves
+        against -- not from any session_state mirror."""
+        resolver = _make_resolver()
+        resolver.known_roles = ("general", "fast", "coding")
+        tool = _make_delegate_tool(model_role_resolver=resolver)
+
+        prop = self._model_role_prop(tool)
+        assert prop is not None
+        assert prop["enum"] == ["general", "fast", "coding"]
+
+    def test_enum_preserves_declaration_order_and_is_not_sorted(self):
+        """The routing bundle injects roles into session context in matrix
+        order. Sorting here would desync the enum from that prose."""
+        resolver = _make_resolver()
+        resolver.known_roles = ("general", "fast", "coding", "ui-coding")
+        tool = _make_delegate_tool(model_role_resolver=resolver)
+
+        enum = self._model_role_prop(tool)["enum"]
+        assert enum == ["general", "fast", "coding", "ui-coding"]
+        assert enum != sorted(enum), "enum must not be alphabetised"
+
+    def test_resolver_without_known_roles_keeps_open_string(self):
+        """known_roles is OPTIONAL. An older routing bundle -- or a strategy
+        with no fixed role set -- still routes, so the parameter must survive
+        as an open string. Dropping it here would break working routing."""
+        resolver = _make_resolver()  # MagicMock: delete the auto-created attr
+        del resolver.known_roles
+        tool = _make_delegate_tool(model_role_resolver=resolver)
+
+        prop = self._model_role_prop(tool)
+        assert prop is not None, "model_role must not be dropped when a resolver exists"
+        assert "enum" not in prop
+
+    def test_resolver_with_empty_known_roles_keeps_open_string(self):
+        """Empty tuple means 'cannot enumerate', not 'no roles exist'."""
+        resolver = _make_resolver()
+        resolver.known_roles = ()
+        tool = _make_delegate_tool(model_role_resolver=resolver)
+
+        prop = self._model_role_prop(tool)
+        assert prop is not None
+        assert "enum" not in prop
+
+    def test_no_resolver_drops_the_parameter(self):
+        """Without a resolver, execute() can only warn -- the parameter is
+        inert, so it should not be advertised as if it worked."""
+        tool = _make_delegate_tool(model_role_resolver=None)
+        assert self._model_role_prop(tool) is None
+
+    def test_coordinator_without_get_capability_drops_the_parameter(self):
+        """Host that predates the capability API: must not raise."""
+        tool = _make_delegate_tool(model_role_resolver=None)
+        del tool.coordinator.get_capability
+        assert not hasattr(tool.coordinator, "get_capability")
+        assert self._model_role_prop(tool) is None
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "general",  # a bare string is iterable -- must not become 7 letters
+            {"general": {}},
+            123,
+            ["general", 42],  # mixed types
+            [None],
+        ],
+        ids=["bare-str", "dict", "int", "mixed-types", "none-item"],
+    )
+    def test_malformed_known_roles_degrades_without_raising(self, bad_value):
+        """Third-party resolvers may register anything under this capability
+        name. A bad value degrades to 'cannot enumerate' -- it must never leak
+        into the schema and must never raise, since this runs per request."""
+        resolver = _make_resolver()
+        resolver.known_roles = bad_value
+        tool = _make_delegate_tool(model_role_resolver=resolver)
+
+        prop = self._model_role_prop(tool)
+        assert prop is not None
+        assert "enum" not in prop
+
+    def test_static_schema_remains_a_pure_literal(self):
+        """foundation's bundle-docs token estimator statically evaluates the
+        schema body via ast.literal_eval. The dynamic enum is applied by
+        input_schema() afterwards and must not push computation into the
+        literal."""
+        import ast
+        import inspect
+        import textwrap
+
+        src = textwrap.dedent(inspect.getsource(DelegateTool._static_input_schema))
+        ret = next(
+            node for node in ast.walk(ast.parse(src)) if isinstance(node, ast.Return)
+        )
+        literal = ast.literal_eval(ret.value)  # raises if not a pure literal
+
+        assert "model_role" in literal["properties"]
+        assert "enum" not in literal["properties"]["model_role"]


### PR DESCRIPTION
## Summary

`tool-delegate` advertises a `model_role` parameter to the model as an unconstrained string. Nothing tells the model which values are legal, and nothing checks the value it picks. When it picks one the routing matrix does not define — `"default"` is the one seen in the wild — `resolve()` returns no candidates and the spawn proceeds on the agent's default model.

This PR shapes the parameter to what the session can actually honour, sourcing the legal values from the `model_role_resolver` capability.

## What the model sees today

```json
"model_role": {"type": "string", "description": "Override the agent's default model role..."}
```

The legal values live only in prose injected into session context by the routing bundle. Prose the model may or may not weight. The parameter it is actually filling carries no constraint at all.

## What goes wrong

Two distinct failures, and the fix addresses both:

**1. Invented role names.** The model passes `"default"`. `resolve()` matches nothing and returns `[]`. `execute()` logs:

```
model_role '%s' resolved to no candidates against installed providers (resolver=%s)
```

…and then spawns on the agent's default model. So it is **not silent** — there is a stderr warning. But it is easy to miss, the spawn still proceeds, and the delegation quietly runs on a model nobody chose. The routing decision the caller asked for did not happen.

**2. A parameter advertised in sessions that cannot honour it.** With no routing bundle loaded, there is no resolver at all. `model_role` is still advertised. The model fills it in — reasonably, it is right there in the schema — and every single delegation takes the miss path. This was the originating case. An enum alone would not have fixed it: the model would still invent a value for an advertised parameter. Advertising a parameter the session cannot honour is the defect.

## The fix

`input_schema` is a property, evaluated per request (`loop-streaming/__init__.py:423` builds `ToolSpec(parameters=t.input_schema)` inside the request loop), so it can reflect live session state. It now reads the `model_role_resolver` capability and branches three ways:

| Capability state | Schema | Why |
|---|---|---|
| No resolver registered | `model_role` **removed** | `execute()` can only warn. The parameter is inert — do not advertise it. |
| Resolver, no `known_roles` | `model_role` kept, **no enum** | Routing works; we just cannot enumerate it. Dropping the parameter here would break working routing. |
| Resolver with `known_roles` | `enum` set to those roles | Constrain to what the session can resolve. |

The middle row is the one worth calling out. `known_roles` is an **optional** member of a duck-typed contract — another bundle may register its own resolver under this capability name, and a cost-aware or latency-aware strategy may have no fixed role set. "Cannot enumerate" and "no resolver" are different states and must not collapse to the same branch.

**Roles come from the capability, not from `session_state`.** An earlier revision of this PR read `session_state["routing_matrix"]`. That key is a leftover: it was deliberately removed during the capability migration, restored by accident by a stale perf branch, and left behind by the repair — no consumer reads it. Sourcing from it would have made this constraint go silently inert the moment the key was cleaned up. The capability cannot fail that way: if it disappears, `execute()` breaks loudly too. The key is being deleted in the companion PR.

**Declaration order, not sorted.** The routing bundle injects role names into session context in matrix order (`general, fast, coding, ui-coding, …`). Alphabetising the enum would desync the two surfaces the model reads.

**Type-guarded.** Any bundle can register under this capability name. A malformed `known_roles` degrades to "cannot enumerate" — it never leaks into the schema and never raises, since this runs on every request.

## What the enum is, and is not

**It is a strong steering signal. It is not a gate.**

The OpenAI provider emits tools as `{"type": "function", "name", "description", "parameters"}` with **no `strict: true`** (`amplifier-module-provider-openai/.../__init__.py` ~line 3222). Without strict mode, OpenAI does not enforce `enum`. Anthropic does not validate tool input against the schema at all. Nothing rejects a bad value at the provider boundary.

What the enum does is put the legal values inside the parameter the model is filling, rather than only in prose elsewhere in context. Models follow enums well, so this is worth doing — but it does not make bad values unemittable.

**Consequence: the `execute()`-side warning stays load-bearing and is unchanged by this PR.** `known_roles` is advisory in the other direction too — a role can be listed and still resolve to `[]` when no installed provider serves it. The miss path does not go away.

## Dependency

Requires microsoft/amplifier-bundle-routing-matrix#37, which adds `known_roles` to the resolver contract.

**Safe to merge before it.** Until that lands, no resolver publishes `known_roles`, so every session with a routing bundle takes the "keep as open string" branch — identical to today's behaviour. The parameter-removal branch for resolver-less sessions works immediately and independently.

## Scope

`delegate` is the only LLM-facing surface exposing `model_role`. `recipes` and `load_skill` take it from config, not model output. This covers the only path where a model chooses the value.

`_static_input_schema()` stays a pure literal — the enum is applied by `input_schema` afterwards — so foundation's bundle-docs token estimator can still `ast.literal_eval` it. A test pins this.

## Testing

```
$ python3 -m pytest tests -q     # from modules/tool-delegate
60 passed in 0.10s
```

New `TestModelRoleSchemaShaping` covers all three branches and the failure modes:

- enum matches the resolver's `known_roles`
- enum preserves declaration order and asserts it is **not** sorted
- resolver without `known_roles` → parameter kept as open string (regression guard: this branch must not drop it)
- resolver with empty `known_roles` → parameter kept as open string
- no resolver → parameter removed
- coordinator predating `get_capability` → parameter removed, no raise
- malformed `known_roles` (bare string, dict, int, mixed-type list, `[None]`) → degrades without raising, never reaches the schema
- `_static_input_schema()` still `ast.literal_eval`-parses

`ruff check` clean.
