### PR TITLE
fix: index both `id` and `instance_id` in provider-preference lookup

### DIFF
--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -318,7 +318,17 @@ def _spec_for_instance(
     for spec in provider_specs:
         if not isinstance(spec, dict):
             continue
-        spec_id = spec.get("id") or spec.get("module", "")
+        # Kernel uses instance_id as the mount name (see _session_init.py:132),
+        # but bundle YAMLs may use id (app-cli/bundle-facing spelling) or module
+        # Check both id and instance_id; if both present and different, both are valid
+        spec_id = spec.get("instance_id")
+        if spec_id == instance_id:
+            return spec
+        spec_id = spec.get("id")
+        if spec_id == instance_id:
+            return spec
+        # Fall back to module if neither id nor instance_id matched
+        spec_id = spec.get("module", "")
         if spec_id == instance_id:
             return spec
     return None
@@ -412,12 +422,15 @@ def _find_provider_index(
     """
     for i, p in enumerate(providers):
         module_id = p.get("module", "")
-        instance_id = p.get("id", "")
+        # Kernel uses instance_id as the mount name; bundle YAMLs may use id or module
+        instance_id = p.get("instance_id")
+        id_val = p.get("id")
         if provider_id in (
             module_id,
             module_id.replace("provider-", ""),
             f"provider-{provider_id}",
             instance_id,
+            id_val,
         ):
             return i
     return None
@@ -433,6 +446,15 @@ def _build_provider_lookup(
 
     Returns:
         Dict mapping various name formats to provider index.
+
+    Note: Both ``id`` and ``instance_id`` are indexed because:
+    - ``id`` is the app-cli/bundle-facing spelling (bridged to ``instance_id``
+      by ``amplifier_app_cli/runtime/config.py``)
+    - ``instance_id`` is the kernel's own field name (``_session_init.py:132``)
+    - A bundle loaded WITHOUT the app-cli bridge (e.g. a runner calling
+      ``Bundle.prepare()`` directly) only ever has ``instance_id``
+    If both are present and different, both keys are indexed to support both
+    the app-cli-bundled and direct kernel usage scenarios.
     """
     lookup: dict[str, int] = {}
     for i, p in enumerate(providers):
@@ -444,10 +466,15 @@ def _build_provider_lookup(
             lookup[short_name] = i
         # And with provider- prefix
         lookup[f"provider-{short_name}"] = i
-        # Add id-based lookup if present
-        instance_id = p.get("id")
-        if instance_id:
-            lookup[instance_id] = i
+        # Index both id and instance_id for flexibility
+        # id: app-cli/bundle-facing spelling
+        # instance_id: kernel's field name for mounts
+        id_val = p.get("id")
+        if id_val:
+            lookup[id_val] = i
+        instance_id_val = p.get("instance_id")
+        if instance_id_val:
+            lookup[instance_id_val] = i
     return lookup
 
 

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -12,6 +12,7 @@ from amplifier_foundation.spawn_utils import _apply_single_override
 from amplifier_foundation.spawn_utils import _build_provider_lookup
 from amplifier_foundation.spawn_utils import _find_provider_index
 from amplifier_foundation.spawn_utils import _find_provider_instance
+from amplifier_foundation.spawn_utils import _spec_for_instance
 from amplifier_foundation.spawn_utils import apply_provider_preferences
 from amplifier_foundation.spawn_utils import apply_provider_preferences_with_resolution
 from amplifier_foundation.spawn_utils import is_glob_pattern
@@ -988,3 +989,86 @@ class TestProviderPreferenceConfigWiring:
         assert result_config["temperature"] == 0.3
         # Existing protected key untouched
         assert result_config["api_key"] == "sk-test"
+
+
+class TestInstanceIdLookup:
+    """Tests for instance_id lookup alongside id (kernel vs app-cli spelling)."""
+
+    def test_spec_for_instance_with_id_only(self) -> None:
+        """A provider with only id field is resolvable (regression lock)."""
+        specs = [{"module": "provider-anthropic", "id": "local"}]
+        assert _spec_for_instance(specs, "local") == specs[0]
+
+    def test_spec_for_instance_with_instance_id_only(self) -> None:
+        """A provider with only instance_id field is resolvable (THE FIX)."""
+        specs = [{"module": "provider-anthropic", "instance_id": "local"}]
+        assert _spec_for_instance(specs, "local") == specs[0]
+
+    def test_spec_for_instance_with_both_id_and_instance_id(self) -> None:
+        """A provider with both id and instance_id is resolvable by instance_id."""
+        specs = [{"module": "provider-anthropic", "id": "alpha", "instance_id": "beta"}]
+        # Kernel uses instance_id as the mount name
+        assert _spec_for_instance(specs, "beta") == specs[0]
+        # id is also valid for app-cli compatibility
+        assert _spec_for_instance(specs, "alpha") == specs[0]
+
+    def test_spec_for_instance_with_neither(self) -> None:
+        """A provider without id/instance_id falls back to module (regression lock)."""
+        specs = [{"module": "provider-anthropic"}]
+        assert _spec_for_instance(specs, "provider-anthropic") == specs[0]
+
+    def test_find_provider_index_with_id_only(self) -> None:
+        """Can find a provider by its id field (regression lock)."""
+        providers = [
+            {"module": "provider-anthropic", "id": "local", "config": {}},
+        ]
+        assert _find_provider_index(providers, "local") == 0
+
+    def test_find_provider_index_with_instance_id_only(self) -> None:
+        """Can find a provider by its instance_id field (THE FIX)."""
+        providers = [
+            {"module": "provider-anthropic", "instance_id": "local", "config": {}},
+        ]
+        assert _find_provider_index(providers, "local") == 0
+
+    def test_find_provider_index_with_both_id_and_instance_id(self) -> None:
+        """Can find a provider by either id or instance_id."""
+        providers = [
+            {
+                "module": "provider-anthropic",
+                "id": "alpha",
+                "instance_id": "beta",
+                "config": {},
+            },
+        ]
+        assert _find_provider_index(providers, "alpha") == 0
+        assert _find_provider_index(providers, "beta") == 0
+
+    def test_build_provider_lookup_with_instance_id_only(self) -> None:
+        """Lookup dict includes instance_id keys when providers have instance_id only."""
+        providers = [
+            {"module": "provider-anthropic", "instance_id": "local", "config": {}},
+        ]
+        lookup = _build_provider_lookup(providers)
+        assert lookup["local"] == 0
+        # Also index module and short names
+        assert lookup["provider-anthropic"] == 0
+        assert lookup["anthropic"] == 0
+
+    def test_build_provider_lookup_with_both_id_and_instance_id(self) -> None:
+        """Lookup dict includes both id and instance_id keys when both present."""
+        providers = [
+            {
+                "module": "provider-anthropic",
+                "id": "alpha",
+                "instance_id": "beta",
+                "config": {},
+            },
+        ]
+        lookup = _build_provider_lookup(providers)
+        # Both keys should map to the same provider
+        assert lookup["alpha"] == 0
+        assert lookup["beta"] == 0
+        # And also module/short names
+        assert lookup["provider-anthropic"] == 0
+        assert lookup["anthropic"] == 0


### PR DESCRIPTION
## Summary

`_build_provider_lookup` in `spawn_utils.py` indexes a mount-plan provider entry by its `id` key but never by `instance_id` — even though `instance_id` is the field the **kernel itself** defines as provider instance identity (`amplifier-core/python/amplifier_core/_session_init.py:132` reads `provider_config.get("instance_id")` and remaps the mount name from it).

Consequence: a bundle that declares a provider using the kernel's own spelling mounts correctly but is **invisible** to `apply_provider_preferences`. The preference is silently dropped, along with any model or config override it carried.

## Reproduction

Against the currently published `amplifier_foundation` (no patch applied):

```python
plan_id  = [{"module": "provider-chat-completions", "id": "local", ...}]
plan_iid = [{"module": "provider-chat-completions", "instance_id": "local", ...}]

_build_provider_lookup(plan_id)   -> keys ['chat-completions', 'local', 'provider-chat-completions']
_find_provider_index(plan_id,  "local") -> 0

_build_provider_lookup(plan_iid)  -> keys ['chat-completions', 'provider-chat-completions']
_find_provider_index(plan_iid, "local") -> None      # <- miss
```

## Why this is reachable, not theoretical

The kernel *instructs* users to write `instance_id`. From `_session_init.py:122`:

```
"Multi-instance providers require explicit 'instance_id' on each additional entry.
 Found {n} entries for module '{mid}' without instance_id
 (at most 1 allowed as the default instance)."
```

So mounting two instances of the same provider module — e.g. a local endpoint and a remote GPU server, both `provider-chat-completions` — **fails to start unless you write `instance_id`**. Do what the kernel says, and preference resolution can then see neither instance.

It also affects any bundle prepared directly via `Bundle.prepare()` without the app-cli bridge, since that bridge is what copies `id` -> `instance_id`; such a plan only ever has `instance_id`.

## The existing code reads as an oversight, not a design choice

```python
# Add id-based lookup if present
instance_id = p.get("id")     # variable named instance_id, reads the "id" key
if instance_id:
    lookup[instance_id] = i
```

## The fix

Index **both** spellings at the three sites that shared the same `p.get("id")` pattern: `_build_provider_lookup`, `_find_provider_index`, and `_spec_for_instance`. Where both keys are present and differ, both are indexed rather than silently preferring one.

Purely additive — every existing `id`-based entry resolves exactly as before.

Also documents *why* both are indexed at the lookup builder: `id` is the app-cli/bundle-facing spelling, `instance_id` is the kernel's own field name, and a directly-prepared bundle has only the latter.

## Tests

+9 covering:
- `id` only — regression lock on existing behaviour
- `instance_id` only — the actual fix (fails before this change)
- both present and different — resolvable under either name
- neither present — still falls back to module name and the `provider-`-stripped short name

Full foundation suite: **1537 passed**. The 9 pre-existing failures were diffed against a stashed baseline and are byte-for-byte identical — no new failures.

## Notes for reviewers

Found while enabling local / OpenAI-compatible model providers in attractor pipelines (see microsoft/amplifier-bundle-attractor#100 — that PR does **not** depend on this one and was verified end-to-end against unmodified published foundation).

The mis-signalling is worth noting for anyone who hits this: the diagnostic that surfaces is `"No preferred providers found in mount plan. Preferences: ['local'], Available: ['provider-chat-completions']"`, which prints **module IDs**, not mount names. It reads as though the kernel's mount remap failed when it had not — the remap works fine and the miss is one layer up, in preference resolution.

Separate follow-up, not included here: neither `id` nor `instance_id` is documented anywhere in `amplifier-core/docs/` — `MOUNT_PLAN_SPECIFICATION.md` documents a provider entry as `{module, source, config}` only.
