### PR TITLE
fix(behaviors): stop overriding hooks-status-context's date granularity

### DIFF
--- a/behaviors/status-context.yaml
+++ b/behaviors/status-context.yaml
@@ -6,6 +6,16 @@ bundle:
 hooks:
   - module: hooks-status-context
     source: git+https://github.com/microsoft/amplifier-module-hooks-status-context@main
-    config:
-      include_datetime: true
-      datetime_include_timezone: false
+    # No config override: the module's own defaults are what we want.
+    #
+    # This previously set `include_datetime: true`, which renders the "Today's date"
+    # field at second resolution. That field is re-rendered live on every single
+    # provider request (it is deliberately never cached, so it cannot go stale), so
+    # second-resolution timestamps make the injected block differ on nearly every
+    # turn -- which defeats provider-side prompt caching. Measured on real Gemini
+    # traffic: -17 to -20 percentage points of implicit cache-hit rate, and a Gemini
+    # miss bills the entire prefix at full price.
+    #
+    # The module now defaults to calendar-day resolution (see
+    # microsoft/amplifier-module-hooks-status-context#9). Do not re-add
+    # `include_datetime: true` here without re-measuring that cost.


### PR DESCRIPTION
## Summary

**This PR is what makes microsoft/amplifier-module-hooks-status-context#9 actually take effect for foundation users.** That PR changes a module *default*; this file was explicitly overriding it.

`behaviors/status-context.yaml` set `include_datetime: true`, which renders the injected `Today's date` field at **second resolution**. That field is re-rendered live on every single provider request (it is deliberately never cached, so it cannot go stale) — so second-resolution timestamps make the injected `<system-reminder>` block differ on nearly every turn, defeating provider-side prompt caching.

Without this PR, hooks-status-context#9 would ship a better default and the foundation bundle would keep opting straight back out of it. Same coupling shape as the loop-streaming / provider-anthropic pairing.

### The change

```diff
 hooks:
   - module: hooks-status-context
     source: git+https://github.com/microsoft/amplifier-module-hooks-status-context@main
-    config:
-      include_datetime: true
-      datetime_include_timezone: false
+    # No config override: the module's own defaults are what we want.
+    # ... (comment explaining why, so it is not reinstated blind)
```

`datetime_include_timezone: false` is removed alongside it — it only applies when `include_datetime` is true, and it already matched the module default. A comment is left in its place so the override is not reinstated without re-measuring the cost.

## Measured cost of the override

300 real API calls; method pre-registered before the run; 2 models × 2 arms × 5 independent sessions × 15 turns:

```
gemini-2.5-flash        tail 0.813  |  no-tail 0.987   -> -17.3pp cache hit rate
gemini-2.5-flash-lite   tail 0.667  |  no-tail 0.867   -> -20.0pp
```

Near-complete rank separation — for flash, every tail-arm session scored below every no-tail-arm session. Conditional on a hit, magnitude was unaffected: the churn reduces hit *probability*, not hit size. A Gemini cache miss bills the entire prefix at full price, and Gemini's caching is implicit/content-addressed with no server-side lever to compensate.

**Honest caveat:** the pre-registered magnitude threshold was **25pp**; the observed gap was **17–20pp**, i.e. below the pre-registered bar. The direction-consistency criterion (>=4/5 replicates) was met more strongly than the magnitude proxy anticipated. Stating this rather than rounding it away.

**Scope:** OpenAI measured immune (0.906 vs 0.909). Anthropic is protected by a separate breakpoint fix (microsoft/amplifier-module-provider-anthropic#86) — a distinct measurement, not this one. Nothing here has been re-run against the patched hook; these numbers characterize the problem, not the fix.

## What still works after this change

Removing the override does **not** remove the date from the injected context. The module still renders `Today's date`, recomputed live on every request — just at calendar-day resolution instead of `hh:mm:ss`. The field is *labeled* "Today's date", so date-only is a more accurate match to its own label. Anyone who genuinely needs sub-day precision can still set `include_datetime: true` explicitly, with the cache cost documented at both the module and this call site.

## Test plan

- [x] YAML parses and produces the intended structure — verified with `yaml.safe_load`; the hook entry retains `module` and `source`, with `config` absent.
- [x] Absent `config` is safe — the module's `mount()` does `config = config or {}` (`amplifier_module_hooks_status_context/__init__.py:108`), so dropping the key falls through to defaults rather than erroring.
- [x] Full foundation suite: **1549 passed** (`uv run pytest tests/ -q --tb=short`, ~16s). Working tree was clean before this edit, so this is the suite state with the change applied.
- [x] N/A — no new tests added; this is a one-file config change with no new behavior of its own. The behavior it enables is tested in microsoft/amplifier-module-hooks-status-context#9 (`tests/test_caching.py`, 10 new tests).
- [x] N/A — no measurement re-run against the patched configuration. The figures above characterize the problem as measured on the unpatched code.

## Related

- **microsoft/amplifier-module-hooks-status-context#9** — the module-side change this PR unblocks. That PR flips `include_datetime` to `False` and additionally caches the git status/branch/commits block once per session (a correctness fix: the injected text already promised "a snapshot in time ... will not update during the conversation" while the code re-ran `git status` every request).
- Merge order: either order is safe. Merging #9 alone leaves the date-granularity half inert for foundation users (its git-caching half still takes effect, since that is not config-gated). Merging this alone is a no-op until #9 lands, since the current module default is still `True`.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
