### PR TITLE
fix(bundle): forward the agents: access-control declaration; document it

### DIFF
--- a/amplifier_foundation/bundle/_dataclass.py
+++ b/amplifier_foundation/bundle/_dataclass.py
@@ -790,13 +790,29 @@ class Bundle:
 
 
 def _parse_agents(
-    agents_config: dict[str, Any], base_path: Path | None
+    agents_config: dict[str, Any] | str | list[Any],
+    base_path: Path | None,
 ) -> dict[str, dict[str, Any]]:
     """Parse agents config section.
 
     Handles both include lists and direct definitions.
+
+    The bundle `agents:` key is overloaded with two unrelated meanings,
+    distinguished only by value TYPE:
+      - dict:       the agent roster (include list / inline definitions),
+                    handled entirely by this function.
+      - str/list:   the "Smart Single Value" access-control declaration
+                    ("all" | "none" | [agent names]) that restricts which
+                    sub-agents a spawned session may delegate to. That form
+                    isn't a roster at all -- it's carried through as-is by
+                    the config dict (see _load_agent_file_metadata), so
+                    here we simply return an empty roster rather than
+                    attempting to parse it as one.
     """
     if not agents_config:
+        return {}
+
+    if isinstance(agents_config, (str, list)):
         return {}
 
     result: dict[str, dict[str, Any]] = {}
@@ -866,6 +882,39 @@ def _load_agent_file_metadata(path: Path, fallback_name: str) -> dict[str, Any]:
 
     if "model_role" in frontmatter:
         result["model_role"] = frontmatter["model_role"]
+
+    # Top-level `agents:` is overloaded with two unrelated meanings, distinguished
+    # only by value TYPE:
+    #   - dict:     an agent roster (include list / inline definitions). That form
+    #               is bundle-level configuration, not something an individual
+    #               agent file declares about itself -- leave it dropped here, as
+    #               it always has been; rosters are parsed by _parse_agents via
+    #               the bundle path.
+    #   - str/list: the "Smart Single Value" access-control declaration
+    #               ("all" | "none" | [agent names]) that restricts which
+    #               sub-agents this agent's spawned session may delegate to.
+    #               This is the form we must forward so amplifier-app-cli's
+    #               spawner can honor it.
+    if "agents" in frontmatter:
+        agents_value = frontmatter["agents"]
+        if isinstance(agents_value, str):
+            if agents_value not in ("all", "none"):
+                raise ValueError(
+                    f"Invalid 'agents' value in {path}: {agents_value!r} (str). "
+                    'Expected "all", "none", a list of agent names, or a mapping '
+                    "of agent definitions."
+                )
+            result["agents"] = agents_value
+        elif isinstance(agents_value, list):
+            result["agents"] = agents_value
+        elif isinstance(agents_value, dict):
+            pass  # roster form -- not forwarded from the agent-file layer
+        else:
+            raise ValueError(
+                f"Invalid 'agents' value in {path}: {agents_value!r} "
+                f'({type(agents_value).__name__}). Expected "all", "none", '
+                "a list of agent names, or a mapping of agent definitions."
+            )
 
     # Include instruction from markdown body (same as bundle loading does)
     if body and body.strip():

