### PR TITLE
fix: force UTF-8 in subprocess-mode child env (Windows encoding mismatch)

### DIFF
--- a/amplifier_foundation/subprocess_runner.py
+++ b/amplifier_foundation/subprocess_runner.py
@@ -168,17 +168,22 @@ def _build_child_env() -> dict[str, str]:
         if key in _ENV_ALLOWED_EXACT
         or any(key.startswith(prefix) for prefix in _ENV_ALLOWED_PREFIXES)
     }
-    # Force UTF-8 for the child's stdio. The child writes its result envelope to
-    # a PIPE (not a console), and on native Windows a piped stdout defaults to the
-    # locale ANSI codepage (e.g. cp1252) -- so any non-ASCII character in agent
-    # output (em dash, checkmark, non-Latin text -- all common in LLM output)
-    # raises UnicodeEncodeError and crashes the child BEFORE the envelope is
-    # written, turning a real result into an opaque RuntimeError. PYTHONUTF8=1
-    # puts the interpreter in UTF-8 mode (stdio + filesystem encoding);
-    # PYTHONIOENCODING is a belt-and-suspenders for any child that re-derives its
-    # stream encoding. These are set unconditionally rather than merely forwarded,
-    # so the child is UTF-8 even when the parent's environment is not. No-op on
-    # POSIX, where UTF-8 is already the effective default.
+    # Force UTF-8 for the child's stdio. The child writes to a PIPE (not a
+    # console), and on native Windows a piped stdout defaults to the locale ANSI
+    # codepage (e.g. cp1252). The result envelope itself is never at risk --
+    # json.dumps() defaults to ensure_ascii=True, so the envelope is pure ASCII by
+    # construction. The risk is everything AROUND it: log lines, tool output,
+    # third-party prints (em dash, checkmark, non-Latin text -- all common in LLM
+    # output), which _extract_framed_result deliberately tolerates and which land
+    # in the same pipe. Those get encoded in the ANSI codepage, and the parent
+    # then decodes the whole stream with stdout.decode("utf-8") and no error
+    # handler -- so the undecodable bytes raise UnicodeDecodeError in the PARENT,
+    # turning a successful child run into an opaque failure. PYTHONUTF8=1 puts the
+    # interpreter in UTF-8 mode (stdio + filesystem encoding); PYTHONIOENCODING is
+    # a belt-and-suspenders for any child that re-derives its stream encoding.
+    # These are set unconditionally rather than merely forwarded, so the child is
+    # UTF-8 even when the parent's environment is not. No-op on POSIX, where UTF-8
+    # is already the effective default.
     env["PYTHONUTF8"] = "1"
     env["PYTHONIOENCODING"] = "utf-8"
     return env

--- a/amplifier_foundation/subprocess_runner.py
+++ b/amplifier_foundation/subprocess_runner.py
@@ -162,12 +162,26 @@ def _build_child_env() -> dict[str, str]:
     Returns:
         A new dict containing only the allowed environment variables.
     """
-    return {
+    env = {
         key: value
         for key, value in os.environ.items()
         if key in _ENV_ALLOWED_EXACT
         or any(key.startswith(prefix) for prefix in _ENV_ALLOWED_PREFIXES)
     }
+    # Force UTF-8 for the child's stdio. The child writes its result envelope to
+    # a PIPE (not a console), and on native Windows a piped stdout defaults to the
+    # locale ANSI codepage (e.g. cp1252) -- so any non-ASCII character in agent
+    # output (em dash, checkmark, non-Latin text -- all common in LLM output)
+    # raises UnicodeEncodeError and crashes the child BEFORE the envelope is
+    # written, turning a real result into an opaque RuntimeError. PYTHONUTF8=1
+    # puts the interpreter in UTF-8 mode (stdio + filesystem encoding);
+    # PYTHONIOENCODING is a belt-and-suspenders for any child that re-derives its
+    # stream encoding. These are set unconditionally rather than merely forwarded,
+    # so the child is UTF-8 even when the parent's environment is not. No-op on
+    # POSIX, where UTF-8 is already the effective default.
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return env
 
 
 # Credential patterns — used by _sanitize_error() to redact sensitive values

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -1563,3 +1563,37 @@ class TestMentionMappingsSerialization:
         deserialized = deserialize_subprocess_config(serialized)
 
         assert deserialized["mention_mappings"] == {}
+
+
+class TestChildEnvForcesUtf8:
+    """GAP-6b: the child subprocess must run in UTF-8 mode.
+
+    The child writes its result envelope to a PIPE. On native Windows a piped
+    stdout defaults to the locale ANSI codepage (e.g. cp1252), so any non-ASCII
+    character in agent output raises UnicodeEncodeError and crashes the child
+    before the envelope is written. _build_child_env() must force UTF-8 so this
+    cannot happen, regardless of the parent's own environment.
+    """
+
+    def test_child_env_sets_pythonutf8(self) -> None:
+        env = _build_child_env()
+        assert env.get("PYTHONUTF8") == "1"
+
+    def test_child_env_sets_pythonioencoding(self) -> None:
+        env = _build_child_env()
+        assert env.get("PYTHONIOENCODING") == "utf-8"
+
+    def test_child_env_forces_utf8_even_when_parent_has_none(self) -> None:
+        # Parent env with NO utf-8 hints must still yield a utf-8 child env.
+        with patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True):
+            env = _build_child_env()
+        assert env.get("PYTHONUTF8") == "1"
+        assert env.get("PYTHONIOENCODING") == "utf-8"
+
+    def test_child_env_overrides_hostile_parent_value(self) -> None:
+        # A parent that pins a NON-utf-8 io encoding must not win: the child is
+        # forced to utf-8 so the envelope write cannot raise UnicodeEncodeError.
+        with patch.dict("os.environ", {"PYTHONIOENCODING": "cp1252"}, clear=True):
+            env = _build_child_env()
+        assert env.get("PYTHONIOENCODING") == "utf-8"
+        assert env.get("PYTHONUTF8") == "1"

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -1568,11 +1568,13 @@ class TestMentionMappingsSerialization:
 class TestChildEnvForcesUtf8:
     """GAP-6b: the child subprocess must run in UTF-8 mode.
 
