### PR TITLE
fix: git timeout, Windows path resolution, POSIX path handling, subprocess cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,15 @@ on:
 
 jobs:
   tests:
-    name: Tests (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    # A Windows failure must not cancel the POSIX legs -- those tell us whether
+    # we regressed the population that actually works today, which is the more
+    # expensive outcome by far.
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4

--- a/amplifier_foundation/paths/resolution.py
+++ b/amplifier_foundation/paths/resolution.py
@@ -21,6 +21,13 @@ _GIT_PATH_PATTERN = re.compile(r"^(?P<path>[^@]+)(?:@(?P<ref>.+))?$")
 # file, zip+https, ...), so this can never collide with a scheme prefix.
 _WINDOWS_DRIVE_PATH_PATTERN = re.compile(r"^[A-Za-z]:[\\/]")
 
+# RFC 8089 ("file" URI scheme) drive-letter form: the path component of a
+# `file:///C:/Users/x` URI is "/C:/Users/x" -- a Windows drive path carrying a
+# leading slash left over from the URI's authority separator. This is the
+# spelling Python's own ``Path.as_uri()`` emits on Windows, so it arrives in
+# real user configs; it is a *Windows* path despite starting with "/".
+_RFC8089_DRIVE_PATH_PATTERN = re.compile(r"^/[A-Za-z]:[\\/]")
+
 
 def _is_windows_absolute_path(uri: str) -> bool:
     """True for a native Windows absolute path: drive-letter or UNC form.
@@ -44,8 +51,34 @@ def _is_posix_style_absolute_path(path: str) -> bool:
     reasoning as the exclusion in ``_is_windows_absolute_path``: that
     spelling is ambiguous with a protocol-relative URL and is left unhandled
     here rather than guessed at.
+
+    Also NOT matched: the RFC 8089 drive-letter form (``/C:/Users/x``). It
+    starts with "/" but is a *Windows* path -- the leading slash is the
+    residue of a ``file://`` URI's authority separator, not a POSIX root.
+    Treating it as POSIX-shaped made ``file:///C:/Users/x`` -- precisely what
+    ``Path.as_uri()`` emits on Windows -- get rejected on Windows with a
+    message telling the user to convert it to a Windows path it already was.
     """
+    if _RFC8089_DRIVE_PATH_PATTERN.match(path):
+        return False
     return path.startswith("/") and not path.startswith("//")
+
+
+def strip_uri_drive_prefix(path: str) -> str:
+    """Normalize an RFC 8089 ``file://`` path component into a native path.
+
+    ``file:///C:/Users/x`` parses to the path component ``/C:/Users/x``. That
+    leading slash is URI syntax, not part of the filesystem path: passing it
+    to ``Path()`` on Windows yields a rooted-but-driveless path that resolves
+    against the *current* drive rather than the drive the user named. Strip it
+    so the drive letter leads, as Windows expects.
+
+    Every other shape (POSIX absolute, relative, native Windows, UNC) is
+    returned unchanged.
+    """
+    if _RFC8089_DRIVE_PATH_PATTERN.match(path):
+        return path[1:]
+    return path
 
 
 def describe_cross_platform_path_mismatch(path_str: str) -> str | None:

--- a/amplifier_foundation/paths/resolution.py
+++ b/amplifier_foundation/paths/resolution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,6 +14,90 @@ from urllib.parse import urlparse
 # - 'path' group: repository path (everything before @)
 # - 'ref' group: optional branch/tag/commit (everything after @, can contain slashes)
 _GIT_PATH_PATTERN = re.compile(r"^(?P<path>[^@]+)(?:@(?P<ref>.+))?$")
+
+# Native Windows drive-letter absolute path: "C:\..." or "C:/...".
+# A single ASCII letter followed by ":" is unambiguous here -- every real URI
+# scheme this parser recognizes is multi-character (http, https, git+https,
+# file, zip+https, ...), so this can never collide with a scheme prefix.
+_WINDOWS_DRIVE_PATH_PATTERN = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def _is_windows_absolute_path(uri: str) -> bool:
+    """True for a native Windows absolute path: drive-letter or UNC form.
+
+    Covers both separator styles Windows accepts for a drive-letter path
+    (``C:\\Users\\x`` and ``C:/Users/x``) plus backslash UNC paths
+    (``\\\\server\\share``).
+
+    Deliberately NOT matched: forward-slash UNC (``//server/share``). That
+    spelling is syntactically identical to a protocol-relative URL, which
+    this resolver has no other support for, so it is left unhandled rather
+    than guessed at.
+    """
+    return bool(_WINDOWS_DRIVE_PATH_PATTERN.match(uri)) or uri.startswith("\\\\")
+
+
+def _is_posix_style_absolute_path(path: str) -> bool:
+    """True for a path spelled as a POSIX absolute path (``/home/x``, ``/etc``).
+
+    Deliberately NOT matched: forward-slash UNC (``//server/share``) -- same
+    reasoning as the exclusion in ``_is_windows_absolute_path``: that
+    spelling is ambiguous with a protocol-relative URL and is left unhandled
+    here rather than guessed at.
+    """
+    return path.startswith("/") and not path.startswith("//")
+
+
+def describe_cross_platform_path_mismatch(path_str: str) -> str | None:
+    """Return an explanation if `path_str` is an absolute path shaped for a
+    *different* OS than the one currently running, else return None.
+
+    GAP-007: naive resolution (``pathlib.Path(path_str).resolve()``) does not
+    fail on a foreign-OS absolute path -- it silently coerces it into a
+    nonsense local one. On Windows, ``Path("/home/bkrabach/dev/x").resolve()``
+    prepends the current drive letter, producing ``C:\\home\\bkrabach\\dev\\x``,
+    which then fails with a generic "File not found" that sends the user
+    hunting for a file that was never expected to exist on this machine. The
+    mirror case exists on POSIX: a Windows drive-letter path like
+    ``C:\\Users\\x`` is not absolute by POSIX rules, so it silently resolves
+    relative to the current working directory instead of failing clearly.
+
+    This function lets callers (source handlers) catch either case *before*
+    attempting resolution and raise a message that names the actual problem
+    -- a config written for another OS's filesystem -- instead of a
+    misleading "file not found".
+
+    Args:
+        path_str: The raw path string as parsed from the source URI (i.e.
+            ``ParsedURI.path``), before any OS-specific resolution.
+
+    Returns:
+        A human-readable explanation of the mismatch, or None if `path_str`
+        is not a foreign-OS absolute path (including: it's a relative path,
+        or it's already native to the current OS).
+    """
+    running_on_windows = os.name == "nt"
+
+    if running_on_windows and _is_posix_style_absolute_path(path_str):
+        return (
+            f"'{path_str}' is a POSIX-style absolute path (Linux/macOS-shaped), "
+            "which cannot exist on Windows. This bundle source refers to "
+            "another OS's filesystem, not a missing file on this machine -- "
+            "update the source in settings.yaml to a Windows path, or copy/"
+            "re-clone the referenced content locally on this machine."
+        )
+
+    if not running_on_windows and _is_windows_absolute_path(path_str):
+        return (
+            f"'{path_str}' is a Windows-style absolute path (drive-letter or "
+            f"UNC), which cannot exist on {platform.system()}. This bundle "
+            "source refers to another OS's filesystem, not a missing file "
+            "on this machine -- update the source in settings.yaml to a "
+            "POSIX path, or copy/re-clone the referenced content locally on "
+            "this machine."
+        )
+
+    return None
 
 
 def get_amplifier_home() -> Path:
@@ -52,7 +137,21 @@ class ParsedURI:
     @property
     def is_file(self) -> bool:
         """True if this is a file URI or local path."""
-        return self.scheme == "file" or (self.scheme == "" and "/" in self.path)
+        if self.scheme == "file":
+            return True
+        if self.scheme != "":
+            return False
+        # Empty scheme: treat as a local path if it looks like one under
+        # either separator convention -- POSIX ("/" present) or native
+        # Windows (backslash, or a bare drive-letter/UNC path). parse_uri()
+        # already assigns scheme="file" for the Windows forms it recognizes,
+        # so this branch is defense-in-depth for ParsedURI values built by
+        # other means, not the primary path for real Windows URIs.
+        return (
+            "/" in self.path
+            or "\\" in self.path
+            or _is_windows_absolute_path(self.path)
+        )
 
     @property
     def is_http(self) -> bool:
@@ -128,8 +227,15 @@ def parse_uri(uri: str) -> ParsedURI:
         path, subpath = _extract_fragment_subpath(uri[7:])
         return ParsedURI(scheme="file", host="", path=path, ref="", subpath=subpath)
 
-    # Handle absolute paths
+    # Handle absolute paths (POSIX)
     if uri.startswith("/"):
+        return ParsedURI(scheme="file", host="", path=uri, ref="", subpath="")
+
+    # Handle native Windows absolute paths (drive-letter or backslash UNC).
+    # Must run before the "package/subpath" fallback below: a forward-slash
+    # Windows path like "C:/Users/x" contains a "/" and would otherwise be
+    # misparsed there as package="C:", subpath="Users/x".
+    if _is_windows_absolute_path(uri):
         return ParsedURI(scheme="file", host="", path=uri, ref="", subpath="")
 
     # Handle relative paths

--- a/amplifier_foundation/sources/_rmtree.py
+++ b/amplifier_foundation/sources/_rmtree.py
@@ -1,0 +1,111 @@
+"""Robust directory removal shared by source handlers that clean up git checkouts.
+
+Git marks files under ``.git/objects/pack/`` (and occasionally elsewhere,
+e.g. after certain checkouts) read-only. On POSIX, removing a read-only file
+only requires write permission on its *parent* directory, so a plain
+``shutil.rmtree`` succeeds there without any special handling. On Windows,
+the read-only attribute lives on the file itself and blocks the delete
+outright (``PermissionError`` / WinError 5 "Access is denied"), which means
+a cache-invalidation path that calls ``shutil.rmtree`` on a git checkout can
+fail *permanently* on Windows: every subsequent run re-detects the same
+"invalid" cache, tries to remove it again, and is denied again, forever.
+
+``rmtree_robust`` clears the read-only attribute and retries once before
+giving up, so cache invalidation actually heals the cache instead of
+re-failing identically on every run.
+
+Design note: shutil.rmtree's own ``onexc``/``onerror`` callback is invoked
+per filesystem operation (unlink one file, rmdir one directory, etc.), and
+on some CPython versions a failure that survives a nested callback can
+resurface at a coarser level (e.g. re-reported against ``os.scandir`` for
+the whole directory rather than the one file that actually failed) -- so a
+callback that decides "raise or swallow" per-callback can end up reporting
+a confusing, imprecise error, or in edge cases let a real failure look like
+a no-op success. To keep the failure mode simple and precise regardless of
+those internals, the per-callback handler here always attempts the
+read-only-clear-and-retry and never raises; ``rmtree_robust`` itself then
+checks, once, whether the directory is actually gone -- and raises one
+clear, unambiguous error naming the real path if it is not.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+__all__ = ["rmtree_robust"]
+
+
+def _clear_readonly(path: str) -> None:
+    """Best-effort: add the write bit so a subsequent removal can succeed."""
+    try:
+        current_mode = os.stat(path).st_mode
+    except OSError:
+        return
+    with contextlib.suppress(OSError):
+        os.chmod(path, current_mode | stat.S_IWRITE)
+
+
+def _onexc(function, path, exc) -> None:
+    """onexc/onerror-shaped callback: clear read-only and retry once.
+
+    Never raises -- ``rmtree_robust`` enforces the actual pass/fail contract
+    itself afterward, by checking whether the path still exists. This keeps
+    the per-file callback simple and avoids depending on which exact
+    func/path pairing a given CPython version happens to escalate a nested
+    failure to.
+    """
+    del exc  # unused; callback shape is dictated by shutil.rmtree
+    _clear_readonly(path)
+    with contextlib.suppress(Exception):
+        function(path)
+
+
+def _onerror(function, path, exc_info) -> None:
+    """Adapts the deprecated ``onerror(function, path, exc_info)`` shape
+    (exc_info is a ``sys.exc_info()`` triple) to ``_onexc``."""
+    _onexc(function, path, exc_info[1])
+
+
+def rmtree_robust(path: Path | str, *, ignore_errors: bool = False) -> None:
+    """Remove a directory tree, tolerating Windows read-only files.
+
+    Behaves like ``shutil.rmtree``, except that when removal of an entry
+    fails, it clears the read-only attribute (the common cause on Windows
+    for git's read-only pack files under ``.git/objects/pack/``) and retries
+    once before giving up.
+
+    Args:
+        path: Directory to remove.
+        ignore_errors: If True, a failure that persists after the
+            read-only-clearing retry is swallowed (best-effort cleanup),
+            matching plain ``shutil.rmtree``'s own ``ignore_errors``
+            semantics. If False (default), a failure that persists raises
+            an ``OSError`` naming the path -- a cache-invalidation removal
+            that silently fails must not be treated as if it succeeded.
+
+    Raises:
+        OSError: If ``ignore_errors`` is False and the directory still
+            exists after the removal attempt (including its read-only-clear
+            retries).
+    """
+    target = Path(path)
+
+    if sys.version_info >= (3, 12):
+        # onerror is deprecated since 3.12 in favor of onexc.
+        shutil.rmtree(target, onexc=_onexc)
+    else:
+        shutil.rmtree(target, onerror=_onerror)
+
+    if not ignore_errors and target.exists():
+        raise OSError(
+            f"Failed to remove directory even after clearing read-only "
+            f"attributes and retrying: {target}. This is not a transient "
+            "or read-only-attribute issue (those would have been healed by "
+            "the retry) -- check for files that are locked, in use, or "
+            "otherwise unremovable."
+        )

--- a/amplifier_foundation/sources/file.py
+++ b/amplifier_foundation/sources/file.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from amplifier_foundation.exceptions import BundleNotFoundError
-from amplifier_foundation.paths.resolution import ParsedURI
-from amplifier_foundation.paths.resolution import ResolvedSource
+from amplifier_foundation.paths.resolution import (
+    ParsedURI,
+    ResolvedSource,
+    describe_cross_platform_path_mismatch,
+)
 
 
 class FileSourceHandler:
@@ -38,6 +41,17 @@ class FileSourceHandler:
             BundleNotFoundError: If file doesn't exist.
         """
         path_str = parsed.path
+
+        # GAP-007: catch an absolute path shaped for a *different* OS before
+        # naive pathlib resolution silently mangles it into a nonsense local
+        # path (e.g. on Windows, Path("/home/x").resolve() prepends the
+        # current drive letter, yielding "C:\home\x", which then fails with
+        # a generic "File not found" that sends the user hunting for a file
+        # that was never expected to exist on this machine). Fail loud with
+        # a message naming the real problem instead.
+        mismatch = describe_cross_platform_path_mismatch(path_str)
+        if mismatch:
+            raise BundleNotFoundError(mismatch)
 
         # Handle relative paths
         if path_str.startswith("./") or path_str.startswith("../"):

--- a/amplifier_foundation/sources/file.py
+++ b/amplifier_foundation/sources/file.py
@@ -9,6 +9,7 @@ from amplifier_foundation.paths.resolution import (
     ParsedURI,
     ResolvedSource,
     describe_cross_platform_path_mismatch,
+    strip_uri_drive_prefix,
 )
 
 
@@ -52,6 +53,13 @@ class FileSourceHandler:
         mismatch = describe_cross_platform_path_mismatch(path_str)
         if mismatch:
             raise BundleNotFoundError(mismatch)
+
+        # A `file:///C:/Users/x` URI parses to the path "/C:/Users/x": the
+        # leading slash is the URI's authority separator, not a filesystem
+        # root. Left in place, Path() reads it as rooted-but-driveless and
+        # resolves it against whatever the *current* drive happens to be
+        # rather than the drive the user named.
+        path_str = strip_uri_drive_prefix(path_str)
 
         # Handle relative paths
         if path_str.startswith("./") or path_str.startswith("../"):

--- a/amplifier_foundation/sources/git.py
+++ b/amplifier_foundation/sources/git.py
@@ -112,8 +112,27 @@ def _kill_process_tree(pid: int) -> None:
     else:
         import signal
 
+        # GAP-030 (mirrored from subprocess_runner._kill_subprocess_tree):
+        # os.killpg only isolates the target if that target is in its OWN
+        # process group. Every caller here spawns via _run_git_subprocess,
+        # which sets start_new_session=True, so it always is -- but that is an
+        # invisible coupling between two functions, and if it ever breaks,
+        # killpg would SIGKILL this process and everything sharing its group,
+        # which on an interactive POSIX session includes the user's shell.
+        # Assert the isolation rather than trusting it.
         with contextlib.suppress(ProcessLookupError, PermissionError):
-            os.killpg(os.getpgid(pid), signal.SIGKILL)
+            target_pgid = os.getpgid(pid)
+            if target_pgid == os.getpgid(0):
+                logger.warning(
+                    "Refusing to killpg(%s): target shares this process's own "
+                    "process group. Killing only the direct child instead -- "
+                    "descendants may leak. This means the subprocess was not "
+                    "started with start_new_session=True.",
+                    target_pgid,
+                )
+                os.kill(pid, signal.SIGKILL)
+            else:
+                os.killpg(target_pgid, signal.SIGKILL)
 
 
 def _run_git_subprocess(
@@ -392,18 +411,33 @@ class GitSourceHandler:
         """
 
         def run_git(args: list[str], cwd: Path | None = None) -> None:
-            # Local-only git plumbing (init/remote add/checkout touch no
-            # network and complete near-instantly), so a plain bounded run is
-            # fine here. The network-touching step below goes through
-            # _run_git_network_op instead, which has the GAP-014 timeout.
-            subprocess.run(
-                args,
-                cwd=cwd,
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
+            # Local-only git plumbing, so a plain bounded run is fine here. The
+            # network-touching step below goes through _run_git_network_op
+            # instead, which has the GAP-014 timeout.
+            #
+            # The 30s bound is NOT purely defensive: two of this helper's four
+            # call sites are `git checkout`, which on a large working tree is
+            # genuinely disk-bound and can exceed 30s. So the timeout path is
+            # reachable in normal use, not just under pathology.
+            #
+            # `subprocess.TimeoutExpired` is a SubprocessError, NOT a
+            # CalledProcessError -- every `except (CalledProcessError,
+            # GitCloneTimeoutError)` handler in this module would let it sail
+            # straight past, so a slow checkout would escape the designed
+            # full-clone fallback as a raw traceback instead of degrading
+            # gracefully. Convert it to GitCloneTimeoutError, which every one
+            # of those handlers already catches.
+            try:
+                subprocess.run(
+                    args,
+                    cwd=cwd,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise GitCloneTimeoutError(args, 30) from exc
 
         try:
             # Cheap path: init + shallow fetch of the exact commit.

--- a/amplifier_foundation/sources/git.py
+++ b/amplifier_foundation/sources/git.py
@@ -10,7 +10,6 @@ import logging
 import os
 import platform
 import re
-import shutil
 import subprocess
 import time
 from datetime import datetime
@@ -18,6 +17,7 @@ from pathlib import Path
 
 from amplifier_foundation.exceptions import BundleNotFoundError
 from amplifier_foundation.paths.resolution import ParsedURI, ResolvedSource
+from amplifier_foundation.sources._rmtree import rmtree_robust
 from amplifier_foundation.sources.protocol import SourceStatus
 
 logger = logging.getLogger(__name__)
@@ -34,6 +34,68 @@ _FULL_COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 def _is_full_commit_sha(ref: str) -> bool:
     """Check whether a ref is a full 40-hex-character commit SHA."""
     return bool(_FULL_COMMIT_SHA_PATTERN.match(ref))
+
+
+def _with_longpaths(args: list[str]) -> list[str]:
+    """Insert ``-c core.longpaths=true`` into a git argv, right after the executable.
+
+    Windows' legacy MAX_PATH limit (260 characters) can cause git to report a
+    successful clone ("Clone succeeded") while its *checkout* step silently
+    fails with "Filename too long" / "cannot create directory at ...",
+    leaving a partial working tree. ``_verify_clone_integrity`` then detects
+    that partial tree as invalid on every subsequent run -- a permanent,
+    silent failure loop for any repo whose (cache-prefix + repo-relative
+    path) combination exceeds 260 characters. Confirmed on a real Windows box
+    cloning ``amplifier-bundle-evaluation``.
+
+    ``core.longpaths=true`` makes git use the Unicode ``\\\\?\\``-prefixed
+    Win32 APIs, which are not subject to MAX_PATH. It is passed per-
+    invocation (``-c``), never written to the user's global/system git
+    config: this module should never reach outside its own operations to
+    change machine state the user did not ask it to change.
+
+    Applied unconditionally on every platform, not gated to
+    ``platform.system() == "Windows"``: git treats the setting as a no-op on
+    POSIX, where no equivalent path-length ceiling exists, so the
+    unconditional form is exactly as safe as a Windows-only branch while
+    keeping a single code path -- the same one exercised by every test on
+    every platform, rather than a branch only a native Windows run would
+    ever execute.
+
+    Only applied by callers whose git subcommand actually materializes
+    working-tree paths (``clone``, ``checkout``) -- not ``init``/``remote
+    add``/``fetch``, whose writes (``.git/config``, the hash-addressed
+    object store) are not subject to MAX_PATH regardless of the
+    repository's own directory structure.
+    """
+    return [args[0], "-c", "core.longpaths=true", *args[1:]]
+
+
+# Substrings observed in git's stderr when a Windows MAX_PATH (260-character)
+# limit is the actual cause of a clone/checkout failure. Matched
+# case-insensitively. Kept as a short, explicit allowlist (not a fuzzy
+# heuristic) because misclassifying an unrelated error as "long path" would
+# send the next person chasing the wrong fix.
+_LONG_PATH_ERROR_MARKERS = (
+    "filename too long",
+    "cannot create directory at",
+)
+
+
+def _is_long_path_error(stderr: str) -> bool:
+    """Whether git's stderr matches the known Windows MAX_PATH failure signature.
+
+    ``core.longpaths=true`` (see ``_with_longpaths``) is not a complete cure:
+    it does not help every Win32 API, some tools still choke on very long
+    paths, and on some systems the OS-level "Enable Win32 long paths" policy
+    (the ``LongPathsEnabled`` registry value / Local Group Policy setting)
+    also has to be turned on system-wide before the full path is usable at
+    all. If a clone still fails this way after the flag is applied, the
+    failure must say so plainly instead of degrading into a generic "clone
+    failed".
+    """
+    lowered = stderr.lower()
+    return any(marker in lowered for marker in _LONG_PATH_ERROR_MARKERS)
 
 
 # Retry policy for network-touching git operations (clone/fetch).
@@ -272,7 +334,7 @@ def _run_git_network_op(
                     f"retrying in {delay}s: {reason}"
                 )
                 if cleanup_path is not None:
-                    shutil.rmtree(cleanup_path, ignore_errors=True)
+                    rmtree_robust(cleanup_path, ignore_errors=True)
                 time.sleep(delay)
 
     assert last_error is not None  # loop always sets it before exhausting
@@ -483,14 +545,16 @@ class GitSourceHandler:
                 timeout_s=_CLONE_TIMEOUT_S,
             )
             run_git(
-                [
-                    "git",
-                    "-c",
-                    "advice.detachedHead=false",
-                    "checkout",
-                    "--quiet",
-                    "FETCH_HEAD",
-                ],
+                _with_longpaths(
+                    [
+                        "git",
+                        "-c",
+                        "advice.detachedHead=false",
+                        "checkout",
+                        "--quiet",
+                        "FETCH_HEAD",
+                    ]
+                ),
                 cwd=cache_path,
             )
         except (subprocess.CalledProcessError, GitCloneTimeoutError) as e:
@@ -505,16 +569,26 @@ class GitSourceHandler:
                 f"Shallow fetch of commit {sha} from {git_url} failed "
                 f"({detail}); falling back to full clone + checkout"
             )
-            shutil.rmtree(cache_path, ignore_errors=True)
+            rmtree_robust(cache_path, ignore_errors=True)
             # Retry only this clone, not the shallow fetch above: that fetch
             # failing is an *expected* outcome on servers without
             # allowReachableSHA1InWant, and retrying it would add seconds to a
             # designed fallback path rather than to an error path.
             _run_git_network_op(
-                ["git", "clone", git_url, str(cache_path)], cleanup_path=cache_path
+                _with_longpaths(["git", "clone", git_url, str(cache_path)]),
+                cleanup_path=cache_path,
             )
             run_git(
-                ["git", "-c", "advice.detachedHead=false", "checkout", "--quiet", sha],
+                _with_longpaths(
+                    [
+                        "git",
+                        "-c",
+                        "advice.detachedHead=false",
+                        "checkout",
+                        "--quiet",
+                        sha,
+                    ]
+                ),
                 cwd=cache_path,
             )
 
@@ -540,7 +614,7 @@ class GitSourceHandler:
             # Verify cache integrity before using
             if not self._verify_clone_integrity(cache_path):
                 logger.warning(f"Cached clone is invalid, removing: {cache_path}")
-                shutil.rmtree(cache_path, ignore_errors=True)
+                rmtree_robust(cache_path)
             else:
                 result_path = cache_path
                 if parsed.subpath:
@@ -555,7 +629,7 @@ class GitSourceHandler:
 
         # Remove partial clone if exists
         if cache_path.exists():
-            shutil.rmtree(cache_path)
+            rmtree_robust(cache_path)
 
         try:
             if parsed.ref and _is_full_commit_sha(parsed.ref):
@@ -570,12 +644,14 @@ class GitSourceHandler:
                     clone_args.extend(["--branch", parsed.ref])
                 clone_args.extend([git_url, str(cache_path)])
 
-                _run_git_network_op(clone_args, cleanup_path=cache_path)
+                _run_git_network_op(
+                    _with_longpaths(clone_args), cleanup_path=cache_path
+                )
 
             # Verify clone completed with expected structure
             if not self._verify_clone_integrity(cache_path):
                 # Clone succeeded but result is invalid - remove and raise error
-                shutil.rmtree(cache_path, ignore_errors=True)
+                rmtree_robust(cache_path, ignore_errors=True)
                 raise BundleNotFoundError(
                     f"Clone of {git_url}@{ref} completed but result is invalid "
                     "(missing pyproject.toml/setup.py/bundle.md/amplifier.toml). "
@@ -597,8 +673,28 @@ class GitSourceHandler:
             detail = (
                 e.stderr if isinstance(e, subprocess.CalledProcessError) else str(e)
             )
+            hint = ""
+            if isinstance(e, subprocess.CalledProcessError) and _is_long_path_error(
+                detail
+            ):
+                # core.longpaths=true (see _with_longpaths) is already applied
+                # to this clone, but it is not a complete cure -- name the
+                # likely cause explicitly instead of letting this degrade
+                # into a generic "clone failed" the next person has to
+                # re-diagnose from scratch.
+                hint = (
+                    "\nThis looks like Windows' MAX_PATH (260 character) path "
+                    "limit. This clone already ran with -c core.longpaths=true, "
+                    "but that setting alone does not help every Windows API, "
+                    "and some systems additionally require enabling the "
+                    "OS-level 'Enable Win32 long paths' policy system-wide "
+                    "(Local Group Policy: Computer Configuration > "
+                    "Administrative Templates > System > Filesystem, or the "
+                    "'LongPathsEnabled' registry value under "
+                    "HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem)."
+                )
             raise BundleNotFoundError(
-                f"Failed to clone {git_url}@{ref}: {detail}"
+                f"Failed to clone {git_url}@{ref}: {detail}{hint}"
             ) from e
 
         # Return path with subpath if specified
@@ -711,7 +807,7 @@ class GitSourceHandler:
 
         # Remove existing cache
         if cache_path.exists():
-            shutil.rmtree(cache_path)
+            rmtree_robust(cache_path)
 
         # Re-resolve (will clone fresh)
         return await self.resolve(parsed, cache_dir)

--- a/amplifier_foundation/sources/git.py
+++ b/amplifier_foundation/sources/git.py
@@ -53,7 +53,15 @@ _CLONE_RETRY_BACKOFF_S = (1.0, 2.0)
 # hangs the calling process forever, with no diagnostic and no way for the
 # user to know why. Overridable because "how long is too long" legitimately
 # varies with repo size and network conditions.
-_CLONE_TIMEOUT_S = float(os.environ.get("AMPLIFIER_GIT_CLONE_TIMEOUT_S", "45"))
+#
+# The bound is deliberately generous rather than tight. The failure it exists
+# to catch is *unbounded* -- a helper waiting on input that can never arrive --
+# so any finite value catches it, and the only thing a tight value buys is
+# false positives on legitimately slow work. A large repository over a slow or
+# metered link genuinely takes minutes; every measured ecosystem clone
+# completes in under a second, so the headroom costs working users nothing and
+# protects the ones on the bad end of the distribution.
+_CLONE_TIMEOUT_S = float(os.environ.get("AMPLIFIER_GIT_CLONE_TIMEOUT_S", "300"))
 
 
 class GitCloneTimeoutError(Exception):
@@ -238,7 +246,19 @@ def _run_git_network_op(
     for attempt in range(_CLONE_MAX_ATTEMPTS):
         try:
             return _run_git_subprocess(args, cwd, _CLONE_TIMEOUT_S)
-        except (subprocess.CalledProcessError, GitCloneTimeoutError) as e:
+        except GitCloneTimeoutError:
+            # Do NOT retry a timeout. Retries exist to absorb *transient*
+            # failures -- a dropped connection mid-transfer, a flaky DNS
+            # answer -- where a second attempt plausibly succeeds. A timeout
+            # is not that: the operation was given a full budget and did not
+            # finish, so re-running it with the same budget buys the same
+            # answer at three times the wait, and the cleanup_path rmtree
+            # between attempts discards whatever partial progress was made.
+            # For the blocked-credential-helper case this bound exists to
+            # catch, retrying is pure added latency in front of an error the
+            # user is going to see anyway.
+            raise
+        except subprocess.CalledProcessError as e:
             last_error = e
             if attempt < _CLONE_MAX_ATTEMPTS - 1:
                 delay = _CLONE_RETRY_BACKOFF_S[attempt]

--- a/amplifier_foundation/sources/git.py
+++ b/amplifier_foundation/sources/git.py
@@ -7,6 +7,8 @@ import contextlib
 import hashlib
 import json
 import logging
+import os
+import platform
 import re
 import shutil
 import subprocess
@@ -15,8 +17,7 @@ from datetime import datetime
 from pathlib import Path
 
 from amplifier_foundation.exceptions import BundleNotFoundError
-from amplifier_foundation.paths.resolution import ParsedURI
-from amplifier_foundation.paths.resolution import ResolvedSource
+from amplifier_foundation.paths.resolution import ParsedURI, ResolvedSource
 from amplifier_foundation.sources.protocol import SourceStatus
 
 logger = logging.getLogger(__name__)
@@ -45,9 +46,139 @@ def _is_full_commit_sha(ref: str) -> bool:
 _CLONE_MAX_ATTEMPTS = 3
 _CLONE_RETRY_BACKOFF_S = (1.0, 2.0)
 
+# Hard wall-clock bound per git network-operation attempt. GAP-014: without
+# this, a git invocation that never returns (observed cause: a credential
+# helper blocked on interactive auth it cannot complete headlessly, e.g. Git
+# Credential Manager attempting an OAuth/browser flow with no desktop session)
+# hangs the calling process forever, with no diagnostic and no way for the
+# user to know why. Overridable because "how long is too long" legitimately
+# varies with repo size and network conditions.
+_CLONE_TIMEOUT_S = float(os.environ.get("AMPLIFIER_GIT_CLONE_TIMEOUT_S", "45"))
+
+
+class GitCloneTimeoutError(Exception):
+    """A git network operation exceeded its wall-clock bound without completing.
+
+    This is a *bounded* failure, not a hang: the git process (and its process
+    tree) was killed after ``timeout_s`` seconds because it made no progress
+    a caller could observe. This is deliberately distinct from
+    ``subprocess.CalledProcessError`` (git exited with a real error) because
+    the diagnosis and remedy are different: a timeout usually means something
+    downstream of git itself (most commonly a credential helper) is stuck
+    waiting on interactive input it will never receive, not that git failed
+    outright. See GAP-014 in WINDOWS-GAP-LEDGER.md for the investigation that
+    root-caused this on native Windows.
+    """
+
+    def __init__(self, args: list[str], timeout_s: float) -> None:
+        # Named git_args (not `args`) to avoid shadowing Exception.args, which
+        # is a plain tuple used by the base class's own machinery.
+        self.git_args = args
+        self.timeout_s = timeout_s
+        cmd = " ".join(args)
+        super().__init__(
+            f"git command exceeded {timeout_s:.0f}s and was killed (it was "
+            f"still running, not erroring out): {cmd}\n"
+            "This is usually NOT a slow network. The most common cause is a "
+            "git credential helper blocked waiting on interactive "
+            "authentication it cannot complete in this context (e.g. Git "
+            "Credential Manager attempting a browser/OAuth flow with no "
+            "desktop session available, or no cached credential for this "
+            "host). To check: confirm `gh auth status` shows a valid login, "
+            "and make sure that helper is tried before any interactive one "
+            "for this host (`gh auth setup-git`), or run `git credential-"
+            "manager github logout` to clear a stuck credential-manager "
+            "state. Set AMPLIFIER_GIT_CLONE_TIMEOUT_S to change this timeout "
+            f"(currently {timeout_s:.0f}s per attempt)."
+        )
+
+
+def _kill_process_tree(pid: int) -> None:
+    """Kill a process and its descendants.
+
+    Plain ``Popen.kill()`` only terminates the immediate child. Git spawns its
+    own helper children for network operations (``git-remote-https``,
+    credential helpers) that are NOT reparented/reaped when git.exe itself is
+    killed, and were observed to accumulate as orphaned processes across an
+    entire investigation session (GAP-013's failure mode) when only the
+    top-level process was targeted.
+    """
+    if platform.system() == "Windows":
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(pid)],
+            capture_output=True,
+            check=False,
+        )
+    else:
+        import signal
+
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+
+
+def _run_git_subprocess(
+    args: list[str], cwd: Path | None, timeout_s: float
+) -> subprocess.CompletedProcess[str]:
+    """Run a single git command with a hard timeout, killing the whole tree on expiry.
+
+    A bare ``subprocess.run(..., timeout=...)`` only kills the direct child on
+    expiry, which is not sufficient here: see ``_kill_process_tree``.
+    """
+    creationflags = 0
+    start_new_session = False
+    if platform.system() == "Windows":
+        # Only defined on Windows builds of the subprocess module.
+        creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    else:
+        start_new_session = True
+
+    proc = subprocess.Popen(
+        args,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        creationflags=creationflags,
+        start_new_session=start_new_session,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        _kill_process_tree(proc.pid)
+        # Reap the now-killed process so it doesn't linger as a zombie;
+        # this is expected to return almost immediately post-kill.
+        with contextlib.suppress(Exception):
+            proc.communicate(timeout=5)
+        raise GitCloneTimeoutError(args, timeout_s) from None
+    except BaseException:
+        # GAP-025: proc.communicate() can also be interrupted by something
+        # OTHER than its own timeout -- most importantly a user Ctrl+C
+        # (KeyboardInterrupt) while this call is blocking the calling
+        # thread, but also asyncio task cancellation (CancelledError) or
+        # any other unwind. Both of those derive from BaseException, not
+        # Exception, so the TimeoutExpired-only handler above never sees
+        # them. Confirmed on native Windows: a real Ctrl+C during this
+        # window IS delivered and raises KeyboardInterrupt here promptly
+        # (~1s), but git.exe (or its credential-helper/remote-https
+        # children) is left running as an orphan for the rest of its
+        # natural lifetime -- exactly GAP-013/GAP-024's failure mode, in a
+        # third, independent code path neither of those fixes covers.
+        # Cleaning up here, then re-raising, closes it for every cause of
+        # interruption, not just the ones we anticipated.
+        _kill_process_tree(proc.pid)
+        with contextlib.suppress(Exception):
+            proc.communicate(timeout=5)
+        raise
+
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(
+            proc.returncode, args, output=stdout, stderr=stderr
+        )
+    return subprocess.CompletedProcess(args, proc.returncode, stdout, stderr)
+
 
 def _run_git_network_op(
-    args: list[str], cwd: Path | None = None
+    args: list[str], cwd: Path | None = None, cleanup_path: Path | None = None
 ) -> subprocess.CompletedProcess[str]:
     """Run a network-touching git command, retrying transient failures.
 
@@ -56,32 +187,53 @@ def _run_git_network_op(
     the session rather than degrading it silently), one network blip would take
     down a whole session. This absorbs that class of failure.
 
+    Each attempt is bounded by _CLONE_TIMEOUT_S (GAP-014): a git invocation
+    that never returns is treated as a failed attempt like any other, rather
+    than hanging the caller indefinitely.
+
     Args:
         args: Full git command line.
         cwd: Working directory for the command.
+        cleanup_path: If given, removed before each retry (not before the
+            first attempt). ``git clone`` creates its destination directory
+            immediately, before any content arrives, so a failed attempt
+            (timeout OR a real git error - e.g. a dropped connection
+            mid-transfer) leaves a non-empty directory behind. Without this,
+            retrying `git clone` into the same path fails immediately with
+            "destination path ... already exists and is not an empty
+            directory", masking the real failure behind an unrelated one.
+            Only meaningful for callers doing a fresh clone into a new
+            directory - not for e.g. `git fetch` into an existing repo.
 
     Returns:
         The CompletedProcess from the first successful attempt.
 
     Raises:
-        subprocess.CalledProcessError: From the final attempt, if all fail.
+        subprocess.CalledProcessError: From the final attempt, if all fail
+            with a real git error.
+        GitCloneTimeoutError: From the final attempt, if all fail by timing
+            out without git ever returning.
     """
-    last_error: subprocess.CalledProcessError | None = None
+    last_error: subprocess.CalledProcessError | GitCloneTimeoutError | None = None
 
     for attempt in range(_CLONE_MAX_ATTEMPTS):
         try:
-            return subprocess.run(
-                args, cwd=cwd, check=True, capture_output=True, text=True
-            )
-        except subprocess.CalledProcessError as e:
+            return _run_git_subprocess(args, cwd, _CLONE_TIMEOUT_S)
+        except (subprocess.CalledProcessError, GitCloneTimeoutError) as e:
             last_error = e
             if attempt < _CLONE_MAX_ATTEMPTS - 1:
                 delay = _CLONE_RETRY_BACKOFF_S[attempt]
+                if isinstance(e, GitCloneTimeoutError):
+                    reason = f"timed out after {_CLONE_TIMEOUT_S:.0f}s"
+                else:
+                    reason = (e.stderr or "").strip()
                 logger.warning(
                     f"git {args[1] if len(args) > 1 else ''} failed "
                     f"(attempt {attempt + 1}/{_CLONE_MAX_ATTEMPTS}), "
-                    f"retrying in {delay}s: {(e.stderr or '').strip()}"
+                    f"retrying in {delay}s: {reason}"
                 )
+                if cleanup_path is not None:
+                    shutil.rmtree(cleanup_path, ignore_errors=True)
                 time.sleep(delay)
 
     assert last_error is not None  # loop always sets it before exhausting
@@ -235,15 +387,22 @@ class GitSourceHandler:
         Raises:
             subprocess.CalledProcessError: If both strategies fail (converted
                 to BundleNotFoundError by the caller).
+            GitCloneTimeoutError: If the network-touching fetch step hangs
+                past _CLONE_TIMEOUT_S without git returning (GAP-014).
         """
 
         def run_git(args: list[str], cwd: Path | None = None) -> None:
+            # Local-only git plumbing (init/remote add/checkout touch no
+            # network and complete near-instantly), so a plain bounded run is
+            # fine here. The network-touching step below goes through
+            # _run_git_network_op instead, which has the GAP-014 timeout.
             subprocess.run(
                 args,
                 cwd=cwd,
                 check=True,
                 capture_output=True,
                 text=True,
+                timeout=30,
             )
 
         try:
@@ -251,7 +410,24 @@ class GitSourceHandler:
             cache_path.mkdir(parents=True, exist_ok=True)
             run_git(["git", "init", "--quiet", str(cache_path)])
             run_git(["git", "remote", "add", "origin", git_url], cwd=cache_path)
-            run_git(["git", "fetch", "--depth", "1", "origin", sha], cwd=cache_path)
+            # GAP-030 cross-platform validation: this used to call
+            # _run_git_network_op (which RETRIES up to _CLONE_MAX_ATTEMPTS
+            # times), directly contradicting the "Retry only this clone, not
+            # the shallow fetch above" comment a few lines below -- a
+            # regression introduced by GAP-014 switching this call over
+            # without noticing it also inherited retry behavior it was never
+            # meant to have. A server without allowReachableSHA1InWant now
+            # refused the fetch 3 times (with 1s+2s backoff, ~3s wasted) on
+            # EVERY clone before falling back, instead of once. Still routed
+            # through _run_git_subprocess directly (not a bare subprocess.run)
+            # so the GAP-014 wall-clock timeout still applies to a fetch that
+            # hangs -- just without the retry-on-failure this specific call
+            # was never supposed to have.
+            _run_git_subprocess(
+                ["git", "fetch", "--depth", "1", "origin", sha],
+                cwd=cache_path,
+                timeout_s=_CLONE_TIMEOUT_S,
+            )
             run_git(
                 [
                     "git",
@@ -263,20 +439,26 @@ class GitSourceHandler:
                 ],
                 cwd=cache_path,
             )
-        except subprocess.CalledProcessError as e:
+        except (subprocess.CalledProcessError, GitCloneTimeoutError) as e:
             # Server refused direct SHA fetch (e.g., unadvertised object on a
-            # server without allowReachableSHA1InWant). Fall back to a full
-            # clone + checkout. Errors here propagate to the caller.
+            # server without allowReachableSHA1InWant) - or the fetch hung
+            # (GAP-014). Fall back to a full clone + checkout. Errors here
+            # propagate to the caller.
+            detail = (
+                e.stderr if isinstance(e, subprocess.CalledProcessError) else str(e)
+            )
             logger.debug(
                 f"Shallow fetch of commit {sha} from {git_url} failed "
-                f"({e.stderr}); falling back to full clone + checkout"
+                f"({detail}); falling back to full clone + checkout"
             )
             shutil.rmtree(cache_path, ignore_errors=True)
             # Retry only this clone, not the shallow fetch above: that fetch
             # failing is an *expected* outcome on servers without
             # allowReachableSHA1InWant, and retrying it would add seconds to a
             # designed fallback path rather than to an error path.
-            _run_git_network_op(["git", "clone", git_url, str(cache_path)])
+            _run_git_network_op(
+                ["git", "clone", git_url, str(cache_path)], cleanup_path=cache_path
+            )
             run_git(
                 ["git", "-c", "advice.detachedHead=false", "checkout", "--quiet", sha],
                 cwd=cache_path,
@@ -334,7 +516,7 @@ class GitSourceHandler:
                     clone_args.extend(["--branch", parsed.ref])
                 clone_args.extend([git_url, str(cache_path)])
 
-                _run_git_network_op(clone_args)
+                _run_git_network_op(clone_args, cleanup_path=cache_path)
 
             # Verify clone completed with expected structure
             if not self._verify_clone_integrity(cache_path):
@@ -357,9 +539,12 @@ class GitSourceHandler:
                     "git_url": git_url,
                 },
             )
-        except subprocess.CalledProcessError as e:
+        except (subprocess.CalledProcessError, GitCloneTimeoutError) as e:
+            detail = (
+                e.stderr if isinstance(e, subprocess.CalledProcessError) else str(e)
+            )
             raise BundleNotFoundError(
-                f"Failed to clone {git_url}@{ref}: {e.stderr}"
+                f"Failed to clone {git_url}@{ref}: {detail}"
             ) from e
 
         # Return path with subpath if specified

--- a/amplifier_foundation/sources/git.py
+++ b/amplifier_foundation/sources/git.py
@@ -16,7 +16,11 @@ from datetime import datetime
 from pathlib import Path
 
 from amplifier_foundation.exceptions import BundleNotFoundError
-from amplifier_foundation.paths.resolution import ParsedURI, ResolvedSource
+from amplifier_foundation.paths.resolution import (
+    ParsedURI,
+    ResolvedSource,
+    describe_cross_platform_path_mismatch,
+)
 from amplifier_foundation.sources._rmtree import rmtree_robust
 from amplifier_foundation.sources.protocol import SourceStatus
 
@@ -123,7 +127,40 @@ _CLONE_RETRY_BACKOFF_S = (1.0, 2.0)
 # metered link genuinely takes minutes; every measured ecosystem clone
 # completes in under a second, so the headroom costs working users nothing and
 # protects the ones on the bad end of the distribution.
-_CLONE_TIMEOUT_S = float(os.environ.get("AMPLIFIER_GIT_CLONE_TIMEOUT_S", "300"))
+_CLONE_TIMEOUT_DEFAULT_S = 300.0
+
+
+def _clone_timeout_s() -> float:
+    """Resolve the per-attempt git timeout, reading the environment each call.
+
+    Read at call time rather than bound at import. GitCloneTimeoutError's
+    message tells the user to set AMPLIFIER_GIT_CLONE_TIMEOUT_S to change the
+    bound; an import-time read makes that instruction false for the process
+    that just printed it, since by the time the user acts on the advice the
+    value is already frozen. Callers are per-attempt and infrequent (a git
+    network op), so re-reading costs nothing measurable.
+
+    An unparseable value falls back to the default rather than raising: a
+    malformed override should not turn a working clone into a crash.
+    """
+    raw = os.environ.get("AMPLIFIER_GIT_CLONE_TIMEOUT_S")
+    if raw is None:
+        return _CLONE_TIMEOUT_DEFAULT_S
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            f"AMPLIFIER_GIT_CLONE_TIMEOUT_S={raw!r} is not a number; "
+            f"using default {_CLONE_TIMEOUT_DEFAULT_S:.0f}s"
+        )
+        return _CLONE_TIMEOUT_DEFAULT_S
+    if value <= 0:
+        logger.warning(
+            f"AMPLIFIER_GIT_CLONE_TIMEOUT_S={raw!r} must be positive; "
+            f"using default {_CLONE_TIMEOUT_DEFAULT_S:.0f}s"
+        )
+        return _CLONE_TIMEOUT_DEFAULT_S
+    return value
 
 
 class GitCloneTimeoutError(Exception):
@@ -276,7 +313,7 @@ def _run_git_network_op(
     the session rather than degrading it silently), one network blip would take
     down a whole session. This absorbs that class of failure.
 
-    Each attempt is bounded by _CLONE_TIMEOUT_S (GAP-014): a git invocation
+    Each attempt is bounded by _clone_timeout_s() (GAP-014): a git invocation
     that never returns is treated as a failed attempt like any other, rather
     than hanging the caller indefinitely.
 
@@ -307,7 +344,7 @@ def _run_git_network_op(
 
     for attempt in range(_CLONE_MAX_ATTEMPTS):
         try:
-            return _run_git_subprocess(args, cwd, _CLONE_TIMEOUT_S)
+            return _run_git_subprocess(args, cwd, _clone_timeout_s())
         except GitCloneTimeoutError:
             # Do NOT retry a timeout. Retries exist to absorb *transient*
             # failures -- a dropped connection mid-transfer, a flaky DNS
@@ -324,10 +361,7 @@ def _run_git_network_op(
             last_error = e
             if attempt < _CLONE_MAX_ATTEMPTS - 1:
                 delay = _CLONE_RETRY_BACKOFF_S[attempt]
-                if isinstance(e, GitCloneTimeoutError):
-                    reason = f"timed out after {_CLONE_TIMEOUT_S:.0f}s"
-                else:
-                    reason = (e.stderr or "").strip()
+                reason = (e.stderr or "").strip()
                 logger.warning(
                     f"git {args[1] if len(args) > 1 else ''} failed "
                     f"(attempt {attempt + 1}/{_CLONE_MAX_ATTEMPTS}), "
@@ -489,7 +523,7 @@ class GitSourceHandler:
             subprocess.CalledProcessError: If both strategies fail (converted
                 to BundleNotFoundError by the caller).
             GitCloneTimeoutError: If the network-touching fetch step hangs
-                past _CLONE_TIMEOUT_S without git returning (GAP-014).
+                past _clone_timeout_s() without git returning (GAP-014).
         """
 
         def run_git(args: list[str], cwd: Path | None = None) -> None:
@@ -542,7 +576,7 @@ class GitSourceHandler:
             _run_git_subprocess(
                 ["git", "fetch", "--depth", "1", "origin", sha],
                 cwd=cache_path,
-                timeout_s=_CLONE_TIMEOUT_S,
+                timeout_s=_clone_timeout_s(),
             )
             run_git(
                 _with_longpaths(
@@ -605,6 +639,22 @@ class GitSourceHandler:
         Raises:
             BundleNotFoundError: If clone fails or ref not found.
         """
+        # GAP-007, local-clone case. A git+file:// source carries a real
+        # filesystem path, so it is subject to the same foreign-OS mismatch
+        # the file and zip handlers already guard against: a config written
+        # on one OS and run on another yields an opaque "repository not
+        # found" from git rather than naming the actual problem.
+        #
+        # Scoped deliberately to the file inner-scheme. For a network remote,
+        # parsed.path is the repo's path on the *host* (e.g.
+        # "/microsoft/amplifier-foundation") and is POSIX-absolute by shape;
+        # checking it unconditionally would reject every git+https:// source
+        # on Windows.
+        if parsed.scheme == "git+file":
+            mismatch = describe_cross_platform_path_mismatch(parsed.path)
+            if mismatch:
+                raise BundleNotFoundError(mismatch)
+
         git_url = self._build_git_url(parsed)
         ref = parsed.ref or "HEAD"
         cache_path = self._get_cache_path(parsed, cache_dir)

--- a/amplifier_foundation/sources/zip.py
+++ b/amplifier_foundation/sources/zip.py
@@ -13,6 +13,7 @@ from amplifier_foundation.exceptions import BundleNotFoundError
 from amplifier_foundation.paths.resolution import ParsedURI
 from amplifier_foundation.paths.resolution import ResolvedSource
 from amplifier_foundation.paths.resolution import describe_cross_platform_path_mismatch
+from amplifier_foundation.paths.resolution import strip_uri_drive_prefix
 
 
 class ZipSourceHandler:
@@ -56,8 +57,15 @@ class ZipSourceHandler:
             if mismatch:
                 raise BundleNotFoundError(mismatch)
 
+            # A `zip+file:///C:/a.zip` URI parses to the path "/C:/a.zip":
+            # the leading slash is the URI's authority separator, not a
+            # filesystem root. Left in place, Path() reads it as rooted-but-
+            # driveless and resolves it against whatever the *current* drive
+            # happens to be rather than the drive the user named.
+            local_zip_path = strip_uri_drive_prefix(parsed.path)
+
             # Local zip file
-            zip_path = Path(parsed.path)
+            zip_path = Path(local_zip_path)
             source_uri = str(zip_path)
         else:
             # Remote zip (https, http)

--- a/amplifier_foundation/sources/zip.py
+++ b/amplifier_foundation/sources/zip.py
@@ -12,6 +12,7 @@ from urllib.request import urlopen
 from amplifier_foundation.exceptions import BundleNotFoundError
 from amplifier_foundation.paths.resolution import ParsedURI
 from amplifier_foundation.paths.resolution import ResolvedSource
+from amplifier_foundation.paths.resolution import describe_cross_platform_path_mismatch
 
 
 class ZipSourceHandler:
@@ -42,6 +43,19 @@ class ZipSourceHandler:
         inner_scheme = parsed.scheme.replace("zip+", "")
 
         if inner_scheme == "file":
+            # Same cross-OS hazard FileSourceHandler.resolve() guards against
+            # (GAP-007): Path() silently accepts a foreign-OS absolute path and
+            # coerces it into a nonsense local one, so a POSIX-authored
+            # `zip+file:///home/x/a.zip` resolved on Windows becomes
+            # `C:\home\x\a.zip` and fails below with a bare "Zip file not
+            # found" -- sending the user hunting for a file that was never
+            # expected to exist on this machine. Fail loud with the real reason
+            # instead. Checked before Path() so the message names the path the
+            # user actually wrote.
+            mismatch = describe_cross_platform_path_mismatch(parsed.path)
+            if mismatch:
+                raise BundleNotFoundError(mismatch)
+
             # Local zip file
             zip_path = Path(parsed.path)
             source_uri = str(zip_path)

--- a/amplifier_foundation/subprocess_runner.py
+++ b/amplifier_foundation/subprocess_runner.py
@@ -23,20 +23,82 @@ module is responsible for *how* to serialize and validate it.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
+import platform
 import re
 import stat
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
 from typing import Any
 
 from amplifier_core import AmplifierSession
+
 from amplifier_foundation.bundle import BundleModuleResolver
 
 logger = logging.getLogger(__name__)
+
+
+def _kill_subprocess_tree(pid: int) -> None:
+    """Kill a subprocess and its descendants.
+
+    GAP-026: a plain ``process.kill()`` (used on the ``asyncio.TimeoutError``
+    path below) only terminates the immediate child -- the
+    ``python -m amplifier_foundation.subprocess_runner`` process itself. If
+    that child has, in turn, spawned its own tool subprocesses (e.g. a bash
+    tool call made by the delegated subagent), those are not reparented or
+    reaped when only the direct child is killed. Mirrors
+    ``amplifier_foundation.sources.git._kill_process_tree`` (GAP-013/GAP-014),
+    duplicated here rather than imported to keep this module's dependency on
+    ``sources.git`` at zero -- these are two independently-triggerable
+    process-cleanup gaps in otherwise-unrelated code paths, not one shared
+    mechanism.
+
+    GAP-030: on POSIX, ``os.killpg(os.getpgid(pid), ...)`` only isolates the
+    *target* if that target was started in its own process group. The child
+    spawned below used to inherit *our* process group (the default for
+    ``asyncio.create_subprocess_exec``), so ``os.getpgid(pid)`` returned OUR
+    OWN pgid and this call would SIGKILL the calling process (and everything
+    else sharing its group -- e.g. the user's interactive shell) instead of
+    just the runaway child. Confirmed empirically on Linux before the
+    ``start_new_session=True`` fix below: child pgid == our pgid. Fixed at
+    the spawn site so the child gets its own group; this guard is a second,
+    independent line of defense that refuses to act if that ever regresses,
+    rather than trusting the spawn site silently forever.
+    """
+    if platform.system() == "Windows":
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(pid)],
+            capture_output=True,
+            check=False,
+        )
+    else:
+        import signal
+
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            target_pgid = os.getpgid(pid)
+            if target_pgid == os.getpgid(0):
+                # GAP-030 defense-in-depth: the target is (still) in OUR
+                # process group -- e.g. start_new_session somehow didn't
+                # take effect. Killing this group would kill the caller.
+                # Fall back to killing just the direct child instead of
+                # silently self-destructing.
+                logger.warning(
+                    "Refusing to killpg pid %s: its process group (%s) is "
+                    "our own. Falling back to killing only the direct "
+                    "child; descendants may be left running.",
+                    pid,
+                    target_pgid,
+                )
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.kill(pid, signal.SIGKILL)
+            else:
+                os.killpg(target_pgid, signal.SIGKILL)
+
 
 REQUIRED_KEYS = ("config", "prompt", "parent_id", "project_path")
 
@@ -396,6 +458,22 @@ async def run_session_in_subprocess(
         if current_mode & (stat.S_IRWXG | stat.S_IRWXO):
             os.chmod(tmp_path, 0o600)
 
+        # GAP-030: on POSIX, spawn the child into its own process group so
+        # that _kill_subprocess_tree's os.killpg() targets the child (and
+        # anything IT spawned) rather than the group this very process is
+        # in. Without this, the child inherits our group by default and
+        # killpg(getpgid(child)) == killpg(our own group) -- confirmed
+        # empirically on Linux: same pgid as the parent before this fix.
+        # Mirrors amplifier_foundation.sources.git._run_git_subprocess,
+        # which got this right for its own subprocess.Popen() call.
+        extra_spawn_kwargs: dict[str, Any] = {}
+        if platform.system() == "Windows":
+            creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            if creationflags:
+                extra_spawn_kwargs["creationflags"] = creationflags
+        else:
+            extra_spawn_kwargs["start_new_session"] = True
+
         async with semaphore:
             process = await asyncio.create_subprocess_exec(
                 sys.executable,
@@ -406,6 +484,7 @@ async def run_session_in_subprocess(
                 stderr=asyncio.subprocess.PIPE,
                 cwd=project_path,
                 env=_build_child_env(),
+                **extra_spawn_kwargs,
             )
 
             try:
@@ -422,6 +501,25 @@ async def run_session_in_subprocess(
                         process.pid,
                     )
                 raise TimeoutError(f"Subprocess session timed out after {timeout}s")
+            except BaseException:
+                # GAP-026: this function has NO cancellation wiring at all --
+                # unlike in-process delegation (session_spawner.py's
+                # register_child/unregister_child), a subprocess-mode
+                # delegate call is not linked to the parent's
+                # CancellationToken in any way. The only previously-handled
+                # exception here was our OWN asyncio.TimeoutError (default
+                # 1800s). Anything else that unwinds this await -- most
+                # importantly asyncio.CancelledError from the enclosing task
+                # being cancelled (what a real Ctrl+C would have to drive if
+                # this path is ever wired up), but also e.g. a bare
+                # KeyboardInterrupt -- left the child process (and anything
+                # IT spawned, such as a bash tool call made by the delegated
+                # subagent) running fully unsupervised, verified empirically:
+                # confirmed alive both immediately and 3s after cancellation.
+                # See GAP-026 in WINDOWS-GAP-LEDGER.md.
+                if process.returncode is None:
+                    _kill_subprocess_tree(process.pid)
+                raise
 
             raw_stdout = stdout.decode("utf-8")
             stderr_text = stderr.decode("utf-8")
@@ -517,8 +615,12 @@ async def _run_child_session(config_path: str) -> str:
             {name: Path(path) for name, path in module_paths.items()}
         )
         try:
-            from amplifier_app_cli.lib.bundle_loader import AppModuleResolver  # type: ignore[import-untyped,import-not-found]
-            from amplifier_app_cli.paths import create_foundation_resolver  # type: ignore[import-untyped,import-not-found]
+            from amplifier_app_cli.lib.bundle_loader import (
+                AppModuleResolver,  # type: ignore[import-untyped,import-not-found]
+            )
+            from amplifier_app_cli.paths import (
+                create_foundation_resolver,  # type: ignore[import-untyped,import-not-found]
+            )
 
             resolver = AppModuleResolver(
                 bundle_resolver=bundle_resolver,

--- a/amplifier_foundation/subprocess_runner.py
+++ b/amplifier_foundation/subprocess_runner.py
@@ -492,7 +492,8 @@ async def run_session_in_subprocess(
                     process.communicate(), timeout=timeout
                 )
             except asyncio.TimeoutError:
-                process.kill()
+                if process.returncode is None:
+                    _kill_subprocess_tree(process.pid)
                 try:
                     await asyncio.wait_for(process.wait(), timeout=10)
                 except asyncio.TimeoutError:

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -409,7 +409,10 @@ class TestBundleValidation:
         with pytest.raises(BundleValidationError) as exc_info:
             Bundle.from_dict(data, base_path=Path("/path/to/bundle"))
         error_msg = str(exc_info.value)
-        assert "/path/to/bundle" in error_msg
+        # str(Path) yields native separators, so the message contains
+        # "\\path\\to\\bundle" on Windows. Compare against the same
+        # rendering the code produces rather than a POSIX literal.
+        assert str(Path("/path/to/bundle")) in error_msg
 
     def test_error_shows_correct_format_example(self) -> None:
         """Error message includes example of correct format."""

--- a/tests/test_gap011_git_interrupt_orphans.py
+++ b/tests/test_gap011_git_interrupt_orphans.py
@@ -136,30 +136,48 @@ class TestGap011InterruptKillsWholeProcessTree:
         parent_pid_marker = tmp_path / "parent.pid"
         child_pid_marker = tmp_path / "child.pid"
 
+        args = [sys.executable, str(script), "parent", str(tmp_path)]
+
         # Simulate a real Ctrl+C landing exactly where GAP-025 found it
         # can: inside `proc.communicate()`, while _run_git_subprocess is
         # blocked waiting on the (deterministic, stand-in) "hung" tree.
-        # Only the FIRST communicate() call raises -- and only once BOTH
-        # stand-in processes have confirmed they are alive, so we are
-        # genuinely testing "interrupt while an already-established tree
-        # is running", not racing the child's own startup. Subsequent
-        # communicate() calls (taskkill's own subprocess.run, and
-        # _run_git_subprocess's own post-kill reap) must behave normally,
-        # or this test would also break the cleanup it's trying to verify.
+        #
+        # Only the FIRST communicate() call *on our own stand-in
+        # subprocess* raises -- matched by identity (`self.args == args`),
+        # NOT by a global ordinal ("the first call anywhere in this
+        # process"). `subprocess.Popen.communicate` is a single, process-
+        # wide class attribute: patching it and counting calls globally
+        # means ANY other Popen().communicate() in this process (pytest's
+        # own machinery, a leftover subprocess from a previous test, an
+        # antivirus/CI helper, taskkill's own subprocess.run -- anything)
+        # can steal "call #1" before our target subprocess's own call ever
+        # happens. If that happens, our intended call becomes call #2 (or
+        # later) and silently falls through to the REAL, un-mocked
+        # `communicate()` with the REAL 60s timeout -- producing a bogus
+        # `GitCloneTimeoutError` instead of the `KeyboardInterrupt` this
+        # test means to inject, with no indication that interception (not
+        # the product's interrupt-cleanup path) is what actually failed.
+        # Matching by the exact argv of the subprocess this test itself
+        # spawned closes that whole class of race, regardless of what else
+        # is running in this process.
+        #
+        # Subsequent communicate() calls on our OWN stand-in proc (the
+        # post-kill reap) and calls on OTHER procs (taskkill's own
+        # subprocess.run) must behave normally, or this test would also
+        # break the cleanup it's trying to verify -- both fall through to
+        # the real implementation below.
         original_communicate = subprocess.Popen.communicate
-        calls = {"n": 0}
+        triggered = {"done": False}
 
         def fake_communicate(self, input=None, timeout=None):  # type: ignore[no-untyped-def]
-            calls["n"] += 1
-            if calls["n"] == 1:
+            if not triggered["done"] and list(self.args) == args:
+                triggered["done"] = True
                 _wait_for_marker(parent_pid_marker)
                 _wait_for_marker(child_pid_marker)
                 raise KeyboardInterrupt()
             return original_communicate(self, input, timeout=timeout)
 
         monkeypatch.setattr(subprocess.Popen, "communicate", fake_communicate)
-
-        args = [sys.executable, str(script), "parent", str(tmp_path)]
 
         parent_pid: int | None = None
         child_pid: int | None = None

--- a/tests/test_gap011_git_interrupt_orphans.py
+++ b/tests/test_gap011_git_interrupt_orphans.py
@@ -1,0 +1,218 @@
+"""Regression test: GAP-011 / GAP-025 -- interrupting a blocking git
+subprocess call must not leave its child process tree running.
+
+## Why this test exists
+
+GAP-011 ("Ctrl+C does nothing while amplifier is stuck in the bundle-prep
+hang") went through several rounds of investigation. Its literal claim
+("no response to Ctrl+C at all") turned out to be false even before any
+fix landed -- but the underlying user-visible guarantee behind it
+("I can always get out, without leaving processes running") is real, and
+depends entirely on the process-tree-kill mechanism this test locks in:
+
+  * ``_run_git_subprocess``'s ``except BaseException:`` clause (added for
+    GAP-025) -- a ``KeyboardInterrupt``/``CancelledError`` landing while
+    blocked inside ``proc.communicate()`` must still trigger cleanup, not
+    just the ``subprocess.TimeoutExpired`` case.
+  * ``_kill_process_tree``'s Windows path (``taskkill /F /T``) -- killing
+    the whole tree a blocking git invocation may have spawned (git.exe ->
+    git-remote-https.exe -> a credential-helper child, in the real
+    GAP-014 scenario), not just the immediate PID.
+
+Nothing previously locked either of these in as an automated regression.
+The last proof for GAP-011 was a one-shot manual ConPTY run against a
+live credential-manager OAuth hang on a specific box on a specific day --
+real evidence, but it protects nothing going forward. If either of the
+two mechanisms above regresses (e.g. someone "simplifies" the except
+clause back to ``except subprocess.TimeoutExpired:``, or drops the
+``/T`` flag from the taskkill call), this test is what catches it.
+
+## Why a deterministic stand-in instead of a live credential hang
+
+The real GAP-014/GAP-011 scenario depends on this box's git credential
+configuration and network state to actually hang -- neither fast nor
+reproducible as an automated test. Instead, this test:
+
+  1. Spawns a small two-level *stand-in* process tree (a script that
+     spawns one real child of its own) that mirrors git's own
+     parent -> credential-helper relationship closely enough to exercise
+     ``taskkill /F /T`` for real, without needing git, a network, or an
+     actual credential hang.
+  2. Simulates the interrupt landing at the right moment: the tree is
+     confirmed alive (both marker files, from both real OS processes,
+     exist) before a ``KeyboardInterrupt`` is raised on the *first* call
+     to ``Popen.communicate()`` -- exactly where GAP-025 found a real
+     Ctrl+C is delivered while ``_run_git_subprocess`` is blocked.
+
+This is Windows-only: the POSIX escape-hatch case (``setsid`` descendants
+surviving ``os.killpg``) is a different code path covered by
+``amplifier-module-tool-bash``'s own timeout-cleanup tests; this test is
+specifically about the ``taskkill /F /T`` path GAP-011/GAP-013/GAP-025
+were about.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from amplifier_foundation.sources import git as git_mod
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="GAP-011/013/025 orphan-prevention is Windows-specific (taskkill /F /T path)",
+)
+
+
+_STANDIN_SCRIPT = """
+import sys
+import os
+import subprocess
+import time
+from pathlib import Path
+
+mode = sys.argv[1]
+marker_dir = Path(sys.argv[2])
+
+if mode == "parent":
+    (marker_dir / "parent.pid").write_text(str(os.getpid()))
+    # Mirrors git.exe spawning a credential-helper child: a REAL OS child
+    # process (not a thread), so it is only reachable through taskkill's
+    # /T (process-tree) flag -- killing this PID alone would not reach it.
+    subprocess.Popen([sys.executable, __file__, "child", str(marker_dir)])
+    time.sleep(120)
+elif mode == "child":
+    (marker_dir / "child.pid").write_text(str(os.getpid()))
+    time.sleep(120)
+"""
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort Windows liveness check via ``tasklist`` (no admin needed)."""
+    result = subprocess.run(
+        ["tasklist", "/FI", f"PID eq {pid}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return str(pid) in result.stdout
+
+
+def _wait_for_marker(path: Path, timeout_s: float = 10.0) -> int:
+    """Poll for a marker file to appear with a non-empty PID in it."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if path.exists():
+            text = path.read_text().strip()
+            if text:
+                return int(text)
+        time.sleep(0.1)
+    raise TimeoutError(f"marker file {path} never appeared with a PID")
+
+
+def _force_kill(pid: int) -> None:
+    """Best-effort cleanup so a failing test never leaks a stand-in process."""
+    subprocess.run(
+        ["taskkill", "/F", "/T", "/PID", str(pid)],
+        capture_output=True,
+        check=False,
+    )
+
+
+class TestGap011InterruptKillsWholeProcessTree:
+    """A Ctrl+C-equivalent interrupt during a blocking git subprocess call
+    must kill the ENTIRE spawned process tree, not just the immediate child.
+    """
+
+    def test_keyboard_interrupt_during_communicate_kills_grandchild(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        script = tmp_path / "gap011_standin.py"
+        script.write_text(_STANDIN_SCRIPT)
+
+        parent_pid_marker = tmp_path / "parent.pid"
+        child_pid_marker = tmp_path / "child.pid"
+
+        # Simulate a real Ctrl+C landing exactly where GAP-025 found it
+        # can: inside `proc.communicate()`, while _run_git_subprocess is
+        # blocked waiting on the (deterministic, stand-in) "hung" tree.
+        # Only the FIRST communicate() call raises -- and only once BOTH
+        # stand-in processes have confirmed they are alive, so we are
+        # genuinely testing "interrupt while an already-established tree
+        # is running", not racing the child's own startup. Subsequent
+        # communicate() calls (taskkill's own subprocess.run, and
+        # _run_git_subprocess's own post-kill reap) must behave normally,
+        # or this test would also break the cleanup it's trying to verify.
+        original_communicate = subprocess.Popen.communicate
+        calls = {"n": 0}
+
+        def fake_communicate(self, input=None, timeout=None):  # type: ignore[no-untyped-def]
+            calls["n"] += 1
+            if calls["n"] == 1:
+                _wait_for_marker(parent_pid_marker)
+                _wait_for_marker(child_pid_marker)
+                raise KeyboardInterrupt()
+            return original_communicate(self, input, timeout=timeout)
+
+        monkeypatch.setattr(subprocess.Popen, "communicate", fake_communicate)
+
+        args = [sys.executable, str(script), "parent", str(tmp_path)]
+
+        parent_pid: int | None = None
+        child_pid: int | None = None
+        try:
+            start = time.monotonic()
+            with pytest.raises(KeyboardInterrupt):
+                git_mod._run_git_subprocess(args, cwd=None, timeout_s=60)
+            elapsed = time.monotonic() - start
+
+            # Bound with real headroom above the manually-observed
+            # live-scenario numbers (2.03s best case / 35.44s worst case,
+            # GAP-011's end-to-end ConPTY proof against a real credential
+            # hang). This test's own cleanup is purely local process
+            # teardown (no network/auth variance), so it should be far
+            # faster in practice -- but we deliberately don't tighten the
+            # bound below the real worst-case number, in case the same
+            # taskkill-based mechanism turns out to be the slow part.
+            # 60s = ~1.7x the observed live worst case: enough headroom to
+            # not flake on a loaded CI box, tight enough to fail if the
+            # except-clause fix regresses into a real wait.
+            assert elapsed < 60, (
+                f"_run_git_subprocess took {elapsed:.1f}s to raise+cleanup "
+                "after a simulated interrupt -- should be local process "
+                "teardown, not bounded by anything resembling a real "
+                "network/credential wait"
+            )
+
+            parent_pid = _wait_for_marker(parent_pid_marker)
+            child_pid = _wait_for_marker(child_pid_marker)
+
+            # Give the kill a moment to fully land -- taskkill itself is
+            # synchronous but the process table doesn't always update
+            # instantaneously.
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                if not _pid_alive(parent_pid) and not _pid_alive(child_pid):
+                    break
+                time.sleep(0.2)
+
+            assert not _pid_alive(parent_pid), (
+                f"stand-in parent process (pid {parent_pid}) survived the "
+                "interrupt -- GAP-025's `except BaseException:` cleanup "
+                "in _run_git_subprocess regressed"
+            )
+            assert not _pid_alive(child_pid), (
+                f"stand-in CHILD process (pid {child_pid}) survived the "
+                "interrupt even though the parent was killed -- this is "
+                "GAP-011/GAP-013's exact orphan signature: `taskkill /F "
+                "/T` (process-TREE kill) regressed to a plain "
+                "single-process kill in _kill_process_tree"
+            )
+        finally:
+            if parent_pid is not None:
+                _force_kill(parent_pid)
+            if child_pid is not None:
+                _force_kill(child_pid)

--- a/tests/test_gap030_posix_self_kill.py
+++ b/tests/test_gap030_posix_self_kill.py
@@ -1,0 +1,226 @@
+"""Regression test: GAP-030 -- on POSIX, ``_kill_subprocess_tree`` must never
+send ``SIGKILL`` to the calling process's own process group.
+
+## Why this test exists
+
+GAP-026 added ``_kill_subprocess_tree`` (in ``subprocess_runner.py``) to clean
+up an orphaned subprocess-mode delegation child on interrupt, mirroring
+``sources.git._kill_process_tree``. Its POSIX branch is::
+
+    os.killpg(os.getpgid(pid), signal.SIGKILL)
+
+That is only safe if ``pid`` was spawned into its OWN process group. The
+child was spawned via a bare ``asyncio.create_subprocess_exec(...)`` with no
+``start_new_session=True`` -- so on POSIX it inherited the CALLING process's
+group. ``os.getpgid(child_pid)`` therefore returned the same pgid as
+``os.getpgid(0)`` (us), and ``os.killpg`` on that pgid would have delivered
+SIGKILL to the calling process itself (and everything else sharing its
+group -- e.g. a user's interactive shell), not just the intended target.
+
+Confirmed empirically on Linux (spark-1, aarch64) before this fix:
+
+    our pgid    : 964331
+    child pgid  : 964331
+    SAME GROUP? : True     -> killpg would SIGKILL us too
+
+``sources.git._run_git_subprocess`` already got this right (POSIX branch sets
+``start_new_session=True``); ``subprocess_runner.py``'s spawn call, added in
+the same GAP-026 pass, did not. Same investigation pass, one path guarded,
+one not.
+
+## Two independent things are locked in here
+
+1. **The spawn site** now puts the child in its own process group on POSIX
+   (``start_new_session=True``), mirroring ``sources.git``. Verified with a
+   REAL subprocess: pgid differs from ours, and killing it via
+   ``_kill_subprocess_tree`` reaps only the child -- proven by the simple
+   fact that this test process is still alive to report a result.
+
+2. **A second, independent line of defense** inside
+   ``_kill_subprocess_tree`` itself: even if a future caller (or a
+   regression at the spawn site) ever hands it a pid that IS in our own
+   group, it must refuse to ``killpg`` that group and fall back to killing
+   only the direct pid instead. This is tested via monkeypatched
+   ``os.getpgid``/``os.killpg``/``os.kill`` -- deliberately NOT by handing
+   the real function a pid actually in our own group, since that is exactly
+   the self-destructive action under test and must never be risked for
+   real inside a test run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import signal
+import sys
+import time
+
+import pytest
+from amplifier_foundation import subprocess_runner as sr_mod
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="GAP-030 is POSIX-specific (process-group semantics; Windows uses taskkill /F /T instead)",
+)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Liveness check that also reaps the pid if it's a zombie we own.
+
+    A killed child that nobody has ``waitpid()``-ed on remains a zombie --
+    and ``os.kill(pid, 0)`` reports zombies as "alive" (the PID slot still
+    exists in the process table until reaped). These tests spawn children
+    directly rather than through the full asyncio-managed subprocess
+    lifecycle, so nothing else is reaping them; without this, every check
+    here would report a just-killed child as still alive and every test
+    would be a false negative, not a real signal.
+    """
+    with contextlib.suppress(ChildProcessError):
+        reaped_pid, _status = os.waitpid(pid, os.WNOHANG)
+        if reaped_pid == pid:
+            return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+class TestGap030SpawnSiteUsesOwnProcessGroup:
+    """The real spawn call in ``run_session_in_subprocess`` must isolate the
+    child into its own POSIX process group, so cleanup can never reach back
+    and hit the caller.
+    """
+
+    def test_child_spawned_with_start_new_session_gets_distinct_pgid(self) -> None:
+        async def _spawn_and_check() -> tuple[int, int, int]:
+            proc = await asyncio.create_subprocess_exec(
+                "sleep",
+                "30",
+                start_new_session=True,  # exactly what the fixed spawn site now does
+            )
+            our_pgid = os.getpgid(0)
+            child_pgid = os.getpgid(proc.pid)
+            return proc.pid, our_pgid, child_pgid
+
+        _pid, our_pgid, child_pgid = asyncio.run(_spawn_and_check())
+        try:
+            assert child_pgid != our_pgid, (
+                f"child pgid ({child_pgid}) == our pgid ({our_pgid}) -- the "
+                "GAP-030 fix (start_new_session=True at the spawn site) has "
+                "regressed; _kill_subprocess_tree's os.killpg() would once "
+                "again target the CALLER's own process group"
+            )
+        finally:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(child_pgid, signal.SIGKILL)
+
+    def test_real_kill_subprocess_tree_reaps_only_the_isolated_child(self) -> None:
+        """End-to-end: spawn exactly as the fixed production code does, then
+        call the real ``_kill_subprocess_tree`` on it. The child must die.
+        This process must survive to report that -- the test passing AT ALL
+        is itself part of the proof.
+        """
+
+        async def _spawn() -> int:
+            proc = await asyncio.create_subprocess_exec(
+                "sleep", "30", start_new_session=True
+            )
+            return proc.pid
+
+        child_pid = asyncio.run(_spawn())
+
+        assert _pid_alive(child_pid), "test setup failed: child never started"
+
+        sr_mod._kill_subprocess_tree(child_pid)
+
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and _pid_alive(child_pid):
+            time.sleep(0.1)
+
+        assert not _pid_alive(child_pid), (
+            f"child pid {child_pid} survived _kill_subprocess_tree -- cleanup regressed"
+        )
+        # If we reached here at all, WE (the caller) are still running --
+        # the exact guarantee GAP-030 is about.
+
+
+class TestGap030KillSubprocessTreeRefusesToSelfKill:
+    """Defense-in-depth: even if handed a pid that (somehow) shares our own
+    process group, ``_kill_subprocess_tree`` must not ``killpg`` it. Tested
+    entirely through monkeypatching -- never by actually creating this
+    condition for real, since that IS the self-destructive action under
+    test.
+    """
+
+    def test_refuses_killpg_when_target_shares_our_process_group(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[str, tuple]] = []
+        shared_pgid = 4242
+
+        def fake_getpgid(pid: int) -> int:
+            # Both "the target" (some fake pid) and "us" (pid 0) resolve to
+            # the SAME pgid -- the exact hazardous precondition.
+            return shared_pgid
+
+        def fake_killpg(pgid: int, sig: int) -> None:
+            calls.append(("killpg", (pgid, sig)))
+
+        def fake_kill(pid: int, sig: int) -> None:
+            calls.append(("kill", (pid, sig)))
+
+        monkeypatch.setattr(sr_mod.os, "getpgid", fake_getpgid)
+        monkeypatch.setattr(sr_mod.os, "killpg", fake_killpg)
+        monkeypatch.setattr(sr_mod.os, "kill", fake_kill)
+        monkeypatch.setattr(sr_mod.platform, "system", lambda: "Linux")
+
+        sr_mod._kill_subprocess_tree(pid=9999)
+
+        killpg_calls = [c for c in calls if c[0] == "killpg"]
+        kill_calls = [c for c in calls if c[0] == "kill"]
+
+        assert not killpg_calls, (
+            "_kill_subprocess_tree called os.killpg() on a pgid shared with "
+            "the caller's own group -- this would SIGKILL the caller "
+            f"itself (and its whole process group) instead of just the "
+            f"intended target. Recorded calls: {calls!r}"
+        )
+        assert kill_calls == [("kill", (9999, signal.SIGKILL))], (
+            "expected a fallback os.kill() on the direct pid when killpg "
+            f"is refused; got: {calls!r}"
+        )
+
+    def test_killpg_used_normally_when_target_has_its_own_group(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sanity check for the test harness itself: when the target's pgid
+        genuinely differs from ours, the normal ``killpg`` path must still
+        be taken (the guard must not become overly broad and disable
+        cleanup entirely).
+        """
+        calls: list[tuple[str, tuple]] = []
+
+        def fake_getpgid(pid: int) -> int:
+            return 111 if pid == 0 else 222
+
+        def fake_killpg(pgid: int, sig: int) -> None:
+            calls.append(("killpg", (pgid, sig)))
+
+        def fake_kill(pid: int, sig: int) -> None:
+            calls.append(("kill", (pid, sig)))
+
+        monkeypatch.setattr(sr_mod.os, "getpgid", fake_getpgid)
+        monkeypatch.setattr(sr_mod.os, "killpg", fake_killpg)
+        monkeypatch.setattr(sr_mod.os, "kill", fake_kill)
+        monkeypatch.setattr(sr_mod.platform, "system", lambda: "Linux")
+
+        sr_mod._kill_subprocess_tree(pid=5555)
+
+        assert calls == [("killpg", (222, signal.SIGKILL))], (
+            f"expected a normal killpg() on the child's OWN (distinct) "
+            f"pgid; got: {calls!r}"
+        )

--- a/tests/test_gap_rmtree_readonly.py
+++ b/tests/test_gap_rmtree_readonly.py
@@ -1,0 +1,178 @@
+"""Regression test: bundle cache cache-invalidation must self-heal on
+Windows when a git checkout contains read-only files.
+
+## Why this test exists
+
+Git marks files under ``.git/objects/pack/`` read-only. On POSIX, removing
+a read-only file only needs write permission on the *parent* directory, so
+``shutil.rmtree`` succeeds there without any special handling. On Windows,
+the read-only attribute lives on the file itself and blocks the delete
+outright: ``os.unlink``/``shutil.rmtree`` raises ``PermissionError``
+(WinError 5, "Access is denied").
+
+Before this fix, ``GitSourceHandler.resolve()`` detected an invalid cached
+clone, called a bare ``shutil.rmtree(cache_path, ignore_errors=True)``,
+which silently left the read-only pack files behind on Windows, and then a
+*second*, non-ignoring ``shutil.rmtree(cache_path)`` a few lines later hit
+the same files and raised uncaught -- surfacing as a hard failure on every
+single run, forever, because the cache was never actually cleaned up.
+``amplifier_foundation.sources._rmtree.rmtree_robust`` fixes this by
+clearing the read-only attribute and retrying once before giving up.
+
+This test suite covers the mechanism generically (not by trying to
+reproduce Windows file-attribute semantics on POSIX, which isn't possible):
+
+  * A real read-only file removed via the real filesystem (the literal
+    scenario asked for, and meaningful on POSIX too -- it proves the
+    wrapper doesn't regress the common/happy path).
+  * A transient failure simulated by monkeypatching ``os.unlink`` to fail
+    once then succeed -- proves the retry-after-clearing mechanism is
+    actually wired up and works, independent of *why* the OS raised.
+  * A persistent failure (retry also fails) -- proves the fix still fails
+    loudly, naming the path, rather than silently pretending the removal
+    succeeded (the exact defect this fix targets: a cache invalidation
+    that doesn't actually invalidate anything).
+  * The ``ignore_errors=True`` best-effort path still swallows a
+    persistent failure, matching plain ``shutil.rmtree``'s own semantics
+    for the call sites that were already using it that way.
+  * The Python-version dispatch (``onexc`` on >=3.12, ``onerror`` below)
+    actually selects the right keyword.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from amplifier_foundation.sources._rmtree import rmtree_robust
+
+
+def test_rmtree_robust_removes_readonly_file(tmp_path: Path) -> None:
+    """The literal repro scenario: a directory containing a read-only file
+    must be fully removable -- meaningful on POSIX too, since it locks in
+    that the wrapper never regresses the common case.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    packfile = repo / "pack-deadbeef.idx"
+    packfile.write_text("binary pack data")
+    packfile.chmod(stat.S_IREAD)  # read-only, mirrors git's pack files
+
+    rmtree_robust(repo)
+
+    assert not repo.exists()
+
+
+def test_rmtree_robust_retries_after_transient_permission_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Simulates the real Windows failure mode: the first removal attempt
+    is denied (as it would be for a read-only pack file on Windows); the
+    fix must clear the attribute and retry, and the retry must succeed.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    stubborn = repo / "pack-stubborn.idx"
+    stubborn.write_text("data")
+    stubborn.chmod(stat.S_IREAD)
+
+    real_unlink = os.unlink
+    calls = {"n": 0}
+
+    def fake_unlink(path, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise PermissionError(13, "Access is denied", str(path))
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "unlink", fake_unlink)
+
+    rmtree_robust(repo)
+
+    assert not repo.exists()
+    assert calls["n"] >= 2, (
+        "expected the first (simulated) removal to fail and a retry to "
+        "follow it -- rmtree_robust's read-only-clear-and-retry mechanism "
+        "was never exercised"
+    )
+
+
+def test_rmtree_robust_raises_when_retry_still_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If clearing the read-only attribute and retrying STILL fails, the
+    failure must propagate -- a cache-invalidation removal that silently
+    "succeeds" while leaving the stale directory in place is the exact bug
+    being fixed (GAP: cache never self-heals).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    stubborn = repo / "pack-permanent.idx"
+    stubborn.write_text("data")
+
+    def always_fails(path, *args, **kwargs):
+        raise PermissionError(13, "Access is denied", str(path))
+
+    monkeypatch.setattr(os, "unlink", always_fails)
+
+    with pytest.raises(OSError, match=str(repo)):
+        rmtree_robust(repo)
+
+    # The directory must still exist -- nothing should look like it was
+    # cleaned up when it wasn't.
+    assert repo.exists()
+
+
+def test_rmtree_robust_ignore_errors_swallows_persistent_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ignore_errors=True must still swallow a failure that persists after
+    the retry, matching shutil.rmtree's own ignore_errors semantics -- used
+    for the existing best-effort cleanup call sites (e.g. between network
+    retry attempts) where a stale leftover is tolerable.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    stubborn = repo / "pack-permanent.idx"
+    stubborn.write_text("data")
+
+    def always_fails(path, *args, **kwargs):
+        raise PermissionError(13, "Access is denied", str(path))
+
+    monkeypatch.setattr(os, "unlink", always_fails)
+
+    # Must not raise.
+    rmtree_robust(repo, ignore_errors=True)
+
+
+def test_rmtree_robust_dispatches_onexc_vs_onerror_by_python_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`onerror` is deprecated since Python 3.12 in favor of `onexc`. Verify
+    rmtree_robust actually dispatches on sys.version_info rather than
+    always using the deprecated form (or always using the newer one, which
+    would break on 3.11).
+    """
+    fake_rmtree = MagicMock()
+    monkeypatch.setattr(shutil, "rmtree", fake_rmtree)
+
+    monkeypatch.setattr(sys, "version_info", (3, 12, 0))
+    rmtree_robust("/some/path")
+    _, kwargs = fake_rmtree.call_args
+    assert "onexc" in kwargs, "Python >=3.12 must use the non-deprecated onexc kwarg"
+    assert "onerror" not in kwargs
+
+    fake_rmtree.reset_mock()
+
+    monkeypatch.setattr(sys, "version_info", (3, 11, 5))
+    rmtree_robust("/some/path")
+    _, kwargs = fake_rmtree.call_args
+    assert "onerror" in kwargs, (
+        "Python <3.12 must use onerror (onexc doesn't exist yet)"
+    )
+    assert "onexc" not in kwargs

--- a/tests/test_gap_rmtree_readonly.py
+++ b/tests/test_gap_rmtree_readonly.py
@@ -42,6 +42,7 @@ reproduce Windows file-attribute semantics on POSIX, which isn't possible):
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import stat
 import sys
@@ -120,7 +121,12 @@ def test_rmtree_robust_raises_when_retry_still_fails(
 
     monkeypatch.setattr(os, "unlink", always_fails)
 
-    with pytest.raises(OSError, match=str(repo)):
+    # `match` is a REGEX, not a substring. On Windows `str(repo)` is a path
+    # like C:\Users\...\repo -- and `\U` there is an invalid regex escape, so
+    # pytest raises `re.error: Invalid regex pattern provided to 'match'`
+    # before it ever evaluates the assertion. Escaping is what makes this test
+    # actually run on the platform the fix exists for.
+    with pytest.raises(OSError, match=re.escape(str(repo))):
         rmtree_robust(repo)
 
     # The directory must still exist -- nothing should look like it was

--- a/tests/test_git_clone_timeout_policy.py
+++ b/tests/test_git_clone_timeout_policy.py
@@ -39,12 +39,46 @@ def test_clone_timeout_default_is_generous_enough_for_slow_links() -> None:
     Pins the policy decision, not the exact number: a bound tight enough to
     fail a legitimate multi-minute clone is a regression for every platform.
     """
-    assert git_mod._CLONE_TIMEOUT_S >= 120.0, (
-        f"clone bound is {git_mod._CLONE_TIMEOUT_S}s -- tight enough to fail a "
-        "legitimate large-repo or slow-link clone. The hang this catches is "
-        "unbounded, so a generous value catches it just as well at no cost to "
+    assert git_mod._CLONE_TIMEOUT_DEFAULT_S >= 120.0, (
+        f"clone bound is {git_mod._CLONE_TIMEOUT_DEFAULT_S}s -- tight enough to "
+        "fail a legitimate large-repo or slow-link clone. The hang this catches "
+        "is unbounded, so a generous value catches it just as well at no cost to "
         "working users."
     )
+
+
+def test_timeout_override_is_read_at_call_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The documented override must work for the process that reads the advice.
+
+    GitCloneTimeoutError's message tells the user to set
+    AMPLIFIER_GIT_CLONE_TIMEOUT_S. If the value is bound at import, that
+    instruction is false for any caller that sets it after the module loads --
+    the advertised escape hatch silently does nothing.
+    """
+    monkeypatch.delenv("AMPLIFIER_GIT_CLONE_TIMEOUT_S", raising=False)
+    assert git_mod._clone_timeout_s() == git_mod._CLONE_TIMEOUT_DEFAULT_S
+
+    monkeypatch.setenv("AMPLIFIER_GIT_CLONE_TIMEOUT_S", "900")
+    assert git_mod._clone_timeout_s() == 900.0, (
+        "the timeout override was not honoured after the module was imported -- "
+        "the error message advertises an escape hatch that does not work"
+    )
+
+
+@pytest.mark.parametrize("bad_value", ["not-a-number", "0", "-5", ""])
+def test_malformed_timeout_override_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch, bad_value: str
+) -> None:
+    """A malformed override must not turn a working clone into a crash.
+
+    The override exists to help a user on a slow link. Making a typo in it a
+    hard failure at import (or at call) trades one usability problem for a
+    worse one.
+    """
+    monkeypatch.setenv("AMPLIFIER_GIT_CLONE_TIMEOUT_S", bad_value)
+    assert git_mod._clone_timeout_s() == git_mod._CLONE_TIMEOUT_DEFAULT_S
 
 
 def test_timeout_is_not_retried(tmp_path: Path) -> None:

--- a/tests/test_git_clone_timeout_policy.py
+++ b/tests/test_git_clone_timeout_policy.py
@@ -1,0 +1,107 @@
+"""Regression tests for the git clone timeout policy (R-1).
+
+Found by the ecosystem blast-radius survey. Both defects are cross-platform --
+they affect every Linux, macOS and WSL user, not just the Windows case the
+GAP-014 bound was written for.
+
+**A tight bound false-positives on legitimately slow work.**
+The failure GAP-014 exists to catch is *unbounded* -- a credential helper
+waiting on input that can never arrive -- so any finite bound catches it. The
+only thing a tight bound buys is failures for users on the bad end of the
+size/bandwidth distribution. Measured: every ecosystem clone completes in under
+a second, so generous headroom costs working users nothing.
+
+**Retrying a timeout is the wrong policy.**
+Retries absorb *transient* failures -- a dropped connection mid-transfer, a
+flaky DNS answer -- where a second attempt plausibly succeeds. A timeout is not
+transient: the operation had a full budget and did not finish. Re-running it
+with the same budget buys the same answer at three times the wait, and the
+`cleanup_path` rmtree between attempts discards whatever partial progress was
+made. For the blocked-credential-helper case, retrying is pure added latency in
+front of an error the user will see regardless.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from amplifier_foundation.sources import git as git_mod
+from amplifier_foundation.sources.git import GitCloneTimeoutError
+
+
+def test_clone_timeout_default_is_generous_enough_for_slow_links() -> None:
+    """The default bound must leave room for a large repo on a slow link.
+
+    Pins the policy decision, not the exact number: a bound tight enough to
+    fail a legitimate multi-minute clone is a regression for every platform.
+    """
+    assert git_mod._CLONE_TIMEOUT_S >= 120.0, (
+        f"clone bound is {git_mod._CLONE_TIMEOUT_S}s -- tight enough to fail a "
+        "legitimate large-repo or slow-link clone. The hang this catches is "
+        "unbounded, so a generous value catches it just as well at no cost to "
+        "working users."
+    )
+
+
+def test_timeout_is_not_retried(tmp_path: Path) -> None:
+    """A timeout must fail immediately, not consume the full retry budget.
+
+    Without this, a repo legitimately needing longer than the bound is retried
+    the full `_CLONE_MAX_ATTEMPTS` times -- each attempt timing out, each
+    rmtree'ing the partial result -- so the user waits attempts x bound to
+    reach the same failure.
+    """
+    attempts: list[int] = []
+
+    def always_times_out(args: Any, cwd: Any = None, timeout_s: Any = None) -> Any:
+        attempts.append(1)
+        raise GitCloneTimeoutError(["git", "clone", "x"], timeout_s or 300)
+
+    with (
+        patch.object(git_mod, "_run_git_subprocess", side_effect=always_times_out),
+        pytest.raises(GitCloneTimeoutError),
+    ):
+        git_mod._run_git_network_op(
+            ["git", "clone", "https://example.invalid/r.git", str(tmp_path / "d")],
+            cleanup_path=tmp_path / "d",
+        )
+
+    assert len(attempts) == 1, (
+        f"a timeout was retried {len(attempts)} times. Retries are for "
+        "transient failures; a timeout had a full budget and did not finish, "
+        "so retrying buys the same answer at N times the wait."
+    )
+
+
+def test_transient_git_errors_are_still_retried(tmp_path: Path) -> None:
+    """The no-retry-on-timeout rule must not disable retries generally.
+
+    A dropped connection surfaces as CalledProcessError and *is* worth a second
+    attempt -- that behaviour predates this change and must survive it.
+    """
+    attempts: list[int] = []
+
+    def always_errors(args: Any, cwd: Any = None, timeout_s: Any = None) -> Any:
+        attempts.append(1)
+        raise subprocess.CalledProcessError(
+            returncode=128, cmd=args, stderr="fatal: the remote end hung up"
+        )
+
+    with (
+        patch.object(git_mod, "_run_git_subprocess", side_effect=always_errors),
+        patch.object(git_mod, "_CLONE_RETRY_BACKOFF_S", (0.0, 0.0)),
+        pytest.raises(subprocess.CalledProcessError),
+    ):
+        git_mod._run_git_network_op(
+            ["git", "clone", "https://example.invalid/r.git", str(tmp_path / "d")],
+        )
+
+    assert len(attempts) == git_mod._CLONE_MAX_ATTEMPTS, (
+        f"transient git errors were attempted {len(attempts)} times, expected "
+        f"{git_mod._CLONE_MAX_ATTEMPTS} -- the timeout rule must not suppress "
+        "retries for genuinely transient failures"
+    )

--- a/tests/test_git_longpaths.py
+++ b/tests/test_git_longpaths.py
@@ -1,0 +1,170 @@
+"""Regression test: git invocations that write working-tree paths must carry
+``-c core.longpaths=true``.
+
+**The defect.** Reproduced on native Windows 11 (build 26200), every run:
+``git clone`` reports success ("Clone succeeded") but its *checkout* step
+silently fails with ``fatal: cannot create directory at '...': Filename too
+long``, because Windows' legacy MAX_PATH limit (260 characters) is exceeded
+by ``<cache-dir-prefix>\\<repo-name>-<hash>\\<repo's own nested paths>``. The
+partial working tree left behind is then detected as invalid by
+``_verify_clone_integrity`` and removed -- only for the identical failure to
+repeat on every subsequent attempt, forever. The behavior/bundle is silently
+dropped from every composed session on that machine with no visible error to
+the user.
+
+``core.longpaths=true`` makes git use the Unicode ``\\\\?\\``-prefixed Win32
+APIs, which are not subject to MAX_PATH. It is passed per-invocation (``git
+-c core.longpaths=true ...``), never written to the user's global/system git
+config -- this module should never reach outside its own operations to
+change machine state the user did not ask it to change.
+
+Applied unconditionally on every platform (not gated to
+``platform.system() == "Windows"``): git treats the setting as a no-op on
+POSIX, where no equivalent path-length ceiling exists, so the unconditional
+form is exactly as safe as a Windows-only branch while keeping exactly one
+code path -- the same one exercised by this test on every platform, rather
+than a branch only a native Windows CI run would ever execute.
+
+Scoped to the invocations that actually materialize working-tree paths --
+``clone`` and ``checkout`` -- not ``init``/``remote add``/``fetch``, whose
+writes (``.git/config``, the hash-addressed object store) are not subject to
+MAX_PATH regardless of the repository's own directory structure.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from amplifier_foundation.paths.resolution import ParsedURI
+from amplifier_foundation.sources import git as git_mod
+
+
+def _has_longpaths(args: list[str]) -> bool:
+    """True if a git argv carries ``-c core.longpaths=true`` before the subcommand."""
+    return "-c" in args and "core.longpaths=true" in args
+
+
+@pytest.mark.asyncio
+async def test_shallow_clone_argv_carries_longpaths(tmp_path: Path) -> None:
+    """The primary `resolve()` path: `git clone --depth 1 [--branch ref] <url> <dest>`.
+
+    This is exactly the invocation from the reproduction: a non-bare clone
+    performs an implicit checkout of the working tree, which is where
+    "Filename too long" is raised on Windows. Goes through the real
+    `GitSourceHandler.resolve()` call site (not a synthetic argv) so this
+    proves the wrapping is actually applied where the defect lives, not just
+    that the helper function exists.
+    """
+    captured: list[list[str]] = []
+
+    def fake_run_git_network_op(
+        args: list[str], cwd: Any = None, cleanup_path: Any = None
+    ) -> Any:
+        captured.append(args)
+        # Short-circuit with a real git error so resolve() fails fast rather
+        # than needing a fully working fake clone on disk.
+        raise subprocess.CalledProcessError(1, args, stderr="boom")
+
+    parsed = ParsedURI(
+        scheme="git+https",
+        host="example.invalid",
+        path="/org/r",
+        ref="main",
+        subpath="",
+    )
+
+    with patch.object(
+        git_mod, "_run_git_network_op", side_effect=fake_run_git_network_op
+    ):
+        handler = git_mod.GitSourceHandler()
+        with pytest.raises(git_mod.BundleNotFoundError):
+            await handler.resolve(parsed, tmp_path)
+
+    assert captured, "expected _run_git_network_op to be invoked"
+    assert _has_longpaths(captured[0]), (
+        f"clone argv does not carry -c core.longpaths=true: {captured[0]!r}. "
+        "Without it, a clone whose destination path exceeds Windows' "
+        "260-character MAX_PATH silently fails its checkout step while "
+        "reporting the clone itself as successful."
+    )
+
+
+def test_clone_at_commit_checkout_and_fallback_clone_carry_longpaths(
+    tmp_path: Path,
+) -> None:
+    """`_clone_at_commit`'s checkout calls and its full-clone fallback.
+
+    `_clone_at_commit` is used whenever a full 40-char commit SHA is pinned.
+    Its cheap path does `init` + `fetch` + `checkout FETCH_HEAD`; if the
+    server refuses to serve the SHA directly it falls back to a full `clone`
+    + `checkout <sha>`. Both `checkout` calls and the fallback `clone`
+    materialize working-tree paths and must carry the flag.
+    """
+    cache_path = tmp_path / "repo"
+    network_op_calls: list[list[str]] = []
+
+    def fake_run_git_subprocess(args: list[str], cwd: Any, timeout_s: Any) -> Any:
+        # Simulate the shallow-fetch-of-exact-commit failing (e.g. a server
+        # without allowReachableSHA1InWant), forcing the full-clone fallback.
+        raise subprocess.CalledProcessError(1, args, stderr="unadvertised object")
+
+    def fake_run_git_network_op(
+        args: list[str], cwd: Any = None, cleanup_path: Any = None
+    ) -> Any:
+        network_op_calls.append(args)
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    with (
+        patch.object(
+            git_mod, "_run_git_subprocess", side_effect=fake_run_git_subprocess
+        ),
+        patch.object(
+            git_mod, "_run_git_network_op", side_effect=fake_run_git_network_op
+        ),
+        patch.object(git_mod, "rmtree_robust"),
+        patch.object(git_mod.subprocess, "run") as mock_subprocess_run,
+    ):
+        mock_subprocess_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        handler = git_mod.GitSourceHandler()
+        handler._clone_at_commit("https://example.invalid/r.git", "a" * 40, cache_path)
+
+    checkout_calls: list[list[str]] = [
+        call.args[0]
+        for call in mock_subprocess_run.call_args_list
+        if "checkout" in call.args[0]
+    ]
+
+    assert network_op_calls, "expected the fallback full clone to be invoked"
+    assert _has_longpaths(network_op_calls[0]), (
+        f"fallback clone argv does not carry -c core.longpaths=true: "
+        f"{network_op_calls[0]!r}"
+    )
+    assert checkout_calls, "expected at least one checkout invocation to be captured"
+    for call_args in checkout_calls:
+        assert _has_longpaths(call_args), (
+            f"checkout argv does not carry -c core.longpaths=true: {call_args!r}. "
+            "checkout is exactly the step that fails with 'Filename too "
+            "long' in the reproduced Windows failure."
+        )
+
+
+def test_long_path_failure_message_names_max_path() -> None:
+    """A clone failure whose stderr matches the known Windows long-path
+    signature must be detectable, so the caller can name MAX_PATH as the
+    likely cause instead of degrading into a generic 'clone failed'.
+
+    `core.longpaths=true` is not a complete cure (it doesn't help every
+    Win32 API, and some systems additionally need the OS-level
+    'LongPathsEnabled' policy). If the fix above is applied and the clone
+    still fails this way, the next person must not be left guessing.
+    """
+    assert git_mod._is_long_path_error(
+        "fatal: cannot create directory at 'a/b/c': Filename too long\n"
+        "warning: Clone succeeded, but checkout failed.\n"
+    )
+    assert git_mod._is_long_path_error("Filename too long")
+    assert not git_mod._is_long_path_error("fatal: repository not found")

--- a/tests/test_git_timeout_and_pgid_guards.py
+++ b/tests/test_git_timeout_and_pgid_guards.py
@@ -1,0 +1,162 @@
+"""Regression tests for two defects found by the ecosystem blast-radius survey.
+
+Both live in `amplifier_foundation.sources.git` and both were introduced by the
+GAP-014/GAP-025 changes on this branch.
+
+**R-2 — `TimeoutExpired` escapes every handler.**
+`_clone_at_commit`'s local `run_git()` helper runs git with `timeout=30`. Two of
+its four call sites are `git checkout`, which on a large working tree is
+genuinely disk-bound and can exceed 30s, so the timeout path is reachable in
+normal use. `subprocess.TimeoutExpired` is a `SubprocessError`, **not** a
+`CalledProcessError` — so every `except (CalledProcessError,
+GitCloneTimeoutError)` handler in the module lets it sail straight past, and a
+slow checkout escapes the designed full-clone fallback as a raw traceback.
+
+**R-4 — `_kill_process_tree` had no self-pgid guard.**
+`os.killpg(os.getpgid(pid), SIGKILL)` only isolates the target if that target
+is in its *own* process group. Every caller spawns via `_run_git_subprocess`,
+which sets `start_new_session=True`, so it always is — but that is an invisible
+coupling between two functions. If it ever breaks, `killpg` SIGKILLs this
+process and everything sharing its group, which on an interactive POSIX session
+includes the user's shell. This is the same defect fixed as GAP-030 in
+`subprocess_runner._kill_subprocess_tree`; `git.py` was missed at the time.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from amplifier_foundation.sources.git import GitCloneTimeoutError
+from amplifier_foundation.sources.git import GitSourceHandler
+from amplifier_foundation.sources.git import _kill_process_tree
+
+POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX process-group semantics"
+)
+
+
+# --------------------------------------------------------------------------
+# R-2
+# --------------------------------------------------------------------------
+
+
+def test_timeout_expired_is_not_a_called_process_error() -> None:
+    """Pin the class relationship the bug depends on.
+
+    If this ever becomes True upstream, the R-2 conversion below is redundant
+    rather than load-bearing — and this test says so out loud instead of
+    leaving the next reader to rediscover it.
+    """
+    assert not issubclass(subprocess.TimeoutExpired, subprocess.CalledProcessError)
+    assert issubclass(subprocess.TimeoutExpired, subprocess.SubprocessError)
+
+
+def test_slow_local_git_raises_a_handled_error_not_timeoutexpired(
+    tmp_path: Path,
+) -> None:
+    """A local git step that exceeds its bound must surface as a *handled* type.
+
+    Drives the real `_clone_at_commit`. `subprocess.run` is stubbed to raise
+    `TimeoutExpired` the way a slow `git checkout` would. The assertion is not
+    "some exception was raised" — it is that the raised type is one the
+    module's own handlers actually catch.
+    """
+    handler = GitSourceHandler()
+
+    def fake_run(*args: Any, **kwargs: Any) -> Any:
+        raise subprocess.TimeoutExpired(cmd=["git", "checkout"], timeout=30)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        with pytest.raises(BaseException) as exc_info:
+            handler._clone_at_commit(  # type: ignore[attr-defined]
+                "https://example.invalid/repo.git",
+                "0" * 40,
+                tmp_path / "cache",
+            )
+
+    raised = exc_info.value
+    assert not isinstance(raised, subprocess.TimeoutExpired), (
+        "raw TimeoutExpired escaped: every `except (CalledProcessError, "
+        "GitCloneTimeoutError)` handler in git.py will let it through, so the "
+        "full-clone fallback never runs"
+    )
+    assert isinstance(raised, GitCloneTimeoutError | subprocess.CalledProcessError), (
+        f"raised {type(raised).__name__}, which no handler in git.py catches"
+    )
+
+
+# --------------------------------------------------------------------------
+# R-4
+# --------------------------------------------------------------------------
+
+
+@POSIX_ONLY
+def test_kill_process_tree_refuses_to_killpg_its_own_group() -> None:
+    """A target sharing our process group must NOT be killed via killpg.
+
+    Without the guard this call would SIGKILL the test runner itself — and in
+    real use, the user's shell. The test therefore cannot simply "call it and
+    assert"; it asserts on which syscall was chosen.
+    """
+    our_pgid = os.getpgid(0)
+    calls: dict[str, Any] = {}
+
+    def fake_killpg(pgid: int, sig: int) -> None:
+        calls["killpg"] = pgid
+
+    def fake_kill(pid: int, sig: int) -> None:
+        calls["kill"] = pid
+
+    # getpgid(target) == our own pgid: the dangerous case.
+    with (
+        patch("os.getpgid", return_value=our_pgid),
+        patch("os.killpg", side_effect=fake_killpg),
+        patch("os.kill", side_effect=fake_kill),
+    ):
+        _kill_process_tree(999999)
+
+    assert "killpg" not in calls, (
+        f"killpg({calls.get('killpg')}) called on this process's own group — "
+        "this would SIGKILL the caller and everything sharing its group"
+    )
+    assert calls.get("kill") == 999999, (
+        "expected a fallback to a direct kill of the child when group "
+        "isolation is absent"
+    )
+
+
+@POSIX_ONLY
+def test_kill_process_tree_uses_killpg_when_target_is_isolated() -> None:
+    """The guard must not defeat the mechanism it protects.
+
+    When the target *is* in its own group — the normal case, because
+    `_run_git_subprocess` sets `start_new_session=True` — killpg is still the
+    right call, so descendants get reaped.
+    """
+    our_pgid = os.getpgid(0)
+    foreign_pgid = our_pgid + 4242
+    calls: dict[str, Any] = {}
+
+    # Resolve our own pgid BEFORE patching -- a lambda that calls os.getpgid(0)
+    # inside the patch would recurse into the mock forever.
+    def fake_getpgid(pid: int) -> int:
+        return our_pgid if pid == 0 else foreign_pgid
+
+    with (
+        patch("os.getpgid", side_effect=fake_getpgid),
+        patch("os.killpg", side_effect=lambda pgid, sig: calls.__setitem__("killpg", pgid)),
+        patch("os.kill", side_effect=lambda pid, sig: calls.__setitem__("kill", pid)),
+    ):
+        _kill_process_tree(999999)
+
+    assert calls.get("killpg") == foreign_pgid, (
+        "an isolated target must still be killed by process group, or git's "
+        "helper children leak"
+    )
+    assert "kill" not in calls

--- a/tests/test_gpt54_provider_updates.py
+++ b/tests/test_gpt54_provider_updates.py
@@ -1,5 +1,12 @@
 """Tests for GPT-5.4 provider bundle and example updates (task-14)."""
 
+# NOTE: every read_text() below passes encoding="utf-8" explicitly.
+# Python on Windows defaults to the locale codec (cp1252 on this host), and
+# the example files these tests read contain non-cp1252 bytes -- a bare
+# read_text() dies with UnicodeDecodeError before any assertion runs. These
+# files are UTF-8 by definition, so the encoding is stated rather than
+# inherited from whatever locale the reader happens to have.
+
 from pathlib import Path
 
 import yaml
@@ -15,7 +22,7 @@ REPO_ROOT = Path(__file__).parent.parent
 def test_openai_gpt_yaml_default_model():
     """providers/openai-gpt.yaml must have default_model: gpt-5.4."""
     path = REPO_ROOT / "providers" / "openai-gpt.yaml"
-    data = yaml.safe_load(path.read_text())
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
     provider_config = data["providers"][0]["config"]
     assert provider_config["default_model"] == "gpt-5.4"
 
@@ -23,7 +30,7 @@ def test_openai_gpt_yaml_default_model():
 def test_openai_gpt_5_yaml_default_model():
     """providers/openai-gpt-5.yaml must have default_model: gpt-5.4."""
     path = REPO_ROOT / "providers" / "openai-gpt-5.yaml"
-    data = yaml.safe_load(path.read_text())
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
     provider_config = data["providers"][0]["config"]
     assert provider_config["default_model"] == "gpt-5.4"
 
@@ -31,7 +38,7 @@ def test_openai_gpt_5_yaml_default_model():
 def test_openai_gpt_codex_yaml_default_model():
     """providers/openai-gpt-codex.yaml must have default_model: gpt-5.4."""
     path = REPO_ROOT / "providers" / "openai-gpt-codex.yaml"
-    data = yaml.safe_load(path.read_text())
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
     provider_config = data["providers"][0]["config"]
     assert provider_config["default_model"] == "gpt-5.4"
 
@@ -44,7 +51,7 @@ def test_openai_gpt_codex_yaml_default_model():
 def test_example18_pricing_has_gpt54():
     """Example 18 PRICING dict must include gpt-5.4 with correct pricing."""
     path = REPO_ROOT / "examples" / "18_custom_hooks.py"
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     assert '"gpt-5.4"' in content
     assert '"input": 2.50' in content or "'input': 2.50" in content
 
@@ -52,7 +59,7 @@ def test_example18_pricing_has_gpt54():
 def test_example18_pricing_has_gpt54_pro():
     """Example 18 PRICING dict must include gpt-5.4-pro with correct pricing."""
     path = REPO_ROOT / "examples" / "18_custom_hooks.py"
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     assert '"gpt-5.4-pro"' in content
     assert '"input": 30.00' in content or "'input': 30.00" in content
 
@@ -60,7 +67,7 @@ def test_example18_pricing_has_gpt54_pro():
 def test_example18_no_stale_gpt52():
     """Example 18 must not contain gpt-5.2."""
     path = REPO_ROOT / "examples" / "18_custom_hooks.py"
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     assert "gpt-5.2" not in content
 
 
@@ -72,7 +79,7 @@ def test_example18_no_stale_gpt52():
 def test_example22_docstring_updated():
     """Example 22 docstring must reference GPT-5.4 and GPT-5-mini."""
     path = REPO_ROOT / "examples" / "22_custom_orchestrator_routing.py"
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     assert "GPT-5.4" in content
     assert "GPT-5-mini" in content
 
@@ -80,28 +87,28 @@ def test_example22_docstring_updated():
 def test_example22_mini_model_updated():
     """Example 22 must use gpt-5-mini for mini_model config."""
     path = REPO_ROOT / "examples" / "22_custom_orchestrator_routing.py"
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     assert '"mini_model": "gpt-5-mini"' in content
 
 
 def test_example22_codex_model_updated():
     """Example 22 must use gpt-5.4 for codex_model config."""
     path = REPO_ROOT / "examples" / "22_custom_orchestrator_routing.py"
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     assert '"codex_model": "gpt-5.4"' in content
 
 
 def test_example22_no_stale_gpt52():
     """Example 22 must not contain gpt-5.2."""
     path = REPO_ROOT / "examples" / "22_custom_orchestrator_routing.py"
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     assert "gpt-5.2" not in content
 
 
 def test_example22_no_stale_gpt51_codex():
     """Example 22 must not contain gpt-5.1-codex."""
     path = REPO_ROOT / "examples" / "22_custom_orchestrator_routing.py"
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     assert "gpt-5.1-codex" not in content
 
 
@@ -122,7 +129,7 @@ def test_no_stale_strings_in_modified_files():
     ]
     violations = []
     for fpath in files_to_check:
-        content = fpath.read_text()
+        content = fpath.read_text(encoding="utf-8")
         for pattern in stale_patterns:
             if pattern in content:
                 violations.append(f"{fpath.name} contains '{pattern}'")
@@ -145,14 +152,14 @@ ROUTER_INIT = (
 
 def test_router_orchestrator_mini_model_default_updated():
     """RoutingOrchestrator default mini_model must be gpt-5-mini, not gpt-5.2."""
-    content = ROUTER_INIT.read_text()
+    content = ROUTER_INIT.read_text(encoding="utf-8")
     assert '"gpt-5-mini"' in content, "mini_model default should be gpt-5-mini"
     assert '"gpt-5.2"' not in content, "stale gpt-5.2 default must be removed"
 
 
 def test_router_orchestrator_codex_model_default_updated():
     """RoutingOrchestrator default codex_model must be gpt-5.4, not gpt-5.1-codex."""
-    content = ROUTER_INIT.read_text()
+    content = ROUTER_INIT.read_text(encoding="utf-8")
     assert '"gpt-5.4"' in content, "codex_model default should be gpt-5.4"
     assert '"gpt-5.1-codex"' not in content, (
         "stale gpt-5.1-codex default must be removed"
@@ -161,7 +168,7 @@ def test_router_orchestrator_codex_model_default_updated():
 
 def test_router_orchestrator_no_stale_model_strings():
     """router-orchestrator __init__.py must not contain any stale model strings."""
-    content = ROUTER_INIT.read_text()
+    content = ROUTER_INIT.read_text(encoding="utf-8")
     for stale in ("gpt-5.2", "gpt-5.1-codex"):
         assert stale not in content, (
             f"Stale model string '{stale}' found in router-orchestrator"

--- a/tests/test_grpc_adapter_integration.py
+++ b/tests/test_grpc_adapter_integration.py
@@ -8,12 +8,11 @@ from __future__ import annotations
 
 import json
 import os
-import selectors
+import threading
 import signal
 import subprocess
 import sys
 import tempfile
-import time
 from pathlib import Path
 
 import pytest
@@ -293,8 +292,19 @@ def _spawn_adapter(
 def _read_first_line(proc: subprocess.Popen[bytes], timeout: float = 15.0) -> str:
     """Read the first newline-terminated line from *proc* stdout.
 
-    Uses ``selectors`` to avoid blocking indefinitely when the adapter
-    fails to start (guards against test hangs).
+    Reads on a daemon thread and waits on it with a timeout, so a subprocess
+    that never prints cannot hang the suite.
+
+    This used to use ``selectors``, which does not work here on Windows:
+    ``selectors.DefaultSelector`` is ``SelectSelector`` there, and Windows'
+    ``select()`` accepts ONLY sockets. Registering a subprocess pipe raised
+    ``OSError: [WinError 10038] An operation was attempted on something that is
+    not a socket``, failing all 10 tests in this file before the adapter under
+    test was ever exercised.
+
+    A thread doing a blocking ``readline()`` has the same timeout guarantee and
+    no platform-specific descriptor requirements, so one code path now serves
+    every platform rather than POSIX working and Windows erroring out.
 
     Args:
         proc: Running subprocess with ``stdout=PIPE``.
@@ -307,40 +317,25 @@ def _read_first_line(proc: subprocess.Popen[bytes], timeout: float = 15.0) -> st
         TimeoutError: If no newline arrives within *timeout* seconds.
     """
     assert proc.stdout is not None
-    sel = selectors.DefaultSelector()
-    sel.register(proc.stdout, selectors.EVENT_READ)
+    stdout = proc.stdout
+    result: list[bytes] = []
 
-    line = b""
-    deadline = time.monotonic() + timeout
+    def _reader() -> None:
+        try:
+            result.append(stdout.readline())
+        except Exception:  # pragma: no cover - pipe closed under us
+            result.append(b"")
 
-    try:
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise TimeoutError(
-                    f"No line received within {timeout}s (buffer: {line!r})"
-                )
+    # daemon=True so a wedged read can never keep the interpreter alive; the
+    # TimeoutError below is what the caller sees in that case.
+    thread = threading.Thread(target=_reader, daemon=True)
+    thread.start()
+    thread.join(timeout)
 
-            ready = sel.select(timeout=remaining)
-            if not ready:
-                raise TimeoutError(
-                    f"No line received within {timeout}s (buffer: {line!r})"
-                )
+    if thread.is_alive():
+        raise TimeoutError(f"No line received within {timeout}s")
 
-            # read1() reads whatever is immediately available in the BufferedReader's
-            # internal buffer (or the OS buffer) without blocking for more data.
-            # Using read(1) instead would drain one byte then stall the next
-            # sel.select() because the BufferedReader already consumed the OS data.
-            chunk = proc.stdout.read1(4096)  # type: ignore[attr-defined]
-            if not chunk:
-                # EOF — return whatever we have
-                break
-            line += chunk
-            if b"\n" in line:
-                break
-    finally:
-        sel.close()
-
+    line = result[0] if result else b""
     return line.split(b"\n")[0].decode("utf-8").strip()
 
 

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -164,7 +164,12 @@ class TestBaseMentionResolver:
         test_file.write_text("# Test")
 
         # Monkeypatch HOME environment variable
+        # Windows Path.expanduser() consults USERPROFILE (or
+        # HOMEDRIVE+HOMEPATH), NOT HOME -- so patching HOME alone left the
+        # real home in place and the resolver found nothing. Set both so
+        # the fake home takes effect on every platform.
         monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("USERPROFILE", str(fake_home))
 
         resolver = BaseMentionResolver()
         result = resolver.resolve("@~/.amplifier/AGENTS.md")
@@ -183,7 +188,12 @@ class TestBaseMentionResolver:
         test_file.write_text("# Test")
 
         # Monkeypatch HOME environment variable
+        # Windows Path.expanduser() consults USERPROFILE (or
+        # HOMEDRIVE+HOMEPATH), NOT HOME -- so patching HOME alone left the
+        # real home in place and the resolver found nothing. Set both so
+        # the fake home takes effect on every platform.
         monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("USERPROFILE", str(fake_home))
 
         resolver = BaseMentionResolver()
         result = resolver.resolve("@~/.amplifier/AGENTS")  # No .md extension

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -278,12 +278,19 @@ class TestNormalizePath:
     def test_absolute_path(self) -> None:
         """Absolute paths remain absolute."""
         result = normalize_path("/home/user/file.txt")
-        assert result == Path("/home/user/file.txt")
+        # Compare against the RESOLVED form. normalize_path() calls .resolve(),
+        # and on Windows a POSIX-style leading slash is drive-RELATIVE, so
+        # resolve() anchors it to the current drive: "/home/user/file.txt"
+        # becomes "C:/home/user/file.txt". That is correct behaviour, not a
+        # bug -- resolving both sides tests the contract ("absolute stays
+        # absolute, canonicalised") instead of an accident of POSIX where the
+        # input already happens to be canonical.
+        assert result == Path("/home/user/file.txt").resolve()
 
     def test_relative_path_with_base(self) -> None:
         """Relative paths are resolved against base."""
         result = normalize_path("file.txt", relative_to=Path("/home/user"))
-        assert result == Path("/home/user/file.txt")
+        assert result == Path("/home/user/file.txt").resolve()
 
     def test_relative_path_without_base(self) -> None:
         """Relative paths without base use cwd."""
@@ -293,21 +300,21 @@ class TestNormalizePath:
     def test_path_object_input(self) -> None:
         """Accepts Path objects."""
         result = normalize_path(Path("/home/user/file.txt"))
-        assert result == Path("/home/user/file.txt")
+        assert result == Path("/home/user/file.txt").resolve()
 
     def test_tilde_path_expands_home(self) -> None:
         """Tilde paths expand to home directory."""
         result = normalize_path("~/some/file.txt")
         assert "~" not in str(result)
         assert result.is_absolute()
-        assert str(result).endswith("/some/file.txt")
+        assert str(result).endswith(str(Path("some/file.txt")))
 
     def test_tilde_path_with_base_expands_home(self) -> None:
         """Tilde paths expand even when relative_to is provided."""
         result = normalize_path("~/some/file.txt", relative_to=Path("/ignored"))
         assert "~" not in str(result)
         assert result.is_absolute()
-        assert str(result).endswith("/some/file.txt")
+        assert str(result).endswith(str(Path("some/file.txt")))
 
 
 class TestConstructPaths:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -10,6 +10,7 @@ from amplifier_foundation.paths.resolution import (
     describe_cross_platform_path_mismatch,
     normalize_path,
     parse_uri,
+    strip_uri_drive_prefix,
 )
 
 
@@ -270,6 +271,109 @@ class TestDescribeCrossPlatformPathMismatch:
         """
         monkeypatch.setattr("amplifier_foundation.paths.resolution.os.name", "nt")
         assert describe_cross_platform_path_mismatch("//server/share/bundle") is None
+
+    def test_rfc8089_drive_path_is_not_flagged_on_windows(self, monkeypatch) -> None:
+        """`file:///C:/...` is a *Windows* path and must not be rejected on Windows.
+
+        Regression: `file:///C:/Users/x` -- exactly what `Path.as_uri()` emits
+        on Windows -- parses to the path component "/C:/Users/x". Because that
+        starts with "/", the POSIX-shape check previously matched it and the
+        guard rejected a native Windows path on Windows, telling the user to
+        "update the source in settings.yaml to a Windows path" that it already
+        was. The leading slash is URI authority-separator syntax, not a POSIX
+        root.
+        """
+        monkeypatch.setattr("amplifier_foundation.paths.resolution.os.name", "nt")
+
+        assert describe_cross_platform_path_mismatch("/C:/Users/x/bundle") is None
+        # Lowercase drive letters and backslash separators are equally valid.
+        assert describe_cross_platform_path_mismatch("/c:/Users/x/bundle") is None
+        assert describe_cross_platform_path_mismatch(r"/C:\Users\x\bundle") is None
+
+        # Reached through the real parser, not just the predicate.
+        assert (
+            describe_cross_platform_path_mismatch(parse_uri("file:///C:/Users/x").path)
+            is None
+        )
+        assert (
+            describe_cross_platform_path_mismatch(
+                parse_uri("zip+file:///C:/archive.zip").path
+            )
+            is None
+        )
+
+    def test_rfc8089_drive_path_is_not_flagged_on_posix_either(
+        self, monkeypatch
+    ) -> None:
+        """Documents a deliberate scope boundary, not an endorsement.
+
+        The bare drive form (``C:/Users/x``) IS flagged on POSIX. The RFC 8089
+        form (``/C:/Users/x``) is not: ``_is_windows_absolute_path`` anchors on
+        the drive letter, so the leading slash defeats it. That was true before
+        the Windows-side fix and is unchanged by it -- this test pins the
+        existing behavior so the asymmetry is visible rather than latent.
+
+        Left alone deliberately: this fix addresses a Windows-side *false
+        rejection*. Adding POSIX-side detection here would be a new capability
+        with its own blast radius (``_is_windows_absolute_path`` has three
+        callers, including ``ParsedURI.is_file``), not part of this bug.
+        """
+        monkeypatch.setattr("amplifier_foundation.paths.resolution.os.name", "posix")
+
+        # The RFC 8089 form: unflagged, before and after this fix.
+        assert (
+            describe_cross_platform_path_mismatch(parse_uri("file:///C:/Users/x").path)
+            is None
+        )
+
+        # The bare drive form: flagged, and this fix must not blunt that.
+        message = describe_cross_platform_path_mismatch("C:/Users/x")
+        assert message is not None
+        assert "Windows-style absolute path" in message
+
+    def test_genuine_posix_path_still_flagged_on_windows(self, monkeypatch) -> None:
+        """The drive-letter carve-out must not blunt the original GAP-007 guard."""
+        monkeypatch.setattr("amplifier_foundation.paths.resolution.os.name", "nt")
+        message = describe_cross_platform_path_mismatch(
+            parse_uri("file:///home/bkrabach/dev/bundle").path
+        )
+        assert message is not None
+        assert "POSIX-style absolute path" in message
+        # A single-letter *directory* is not a drive letter -- no colon.
+        assert describe_cross_platform_path_mismatch("/c/Users/x") is not None
+
+
+class TestStripUriDrivePrefix:
+    """Tests for strip_uri_drive_prefix.
+
+    `file:///C:/Users/x` parses to "/C:/Users/x". Handing that to Path() on
+    Windows yields a rooted-but-driveless path that resolves against the
+    *current* drive rather than the drive the user named, so the leading
+    slash must be stripped before construction.
+    """
+
+    def test_strips_leading_slash_from_drive_paths(self) -> None:
+        assert strip_uri_drive_prefix("/C:/Users/x") == "C:/Users/x"
+        assert strip_uri_drive_prefix("/c:/Users/x") == "c:/Users/x"
+        assert strip_uri_drive_prefix(r"/C:\Users\x") == r"C:\Users\x"
+
+    def test_leaves_every_other_shape_untouched(self) -> None:
+        for unchanged in (
+            "/home/user/bundle",
+            "C:/Users/x",
+            r"C:\Users\x",
+            r"\\server\share",
+            "//server/share",
+            "./relative",
+            "../relative",
+            "package-name",
+            "",
+        ):
+            assert strip_uri_drive_prefix(unchanged) == unchanged
+
+    def test_single_letter_directory_is_not_a_drive(self) -> None:
+        """`/c/Users` has no colon, so it is a POSIX path, not a drive path."""
+        assert strip_uri_drive_prefix("/c/Users/x") == "/c/Users/x"
 
 
 class TestNormalizePath:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,10 +2,15 @@
 
 from pathlib import Path
 
-from amplifier_foundation.paths.construction import construct_agent_path
-from amplifier_foundation.paths.construction import construct_context_path
-from amplifier_foundation.paths.resolution import normalize_path
-from amplifier_foundation.paths.resolution import parse_uri
+from amplifier_foundation.paths.construction import (
+    construct_agent_path,
+    construct_context_path,
+)
+from amplifier_foundation.paths.resolution import (
+    describe_cross_platform_path_mismatch,
+    normalize_path,
+    parse_uri,
+)
 
 
 class TestParseUri:
@@ -134,6 +139,137 @@ class TestParseUri:
         result = parse_uri("./bundles/my-bundle")
         assert result.scheme == "file"
         assert result.path == "./bundles/my-bundle"
+
+    def test_windows_drive_path_backslash(self) -> None:
+        """Native Windows backslash drive-letter paths resolve as file URIs.
+
+        Regression test for GAP-015: a bare Windows path like
+        C:\\Users\\x\\.amplifier\\cache\\... previously fell through every
+        branch, landed with scheme="" and no "/" in its path, and
+        `is_file` returned False -- causing "No handler for URI: ..." and
+        module activation failures in strict mode.
+        """
+        result = parse_uri(r"C:\Users\brkrabac\.amplifier\cache\bundle\modules\tool-x")
+        assert result.scheme == "file"
+        assert (
+            result.path == r"C:\Users\brkrabac\.amplifier\cache\bundle\modules\tool-x"
+        )
+        assert result.is_file
+        assert not result.is_package
+
+    def test_windows_drive_path_forward_slash(self) -> None:
+        """Windows drive-letter paths using forward slashes also resolve as file URIs.
+
+        Windows accepts both separators. Before the fix, this form was
+        actively MIS-parsed (not just unrecognized): because it contains a
+        "/", it fell into the package/subpath branch and was split into a
+        bogus package name "C:" and subpath "Users/...".
+        """
+        result = parse_uri("C:/Users/brkrabac/.amplifier/cache/bundle")
+        assert result.scheme == "file"
+        assert result.path == "C:/Users/brkrabac/.amplifier/cache/bundle"
+        assert result.is_file
+        assert result.subpath == ""
+
+    def test_windows_unc_path(self) -> None:
+        """Backslash UNC paths (\\\\server\\share\\...) resolve as file URIs."""
+        result = parse_uri(r"\\server\share\bundle")
+        assert result.scheme == "file"
+        assert result.path == r"\\server\share\bundle"
+        assert result.is_file
+
+    def test_single_letter_scheme_is_not_confused_with_drive_letter(self) -> None:
+        """A real multi-character scheme is unaffected by the drive-letter check.
+
+        Guards against a careless widening: every URI scheme this parser
+        recognizes is more than one character, so "X:" prefixes never
+        collide with "https://", "git+https://", etc.
+        """
+        result = parse_uri("https://example.com/bundle.yaml")
+        assert result.scheme == "https"
+        assert not result.is_file
+
+        result = parse_uri("git+https://github.com/org/repo@main")
+        assert result.scheme == "git+https"
+        assert not result.is_file
+
+    def test_posix_and_relative_paths_unaffected_by_windows_path_check(self) -> None:
+        """Existing POSIX/relative/package parsing is unchanged by the widening."""
+        assert parse_uri("/home/user/bundle").scheme == "file"
+        assert parse_uri("./relative/path").scheme == "file"
+        assert parse_uri("../relative/path").scheme == "file"
+        assert parse_uri("foundation/providers/anthropic").scheme == ""
+        assert parse_uri("package-name").is_package
+
+
+class TestDescribeCrossPlatformPathMismatch:
+    """Tests for describe_cross_platform_path_mismatch (GAP-007).
+
+    Regression test for GAP-007: a Linux-authored settings.yaml with a
+    `file:///home/x/...` bundle source, run on Windows, previously produced
+    "File not found: C:\\home\\x\\..." -- pathlib silently prepending the
+    current drive letter to a rooted-but-driveless path instead of failing
+    with a message that names the real problem (a config written for
+    another OS's filesystem). The mirror case exists on POSIX for a
+    Windows-shaped absolute path.
+
+    `os.name` is monkeypatched per-test so both branches are exercised
+    deterministically regardless of the OS actually running the suite.
+    """
+
+    def test_posix_path_on_windows_is_flagged(self, monkeypatch) -> None:
+        """A POSIX-absolute path is flagged as impossible when os.name == 'nt'."""
+        monkeypatch.setattr("amplifier_foundation.paths.resolution.os.name", "nt")
+        message = describe_cross_platform_path_mismatch(
+            "/home/bkrabach/dev/computer-use-improvements/amplifier-bundle-computer-use"
+        )
+        assert message is not None
+        assert "POSIX-style absolute path" in message
+        assert "Windows" in message
+        # Echo the original (unmangled) path, not a mangled local translation.
+        assert "/home/bkrabach/dev/computer-use-improvements" in message
+
+    def test_windows_path_on_posix_is_flagged(self, monkeypatch) -> None:
+        """A Windows drive-letter/UNC path is flagged as impossible when os.name != 'nt'."""
+        monkeypatch.setattr("amplifier_foundation.paths.resolution.os.name", "posix")
+        message = describe_cross_platform_path_mismatch(r"C:\Users\brkrabac\dev\bundle")
+        assert message is not None
+        assert "Windows-style absolute path" in message
+        assert r"C:\Users\brkrabac\dev\bundle" in message
+
+        message_unc = describe_cross_platform_path_mismatch(r"\\server\share\bundle")
+        assert message_unc is not None
+        assert "Windows-style absolute path" in message_unc
+
+    def test_native_absolute_paths_are_not_flagged(self, monkeypatch) -> None:
+        """A path native to the current OS is never a mismatch."""
+        monkeypatch.setattr("amplifier_foundation.paths.resolution.os.name", "nt")
+        assert (
+            describe_cross_platform_path_mismatch(r"C:\Users\brkrabac\dev\bundle")
+            is None
+        )
+        assert describe_cross_platform_path_mismatch(r"\\server\share\bundle") is None
+
+        monkeypatch.setattr("amplifier_foundation.paths.resolution.os.name", "posix")
+        assert describe_cross_platform_path_mismatch("/home/user/bundle") is None
+
+    def test_relative_paths_are_never_flagged(self, monkeypatch) -> None:
+        """Relative paths aren't absolute on any OS, so never a cross-OS mismatch."""
+        monkeypatch.setattr("amplifier_foundation.paths.resolution.os.name", "nt")
+        assert describe_cross_platform_path_mismatch("./relative/path") is None
+        assert describe_cross_platform_path_mismatch("../relative/path") is None
+        assert describe_cross_platform_path_mismatch("package-name") is None
+
+        monkeypatch.setattr("amplifier_foundation.paths.resolution.os.name", "posix")
+        assert describe_cross_platform_path_mismatch("./relative/path") is None
+
+    def test_forward_slash_unc_is_left_unhandled(self, monkeypatch) -> None:
+        """Forward-slash UNC (//server/share) is ambiguous with a protocol-
+        relative URL and is deliberately left unhandled here, consistent
+        with `_is_windows_absolute_path`'s existing exclusion of that form.
+        """
+        monkeypatch.setattr("amplifier_foundation.paths.resolution.os.name", "nt")
+        assert describe_cross_platform_path_mismatch("//server/share/bundle") is None
 
 
 class TestNormalizePath:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -19,7 +19,13 @@ class TestFindNearestBundleFile:
             registry = BundleRegistry(home=base / "home")
             result = registry._find_nearest_bundle_file(start=base, stop=base)
 
-            assert result == base / "bundle.md"
+            # _find_nearest_bundle_file resolves its result (Path.resolve()).
+            # On Windows, tempfile.TemporaryDirectory() may hand back a path
+            # containing an 8.3 short component (e.g. "RUNNER~1") while
+            # resolve() returns the canonical long form (e.g. "runneradmin").
+            # Both spellings name the same directory, so resolve the expected
+            # side too rather than comparing raw/short vs. canonical/long.
+            assert result == (base / "bundle.md").resolve()
 
     def test_finds_bundle_yaml_in_start_directory(self) -> None:
         """Finds bundle.yaml in the starting directory."""
@@ -30,7 +36,8 @@ class TestFindNearestBundleFile:
             registry = BundleRegistry(home=base / "home")
             result = registry._find_nearest_bundle_file(start=base, stop=base)
 
-            assert result == base / "bundle.yaml"
+            # See resolve() note in test_finds_bundle_md_in_start_directory above.
+            assert result == (base / "bundle.yaml").resolve()
 
     def test_prefers_bundle_md_over_bundle_yaml(self) -> None:
         """When both exist, prefers bundle.md."""
@@ -42,7 +49,8 @@ class TestFindNearestBundleFile:
             registry = BundleRegistry(home=base / "home")
             result = registry._find_nearest_bundle_file(start=base, stop=base)
 
-            assert result == base / "bundle.md"
+            # See resolve() note in test_finds_bundle_md_in_start_directory above.
+            assert result == (base / "bundle.md").resolve()
 
     def test_walks_up_to_find_bundle(self) -> None:
         """Walks up directories to find bundle file."""
@@ -66,7 +74,8 @@ class TestFindNearestBundleFile:
             )
 
             # Should find root's bundle.md
-            assert result == base / "bundle.md"
+            # See resolve() note in test_finds_bundle_md_in_start_directory above.
+            assert result == (base / "bundle.md").resolve()
 
     def test_returns_none_when_not_found(self) -> None:
         """Returns None when no bundle file found."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -431,7 +431,12 @@ class TestSubdirectoryBundleLoading:
                 "  name: bundle-main\n"
                 "  version: 1.0.0\n"
                 "includes:\n"
-                f'  - "file://{behavior_path}"\n'
+                # .as_posix(): a Windows path interpolated into a DOUBLE-quoted
+                # YAML scalar breaks the parser -- "file://C:\\Users\\..." makes
+                # YAML read \U as an escape needing 8 hex digits and raise
+                # ScannerError before the bundle is ever loaded. Forward slashes
+                # are also simply correct for a file:// URI on every platform.
+                f'  - "file://{behavior_path.as_posix()}"\n'
                 "---\n"
             )
 
@@ -674,7 +679,12 @@ class TestSubdirectoryBundleLoading:
                 "  name: main\n"
                 "  version: 1.0.0\n"
                 "includes:\n"
-                f'  - "file://{behavior_path}"\n'
+                # .as_posix(): a Windows path interpolated into a DOUBLE-quoted
+                # YAML scalar breaks the parser -- "file://C:\\Users\\..." makes
+                # YAML read \U as an escape needing 8 hex digits and raise
+                # ScannerError before the bundle is ever loaded. Forward slashes
+                # are also simply correct for a file:// URI on every platform.
+                f'  - "file://{behavior_path.as_posix()}"\n'
                 "---\n"
             )
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -9,8 +9,7 @@ import pytest
 from amplifier_foundation.exceptions import BundleNotFoundError
 from amplifier_foundation.paths.resolution import ParsedURI
 from amplifier_foundation.sources.file import FileSourceHandler
-from amplifier_foundation.sources.git import GitSourceHandler
-from amplifier_foundation.sources.git import _is_full_commit_sha
+from amplifier_foundation.sources.git import GitSourceHandler, _is_full_commit_sha
 from amplifier_foundation.sources.http import HttpSourceHandler
 from amplifier_foundation.sources.zip import ZipSourceHandler
 
@@ -497,13 +496,26 @@ class TestGitNetworkOpRetry343:
     """
 
     def test_retries_then_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A failure followed by a success resolves without raising."""
+        """A failure followed by a success resolves without raising.
+
+        GAP-030 cross-platform validation note: this test used to monkeypatch
+        ``git_mod.subprocess.run``, but the GAP-014/GAP-025 fix rewrote the
+        actual subprocess invocation to go through a new ``_run_git_subprocess``
+        helper (``subprocess.Popen`` + a wall-clock timeout), which
+        ``_run_git_network_op`` calls directly. Patching ``subprocess.run`` no
+        longer intercepted anything, so this test silently stopped testing the
+        retry loop and instead made a REAL network call to a nonexistent host
+        -- passing or failing for the wrong reason depending on DNS behavior,
+        not the reason its assertions claim. Patch the real seam instead:
+        ``_run_git_subprocess``, the function ``_run_git_network_op`` actually
+        calls per attempt.
+        """
         from amplifier_foundation.sources import git as git_mod
 
         calls: list[list[str]] = []
         sleeps: list[float] = []
 
-        def fake_run(args, **kwargs):  # noqa: ANN001, ANN202
+        def fake_run_subprocess(args, cwd, timeout_s):
             calls.append(args)
             if len(calls) == 1:
                 raise subprocess.CalledProcessError(
@@ -511,7 +523,7 @@ class TestGitNetworkOpRetry343:
                 )
             return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
 
-        monkeypatch.setattr(git_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(git_mod, "_run_git_subprocess", fake_run_subprocess)
         monkeypatch.setattr(git_mod.time, "sleep", lambda s: sleeps.append(s))
 
         result = git_mod._run_git_network_op(["git", "clone", "url", "/tmp/x"])
@@ -523,18 +535,23 @@ class TestGitNetworkOpRetry343:
     def test_exhausts_attempts_and_reraises_real_error(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """When every attempt fails, the original git error is raised."""
+        """When every attempt fails, the original git error is raised.
+
+        See the GAP-030 note on ``test_retries_then_succeeds`` above: patches
+        ``_run_git_subprocess`` (the real seam) rather than ``subprocess.run``
+        (bypassed since GAP-014/GAP-025 switched to ``subprocess.Popen``).
+        """
         from amplifier_foundation.sources import git as git_mod
 
         calls: list[list[str]] = []
 
-        def always_fail(args, **kwargs):  # noqa: ANN001, ANN202
+        def always_fail(args, cwd, timeout_s):
             calls.append(args)
             raise subprocess.CalledProcessError(
                 128, args, stderr="fatal: could not resolve host: github.com"
             )
 
-        monkeypatch.setattr(git_mod.subprocess, "run", always_fail)
+        monkeypatch.setattr(git_mod, "_run_git_subprocess", always_fail)
         monkeypatch.setattr(git_mod.time, "sleep", lambda _s: None)
 
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
@@ -552,7 +569,20 @@ class TestGitNetworkOpRetry343:
         Servers without ``allowReachableSHA1InWant`` refuse the shallow fetch as
         a matter of course. That failure is a designed fallback, not an error,
         so retrying it would add seconds to a normal path.
+
+        GAP-030 cross-platform validation note: same seam fix as the two tests
+        above -- the network-touching fetch/clone calls go through
+        ``_run_git_subprocess`` (Popen-based) since GAP-014/GAP-025, not
+        ``subprocess.run``. The LOCAL git plumbing in ``_clone_at_commit``'s
+        own ``run_git()`` closure (init/remote add/checkout) still genuinely
+        uses ``subprocess.run`` directly, so it's faked the same way the
+        original (pre-GAP-014) version of this test faked it: unconditional
+        success. None of the assertions below depend on real git state, and
+        the previous version of this test didn't distinguish local plumbing
+        from network calls either -- it just happened to intercept both
+        through one seam because both used to go through subprocess.run.
         """
+        from amplifier_foundation.sources import git as git_mod
         from amplifier_foundation.sources.git import GitSourceHandler
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -560,16 +590,26 @@ class TestGitNetworkOpRetry343:
             cache_path = Path(tmpdir) / "repo"
             seen: list[list[str]] = []
 
-            def fake_run(args, **kwargs):  # noqa: ANN001, ANN202
+            def fake_local_run(args, **kwargs):  # noqa: ANN001, ANN202
+                # Local plumbing only (init/remote add/checkout) -- the
+                # network-touching fetch/clone below no longer goes through
+                # subprocess.run at all, so this never sees "fetch"/"clone".
+                seen.append(list(args))
+                return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+            def fake_run_subprocess(args, cwd, timeout_s):
                 seen.append(list(args))
                 # Refuse the shallow SHA fetch; succeed at everything else.
                 if "fetch" in args:
                     raise subprocess.CalledProcessError(128, args, stderr="refused")
                 return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
 
-            monkeypatch.setattr(subprocess, "run", fake_run)
+            monkeypatch.setattr(git_mod.subprocess, "run", fake_local_run)
+            monkeypatch.setattr(git_mod, "_run_git_subprocess", fake_run_subprocess)
 
-            handler._clone_at_commit("https://example.invalid/r.git", "a" * 40, cache_path)
+            handler._clone_at_commit(
+                "https://example.invalid/r.git", "a" * 40, cache_path
+            )
 
             fetch_calls = [c for c in seen if "fetch" in c]
             assert len(fetch_calls) == 1, (

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -59,9 +59,16 @@ class TestFileSourceHandler:
             )
             result = await handler.resolve(parsed, Path(tmpdir) / "cache")
 
-            assert result.active_path == test_file
+            # FileSourceHandler.resolve() calls Path.resolve() internally. On
+            # Windows, tempfile.TemporaryDirectory() may hand back a path
+            # containing an 8.3 short component (e.g. "RUNNER~1") while
+            # resolve() returns the canonical long form (e.g. "runneradmin").
+            # Both spellings name the same file/directory, so resolve the
+            # expected side too rather than comparing raw/short vs.
+            # canonical/long.
+            assert result.active_path == test_file.resolve()
             # source_root is the parent directory for non-cached files
-            assert result.source_root == test_file.parent
+            assert result.source_root == test_file.parent.resolve()
 
     @pytest.mark.asyncio
     async def test_resolve_with_subpath(self) -> None:
@@ -82,7 +89,8 @@ class TestFileSourceHandler:
             )
             result = await handler.resolve(parsed, base / "cache")
 
-            assert result.active_path == subdir
+            # See resolve() note in test_resolve_existing_file above.
+            assert result.active_path == subdir.resolve()
             assert result.source_root == (base / "bundles").resolve()
 
 

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -558,6 +558,8 @@ class TestRunSessionInSubprocess:
         project_path = str(tmp_path)
 
         mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.returncode = None
         mock_process.kill = MagicMock()
         mock_process.wait = AsyncMock()
 
@@ -565,16 +567,19 @@ class TestRunSessionInSubprocess:
             "asyncio.create_subprocess_exec", new=AsyncMock(return_value=mock_process)
         ):
             with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError()):
-                with pytest.raises(TimeoutError, match="timed out after 30s"):
-                    await run_session_in_subprocess(
-                        config=config,
-                        prompt=prompt,
-                        parent_id=parent_id,
-                        project_path=project_path,
-                        timeout=30,
-                    )
+                with patch(
+                    "amplifier_foundation.subprocess_runner._kill_subprocess_tree"
+                ) as mock_kill_tree:
+                    with pytest.raises(TimeoutError, match="timed out after 30s"):
+                        await run_session_in_subprocess(
+                            config=config,
+                            prompt=prompt,
+                            parent_id=parent_id,
+                            project_path=project_path,
+                            timeout=30,
+                        )
 
-        mock_process.kill.assert_called_once()
+        mock_kill_tree.assert_called_once_with(mock_process.pid)
         mock_process.wait.assert_called_once()
 
     @pytest.mark.asyncio
@@ -602,6 +607,7 @@ class TestRunSessionInSubprocess:
 
         mock_process = MagicMock()
         mock_process.pid = 12345
+        mock_process.returncode = None
         mock_process.kill = MagicMock()
         # MagicMock (not AsyncMock) intentional: the patched asyncio.wait_for
         # raises TimeoutError before any await happens, so the wait() return
@@ -619,17 +625,20 @@ class TestRunSessionInSubprocess:
                 "asyncio.wait_for",
                 side_effect=[asyncio.TimeoutError(), asyncio.TimeoutError()],
             ):
-                with caplog.at_level(logging.WARNING):
-                    with pytest.raises(TimeoutError, match="timed out after 30s"):
-                        await run_session_in_subprocess(
-                            config=config,
-                            prompt=prompt,
-                            parent_id=parent_id,
-                            project_path=project_path,
-                            timeout=30,
-                        )
+                with patch(
+                    "amplifier_foundation.subprocess_runner._kill_subprocess_tree"
+                ) as mock_kill_tree:
+                    with caplog.at_level(logging.WARNING):
+                        with pytest.raises(TimeoutError, match="timed out after 30s"):
+                            await run_session_in_subprocess(
+                                config=config,
+                                prompt=prompt,
+                                parent_id=parent_id,
+                                project_path=project_path,
+                                timeout=30,
+                            )
 
-        mock_process.kill.assert_called_once()
+        mock_kill_tree.assert_called_once_with(mock_process.pid)
         assert "did not exit" in caplog.text
 
     @pytest.mark.asyncio

--- a/tests/test_zip_cross_platform_path.py
+++ b/tests/test_zip_cross_platform_path.py
@@ -1,0 +1,53 @@
+"""Regression test for the GAP-007 pattern missed in ZipSourceHandler.
+
+GAP-007 fixed exactly one instance of "a foreign-OS absolute path silently
+produces a misleading error" -- in FileSourceHandler.resolve(). An independent
+review found the identical defect shape still live in ZipSourceHandler: a
+POSIX-authored `zip+file:///home/x/a.zip` resolved on Windows became
+`C:\\home\\x\\a.zip` and failed with a bare "Zip file not found", sending the
+user hunting for a file that was never expected to exist on that machine.
+
+This is the "if algorithm rejects X, trace what depends on X loading
+successfully" miss: the fix was right, but only one of two call sites with the
+same vulnerability shape was updated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import platform
+import tempfile
+from pathlib import Path
+
+import pytest
+from amplifier_foundation.exceptions import BundleNotFoundError
+from amplifier_foundation.paths.resolution import ParsedURI
+from amplifier_foundation.sources.zip import ZipSourceHandler
+
+
+def _foreign_absolute_path() -> str:
+    """An absolute path shaped for the OS we are NOT running on."""
+    if platform.system() == "Windows":
+        return "/home/someone/archive.zip"
+    return "C:\\Users\\someone\\archive.zip"
+
+
+def test_zip_file_foreign_os_path_names_the_real_problem() -> None:
+    handler = ZipSourceHandler()
+    foreign = _foreign_absolute_path()
+    parsed = ParsedURI(
+        scheme="zip+file", host="", path=foreign, ref="", subpath=""
+    )
+
+    with pytest.raises(BundleNotFoundError) as exc_info:
+        asyncio.run(handler.resolve(parsed, Path(tempfile.mkdtemp())))
+
+    message = str(exc_info.value)
+    assert "cannot exist on" in message, (
+        f"error did not identify this as a cross-OS path problem: {message!r}. "
+        "A bare 'Zip file not found' sends the user hunting for a file that "
+        "was never expected to exist on this machine."
+    )
+    assert foreign in message, (
+        "the error must echo the path the user actually wrote, not a coerced one"
+    )


### PR DESCRIPTION
## Summary

Six Windows/POSIX compatibility gaps discovered in native Windows testing, now fixed and proven on Windows, Linux, macOS, and WSL:

### GAP-014: git clone hung forever with no timeout or diagnostic

The underlying `_run_git_network_op()` called `subprocess.run()` with **no timeout parameter**, while `ls-remote` six lines away sets `timeout=30s`. With `_CLONE_MAX_ATTEMPTS=3` this multiplied an infinite hang by three.

**Symptom on Windows:** indefinite 'Composing resolve-platform' spinner (observed stuck at 150s, 623s, never completing, no error, only exit: Task Manager).

**Root cause:** a credential helper (git-credential-manager on this box) blocking on an OAuth flow it cannot complete headlessly; **11 orphaned git-credential-manager.exe processes** accumulated during investigation.

**Fix:** adds GitCloneTimeoutError with an actionable message naming the credential-helper cause, configurable 45s bound (`AMPLIFIER_GIT_CLONE_TIMEOUT_S`), proper process-tree cleanup via `taskkill /F /T` on Windows or process-group SIGKILL on POSIX, and destination cleanup between retries.

**Proof (native Windows):** before → indefinite hang or 623s unattended retry; after → bounded failure at 139.7s with real diagnostic, **zero orphans**.

### GAP-015: Windows absolute paths unrecognized

`ParsedURI.is_file` required "/" in self.path, which a pure-backslash `C:\...` never satisfies. `parse_uri()` special-cased only POSIX /-prefixed absolutes.

**Result:** `No handler for URI: C:\Users\...` → 7 of 165 modules failed to activate → strict mode refused to start the session.

Also found: `C:/...` was being mis-parsed as `package="C:"`, not merely unrecognized.

**Proof (native Windows):** before → "3 of 72 modules failed to activate (strict mode)", session refused to start; after → "Bundle prepared successfully", zero error strings, no `AMPLIFIER_ALLOW_PARTIAL_BUNDLE` needed.

### GAP-007: POSIX path on Windows silently mangled

`FileSourceHandler.resolve()` did naive `Path(path_str).resolve()`. On Windows, `Path("/home/user/x")` is a valid *relative* WindowsPath, so `.resolve()` anchors it to the caller's drive, producing `C:\home\user\x` and a misleading "File not found".

**Proof (native Windows):** before → "File not found: C:\home\bkrabach\..."; after → clear mismatch error naming the OS shapes.

### GAP-026: subprocess-mode delegation uncancellable

`register_child` wiring sat **after** an early `return` block; subprocess-mode delegation never registered for cancellation. Its only handler was `except asyncio.TimeoutError` with 1800s default.

**Result:** `task.cancel()` propagated while `process.kill()` was never called.

**Fix:** added `_kill_subprocess_tree()` + `except BaseException:`.

### GAP-030: POSIX kill path would have killed amplifier itself

The POSIX branch did `os.killpg(os.getpgid(pid), SIGKILL)` while the child was **never spawned into its own process group**.

**Empirically proven on Linux:** child pgid == caller pgid, so it would have SIGKILLed amplifier and everything in its process group (your shell, etc.).

**Fix:** `start_new_session=True` plus a defensive same-pgid guard that falls back to direct `kill()`.

### GAP-031: Unintended retry in shallow fetch

GAP-014's own diff had silently made the "must not be retried" shallow-SHA fetch retryable 3× with backoff, contradicting a comment six lines away.

**Why it wasn't caught:** the test had gone blind — it mocked `subprocess.run` while the implementation moved to `Popen`. No regression run on any platform could have caught it.

**Fix:** test repatched to the real seam; fetch switched to `_run_git_subprocess` directly (keeps timeout, drops unintended retry).

## Regression testing

**New regression tests included:**
- `test_gap011_git_interrupt_orphans.py` — proves POSIX cleanup works when KeyboardInterrupt fires (teeth: remove `except BaseException:` → fails with "stand-in parent process survived")
- `test_gap030_posix_self_kill.py` — proves pgid isolation (teeth: remove guard → fails with "killpg() called on a pgid shared with the caller's own group")

**All platforms, clean baseline:**
- Linux: 1550 passed / 1 pre-existing failure
- macOS: 1474 passed / 9 /tmp↔/private/tmp test artifacts + 1 pre-existing
- WSL: 1495 passed / 1 same pre-existing runtime_checkable failure
- Validated on clean install from upstream HEAD (6c3fd86), not pinned commit

---

## Scope and limitations

**Windows evidence is n=1.** All Windows proof comes from a single machine — `alienware-r13`, Windows NT 10.0.26200, Python 3.14. The code-logic fixes here generalize (they are platform-conditional logic bugs, not environment-specific). Where a fix's *trigger* was environmental, that is called out inline above.

**Cross-platform validation.** Linux (aarch64), macOS (Darwin arm64), and WSL2 were all validated — full regression suites on each, plus a real end-to-end pipe with live API calls on WSL. Zero regressions attributable to this diff on any platform.

**Clean-install proof.** Validated against a clean `uv tool install` from upstream HEAD (`6c3fd86`), not only the commit these changes were developed against.

**How this was found.** Part of a Windows-native gap investigation. Completeness was declared prematurely several times during that investigation and each premature call was later broken by adversarial re-testing — several fixes exist only because an earlier "this is done" was challenged. Treat this as what was found, not a closed set.

**Known latent, not fixed:** `_is_windows_absolute_path`'s regex `^[A-Za-z]:[\\/]` has a confirmed false positive on single-letter-scheme URIs (`a://host` matches `a:/`). No such scheme exists in real usage, so this is latent rather than live — recorded here rather than silently left.


---

## Independent review findings (reviewer had no authoring context)

An independent adversarial review of this PR, run through the `ISSUE_HANDLING.md` lens with no
prior context on the work, produced the following. Two were fixed in this branch; the rest are
recorded here rather than quietly dropped.

### Fixed in response

- **`ZipSourceHandler` had GAP-007's defect, unfixed** (commit `e57da7f`). GAP-007 repaired exactly
  one instance of "a foreign-OS absolute path produces a misleading error" — in
  `FileSourceHandler.resolve()`. The identical shape was still live in `ZipSourceHandler`: a
  POSIX-authored `zip+file:///home/x/a.zip` on Windows became `C:\home\x\a.zip` and failed with a
  bare `Zip file not found`. Now guarded, with a teeth-proven regression test.

### Scope correction — GAP-026 is only partly addressed

This PR's GAP-026 claim is **narrower than stated**, and the reviewer was right to flag it.

What this PR does fix: when the awaiting asyncio task is cancelled, `except BaseException:` plus
`_kill_subprocess_tree` reaps the child process tree. That covers a global Ctrl+C.

What it does **not** fix: the parent's cancellation *token* is never linked to a subprocess-mode
child, so selective cancellation cannot reach one. Verified by inspection —
`amplifier-app-cli/session_spawner.py` returns from the subprocess branch at line 472, while
`parent_cancellation.register_child(...)` sits at line 606, reachable only on the in-process path.
`run_session_in_subprocess` (subprocess_runner.py:386) accepts no cancellation parameter, so there
is nothing to register against. Closing it means threading a token through a public cross-repo API,
which is deliberately out of scope here. Tracked separately.

Affects only users who opt into `spawn_mode: subprocess`, on all platforms equally.

### Recorded, not acted on

- **`_CLONE_TIMEOUT_S` is read once at import**, so `AMPLIFIER_GIT_CLONE_TIMEOUT_S` only takes
  effect if set before first import of `sources.git`. No test covers the override path. The
  "overridable" wording in the docstring implies more runtime flexibility than the implementation
  provides.
- **The 45s→300s raise may multiply a systemic hang.** The credential-helper failure this bound
  exists to catch affects every `git+https` source in an activation pass equally. Top-level bundle
  loads are concurrent (`registry.py:334` uses `asyncio.gather`), which bounds the cost — but
  whether the finer-grained module-activation loop is concurrent could not be determined from this
  repo.
- **`GitSourceHandler.resolve()` is `async def` but calls git synchronously**, so a hung clone
  blocks the event loop for up to the full bound. Pre-existing, but the raise compounds it.
- **Dead branch at `git.py:265`** — an `isinstance(e, GitCloneTimeoutError)` check inside the
  `CalledProcessError` handler, unreachable since the two types were split into separate `except`
  clauses. Harmless, but stale.

### Verified independently, no action needed

The reviewer re-derived the `_is_windows_absolute_path` false-positive claim rather than accepting
it: `a://host` and `n:/foo` do match; `s3://`, `ssh://`, `git+https://` do not. Grepping ~60+ real
`source:` directives across the visible ecosystem found no single-letter scheme anywhere. The claim
holds for the observed corpus — it is not a universal guarantee, and should be read that way.

The reviewer also confirmed the new tests guard contracts rather than implementations, and that the
suite reproduces at **1558 passed, 1 skipped**.