--- a/docs/AGENT_AUTHORING.md
+++ b/docs/AGENT_AUTHORING.md
@@ -300,6 +300,79 @@ When both `model_role` and `provider_preferences` are present, `provider_prefere
 
 ---
 
+## Sub-Agent Access Control with `agents`
+
+An agent can declare which sub-agents its own spawned session may delegate to. This is the `agents` field in agent frontmatter - a **Smart Single Value** taking one of three forms.
+
+> **Not the same as a bundle's `agents:` section.** A bundle or behavior uses `agents:` with a **mapping** value (`include:` lists, inline definitions) to declare which agents it *provides*. An agent uses `agents:` with a **string or list** value to declare which agents it may *delegate to*. Same key, two meanings, told apart by value type. See [BUNDLE_GUIDE.md](BUNDLE_GUIDE.md) for the roster form.
+
+### The `agents` Frontmatter Field
+
+`agents` is a top-level key - a sibling of `meta:`, alongside `tools:` and `providers:` - not a field nested inside `meta:`.
+
+**Disable delegation entirely** - the agent does the work itself:
+
+```yaml
+meta:
+  name: leaf-worker
+  description: "..."
+
+agents: none
+```
+
+**Allowlist** - the agent may delegate only to the named agents:
+
+```yaml
+meta:
+  name: coordinator
+  description: "..."
+
+agents: [explorer, bug-hunter]
+```
+
+**Inherit everything** - the default, and identical to omitting the field:
+
+```yaml
+meta:
+  name: orchestrator
+  description: "..."
+
+agents: all
+```
+
+An allowlist is satisfied from every agent available to the parent session - both those declared statically by the bundle and those contributed at runtime by an active mode. Naming an agent that does not exist yields no error; the agent simply is not available to delegate to.
+
+A value that is neither `all`, `none`, a list, nor a mapping raises at load time rather than being ignored, so a typo fails loudly instead of silently granting full access.
+
+### Example Agent Frontmatter
+
+```yaml
+---
+meta:
+  name: security-auditor
+  description: |
+    Use PROACTIVELY for vulnerability assessment and code auditing.
+    Reviews directly without delegating.
+  model_role: security-audit
+
+agents: none
+
+tools:
+  - module: tool-filesystem
+  - module: tool-bash
+---
+
+# Security Auditor
+
+[Agent instructions...]
+```
+
+> **Where this is enforced.** The reference spawn capability (`amplifier-app-cli`'s `session_spawner.py`) applies the declaration when it builds the child session's config, filtering both the parent's static agents and any runtime-contributed ones. An agent declaring `agents: none` receives an empty agent set, so its `delegate` tool has nothing to call.
+
+Restricting delegation is not a security boundary - it shapes what an agent is *meant* to reach for, keeping a focused worker focused. To remove the capability itself, drop the delegation tool from the agent's `tools:` list.
+
+---
+
 ## Agents as Context Sinks
 
 Expert agents serve as **context sinks** - they carry heavy documentation that would bloat every session if always loaded.

--- a/docs/BUNDLE_GUIDE.md
+++ b/docs/BUNDLE_GUIDE.md
@@ -1237,6 +1237,10 @@ spawn:
   # OR use explicit list:
   # tools: [tool-a, tool-b]         # Agents get ONLY these tools
 
+# Declare which agents this bundle PROVIDES (a mapping value).
+# Not to be confused with the same key in an *agent's* frontmatter, where a
+# string or list value declares which agents that agent may DELEGATE TO --
+# see AGENT_AUTHORING.md, "Sub-Agent Access Control".
 agents:
   include:
     - my-bundle:agent-name          # Reference agents in this bundle

--- a/tests/test_agent_metadata.py
+++ b/tests/test_agent_metadata.py
@@ -2,8 +2,10 @@
 
 from pathlib import Path
 
+import pytest
 
 from amplifier_foundation.bundle._dataclass import _load_agent_file_metadata
+from amplifier_foundation.bundle._dataclass import _parse_agents
 
 
 class TestLoadAgentFileMetadata:
@@ -109,3 +111,186 @@ class TestFoundationAgentModelRoles:
                 assert role != "planning", (
                     f"{agent_file.name} still uses deprecated 'planning' role"
                 )
+
+
+class TestLoadAgentFileMetadataAgentsAccessControl:
+    """Tests for _load_agent_file_metadata forwarding of the `agents:` access-
+    control declaration ("all" | "none" | [names]), as distinct from the
+    `agents:` roster form (dict), which is bundle-level and unrelated.
+    """
+
+    def test_top_level_agents_none_is_forwarded(self, tmp_path: Path) -> None:
+        """Top-level `agents: none` is forwarded as the string "none"."""
+        agent_file = tmp_path / "restricted-agent.md"
+        agent_file.write_text(
+            "---\n"
+            "meta:\n"
+            "  name: restricted-agent\n"
+            "  description: A restricted agent\n"
+            "\n"
+            "agents: none\n"
+            "---\n"
+            "\n"
+            "# Restricted Agent\n"
+        )
+
+        result = _load_agent_file_metadata(agent_file, "restricted-agent")
+
+        assert result["agents"] == "none"
+
+    def test_top_level_agents_all_is_forwarded(self, tmp_path: Path) -> None:
+        """Top-level `agents: all` is forwarded as the string "all"."""
+        agent_file = tmp_path / "unrestricted-agent.md"
+        agent_file.write_text(
+            "---\n"
+            "meta:\n"
+            "  name: unrestricted-agent\n"
+            "  description: An unrestricted agent\n"
+            "\n"
+            "agents: all\n"
+            "---\n"
+            "\n"
+            "# Unrestricted Agent\n"
+        )
+
+        result = _load_agent_file_metadata(agent_file, "unrestricted-agent")
+
+        assert result["agents"] == "all"
+
+    def test_top_level_agents_list_is_forwarded(self, tmp_path: Path) -> None:
+        """Top-level `agents: [a, b]` is forwarded as the list ["a", "b"]."""
+        agent_file = tmp_path / "scoped-agent.md"
+        agent_file.write_text(
+            "---\n"
+            "meta:\n"
+            "  name: scoped-agent\n"
+            "  description: A scoped agent\n"
+            "\n"
+            "agents: [a, b]\n"
+            "---\n"
+            "\n"
+            "# Scoped Agent\n"
+        )
+
+        result = _load_agent_file_metadata(agent_file, "scoped-agent")
+
+        assert result["agents"] == ["a", "b"]
+
+    def test_top_level_agents_dict_roster_is_not_forwarded(
+        self, tmp_path: Path
+    ) -> None:
+        """Top-level dict `agents: {include: [...]}` is the roster form and is
+        NOT forwarded from the agent-file layer -- unchanged behavior.
+        """
+        agent_file = tmp_path / "roster-agent.md"
+        agent_file.write_text(
+            "---\n"
+            "meta:\n"
+            "  name: roster-agent\n"
+            "  description: An agent with a roster-shaped agents key\n"
+            "\n"
+            "agents:\n"
+            "  include:\n"
+            "    - foundation:explorer\n"
+            "---\n"
+            "\n"
+            "# Roster Agent\n"
+        )
+
+        result = _load_agent_file_metadata(agent_file, "roster-agent")
+
+        assert "agents" not in result
+
+    def test_meta_nested_agents_none_still_works(self, tmp_path: Path) -> None:
+        """`meta:`-nested `agents: none` still passes through via the meta
+        splat (the shape that has always worked) -- regression guard.
+        """
+        agent_file = tmp_path / "meta-restricted-agent.md"
+        agent_file.write_text(
+            "---\n"
+            "meta:\n"
+            "  name: meta-restricted-agent\n"
+            "  description: A restricted agent (meta-nested form)\n"
+            "  agents: none\n"
+            "---\n"
+            "\n"
+            "# Meta Restricted Agent\n"
+        )
+
+        result = _load_agent_file_metadata(agent_file, "meta-restricted-agent")
+
+        assert result["agents"] == "none"
+
+    def test_invalid_agents_string_raises_with_file_and_value(
+        self, tmp_path: Path
+    ) -> None:
+        """An invalid string value (typo of "none") raises ValueError naming
+        the offending file and value.
+        """
+        agent_file = tmp_path / "typo-agent.md"
+        agent_file.write_text(
+            "---\n"
+            "meta:\n"
+            "  name: typo-agent\n"
+            "  description: An agent with a typo'd agents value\n"
+            "\n"
+            "agents: nonr\n"
+            "---\n"
+            "\n"
+            "# Typo Agent\n"
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            _load_agent_file_metadata(agent_file, "typo-agent")
+
+        message = str(exc_info.value)
+        assert str(agent_file) in message
+        assert "nonr" in message
+
+    def test_invalid_agents_type_raises(self, tmp_path: Path) -> None:
+        """A non-dict/str/list value (e.g. an int) raises ValueError."""
+        agent_file = tmp_path / "bad-type-agent.md"
+        agent_file.write_text(
+            "---\n"
+            "meta:\n"
+            "  name: bad-type-agent\n"
+            "  description: An agent with an invalid agents type\n"
+            "\n"
+            "agents: 42\n"
+            "---\n"
+            "\n"
+            "# Bad Type Agent\n"
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            _load_agent_file_metadata(agent_file, "bad-type-agent")
+
+        assert "42" in str(exc_info.value)
+
+
+class TestParseAgents:
+    """Tests for _parse_agents handling of the roster (dict) vs access-control
+    (str/list) forms of the `agents:` key.
+    """
+
+    def test_string_none_returns_empty_roster(self) -> None:
+        """A str value is the access-control form, not a roster -- no crash."""
+        assert _parse_agents("none", None) == {}
+
+    def test_string_all_returns_empty_roster(self) -> None:
+        """A str value is the access-control form, not a roster -- no crash."""
+        assert _parse_agents("all", None) == {}
+
+    def test_list_returns_empty_roster(self) -> None:
+        """A list value is the access-control form, not a roster -- no crash."""
+        assert _parse_agents(["a", "b"], None) == {}
+
+    def test_dict_include_list_roster_unchanged(self) -> None:
+        """dict `{include: [...]}` still returns the expected roster."""
+        result = _parse_agents({"include": ["x"]}, None)
+        assert result == {"x": {"name": "x"}}
+
+    def test_dict_inline_definition_roster_unchanged(self) -> None:
+        """dict with an inline agent definition still returns it unchanged."""
+        result = _parse_agents({"helper": {"description": "d"}}, None)
+        assert result == {"helper": {"description": "d"}}


### PR DESCRIPTION
## What

An agent's `agents:` field is a Smart Single Value (`"all"" | `"none"" | list) declaring which sub-agents its spawned session may delegate to. amplifier-app-cli 6c3fd86 made the spawner honor it. This makes the field actually reach the spawner, and documents it.

