### PR TITLE
fix(paths): recognize Windows absolute paths (drive-letter/UNC) in parse_uri

### DIFF
--- a/amplifier_foundation/paths/resolution.py
+++ b/amplifier_foundation/paths/resolution.py
@@ -105,6 +105,8 @@ def parse_uri(uri: str) -> ParsedURI:
     - zip+file:///local/archive.zip#subdirectory=path/inside
     - file:///path/to/file
     - /absolute/path
+    - C:\absolute\path or C:/absolute/path (Windows)
+    - \\server\share\path (Windows UNC)
     - ./relative/path
     - package-name
     - package/subpath
@@ -134,6 +136,13 @@ def parse_uri(uri: str) -> ParsedURI:
 
     # Handle relative paths
     if uri.startswith("./") or uri.startswith("../"):
+        return ParsedURI(scheme="file", host="", path=uri, ref="", subpath="")
+
+    # Handle Windows absolute paths (drive-letter or UNC)
+    is_drive_path = (
+        len(uri) >= 3 and uri[0].isalpha() and uri[1] == ":" and uri[2] in "/\\"
+    )
+    if is_drive_path or uri.startswith("\\\\"):
         return ParsedURI(scheme="file", host="", path=uri, ref="", subpath="")
 
     # Handle http/https URLs

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -135,6 +135,34 @@ class TestParseUri:
         assert result.scheme == "file"
         assert result.path == "./bundles/my-bundle"
 
+    def test_windows_drive_letter_path(self) -> None:
+        """Parses Windows drive-letter paths as file URIs."""
+        result = parse_uri("C:/Users/test/bundle")
+        assert result.scheme == "file"
+        assert result.path == "C:/Users/test/bundle"
+        assert result.is_file
+
+    def test_windows_drive_letter_backslash_path(self) -> None:
+        """Parses Windows backslash drive-letter paths as file URIs."""
+        result = parse_uri(r"C:\Users\test\bundle")
+        assert result.scheme == "file"
+        assert result.path == r"C:\Users\test\bundle"
+        assert result.is_file
+
+    def test_windows_unc_path(self) -> None:
+        """Parses Windows UNC paths as file URIs."""
+        result = parse_uri(r"\\server\share\bundle")
+        assert result.scheme == "file"
+        assert result.path == r"\\server\share\bundle"
+        assert result.is_file
+
+    def test_windows_file_uri_with_drive_letter(self) -> None:
+        """Parses file:// URIs containing a drive letter."""
+        result = parse_uri("file://C:/Users/test/bundle")
+        assert result.scheme == "file"
+        assert result.path == "C:/Users/test/bundle"
+        assert result.is_file
+
 
 class TestNormalizePath:
     """Tests for normalize_path function."""


### PR DESCRIPTION
## Problem

On native Windows, `parse_uri` classified only `file://` URLs, POSIX absolute paths (`/...`), and `./` / `../` relative paths as file URIs. Windows absolute paths (`C:\...`, `C:/...`) and UNC paths (`\\server\share\...`) fell through to the package-name heuristic, so no source handler claimed them:

```
BundleNotFoundError: No handler for URI: C:\Users\dan\.amplifier\cache\amplifier-bundle-filesystem-...\modules\tool-apply-patch
```

Two real-world impacts (reproduced on Windows 11, native PowerShell, amplifier 2026.08.14):

1. **Local bundle/behavior references in `settings.yaml`** (e.g. `bundle.app: [C:/Users/dan/code/bundle-the-usual/behaviors/the-usual.yaml]`) fail to compose: `Failed to compose behavior ...`.
2. **Relative module entries inside cached git bundles** are resolved by the app to absolute OS path strings before hitting the resolver; on Windows every such module fails activation and **strict mode aborts session startup** ("Module Activation Failed", suggesting `AMPLIFIER_ALLOW_PARTIAL_BUNDLE=1`).

## Fix

In `parse_uri`, recognize drive-letter (``<letter>:` followed by `\` or `/`) and UNC (`\\`) prefixes as `scheme="file"`, before the package-name fallback. Unconditional (not `os.name`-gated): on POSIX these inputs were previously misclassified as package names too — the file handler now at least reports an accurate `File not found`.

## Tests

Added 4 tests to `tests/test_paths.py` (drive-letter forward/backslash, UNC, `file://C:/...`). Local run: **56 passed**; the 5 failing `TestNormalizePath` tests fail identically on unmodified main (pre-existing POSIX-only assertions on a Windows test box, unrelated to this change). `ruff check` and `ruff format --check` clean.

Fixes https://github.com/microsoft/amplifier/issues/374