-    The child writes its result envelope to a PIPE. On native Windows a piped
-    stdout defaults to the locale ANSI codepage (e.g. cp1252), so any non-ASCII
-    character in agent output raises UnicodeEncodeError and crashes the child
-    before the envelope is written. _build_child_env() must force UTF-8 so this
-    cannot happen, regardless of the parent's own environment.
+    The child writes to a PIPE. On native Windows a piped stdout defaults to the
+    locale ANSI codepage (e.g. cp1252). The result envelope itself is safe --
+    json.dumps() defaults to ensure_ascii=True -- but non-ASCII output around it
+    (logging, tool output, third-party prints) gets encoded in that codepage, and
+    the parent decodes the whole stream with stdout.decode("utf-8") and no error
+    handler, raising UnicodeDecodeError in the parent. _build_child_env() must
+    force UTF-8 so this cannot happen, regardless of the parent's own environment.
     """
 
     def test_child_env_sets_pythonutf8(self) -> None:
@@ -1592,7 +1594,8 @@ class TestChildEnvForcesUtf8:
 
     def test_child_env_overrides_hostile_parent_value(self) -> None:
         # A parent that pins a NON-utf-8 io encoding must not win: the child is
-        # forced to utf-8 so the envelope write cannot raise UnicodeEncodeError.
+        # forced to utf-8 so the parent's stdout.decode("utf-8") cannot raise
+        # UnicodeDecodeError on output printed around the envelope.
         with patch.dict("os.environ", {"PYTHONIOENCODING": "cp1252"}, clear=True):
             env = _build_child_env()
         assert env.get("PYTHONIOENCODING") == "utf-8"


### PR DESCRIPTION
## The bug

In **subprocess-mode** delegation the child's stdout is a **pipe**. On native Windows a piped stdout defaults to the locale ANSI codepage (cp1252), so any non-ASCII character the child prints is encoded in that codepage. The parent then decodes the whole stream with `stdout.decode("utf-8")` and **no error handler** ([`subprocess_runner.py:539-540`](https://github.com/microsoft/amplifier-foundation/blob/main/amplifier_foundation/subprocess_runner.py#L539-L540)) — so those bytes raise `UnicodeDecodeError` **in the parent**, turning a successful child run into an opaque failure. `_build_child_env()` previously neither forwarded nor forced `PYTHONUTF8`/`PYTHONIOENCODING`.

The **result envelope itself is never at risk** — it is built with `json.dumps()`, which defaults to `ensure_ascii=True`, so the envelope is pure ASCII by construction. The exposure is everything *around* the envelope: log lines, tool output, third-party `print()`s (em dash, checkmark, accented / non-Latin text, emoji — all common in LLM output), which `_extract_framed_result` deliberately tolerates and which share the same pipe.

## The fix

`_build_child_env()` now sets `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` **unconditionally** (not merely forwarded) — so the child runs in UTF-8 mode even when the parent environment is not, and even against a hostile parent value. **No-op on POSIX**, where UTF-8 is already the effective default. Confined to the child subprocess env; the in-process default delegation path is untouched.

## Evidence — teeth both ways

**Linux A/B (unit):** the 4 new `TestChildEnvForcesUtf8` tests pass with the fix; **all 4 FAIL against the un-fixed code** (keys absent) — the assertions have teeth.

**Windows (native, Python 3.14.3):** deterministic repro of a child `print()` of non-ASCII text to a pipe:

```
[BASELINE (no PYTHONUTF8)] exit=1 crashed=True  bytes_out=0
    UnicodeEncodeError: 'charmap' codec can't encode character '\u2713' in position 12
[FIXED    (PYTHONUTF8=1)]  exit=0 crashed=False bytes_out=40
SUMMARY: baseline_crashed=True  fixed_crashed=False
```

Note on the repro: it exercises the child-side half of the encoding mismatch in isolation (a bare `print()` with no envelope framing and no parent decode), which is why it surfaces as a child-side `UnicodeEncodeError`. In the real subprocess path the mismatch is not fatal to the child — it produces cp1252 bytes in the pipe that the parent then fails to decode as UTF-8. Same root cause, same fix; the repro isolates one side of it.

The code sets the keys (Linux-proven, and the assignment is platform-independent Python); those keys eliminate the encoding mismatch (Windows-proven).

## Scope / severity

Subprocess-mode is **opt-in** — default delegation runs in-process, so this only bites bundles/agents that set `spawn_mode: subprocess`. But when they do, on Windows, common LLM output printed outside the envelope breaks the parent's decode. Found during a Windows-compat audit of the delegation path (the default in-process path and `subprocess_runner`'s process-group / kill / executable-resolution branches were all verified already Windows-safe; this env-encoding gap was the one real defect).

## Limits

One Windows machine, one Python (3.14.3). No Windows CI leg on this repo yet.
