### PR TITLE
fix(spawn): memoize delegate list_models() with single-flight TTL cache

### DIFF
--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 import asyncio
 import fnmatch
 import logging
+import os
 import time
 import weakref
-from dataclasses import dataclass
-from dataclasses import field
+from dataclasses import dataclass, field
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -26,15 +26,92 @@ logger = logging.getLogger(__name__)
 # fan-out) otherwise fire one identical GET /v1/models per spawned session.
 # Model catalogs change rarely, so a short TTL is functionally exact while
 # collapsing a whole wave into a single upstream call.
+#
+# Overridable via AMPLIFIER_LIST_MODELS_CACHE_TTL_SECONDS (see
+# _get_ttl_seconds()). This module-level name is kept as the fallback/default
+# -- and remains directly monkey-patchable (`su.LIST_MODELS_CACHE_TTL_SECONDS
+# = ...`) -- so existing tests and callers are unaffected.
 LIST_MODELS_CACHE_TTL_SECONDS = 60.0
+
+# Maximum time a caller will wait on another caller's in-flight
+# list_models() fetch before falling through to a direct, uncached call of
+# its own (bounds head-of-line blocking: a single hung/slow fetch must not
+# stall an entire delegate wave indefinitely).
+#
+# Overridable via AMPLIFIER_LIST_MODELS_WAIT_TIMEOUT_SECONDS (see
+# _get_wait_timeout_seconds()); same fallback/monkey-patch contract as
+# LIST_MODELS_CACHE_TTL_SECONDS above.
+LIST_MODELS_WAIT_TIMEOUT_SECONDS = 20.0
+
+
+def _get_ttl_seconds() -> float:
+    """Resolve the cache TTL: env override first, module global fallback.
+
+    Reads the module global by name on every call (not a captured default),
+    so direct monkey-patching (`su.LIST_MODELS_CACHE_TTL_SECONDS = ...`, as
+    the existing test suite does) keeps working unchanged.
+    """
+    raw = os.environ.get("AMPLIFIER_LIST_MODELS_CACHE_TTL_SECONDS")
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            logger.warning(
+                "Invalid AMPLIFIER_LIST_MODELS_CACHE_TTL_SECONDS=%r; "
+                "falling back to default %.1fs",
+                raw,
+                LIST_MODELS_CACHE_TTL_SECONDS,
+            )
+    return LIST_MODELS_CACHE_TTL_SECONDS
+
+
+def _get_wait_timeout_seconds() -> float:
+    """Resolve the single-flight wait timeout: env override first, fallback.
+
+    Same env-first/module-global-fallback contract as _get_ttl_seconds().
+    """
+    raw = os.environ.get("AMPLIFIER_LIST_MODELS_WAIT_TIMEOUT_SECONDS")
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            logger.warning(
+                "Invalid AMPLIFIER_LIST_MODELS_WAIT_TIMEOUT_SECONDS=%r; "
+                "falling back to default %.1fs",
+                raw,
+                LIST_MODELS_WAIT_TIMEOUT_SECONDS,
+            )
+    return LIST_MODELS_WAIT_TIMEOUT_SECONDS
 
 
 @dataclass
 class _ModelListCacheEntry:
-    """Per-provider memoization state for list_models()."""
+    """Per-provider memoization state for list_models().
+
+    `models`/`expires_at` are populated ONLY by a fetch that produced a
+    genuinely non-empty result (see `_fetch_and_store`). Several shipped
+    providers convert a failed fetch into a *successful-looking* return
+    value instead of raising -- ollama returns `[]` on connection errors,
+    chat-completions returns a degraded 1-model fallback list on any
+    exception, azure-openai returns `[]` unconditionally on error. Caching
+    any of those would silently poison model resolution for the full TTL
+    window even after the provider recovers. Treating an empty result as a
+    cache miss (never populating `models`/`expires_at`) means the very next
+    resolution call refetches live instead of being stuck on stale, wrong
+    "success" data.
+
+    `task` holds the shared in-flight fetch (see `_list_models_cached`):
+    concurrent callers await the same asyncio.Task rather than each
+    re-running their own fetch (and, with provider-level retries, their own
+    full retry campaign). A task is only ever left installed here while it
+    is still running or has succeeded; a task that failed clears itself
+    (see `_fetch_and_store`) so the next new caller starts a fresh fetch
+    instead of adopting an already-raised task.
+    """
 
     expires_at: float = 0.0
     models: Any = None
