### PR TITLE
feat(bundles): compose Context Intelligence by default

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -39,6 +39,9 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-module-tool-mcp@main#subdirectory=behaviors/mcp.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-filesystem@main#subdirectory=behaviors/apply-patch.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-routing-matrix@main
+  # Context Intelligence: session event capture + local-JSONL navigation
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=behaviors/context-intelligence-logging.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=behaviors/context-intelligence-navigation.yaml
 
 
 session:

--- a/bundles/anchors-amp-dev/bundle.md
+++ b/bundles/anchors-amp-dev/bundle.md
@@ -17,6 +17,9 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/logging.yaml
   # Dev testing bundle (cross-repo DTU validation)
   - bundle: git+https://github.com/microsoft/amplifier-bundle-amplifier-tester@main
+  # Context Intelligence: session event capture + local-JSONL navigation
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=behaviors/context-intelligence-logging.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=behaviors/context-intelligence-navigation.yaml
 
 session:
   raw: true

--- a/bundles/anchors/bundle.md
+++ b/bundles/anchors/bundle.md
@@ -15,6 +15,9 @@ includes:
   - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/status-context.yaml
   - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/redaction.yaml
   - bundle: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=behaviors/logging.yaml
+  # Context Intelligence: session event capture + local-JSONL navigation
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=behaviors/context-intelligence-logging.yaml
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=behaviors/context-intelligence-navigation.yaml
 
 session:
   raw: true


### PR DESCRIPTION
## What

Adds the two Context Intelligence behaviors to the three bundles that don't already inherit them:

- `bundle.md` (foundation)
- `bundles/anchors/bundle.md`
- `bundles/anchors-amp-dev/bundle.md`

Nine added lines, no code changes.

## Why these three

Everything that includes the foundation bundle — `amplifier-dev`, `distro`, `amplifier`, the provider variants — picks this up transitively from `bundle.md`.

The two anchors bundles are the exception. They deliberately include individual foundation *behavior files* (`behaviors/streaming-ui.yaml`, `behaviors/logging.yaml`, etc.) rather than the foundation bundle itself, so they inherit nothing from it. They need the composition declared directly or they'd be the only bundles left without it.

## What ships

Both halves of the loop, not just one:

- **`context-intelligence-logging.yaml`** — the writer. A hook that records session events.
- **`context-intelligence-navigation.yaml`** — the reader. A `session-navigator` agent that reads those events back.

Shipping only the writer would produce data nobody can query; only the reader would produce an agent with nothing to read.

## Local-only by default

The logging hook writes to its own tree under `~/.amplifier` and sends nothing anywhere unless a destination is explicitly configured through the environment. The navigator reads those local files directly — no server, no service dependency. Users get working session history out of the box with no setup and no egress.

## Composition notes for anchors

The anchors bundles have three characteristics that could have conflicted. None do:

1. **`agents: include:` is additive, not an allowlist.** Composition merges agent maps with a dict union (`bundle/_dataclass.py`), so the navigator lands alongside the bundle's own agents rather than being filtered out by the explicit list.
2. **`tool-delegate` stays configured.** The navigation behavior re-declares `tool-delegate` with no config. `merge_module_lists` (`dicts/merge.py`) indexes by module ID and deep-merges, so a config-less redeclaration overwrites nothing — the existing `features` block and `settings.exclude_tools` survive intact.
3. **Skills sources concatenate.** anchors sets `visibility.enabled: false` on `tool-skills` to save tokens. The navigation skill is installed and invocable by name or slash command; it just isn't auto-advertised in that bundle. The navigator agent, which does the actual work, is unaffected.