### PR TITLE
fix(registry): resolve relative includes against the declaring bundle's base_path

### DIFF
--- a/amplifier_foundation/registry.py
+++ b/amplifier_foundation/registry.py
@@ -43,6 +43,35 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _anchor_relative_include_source(source: str, base_path: Path | None) -> str:
+    """Anchor a literal relative include ('./x' or '../x') to base_path.
+
+    Mirrors ``_resolve_relative_source`` in ``bundle/_dataclass.py`` (commit
+    b667815), which anchored relative ``session``/``providers``/``tools``/
+    ``hooks`` ``source:`` fields to the DECLARING bundle's own ``base_path``
+    instead of the app's. This is the same fix applied to ``includes:``: a
+    bundle's relative include path must resolve against ITS OWN base_path,
+    not the process cwd (a single ``Path.cwd()`` snapshot taken once at
+    ``BundleRegistry.__init__``) and not some unrelated bundle's base_path.
+
+    Only literal "./" and "../" sources are rewritten to an absolute path
+    here -- before the source reaches ``_load_single`` / the source
+    resolver's cwd-based fallback -- so caching and cycle-detection (both
+    keyed on the URI string) stay unambiguous even when two different
+    bundles happen to declare the same relative include text.
+
+    Namespace refs (already turned into file:// / git+... by
+    ``_resolve_include_source``), absolute paths, and other URIs are
+    returned untouched. If base_path is None (the bundle has no known file
+    location -- e.g. loaded from raw text or a URL without a resolved local
+    path), the source is returned untouched and falls back to the source
+    resolver's own default (process cwd) behavior.
+    """
+    if base_path and (source.startswith("./") or source.startswith("../")):
+        return str((base_path / source).resolve())
+    return source
+
+
 # ANSI color codes for terminal output
 class _Colors:
     YELLOW = "\033[93m"
@@ -726,20 +755,33 @@ class BundleRegistry:
                         if self._strict:
                             raise BundleDependencyError(
                                 f"Include resolution failed (strict mode): '{include_source}' "
+                                f"(included by {self._describe_including_bundle(bundle)}) "
                                 f"could not be resolved (unregistered namespace)"
                             )
                         logger.warning(
-                            f"Include skipped (unregistered namespace): {include_source}"
+                            f"Include skipped (unregistered namespace): {include_source} "
+                            f"(included by {self._describe_including_bundle(bundle)})"
                         )
                         continue
+                    # Anchor literal relative includes ('./x', '../x') to the
+                    # DECLARING bundle's own base_path -- not the registry's
+                    # process-cwd snapshot, and not some other bundle's
+                    # base_path. See _anchor_relative_include_source() above.
+                    resolved_source = _anchor_relative_include_source(
+                        resolved_source, bundle.base_path
+                    )
                     include_sources.append(resolved_source)
                 except BundleNotFoundError:
                     if self._strict:
                         raise BundleDependencyError(
-                            f"Include not found (strict mode): '{include_source}'"
+                            f"Include not found (strict mode): '{include_source}' "
+                            f"(included by {self._describe_including_bundle(bundle)})"
                         ) from None
                     # Includes are opportunistic - but warn so users know
-                    logger.warning(f"Include not found (skipping): {include_source}")
+                    logger.warning(
+                        f"Include not found (skipping): {include_source} "
+                        f"(included by {self._describe_including_bundle(bundle)})"
+                    )
 
         if not include_sources:
             return bundle
@@ -774,6 +816,7 @@ class BundleRegistry:
                     source_name = self._extract_bundle_name(source)
                     lines = [
                         f"Bundle: {source_name}",
+                        f"Included by: {self._describe_including_bundle(bundle)}",
                         "",
                         str(result),  # The actual error message
                     ]
@@ -1160,6 +1203,19 @@ class BundleRegistry:
             return uri.split("/")[-1].split("#")[0]
         # Fallback: last path component
         return uri.split("/")[-1].split("@")[0].split("#")[0]