The agent-file loader whitelists top-level frontmatter keys (`tools`, `providers`, `hooks`, `session`, `provider_preferences`, `model_role`). `agents` was not on the list, so it was silently discarded. Measured on `main` — an agent author writes `agents: none` meaning "I cannot delegate":

```
TOP-LEVEL (the shape amplifier-profiles docs tell authors to write)
   loader forwards agents: '(dropped)'
   child may delegate to : ['builder', 'explorer', 'sibling_b']
   -> SILENTLY IGNORED

UNDER meta: (undocumented, worked by accident via the meta splat)
   loader forwards agents: 'none'
   child may delegate to : []
   -> HONORED
```

So the documented shape did nothing, and the working shape was documented nowhere.

## Changes

**`_load_agent_file_metadata`** — forwards top-level `agents:` when the value is the access-control form. The key carries two unrelated meanings, told apart by type:

| value type | meaning | behavior |
|---|---|---|
| `str` (`"all"" / `"none"`) | access control | forwarded |
| `list` | access control (allowlist) | forwarded |
| `dict` | roster (`include:` / inline defs) | unchanged — still not forwarded at this layer; rosters are parsed by the bundle path |
| anything else | invalid | raises `ValueError` naming the file and the value |

An unrecognized string (`agents: nonr`) also raises. A typo that silently means "unrestricted" is the exact failure class this change removes.

**`_parse_agents`** — a str/list value returned `AttributeError: 'str' object has no attribute 'items'`, because `"include" in "none"` is a substring test that falls through to `.items()`. Now returns an empty roster for str/list (they are not rosters; the value is carried through the config dict instead). Dict handling is byte-for-byte unchanged.

## Verified end to end

Agent `.md` file → loader → spawn decision, with a parent whose static agents are `{explorer, builder}` and a live registry additionally holding the mode-contributed `sibling_b`:

| author writes | child may delegate to |
|---|---|
| `agents: none` | `[]` |
| `agents: [sibling_b]` | `[sibling_b]` |
| `agents: [explorer]` | `[explorer]` |
| `agents: all` | `[builder, explorer, sibling_b]` |
| *(field omitted)* | `[builder, explorer, sibling_b]` |

Row 2 is worth noting: `sibling_b` exists only in the runtime registry, so an allowlist naming it is satisfied from the union of static and runtime-contributed agents — not just the static snapshot.

## Tests

12 new tests in `tests/test_agent_metadata.py`: all three forwarded forms, dict-roster unchanged, `meta:`-nested regression guard, both raise paths, and `_parse_agents` for str/list/dict-include/dict-inline.

```
uv run pytest tests/ -q
1549 passed          (baseline on main @ 31a080f: 1537 passed)
```

**Non-vacuousness** — source reverted to `main`, new tests kept:
```
8 failed, 10 passed
  test_top_level_agents_none_is_forwarded
  test_top_level_agents_all_is_forwarded
  test_top_level_agents_list_is_forwarded
  test_invalid_agents_string_raises_with_file_and_value
  test_invalid_agents_type_raises
  test_string_none_returns_empty_roster
  test_string_all_returns_empty_roster
  test_list_returns_empty_roster

  AttributeError: 'str' object has no attribute 'items'
  amplifier_foundation/bundle/_dataclass.py:810
```
The 4 that still pass assert behavior this change does not alter (dict roster untouched, `meta:`-nested already worked).

## Docs

`docs/AGENT_AUTHORING.md` gains **Sub-Agent Access Control with `agents`**, placed with the other frontmatter-field sections. It documents the three forms, states that the field is a top-level sibling of `meta:`, and opens with a callout distinguishing it from a bundle's `agents:` roster — same key, two meanings, told apart by value type.

`docs/BUNDLE_GUIDE.md` gains a comment at its frontmatter reference block, where `spawn:` and roster `agents:` sit four lines apart and are the likeliest place to confuse the two.

Both factual claims in the new section were verified against the code rather than asserted: an allowlist naming a nonexistent agent raises nothing and simply yields no entry, and an allowlist is satisfied from the union of static and runtime-contributed agents.

The section also states plainly that this shapes intent rather than enforcing a security boundary — to remove the capability itself, drop the delegation tool from the agent's `tools:`.

## Known discrepancy in another repo

`microsoft/amplifier-profiles` (`docs/AGENT_AUTHORING.md`, `docs/PROFILE_AUTHORING.md`, `docs/DESIGN.md`, `README.md`) documents this field, including `agents: none  # Cannot call task tool to delegate` and a three-step "How it works". Those docs are now accurate as of this change, but they are the only place the feature was described before it worked. Recorded here; no PR filed there.

## Scope

No changes to amplifier-app-cli — 6c3fd86 is correct and final. Untouched pre-existing issues, noted not fixed: the broken `VALIDATION.md` link at `BUNDLE_GUIDE.md:1635`, `agents` missing from the `CONCEPTS.md` merge-rules table, and `PATTERNS.md:261` using `agent:` where the frontmatter key is `meta:`.