### PR TITLE
fix(hooks): session-naming abort on role-resolution failure, not silent downgrade

### DIFF
--- a/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
+++ b/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
@@ -462,7 +462,18 @@ class SessionNamingHook:
           2. Fallback   — next(iter(providers.values()))
 
         model_role resolution requires amplifier_module_hooks_routing. When that
-        module is not installed, logs a warning and falls back to #2.
+        module is not installed (no model_role_resolver capability registered
+        at all), logs a debug message and falls back to #2 — that fallback is
+        legitimate and intended.
+
+        But when a model_role_resolver IS registered and the resolution itself
+        fails (resolves to no candidates, or raises), that is a failure of an
+        explicitly-configured routing preference, not an absent one. Silently
+        substituting the fallback provider in that case would mean a transient
+        resolver error (e.g. a provider API hiccup while listing models) quietly
+        routes a cheap background chore onto the session's primary/expensive
+        model. Instead, abort this naming attempt (return None) and let the
+        self-retrying trigger try again on a later turn.
         """
         try:
             providers = self.coordinator.get("providers")
@@ -491,7 +502,18 @@ class SessionNamingHook:
                         self.config.model_role,
                     )
                 else:
-                    resolved = await resolver.resolve(self.config.model_role)
+                    try:
+                        resolved = await resolver.resolve(self.config.model_role)
+                    except Exception as e:
+                        logger.warning(
+                            "model_role %r resolver raised %s; skipping session"
+                            " naming for this turn rather than silently falling"
+                            " back to the priority (expensive) provider — will"
+                            " retry on a later turn",
+                            self.config.model_role,
+                            e,
+                        )
+                        return None
                     if resolved:
                         # ProviderPreference attrs: .provider, .model, .config
                         resolved_provider_name = resolved[0].provider
@@ -503,11 +525,16 @@ class SessionNamingHook:
                                 break
                     else:
                         logger.warning(
-                            "model_role %r resolved to no candidates",
+                            "model_role %r resolved to no candidates; skipping"
+                            " session naming for this turn rather than silently"
+                            " falling back to the priority (expensive) provider"
+                            " — will retry on a later turn",
                             self.config.model_role,
                         )
+                        return None
 
-            # Fallback: use first/priority provider
+            # Fallback: use first/priority provider (only reached when
+            # model_role is unset, or no resolver capability is registered)
             if provider is None:
                 provider = next(iter(providers.values()), None)
 

--- a/modules/hooks-session-naming/tests/test_session_naming.py
+++ b/modules/hooks-session-naming/tests/test_session_naming.py
@@ -376,6 +376,96 @@ class TestModelRoleResolution:
         request = call_kwargs[0][0]
         assert request.model is None, "No model override without model_role"
 
+    @pytest.mark.asyncio
+    async def test_resolver_empty_result_aborts_without_calling_provider(self) -> None:
+        """Resolver present but resolves to [] must abort, NOT fall back to the
+        priority provider.
+
+        This is the load-bearing regression test for the bug: a resolver that
+        legitimately exists but fails to resolve any candidates (e.g. a transient
+        provider error inside list_models()) must never silently substitute the
+        session's primary/expensive model for a background naming chore.
+        """
+        priority_provider = _make_mock_provider()
+        providers = {"provider-priority": priority_provider}
+
+        resolver = _make_resolver(return_value=[])
+        hook = _make_hook(
+            providers=providers,
+            model_role_resolver=resolver,
+            model_role="fast",
+        )
+
+        result = await hook._call_provider("name this session")
+
+        assert result is None, (
+            "Must abort (return None) when model_role resolves to no candidates"
+        )
+        assert not priority_provider.complete.called, (
+            "Must NOT silently fall back to the priority provider when an "
+            "explicitly-configured model_role fails to resolve"
+        )
+        resolver.resolve.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resolver_exception_aborts_without_calling_provider(self) -> None:
+        """Resolver present but resolve() raises must abort, NOT propagate and
+        NOT fall back to the priority provider."""
+        priority_provider = _make_mock_provider()
+        providers = {"provider-priority": priority_provider}
+
+        resolver = _make_resolver()
+        resolver.resolve = AsyncMock(side_effect=RuntimeError("boom"))
+        hook = _make_hook(
+            providers=providers,
+            model_role_resolver=resolver,
+            model_role="fast",
+        )
+
+        result = await hook._call_provider("name this session")
+
+        assert result is None, (
+            "Must abort (return None) when the resolver raises, not propagate"
+        )
+        assert not priority_provider.complete.called, (
+            "Must NOT silently fall back to the priority provider when the "
+            "resolver raises"
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolver_empty_result_logs_warning(self, caplog) -> None:
+        """Aborting due to an empty resolution must be logged at WARNING."""
+        hook = _make_hook(
+            providers={"provider-priority": _make_mock_provider()},
+            model_role_resolver=_make_resolver(return_value=[]),
+            model_role="fast",
+        )
+
+        with caplog.at_level("WARNING"):
+            await hook._call_provider("name this session")
+
+        warnings = [r for r in caplog.records if r.levelno >= 30]
+        assert warnings, (
+            "Expected a WARNING log when model_role resolves to no candidates"
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolver_exception_logs_warning(self, caplog) -> None:
+        """Aborting due to a resolver exception must be logged at WARNING."""
+        resolver = _make_resolver()
+        resolver.resolve = AsyncMock(side_effect=RuntimeError("boom"))
+        hook = _make_hook(
+            providers={"provider-priority": _make_mock_provider()},
+            model_role_resolver=resolver,
+            model_role="fast",
+        )
+
+        with caplog.at_level("WARNING"):
+            await hook._call_provider("name this session")
+
+        warnings = [r for r in caplog.records if r.levelno >= 30]
+        assert warnings, "Expected a WARNING log when the resolver raises"
+
 
 # =============================================================================
 # Task 7: Background naming call must not leak llm:stream_* events


### PR DESCRIPTION
## Problem

`SessionNamingHook._call_provider` silently fell back to the session's primary (expensive) model whenever a configured `model_role` failed to resolve.

The code collapsed two distinct scenarios into one silent fallback:
1. **No `model_role_resolver` capability registered** (no routing bundle installed) — falling back to the priority provider is legitimate and intended
2. **Resolver IS registered but resolution fails** (returns no candidates, or raises) — this is a failure of an explicitly-configured routing preference

In case 2, the code logged `logger.warning("model_role %r resolved to no candidates", ...)` and then fell through to `provider = next(iter(providers.values()), None)`, quietly running a trivial background classification chore on the user's primary model.

**Production observation:** A transient `anthropic.APIConnectionError` inside the resolver's `list_models()` made the `fast` role resolve to nothing, and session naming silently ran on `claude-sonnet-5` instead of haiku-4.5. Cost leak and latency regression on background work.

## Solution

**Case 1** (no resolver capability) is unchanged — still `logger.debug` + fallback.

**Case 2** (resolver fails) now aborts the naming attempt (`return None`) and logs a `WARNING` that names the consequence:
- "skipping session naming for this turn to avoid silently routing onto the primary (expensive) provider"
- "will retry on a later turn"

The `await resolver.resolve(...)` call is now wrapped in `try/except Exception`; a raised exception is treated the same as "resolved to nothing" (previously it propagated uncaught out of `_call_provider`).

**Why aborting is safe:** Naming is best-effort and self-retrying: the trigger is `if current_turn >= initial_trigger_turn and not has_name:`, so while the session still has no name the next turn re-attempts. The caller already treats a falsy return as a normal no-op. Skipping one naming attempt costs nothing; silently buying the primary model costs real money and latency on every attempt.

No retry loops, backoff, or caching were added — this is a fail-loud fix, not a resilience redesign. (Model-list caching was addressed separately in amplifier-bundle-routing-matrix PR #41, which narrows the window; this closes the remaining case where the very first resolution of a session fails.)

## Evidence

Behavioral proof with a real `SessionNamingHook` and a real `AnthropicProvider` instance, spying on `provider.complete()` — the load-bearing question is not what got logged but whether the expensive primary model actually gets called:

| scenario | primary model called? |
|---|---|
| resolver returns `[]` (the production failure) | **False** — aborted |
| resolver raises `ConnectionError` | **False** — aborted, no propagation |
| no resolver capability at all (regression guard) | **True** — legitimate fallback preserved |

**Tests:** `modules/hooks-session-naming/tests/` 21 passing at dea5bd8 → 25 with 4 new tests in `TestModelRoleResolution`:
- `test_resolver_empty_result_aborts_without_calling_provider` — resolver returns `[]` → `_call_provider` returns `None` and `provider.complete` is never awaited (load-bearing)
- `test_resolver_exception_aborts_without_calling_provider` — resolver raises → same, exception does not propagate
- `test_resolver_empty_result_logs_warning` — caplog assertion for abort path
- `test_resolver_exception_logs_warning` — caplog assertion for exception path

The two regression guards for the preserved-fallback and happy-path cases already existed in the file and pass unmodified:
- `test_model_role_falls_back_when_no_resolver_capability`
- `test_model_role_uses_resolved_provider_and_model`

**Note for reviewers on running the tests:** This module's tests need the compiled `amplifier_core`, so they run via the amplifier tool venv's site-packages on PYTHONPATH rather than a bare `pytest` in the module venv. See the test file header for the invocation.