+
+    def _describe_including_bundle(self, bundle: Bundle) -> str:
+        """Describe the bundle whose ``includes:`` are being processed.
+
+        Used in include-failure warnings/errors so the message names both
+        the declaring bundle and the base_path relative includes were
+        resolved against -- the two pieces of information needed to
+        actually debug a failed include, instead of only naming the
+        (possibly relative, now-ambiguous) missing target.
+        """
+        name = bundle.name or "<unnamed bundle>"
+        base_path = bundle.base_path if bundle.base_path else "<no base_path>"
+        return f"{name} @ {base_path}"
 
     # =========================================================================
     # Update Methods

--- a/tests/test_include_relative_to_declaring_bundle.py
+++ b/tests/test_include_relative_to_declaring_bundle.py
@@ -1,0 +1,311 @@
+"""Relative bundle `includes:` must resolve against the DECLARING bundle.
+
+Regression oracle for: BundleRegistry resolved relative includes
+(``includes: - bundle: ./base.md``) against a single ``Path.cwd()``
+snapshot taken once at registry-construction time (the CLI process's
+invocation directory), instead of against the INCLUDING bundle file's own
+directory.
+
+Confirmed repro (see registry.py:_source_resolver construction and
+sources/file.py:FileSourceHandler.resolve):
+
+    $ cd <repo>/bundles && load child.md   -> works (cwd happens to match)
+    $ cd /tmp/anywhere  && load child.md   -> "Include Failed (skipping):
+                                              File not found: /tmp/anywhere/base.md"
+                                              composed bundle is EMPTY
+
+The failure does not raise. It produces a bundle that "loads successfully"
+but is empty, which detonates much later and elsewhere as an unrelated
+``ValueError: Configuration must specify session.orchestrator``.
+
+Fix: anchor literal relative include sources ("./x", "../x") to the
+DECLARING bundle's own ``base_path`` (registry.py:
+``_anchor_relative_include_source`` / ``_compose_includes``) before they
+reach ``_load_single``. Mirrors the sibling fix in ``bundle/_dataclass.py``
+(commit b667815), which anchored relative ``session``/``providers``/
+``tools``/``hooks`` ``source:`` fields to the declaring bundle's
+``base_path`` instead of the app's.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+from amplifier_foundation.registry import (
+    BundleRegistry,
+    _anchor_relative_include_source,
+)
+
+
+def _write_child_and_base(bundles_dir: Path) -> tuple[Path, Path]:
+    """Create bundles_dir/child.md (includes ./base.md) and bundles_dir/base.md."""
+    bundles_dir.mkdir(parents=True, exist_ok=True)
+
+    child = bundles_dir / "child.md"
+    child.write_text(
+        "---\nbundle:\n  name: child\nincludes:\n  - bundle: ./base.md\n---\n# Child\n",
+        encoding="utf-8",
+    )
+
+    base_file = bundles_dir / "base.md"
+    base_file.write_text(
+        "---\n"
+        "bundle:\n"
+        "  name: base\n"
+        "session:\n"
+        "  orchestrator: loop-basic\n"
+        "tools:\n"
+        "  - module: tool-example\n"
+        "hooks:\n"
+        "  - module: hook-example\n"
+        "---\n"
+        "# Base\n",
+        encoding="utf-8",
+    )
+    return child, base_file
+
+
+class TestIncludeResolvesAgainstDeclaringBundle:
+    """BundleRegistry._compose_includes anchors relative includes correctly."""
+
+    @pytest.mark.asyncio
+    async def test_include_resolves_when_cwd_matches_bundle_dir(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard existing behavior: cwd == bundle's own directory still works."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir).resolve()
+            bundles_dir = base / "bundles"
+            child, _base_file = _write_child_and_base(bundles_dir)
+
+            monkeypatch.chdir(bundles_dir)
+            registry = BundleRegistry(home=base / "home")
+
+            bundle = await registry._load_single(f"file://{child}")
+
+            assert bundle.name == "child"
+            assert bundle.session.get("orchestrator") == "loop-basic"
+            assert any(t.get("module") == "tool-example" for t in bundle.tools)
+            assert any(h.get("module") == "hook-example" for h in bundle.hooks)
+
+    @pytest.mark.asyncio
+    async def test_include_resolves_when_cwd_is_unrelated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """THE BUG: cwd elsewhere at registry-construction time must not matter.
+
+        Before the fix, the include ('./base.md') was resolved against the
+        registry's Path.cwd() snapshot (captured once in __init__), not
+        against child.md's own directory -- so this raised "File not found"
+        and the composed bundle silently ended up with an empty session/
+        tools/hooks instead of failing loudly.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir).resolve()
+            bundles_dir = base / "bundles"
+            child, _base_file = _write_child_and_base(bundles_dir)
+
+            unrelated_cwd = base / "somewhere" / "else"
+            unrelated_cwd.mkdir(parents=True)
+            monkeypatch.chdir(unrelated_cwd)
+
+            registry = BundleRegistry(home=base / "home")
+
+            bundle = await registry._load_single(f"file://{child}")
+
+            assert bundle.name == "child"
+            assert bundle.session.get("orchestrator") == "loop-basic", (
+                "base.md's session was not composed in -- include failed to "
+                "resolve relative to the declaring bundle's own directory"
+            )
+            assert any(t.get("module") == "tool-example" for t in bundle.tools)
+            assert any(h.get("module") == "hook-example" for h in bundle.hooks)
+
+    @pytest.mark.asyncio
+    async def test_nested_includes_each_anchor_to_their_own_directory(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """C includes B includes A, each in a different directory.
+
+        Loaded from a FOURTH, unrelated directory. Each bundle's relative
+        include must resolve against its OWN directory, independent of the
+        others and independent of cwd.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir).resolve()
+
+            dir_a = base / "dir-a"
+            dir_a.mkdir()
+            (dir_a / "a.md").write_text(
+                "---\n"
+                "bundle:\n"
+                "  name: bundle-a\n"
+                "tools:\n"
+                "  - module: tool-a\n"
+                "---\n"
+                "# A\n",
+                encoding="utf-8",
+            )
+
+            # b.md includes a.md via a RELATIVE sibling-directory path -- this
+            # must resolve against dir_b (b's own directory), not dir_c, not
+            # the fourth_dir cwd, and not dir_a directly.
+            dir_b = base / "dir-b"
+            dir_b.mkdir()
+            (dir_b / "b.md").write_text(
+                "---\n"
+                "bundle:\n"
+                "  name: bundle-b\n"
+                "includes:\n"
+                "  - bundle: ../dir-a/a.md\n"
+                "tools:\n"
+                "  - module: tool-b\n"
+                "---\n"
+                "# B\n",
+                encoding="utf-8",
+            )
+
+            # c.md includes b.md via a RELATIVE sibling-directory path -- this
+            # must resolve against dir_c (c's own directory).
+            dir_c = base / "dir-c"
+            dir_c.mkdir()
+            (dir_c / "c.md").write_text(
+                "---\n"
+                "bundle:\n"
+                "  name: bundle-c\n"
+                "includes:\n"
+                "  - bundle: ../dir-b/b.md\n"
+                "tools:\n"
+                "  - module: tool-c\n"
+                "---\n"
+                "# C\n",
+                encoding="utf-8",
+            )
+
+            fourth_dir = base / "fourth"
+            fourth_dir.mkdir()
+            monkeypatch.chdir(fourth_dir)
+
+            registry = BundleRegistry(home=base / "home")
+            bundle = await registry._load_single(f"file://{dir_c}/c.md")
+
+            assert bundle.name == "bundle-c"
+            module_names = {t.get("module") for t in bundle.tools}
+            assert module_names == {"tool-a", "tool-b", "tool-c"}, module_names
+
+    @pytest.mark.asyncio
+    async def test_dotdot_include_resolves_against_declaring_bundle(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """'../' includes work: bundle in bundles/ includes ../shared/x.md."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir).resolve()
+
+            shared_dir = base / "shared"
+            shared_dir.mkdir()
+            (shared_dir / "x.md").write_text(
+                "---\n"
+                "bundle:\n"
+                "  name: shared-x\n"
+                "tools:\n"
+                "  - module: tool-shared\n"
+                "---\n"
+                "# Shared\n",
+                encoding="utf-8",
+            )
+
+            bundles_dir = base / "bundles"
+            bundles_dir.mkdir()
+            (bundles_dir / "main.md").write_text(
+                "---\n"
+                "bundle:\n"
+                "  name: main\n"
+                "includes:\n"
+                "  - bundle: ../shared/x.md\n"
+                "---\n"
+                "# Main\n",
+                encoding="utf-8",
+            )
+
+            unrelated_cwd = base / "unrelated"
+            unrelated_cwd.mkdir()
+            monkeypatch.chdir(unrelated_cwd)
+
+            registry = BundleRegistry(home=base / "home")
+            bundle = await registry._load_single(f"file://{bundles_dir}/main.md")
+
+            assert bundle.name == "main"
+            assert any(t.get("module") == "tool-shared" for t in bundle.tools)
+
+    @pytest.mark.asyncio
+    async def test_missing_include_message_names_bundle_and_base_path(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A genuinely missing include still fails (non-strict: warns, doesn't raise).
+
+        The warning must name the INCLUDING bundle and the base_path used
+        for resolution -- not just the missing target -- so the failure is
+        actionable instead of a bare 'File not found: <path>'.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir).resolve()
+            bundles_dir = base / "bundles"
+            bundles_dir.mkdir()
+            (bundles_dir / "child.md").write_text(
+                "---\n"
+                "bundle:\n"
+                "  name: child\n"
+                "includes:\n"
+                "  - bundle: ./does-not-exist.md\n"
+                "---\n"
+                "# Child\n",
+                encoding="utf-8",
+            )
+
+            monkeypatch.chdir(bundles_dir)
+            registry = BundleRegistry(home=base / "home")
+
+            with caplog.at_level(logging.WARNING):
+                bundle = await registry._load_single(f"file://{bundles_dir}/child.md")
+
+            # Non-strict mode: doesn't raise, but doesn't silently succeed either.
+            assert bundle.name == "child"
+            assert not bundle.session
+            assert not bundle.tools
+
+            warning_text = "\n".join(caplog.messages)
+            assert "child" in warning_text, warning_text
+            assert str(bundles_dir) in warning_text, warning_text
+
+
+class TestNonRelativeIncludesUnaffected:
+    """Namespace refs, git+, and file:// includes must never be rewritten."""
+
+    def test_git_uri_untouched(self) -> None:
+        source = "git+https://github.com/microsoft/x@main"
+        assert _anchor_relative_include_source(source, Path("/some/base")) == source
+
+    def test_absolute_file_uri_untouched(self) -> None:
+        source = "file:///abs/path/to/bundle.yaml"
+        assert _anchor_relative_include_source(source, Path("/some/base")) == source
+
+    def test_namespace_ref_untouched(self) -> None:
+        source = "foundation:behaviors/logging"
+        assert _anchor_relative_include_source(source, Path("/some/base")) == source
+
+    def test_no_base_path_falls_back_untouched(self) -> None:
+        """When the declaring bundle has no base_path, leave source as-is."""
+        source = "./base.md"
+        assert _anchor_relative_include_source(source, None) == source
+
+    def test_relative_source_is_anchored(self) -> None:
+        base_path = Path("/some/base")
+        assert _anchor_relative_include_source("./base.md", base_path) == str(
+            (base_path / "./base.md").resolve()
+        )
+        assert _anchor_relative_include_source("../shared/x.md", base_path) == str(
+            (base_path / "../shared/x.md").resolve()
+        )


### PR DESCRIPTION
### Problem
`BundleRegistry` resolves relative bundle includes (`includes: - bundle: ./base.md`) against `Path.cwd()` captured **once** at registry-construction time — the CLI process's invocation directory — instead of against the including bundle file's own directory.

- `registry.py:193-195` — `SimpleSourceResolver(..., base_path=Path.cwd())`, captured once, never re-derived per bundle
- `sources/file.py:43-44` — any `./`/`../` source resolves against that single `base_path`
- `_compose_includes` never consulted the declaring bundle's `base_path`, which the registry already tracks via `bundle.base_path` (set in `_load_from_path`) and already uses for namespace resolution

Reproduced with a bundle at `<repo>/bundles/child.md` including `./base.md`:
```
cd <repo>/bundles && load child.md  -> session populated, 13 tools / 15 hooks / 11 agents
cd /tmp/anywhere  && load child.md  -> "Include Failed (skipping): File not found: /tmp/anywhere/base.md"
                                        session {}, 0 tools / 0 hooks / 0 agents
```
The second case **does not raise**. It yields a bundle that "loads successfully" but is empty, detonating much later and elsewhere as `ValueError: Configuration must specify session.orchestrator` — an error naming nothing related to the cause. This cost a real debugging session to track down.

### What this does
Anchors relative include sources to the declaring bundle's `base_path`, following the precedent set by `b667815` (PR #279), which fixed the identical class of bug for `session`/`providers`/`tools`/`hooks` `source:` fields.

New `_anchor_relative_include_source(source, base_path)` mirrors `_resolve_relative_source`'s semantics exactly: only literal `./`/`../` strings are rewritten to an absolute path; URIs, `git+`, `file://`, and already-resolved namespace refs pass through untouched; `base_path=None` falls back to current behavior.

**Design note — why this is in `registry.py` and not `sources/file.py`.** Threading a per-call `base_path` override down into `SimpleSourceResolver.resolve()` / `FileSourceHandler.resolve()` was considered and rejected for two reasons:
1. **Concurrency.** `_compose_includes` Phase 2 loads includes in parallel via `asyncio.gather`, and nested composition can run concurrently for sibling chains with different declaring bundles. A mutate-then-restore override on the shared handler would be a genuine race.
2. **Cache-key ambiguity.** `_load_single` caches bundles and detects cycles keyed on the literal URI string. If two bundles in different directories both declare `./base.md` and resolution became context-dependent, the same cache key would ambiguously refer to two different files — a latent bug the global-cwd design never had (it was globally consistent, if globally wrong).

Resolving to an absolute path **before** the value reaches `_load_single` avoids both: the cache/cycle key becomes the fully-resolved absolute path, unambiguous regardless of declaring bundle or concurrency. Smaller change, confined to one file.

### Diagnosability
All include warn/raise sites now name the including bundle and the base_path used, via a new `_describe_including_bundle()`:
```
Include not found (skipping): ./base.md (included by child @ /tmp/.../bundles)
```

### Open question for reviewers — deliberately NOT implemented
Strict mode already raises `BundleDependencyError`; non-strict (the CLI default) warns. This PR does not change that. But a failed include silently producing an empty bundle is precisely what made this hard to diagnose. A bounded improvement — raise if the **root** bundle ends up with an empty `session` after all includes are processed, regardless of strict mode — would close the gap without making every include failure fatal. That is a semantics decision, so it is flagged here rather than bundled in.

### Testing
1549 -> 1559 passing, zero regressions. 10 new tests in `tests/test_include_relative_to_declaring_bundle.py`: cwd matching the bundle dir (guards existing behavior), cwd unrelated (the bug), nested C->B->A across four directories, `../` includes, missing-include message content, and five cases proving `git+`/`file://`/namespace/no-base_path sources are untouched.

The bug was verified to reproduce without the fix: stashing `registry.py` yields `session {}`, `tools []`, and the "Include Failed (skipping)" warning.

Lint/type: pyright identical to baseline. One new `PIE810` ruff warning at the new helper — the exact same pattern that `b667815`'s `_resolve_relative_source` already triggers on `origin/main`; mirrored the precedent's style rather than diverging.

### Related
Sibling fix for module `source:` fields: #279.