+    task: asyncio.Task[Any] | None = None
     lock: asyncio.Lock | None = None
     loop_id: int = 0
 
@@ -44,14 +121,65 @@ _MODEL_LIST_CACHE: weakref.WeakKeyDictionary[Any, _ModelListCacheEntry] = (
 )
 
 
+async def _fetch_and_store(
+    provider: Any, provider_name: str, entry: _ModelListCacheEntry
+) -> Any:
+    """Run the actual provider.list_models() call as the body of a shared Task.
+
+    This is the one place that talks to the provider; `_list_models_cached`
+    only ever schedules this as a Task and awaits it, so the lock in
+    `_list_models_cached` never has to be held across the network call.
+    """
+    try:
+        models = await provider.list_models()
+    except BaseException:
+        # A failed fetch must not persist as "the" shared in-flight attempt.
+        # Clear it now (synchronously, before this coroutine actually
+        # completes) so the next caller that acquires the entry lock sees
+        # entry.task is None and starts a fresh fetch, rather than adopting
+        # a task that has already raised.
+        entry.task = None
+        raise
+
+    if models:
+        entry.models = models
+        entry.expires_at = time.monotonic() + _get_ttl_seconds()
+    else:
+        # Soft failure: the provider answered without raising, but the
+        # answer is not a real one (see class docstring). Never cache it --
+        # leave entry.models as None (still "no answer yet") and clear the
+        # task so the next resolution retries live instead of being stuck
+        # on this non-answer for the full TTL.
+        logger.debug(
+            "Provider '%s' returned an empty model list -- treating as a "
+            "cache miss, not caching",
+            provider_name,
+        )
+        entry.task = None
+
+    return models
+
+
 async def _list_models_cached(provider: Any, provider_name: str) -> Any:
     """Return provider.list_models(), memoized per provider with single-flight.
 
-    Concurrent resolutions against the same provider coalesce into a single
-    upstream call: the first task fetches while the rest await its result.
+    Concurrent resolutions against the same provider coalesce onto a single
+    shared asyncio.Task: the first caller schedules the fetch, every other
+    caller awaits that same Task instead of running its own fetch (or, with
+    provider-level retries, its own full retry campaign). This holds for
+    both success AND failure -- a failure is delivered once to every waiter
+    that piled up during the window.
+
+    A waiter is bounded: if the shared fetch doesn't finish within
+    `_get_wait_timeout_seconds()`, this falls through to a direct, uncached
+    `provider.list_models()` call of its own rather than blocking forever
+    (the shared fetch is shielded and keeps running for whoever is still
+    waiting on it).
+
     Cache entries are keyed by the provider instance (weakly referenced), so
-    they expire naturally with the provider. Failures are never cached --
-    they propagate exactly as an uncached call would.
+    they expire naturally with the provider. Only a non-empty result is
+    ever cached (see `_fetch_and_store`); empty results and raised
+    exceptions both propagate to callers without poisoning the cache.
     """
     try:
         entry = _MODEL_LIST_CACHE.get(provider)
@@ -70,22 +198,47 @@ async def _list_models_cached(provider: Any, provider_name: str) -> Any:
             _MODEL_LIST_CACHE[provider] = entry
         except TypeError:
             return await provider.list_models()
-    # asyncio primitives are bound to their event loop; rotate the lock if
-    # this provider is being driven from a different loop than before.
+    # asyncio primitives are bound to their event loop; rotate the lock (and
+    # drop any task from that other loop, which could never be safely
+    # awaited here) if this provider is being driven from a different loop
+    # than before.
     if entry.lock is None or entry.loop_id != loop_id:
         entry.lock = asyncio.Lock()
         entry.loop_id = loop_id
+        entry.task = None
 
+    # The lock only guards entry/task bookkeeping -- deciding whether a
+    # fetch is already in flight -- never the network call itself. Holding
+    # it across the await would serialize everyone who arrives after the
+    # lock is released but before the fetch finishes into their own
+    # sequential retry campaigns, exactly the head-of-line problem this is
+    # meant to fix.
     async with entry.lock:
         now = time.monotonic()
