### PR TITLE
fix(recipes): validate-bundle-repo — dict-session getattr flags every standalone bundle; bundle schema misapplied to agent files (v3.6.1)

### DIFF
--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -1,9 +1,23 @@
 # validate-bundle-repo.yaml
-# Repository-Wide Bundle Validator Recipe v3.6.0
+# Repository-Wide Bundle Validator Recipe v3.6.1
 # Validates an entire bundle repository against structural requirements, conventions,
 # and Amplifier bundle philosophy (context sink pattern, thin behaviors, tool placement)
 #
 # CHANGELOG:
+# v3.6.1 - Fix two false-positive defects
+#        - Standalone completeness (Phase 3): Bundle.session is dict[str, Any],
+#          but the check used getattr(session, 'orchestrator'/'context'), which
+#          never resolves dict keys -> has_orchestrator/has_context were False
+#          unconditionally, flagging EVERY standalone bundle in EVERY repo as
+#          ERROR missing_session_config (drove false "critical" classification
+#          on clean repos). New _sess() helper handles dict and object forms;
+#          via_includes derivation now computes correctly downstream.
+#        - Individual validation (Phase 2): the bundle: schema checks
+#          (bundle.name / bundle.description) were applied to files discovery
+#          classified as category "agents", but agent files use meta:
+#          frontmatter (meta.name / meta.description) -> well-formed agents got
+#          2 spurious warnings and name "". Agents are now checked against
+#          meta.name / meta.description.
 # v3.6.0 - Mode Authoring Discipline Validation (Phase 2.7)
 #        - New Phase 2.7: mode-validation checks all modes/*.md files
 #        - Check A: Mode description token budget
@@ -190,7 +204,7 @@ description: |
   - All measurements use TOKENS (len/4), never line counts
   
   For single bundle validation, use validate-bundle.yaml instead.
-version: "3.6.0"
+version: "3.6.1"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "repository", "packaging", "hygiene", "context-sink"]
 
@@ -1002,6 +1016,7 @@ steps:
       python3 << 'EOF'
       import asyncio
       import json
+      import re
       import sys
       from pathlib import Path
 
@@ -1061,11 +1076,33 @@ steps:
               result["agents_count"] = len(bundle.agents)
               result["has_description"] = bool(getattr(bundle, 'description', None))
 
-              if not bundle.name:
-                  result["warnings"].append("Missing bundle.name")
-              
-              if not getattr(bundle, 'description', None):
-                  result["warnings"].append("Missing bundle description")
+              if category == "agents":
+                  # Agent files use meta: frontmatter (meta.name/meta.description),
+                  # not the bundle: schema — check the schema agents actually use.
+                  import yaml
+                  meta = {}
+                  fm_match = re.match(r'^---\n(.*?)\n---', path.read_text(), re.DOTALL)
+                  if fm_match:
+                      try:
+                          fm = yaml.safe_load(fm_match.group(1)) or {}
+                          if isinstance(fm.get("meta"), dict):
+                              meta = fm["meta"]
+                      except Exception:
+                          pass
+                  result["name"] = meta.get("name") or bundle.name
+                  result["has_description"] = bool(meta.get("description") or getattr(bundle, 'description', None))
+
+                  if not result["name"]:
+                      result["warnings"].append("Missing meta.name")
+
+                  if not result["has_description"]:
+                      result["warnings"].append("Missing meta.description")
+              else:
+                  if not bundle.name:
+                      result["warnings"].append("Missing bundle.name")
+                  
+                  if not getattr(bundle, 'description', None):
+                      result["warnings"].append("Missing bundle description")
 
           except BundleDependencyError as e:
               result["passed"] = False
@@ -1766,6 +1803,12 @@ steps:
       # Full validation with foundation available
       from amplifier_foundation import BundleRegistry
 
+      def _sess(s, k):
+          # Bundle.session is dict[str, Any]; handle dict and object forms.
+          # (getattr on a dict never resolves keys, which flagged every
+          # standalone bundle as missing orchestrator/context.)
+          return (s.get(k) if isinstance(s, dict) else getattr(s, k, None)) if s else None
+
       async def check_completeness():
           for bundle_path in standalone_bundles:
               results["bundles_checked"] += 1
@@ -1795,8 +1838,8 @@ steps:
                   # Check composed session config
                   session = getattr(bundle, 'session', None)
                   if session:
-                      detail["has_orchestrator"] = bool(getattr(session, 'orchestrator', None))
-                      detail["has_context"] = bool(getattr(session, 'context', None))
+                      detail["has_orchestrator"] = bool(_sess(session, 'orchestrator'))
+                      detail["has_context"] = bool(_sess(session, 'context'))
                   
                   # Check if bundle itself has orchestrator or got it via includes
                   content = path.read_text()


### PR DESCRIPTION
## Problem

Two false-positive defects in `recipes/validate-bundle-repo.yaml` (v3.6.0), found when the
recipe reported a false **critical** classification on a clean bundle repository.

### 1. Every standalone bundle in every repo flagged ERROR (Phase 3, lines 1796-1799)

`Bundle.session` is `dict[str, Any]` (`amplifier_foundation.bundle.Bundle`), but the
completeness check used `getattr(session, 'orchestrator', None)` / `getattr(session,
'context', None)` — getattr never resolves dict keys, so `has_orchestrator`/`has_context`
were `False` unconditionally and every standalone bundle produced
`ERROR missing_session_config`, driving the repo to "critical".

Reproduced through the recipe's exact `BundleRegistry._load_single(auto_include=True)` path:

| bundle | OLD orch/ctx | NEW orch/ctx | via_includes |
|---|---|---|---|
| `bundles/triage.md` (declares session directly) | False/False | True/True | False |
| `bundles/test-worker.md` (composes foundation) | False/False | True/True | True |

### 2. Agent files get spurious bundle-schema warnings (Phase 2, lines 1057-1068)

The `bundle.name` / `bundle.description` checks were applied to files discovery classified
as category `"agents"` — but agent files use `meta:` frontmatter. Well-formed agents got
`['Missing bundle.name', 'Missing bundle description']` and `"name": ""`.
Reproduced on a real agent file: OLD `name=''` + 2 warnings → NEW `name='triage'`, no warnings.

## Fix

- `_sess(s, k)` helper handling dict and object session forms (Phase 3); downstream
  `via_includes` derivation verified correct with the fixed values.
- Category-aware schema check (Phase 2): `category == "agents"` reads
  `meta.name`/`meta.description` from frontmatter; other categories unchanged.
- CHANGELOG entry + version bump to 3.6.1.

## Validation

- `yaml.safe_load` parses; recipes tool validate → `status: valid, version: 3.6.1`
- `pytest tests/test_behavior_reference_hygiene.py -q` → `40 passed`
- Both patched heredocs executed verbatim (placeholders substituted with real
  discovery/env JSON) against the field repo: 3/3 bundles pass with 0 warnings;
  standalone completeness 2/2 `complete` with correct `via_includes`.
- End-to-end: the full patched recipe re-run against the field repo flipped its verdict
  from a false "critical" (2 errors) to PASS (0 errors, 6/6 bundles good).