-        if entry.models is None or entry.expires_at <= now:
-            logger.debug(
-                "Fetching model list from provider '%s' (cache miss/expired)",
-                provider_name,
+        if entry.models is not None and entry.expires_at > now:
+            return entry.models
+        if entry.task is None or entry.task.done():
+            entry.task = asyncio.ensure_future(
+                _fetch_and_store(provider, provider_name, entry)
             )
-            entry.models = await provider.list_models()
-            entry.expires_at = now + LIST_MODELS_CACHE_TTL_SECONDS
-        return entry.models
+        task = entry.task
+
+    wait_timeout = _get_wait_timeout_seconds()
+    try:
+        async with asyncio.timeout(wait_timeout):
+            # Shielded: a timeout here cancels only this caller's wait, not
+            # the shared fetch itself -- other waiters (and a subsequent
+            # cache read) still benefit from it completing in the background.
+            return await asyncio.shield(task)
+    except TimeoutError:
+        logger.warning(
+            "Timed out after %.1fs waiting for an in-flight list_models() "
+            "fetch from provider '%s'; falling through to a direct call",
+            wait_timeout,
+            provider_name,
+        )
+        return await provider.list_models()
+
 
 PROTECTED_CONFIG_KEYS = frozenset(
     {

--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -9,13 +9,83 @@ when spawning sub-sessions. It supports:
 
 from __future__ import annotations
 
+import asyncio
 import fnmatch
 import logging
+import time
+import weakref
 from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# TTL for memoizing provider.list_models() during pattern resolution.
+# Every child/delegate spawn with a glob-pattern model hint resolves the
+# pattern by querying the provider live. Parallel delegate waves (e.g. recipe
+# fan-out) otherwise fire one identical GET /v1/models per spawned session.
+# Model catalogs change rarely, so a short TTL is functionally exact while
+# collapsing a whole wave into a single upstream call.
+LIST_MODELS_CACHE_TTL_SECONDS = 60.0
+
+
+@dataclass
+class _ModelListCacheEntry:
+    """Per-provider memoization state for list_models()."""
+
+    expires_at: float = 0.0
+    models: Any = None
+    lock: asyncio.Lock | None = None
+    loop_id: int = 0
+
+
+_MODEL_LIST_CACHE: weakref.WeakKeyDictionary[Any, _ModelListCacheEntry] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+async def _list_models_cached(provider: Any, provider_name: str) -> Any:
+    """Return provider.list_models(), memoized per provider with single-flight.
+
+    Concurrent resolutions against the same provider coalesce into a single
+    upstream call: the first task fetches while the rest await its result.
+    Cache entries are keyed by the provider instance (weakly referenced), so
+    they expire naturally with the provider. Failures are never cached --
+    they propagate exactly as an uncached call would.
+    """
+    try:
+        entry = _MODEL_LIST_CACHE.get(provider)
+    except TypeError:
+        # Provider not weak-referenceable/unhashable -- pass through uncached.
+        return await provider.list_models()
+
+    now = time.monotonic()
+    if entry is not None and entry.models is not None and entry.expires_at > now:
+        return entry.models
+
+    loop_id = id(asyncio.get_running_loop())
+    if entry is None:
+        entry = _ModelListCacheEntry()
+        try:
+            _MODEL_LIST_CACHE[provider] = entry
+        except TypeError:
+            return await provider.list_models()
+    # asyncio primitives are bound to their event loop; rotate the lock if
+    # this provider is being driven from a different loop than before.
+    if entry.lock is None or entry.loop_id != loop_id:
+        entry.lock = asyncio.Lock()
+        entry.loop_id = loop_id
+
+    async with entry.lock:
+        now = time.monotonic()
+        if entry.models is None or entry.expires_at <= now:
+            logger.debug(
+                "Fetching model list from provider '%s' (cache miss/expired)",
+                provider_name,
+            )
+            entry.models = await provider.list_models()
+            entry.expires_at = now + LIST_MODELS_CACHE_TTL_SECONDS
+        return entry.models
 
 PROTECTED_CONFIG_KEYS = frozenset(
     {
@@ -206,7 +276,7 @@ async def resolve_model_pattern(
         if providers:
             provider = _find_provider_instance(providers, provider_name, coordinator)
             if provider and hasattr(provider, "list_models"):
-                models = await provider.list_models()
+                models = await _list_models_cached(provider, provider_name)
                 # Handle both list of strings and list of model objects
                 available_models = [
                     m if isinstance(m, str) else getattr(m, "id", str(m))

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -1100,3 +1100,236 @@ class TestListModelsSingleFlightMemoization:
         second = await resolve_model_pattern("claude-*", "anthropic", coordinator)
         assert second.resolved_model == "claude-sonnet-4-5"
         assert provider.list_models.await_count == 2
+
+
+class TestListModelsCacheHardening:
+    """Regression tests for the hardening pass on top of #302's single-flight
+    TTL cache (danshapiro): soft-failure non-answers must never poison the
+    cache, a failing fetch must be shared once (not re-run per waiter) and
+    must not persist past its own delivery, and a waiter must not block
+    forever on a hung shared fetch.
+
+    See repro_302.py / repro_302_hol.py for the standalone demonstrations
+    these tests mirror.
+    """
+
+    def _make_coordinator(
+        self, provider: AsyncMock, key: str = "provider-ollama"
+    ) -> MagicMock:
+        coordinator = MagicMock()
+        coordinator.get.return_value = {key: provider}
+        return coordinator
+
+    @pytest.mark.asyncio
+    async def test_empty_list_not_cached_then_refetches_and_later_caches(
+        self,
+    ) -> None:
+        """Mirrors repro_302.py CASE 1 (ollama-style soft failure -> []).
+
+        An empty result must never be cached -- the next call must refetch
+        live -- but once a genuinely non-empty result comes back, THAT one
+        is cached normally (no refetch on the following call).
+        """
+        provider = AsyncMock()
+        provider.list_models = AsyncMock(
+            side_effect=[[], [], ["qwen3.6-35b-a3b", "llama4:70b"]]
+        )
+        coordinator = self._make_coordinator(provider)
+
+        first = await resolve_model_pattern("qwen3.6-*", "ollama", coordinator)
+        assert first.resolved_model is None
+        assert provider.list_models.await_count == 1
+
+        # [] must NOT have been cached -- this call refetches live.
+        second = await resolve_model_pattern("qwen3.6-*", "ollama", coordinator)
+        assert second.resolved_model is None
+        assert provider.list_models.await_count == 2
+
+        # Server "recovers": a genuinely non-empty result comes back.
+        third = await resolve_model_pattern("qwen3.6-*", "ollama", coordinator)
+        assert third.resolved_model == "qwen3.6-35b-a3b"
+        assert provider.list_models.await_count == 3
+
+        # The non-empty result IS cached -- a 4th call must not refetch.
+        fourth = await resolve_model_pattern("qwen3.6-*", "ollama", coordinator)
+        assert fourth.resolved_model == "qwen3.6-35b-a3b"
+        assert provider.list_models.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_degraded_single_model_list_bounded_by_ttl(self) -> None:
+        """Mirrors repro_302.py CASE 2 (chat-completions degraded fallback).
+
+        A degraded single-model fallback list (e.g. chat-completions
+        returning `[configured_model]` on ANY exception) is NON-empty, so
+        it is indistinguishable at this generic, provider-agnostic cache
+        layer from a legitimately single-model catalog -- and
+        `test_sequential_resolutions_reuse_within_ttl` above requires a
+        genuine single-model result to be cached, so this layer cannot
+        special-case "list of length 1" without breaking that contract.
+
+        What the hardening DOES guarantee: the poisoning window is bounded
+        by the (now-configurable, see TestListModelsConfigurableKnobs) TTL
+        instead of being permanent -- once the TTL expires, a subsequent
+        real catalog fetch replaces the degraded entry rather than being
+        stuck behind it indefinitely.
+        """
+        provider = AsyncMock()
+        provider.list_models = AsyncMock(
+            side_effect=[
+                ["local-default"],  # degraded fallback while "down"
+                ["qwen3.6-35b-a3b", "qwen3.6-8b", "local-default"],  # recovered
+            ]
+        )
+        coordinator = self._make_coordinator(provider)
+
+        import amplifier_foundation.spawn_utils as su
+
+        original_ttl = su.LIST_MODELS_CACHE_TTL_SECONDS
+        su.LIST_MODELS_CACHE_TTL_SECONDS = 0.05
+        try:
+            degraded = await resolve_model_pattern("qwen3.6-*", "ollama", coordinator)
+            # The degraded list is non-empty, so it is cached like any other
+            # answer -- pattern doesn't match it, so resolution fails, but
+            # this is a real answer as far as the cache can tell.
+            assert degraded.resolved_model is None
+            assert provider.list_models.await_count == 1
+
+            await asyncio.sleep(0.1)  # TTL expires
+
+            recovered = await resolve_model_pattern("qwen3.6-*", "ollama", coordinator)
+        finally:
+            su.LIST_MODELS_CACHE_TTL_SECONDS = original_ttl
+
+        # Once the (bounded, configurable) TTL has passed, the degraded
+        # entry is gone and a fresh, real catalog is fetched and resolved
+        # correctly -- not permanently poisoned.
+        assert provider.list_models.await_count == 2
+        # Two matches ("qwen3.6-35b-a3b", "qwen3.6-8b"); descending sort picks
+        # "qwen3.6-8b" ("8" > "3" at the first differing character).
+        assert recovered.resolved_model == "qwen3.6-8b"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_failure_shared_once_then_fresh_fetch(self) -> None:
+        """A failing fetch is shared once across every concurrent waiter --
+        not re-run as a full retry campaign per waiter -- and does not
+        persist past its own delivery: the next NEW caller after the wave
+        settles gets a genuinely fresh fetch.
+        """
+        provider = AsyncMock()
+        started = asyncio.Event()
+
+        async def flaky_list_models() -> list[str]:
+            started.set()
+            await asyncio.sleep(0.05)
+            raise RuntimeError("boom")
+
+        provider.list_models = AsyncMock(side_effect=flaky_list_models)
+        coordinator = self._make_coordinator(provider, key="provider-anthropic")
+
+        results = await asyncio.gather(
+            *(
+                resolve_model_pattern("claude-*", "anthropic", coordinator)
+                for _ in range(20)
+            )
+        )
+
+        # The failure was delivered to every one of the 20 waiters...
+        assert all(r.resolved_model is None for r in results)
+        # ...but the provider was only actually called once for the whole
+        # wave (not once per waiter re-running its own retry campaign).
+        assert provider.list_models.await_count == 1
+
+        # The next NEW caller, after the failed wave has settled, starts a
+        # genuinely fresh fetch rather than adopting the dead failed task.
+        provider.list_models = AsyncMock(return_value=["claude-sonnet-4-5"])
+        result = await resolve_model_pattern("claude-*", "anthropic", coordinator)
+        assert result.resolved_model == "claude-sonnet-4-5"
+        assert provider.list_models.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_waiter_timeout_falls_through_to_direct_call(self) -> None:
+        """A caller must not block forever on someone else's in-flight
+        fetch -- past the configured wait timeout it falls through to a
+        direct, uncached provider.list_models() call of its own.
+        """
+        provider = AsyncMock()
+        release = asyncio.Event()
+        calls = 0
+
+        async def hangs_then_direct_succeeds() -> list[str]:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                # The shared fetch: held open past the wait timeout.
+                await release.wait()
+                return ["claude-sonnet-4-5"]
+            # This caller's own direct fallback call, once it gives up
+            # waiting on the (still-hanging) shared fetch.
+            return ["claude-haiku-4-5"]
+
+        provider.list_models = AsyncMock(side_effect=hangs_then_direct_succeeds)
+        coordinator = self._make_coordinator(provider, key="provider-anthropic")
+
+        import amplifier_foundation.spawn_utils as su
+
+        original_timeout = su.LIST_MODELS_WAIT_TIMEOUT_SECONDS
+        su.LIST_MODELS_WAIT_TIMEOUT_SECONDS = 0.05
+        try:
+            result = await resolve_model_pattern("claude-*", "anthropic", coordinator)
+        finally:
+            su.LIST_MODELS_WAIT_TIMEOUT_SECONDS = original_timeout
+            release.set()
+            # Let the still-in-flight shared fetch drain cleanly instead of
+            # leaving a pending task for the loop to warn about at teardown.
+            entry = su._MODEL_LIST_CACHE.get(provider)
+            if entry is not None and entry.task is not None:
+                await asyncio.wait_for(entry.task, timeout=1)
+
+        assert result.resolved_model == "claude-haiku-4-5"
+        assert calls == 2
+
+
+class TestListModelsConfigurableKnobs:
+    """Regression tests for making the TTL and wait-timeout configurable via
+    environment variables while preserving the existing module-global
+    monkey-patch surface (`su.LIST_MODELS_CACHE_TTL_SECONDS = ...` etc.).
+    """
+
+    def test_ttl_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import amplifier_foundation.spawn_utils as su
+
+        monkeypatch.delenv("AMPLIFIER_LIST_MODELS_CACHE_TTL_SECONDS", raising=False)
+        assert su._get_ttl_seconds() == su.LIST_MODELS_CACHE_TTL_SECONDS
+
+        monkeypatch.setenv("AMPLIFIER_LIST_MODELS_CACHE_TTL_SECONDS", "5")
+        assert su._get_ttl_seconds() == 5.0
+
+    def test_ttl_module_global_still_monkeypatchable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import amplifier_foundation.spawn_utils as su
+
+        monkeypatch.delenv("AMPLIFIER_LIST_MODELS_CACHE_TTL_SECONDS", raising=False)
+        original = su.LIST_MODELS_CACHE_TTL_SECONDS
+        try:
+            su.LIST_MODELS_CACHE_TTL_SECONDS = 123.0
+            assert su._get_ttl_seconds() == 123.0
+        finally:
+            su.LIST_MODELS_CACHE_TTL_SECONDS = original
+
+    def test_wait_timeout_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import amplifier_foundation.spawn_utils as su
+
+        monkeypatch.delenv("AMPLIFIER_LIST_MODELS_WAIT_TIMEOUT_SECONDS", raising=False)
+        assert su._get_wait_timeout_seconds() == su.LIST_MODELS_WAIT_TIMEOUT_SECONDS
+
+        monkeypatch.setenv("AMPLIFIER_LIST_MODELS_WAIT_TIMEOUT_SECONDS", "2.5")
+        assert su._get_wait_timeout_seconds() == 2.5
+
+    def test_invalid_env_value_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import amplifier_foundation.spawn_utils as su
+
+        monkeypatch.setenv("AMPLIFIER_LIST_MODELS_CACHE_TTL_SECONDS", "not-a-number")
+        assert su._get_ttl_seconds() == su.LIST_MODELS_CACHE_TTL_SECONDS

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from unittest.mock import AsyncMock
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -988,3 +989,114 @@ class TestProviderPreferenceConfigWiring:
         assert result_config["temperature"] == 0.3
         # Existing protected key untouched
         assert result_config["api_key"] == "sk-test"
+
+
+class TestListModelsSingleFlightMemoization:
+    """Regression tests: concurrent glob-pattern resolutions must coalesce
+    provider.list_models() into a single upstream call (per provider, per TTL
+    window) instead of firing one GET /v1/models per spawned child session.
+    """
+
+    def _make_coordinator(self, provider: AsyncMock) -> MagicMock:
+        coordinator = MagicMock()
+        coordinator.get.return_value = {"provider-anthropic": provider}
+        return coordinator
+
+    @pytest.mark.asyncio
+    async def test_concurrent_resolutions_fetch_once(self) -> None:
+        """50 parallel spawns resolving the same pattern = 1 upstream call."""
+        provider = AsyncMock()
+        provider.list_models = AsyncMock(
+            return_value=["claude-sonnet-4-5", "claude-haiku-4-5"]
+        )
+        coordinator = self._make_coordinator(provider)
+
+        results = await asyncio.gather(
+            *(
+                resolve_model_pattern("claude-haiku-*", "anthropic", coordinator)
+                for _ in range(50)
+            )
+        )
+
+        assert provider.list_models.await_count == 1
+        assert all(r.resolved_model == "claude-haiku-4-5" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_sequential_resolutions_reuse_within_ttl(self) -> None:
+        provider = AsyncMock()
+        provider.list_models = AsyncMock(return_value=["claude-sonnet-4-5"])
+        coordinator = self._make_coordinator(provider)
+
+        for _ in range(5):
+            result = await resolve_model_pattern(
+                "claude-sonnet-*", "anthropic", coordinator
+            )
+            assert result.resolved_model == "claude-sonnet-4-5"
+
+        assert provider.list_models.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_refresh_after_ttl_expiry(self) -> None:
+        provider = AsyncMock()
+        provider.list_models = AsyncMock(return_value=["claude-sonnet-4-5"])
+        coordinator = self._make_coordinator(provider)
+
+        import amplifier_foundation.spawn_utils as su
+
+        original_ttl = su.LIST_MODELS_CACHE_TTL_SECONDS
+        su.LIST_MODELS_CACHE_TTL_SECONDS = 0.05
+        try:
+            await resolve_model_pattern("claude-*", "anthropic", coordinator)
+            await asyncio.sleep(0.1)
+            await resolve_model_pattern("claude-*", "anthropic", coordinator)
+        finally:
+            su.LIST_MODELS_CACHE_TTL_SECONDS = original_ttl
+
+        assert provider.list_models.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_exact_name_never_fetches(self) -> None:
+        provider = AsyncMock()
+        coordinator = self._make_coordinator(provider)
+
+        result = await resolve_model_pattern(
+            "claude-sonnet-4-5", "anthropic", coordinator
+        )
+
+        assert result.resolved_model == "claude-sonnet-4-5"
+        provider.list_models.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_providers_cached_independently(self) -> None:
+        provider_a = AsyncMock()
+        provider_a.list_models = AsyncMock(return_value=["m-a"])
+        coordinator_a = MagicMock()
+        coordinator_a.get.return_value = {"provider-anthropic": provider_a}
+
+        provider_b = AsyncMock()
+        provider_b.list_models = AsyncMock(return_value=["m-b"])
+        coordinator_b = MagicMock()
+        coordinator_b.get.return_value = {"provider-anthropic": provider_b}
+
+        await asyncio.gather(
+            resolve_model_pattern("m-*", "anthropic", coordinator_a),
+            resolve_model_pattern("m-*", "anthropic", coordinator_b),
+        )
+
+        assert provider_a.list_models.await_count == 1
+        assert provider_b.list_models.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_failures_are_not_cached(self) -> None:
+        provider = AsyncMock()
+        provider.list_models = AsyncMock(
+            side_effect=[RuntimeError("boom"), ["claude-sonnet-4-5"]]
+        )
+        coordinator = self._make_coordinator(provider)
+
+        first = await resolve_model_pattern("claude-*", "anthropic", coordinator)
+        assert first.resolved_model is None
+
+        second = await resolve_model_pattern("claude-*", "anthropic", coordinator)
+        assert second.resolved_model == "claude-sonnet-4-5"
+        assert provider.list_models.await_count == 2


### PR DESCRIPTION
## Summary

Fixes https://github.com/microsoft/amplifier/issues/369

Every child/delegate spawn with a glob-pattern model hint resolved the pattern by calling `provider.list_models()` live — and `resolve_model_pattern` runs once per spawn. Parallel delegate waves therefore fired one identical `GET /v1/models` per spawned session (observed: ~80 concurrent calls per wave, ~16k/day in a multi-agent setup), adding a full network round trip to every spawn and pressuring shared egress connection tables.

## Change

Memoize the fetched model list per provider instance in `spawn_utils`:

- **TTL** of 60s (`LIST_MODELS_CACHE_TTL_SECONDS`) — model catalogs change rarely, so a short window is functionally exact while collapsing a whole wave into a single upstream call.
- **Single-flight**: concurrent resolutions against the same provider coalesce behind one async lock — the first task fetches, the rest await its result. N parallel spawns = 1 upstream call.
- Cache keyed by provider instance via weak references, so entries die with the provider; lock is rotated if the provider is driven from a different event loop.
- **Failures are never cached** — errors propagate exactly as an uncached call would.
- Non-pattern hints still short-circuit before any query, unchanged.

## Tests

6 new regression tests in `tests/test_spawn_utils.py` (`TestListModelsSingleFlightMemoization`):

- 50 concurrent resolutions → exactly 1 upstream fetch
- sequential resolutions reuse the cache within the TTL
- refetch after TTL expiry
- exact (non-glob) model names never fetch
- independent provider instances cached independently
- a failing fetch is not cached; the next resolution retries

Full suite: 1533 passed (`uv run pytest tests/ -q`, excluding the gRPC integration file).

## Notes

- No behavior change to resolution results, ordering, or failure semantics — only fetch frequency and concurrency.
- Providers could separately add their own `list_models()` caching, but that cannot coalesce a parallel wave the way this shared-resolution point does.
