### PR TITLE
fix: tolerate UTF-8 BOM when parsing markdown frontmatter

### DIFF
--- a/amplifier_foundation/bundle_docs/frontmatter.py
+++ b/amplifier_foundation/bundle_docs/frontmatter.py
@@ -24,10 +24,15 @@ def parse_frontmatter(path: Path) -> tuple[dict[str, Any], str]:
     For ``.md`` files the ``---`` delimited frontmatter is parsed and
     everything after the closing ``---`` is returned as the body.
 
+    Read with ``utf-8-sig`` so a leading UTF-8 BOM is stripped. Editors on
+    Windows write UTF-8 *with* a BOM by default; decoding as plain ``utf-8``
+    leaves a U+FEFF at position 0, which defeats the ``startswith("---")``
+    check below and silently discards the frontmatter.
+
     Returns:
         ``(frontmatter_dict, body_str)``
     """
-    content = path.read_text(encoding="utf-8")
+    content = path.read_text(encoding="utf-8-sig")
 
     if path.suffix in (".yaml", ".yml"):
         data = yaml.safe_load(content) or {}

--- a/amplifier_foundation/io/frontmatter.py
+++ b/amplifier_foundation/io/frontmatter.py
@@ -13,6 +13,13 @@ def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
 
     Extracts YAML between --- delimiters at the start of the text.
 
+    A leading UTF-8 BOM (U+FEFF) is tolerated. Editors on Windows (Notepad,
+    PowerShell ``Set-Content``, ``Out-File``) write UTF-8 *with* a BOM by
+    default; when such a file is decoded as plain ``utf-8`` the BOM survives
+    as a leading U+FEFF character. Without stripping it the opening ``---``
+    is no longer at position 0, the pattern below does not match, and the
+    frontmatter is silently discarded rather than reported as an error.
+
     Args:
         text: Markdown text with optional YAML frontmatter.
 
@@ -23,6 +30,8 @@ def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
     Raises:
         yaml.YAMLError: If frontmatter contains invalid YAML.
     """
+    text = text.lstrip("\ufeff")
+
     # Match --- at start, then content, then ---
     pattern = r"^---\s*\n(.*?)\n---\s*\n?"
     match = re.match(pattern, text, re.DOTALL)

--- a/tests/test_frontmatter_bom.py
+++ b/tests/test_frontmatter_bom.py
@@ -1,0 +1,174 @@
+"""Frontmatter parsing must tolerate a leading UTF-8 BOM.
+
+Editors and shells on Windows (Notepad, PowerShell ``Set-Content`` and
+``Out-File``) write UTF-8 *with* a byte-order mark by default. Decoding such a
+file as plain ``utf-8`` leaves a U+FEFF at position 0, which pushes the opening
+``---`` off the start of the text. Frontmatter detection then fails silently:
+the parser returns an empty mapping instead of raising, so an agent, mode, or
+bundle authored on Windows loads with none of its declared configuration and no
+error to explain why.
+
+These tests pin the BOM-tolerant behaviour at every markdown entry point, and
+pin that BOM-free files are unaffected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from amplifier_foundation.bundle._dataclass import (
+    _load_agent_file_metadata,
+    _load_mode_file_metadata,
+)
+from amplifier_foundation.bundle_docs.frontmatter import parse_frontmatter as parse_path
+from amplifier_foundation.io.frontmatter import parse_frontmatter
+from amplifier_foundation.registry import BundleRegistry
+
+BOM = "\ufeff"
+
+AGENT_MD = """\
+---
+meta:
+  name: windows-agent
+  description: An agent authored on Windows
+model_role: fast
+---
+
+You are a helpful agent.
+"""
+
+MODE_MD = """\
+---
+mode:
+  name: windows-mode
+  description: A mode authored on Windows
+  default_action: block
+---
+
+Mode guidance body.
+"""
+
+BUNDLE_MD = """\
+---
+bundle:
+  name: windows-bundle
+  version: 1.0.0
+---
+
+Bundle instruction body.
+"""
+
+
+def _write_with_bom(path: Path, text: str) -> Path:
+    """Write ``text`` as UTF-8 with a BOM, the way Windows editors do."""
+    path.write_bytes((BOM + text).encode("utf-8"))
+    return path
+
+
+class TestParseFrontmatterBOM:
+    """The shared string parser used by agents, modes, and markdown bundles."""
+
+    def test_bom_prefixed_text_parses(self) -> None:
+        data, _body = parse_frontmatter(BOM + AGENT_MD)
+        assert data["meta"]["name"] == "windows-agent"
+        assert data["model_role"] == "fast"
+
+    def test_bom_is_stripped_from_body(self) -> None:
+        _data, body = parse_frontmatter(BOM + AGENT_MD)
+        assert not body.startswith(BOM)
+        assert body.strip() == "You are a helpful agent."
+
+    def test_repeated_bom_tolerated(self) -> None:
+        """A file round-tripped through BOM-adding tools can accumulate marks."""
+        data, body = parse_frontmatter(BOM + BOM + AGENT_MD)
+        assert data["meta"]["name"] == "windows-agent"
+        assert not body.startswith(BOM)
+
+    def test_without_bom_unchanged(self) -> None:
+        data, body = parse_frontmatter(AGENT_MD)
+        assert data["meta"]["name"] == "windows-agent"
+        assert body.strip() == "You are a helpful agent."
+
+    def test_no_frontmatter_body_preserved(self) -> None:
+        """Plain markdown still round-trips, with the BOM removed."""
+        data, body = parse_frontmatter(BOM + "# Heading\n")
+        assert data == {}
+        assert body == "# Heading\n"
+
+
+class TestAgentMetadataBOM:
+    """``_load_agent_file_metadata`` — agent .md files."""
+
+    def test_bom_prefixed_agent_file(self, tmp_path: Path) -> None:
+        path = _write_with_bom(tmp_path / "windows-agent.md", AGENT_MD)
+        meta = _load_agent_file_metadata(path, "fallback-name")
+        assert meta["name"] == "windows-agent"
+        assert meta["description"] == "An agent authored on Windows"
+        assert meta["model_role"] == "fast"
+        assert not str(meta["instruction"]).startswith(BOM)
+
+    def test_without_bom_unchanged(self, tmp_path: Path) -> None:
+        path = tmp_path / "plain-agent.md"
+        path.write_text(AGENT_MD, encoding="utf-8")
+        meta = _load_agent_file_metadata(path, "fallback-name")
+        assert meta["name"] == "windows-agent"
+        assert meta["model_role"] == "fast"
+
+
+class TestModeMetadataBOM:
+    """``_load_mode_file_metadata`` — mode .md files."""
+
+    def test_bom_prefixed_mode_file(self, tmp_path: Path) -> None:
+        path = _write_with_bom(tmp_path / "windows-mode.md", MODE_MD)
+        meta = _load_mode_file_metadata(path, "fallback-name")
+        assert meta["name"] == "windows-mode"
+        assert meta["description"] == "A mode authored on Windows"
+        assert meta["default_action"] == "block"
+
+    def test_without_bom_unchanged(self, tmp_path: Path) -> None:
+        path = tmp_path / "plain-mode.md"
+        path.write_text(MODE_MD, encoding="utf-8")
+        meta = _load_mode_file_metadata(path, "fallback-name")
+        assert meta["name"] == "windows-mode"
+        assert meta["default_action"] == "block"
+
+
+class TestMarkdownBundleBOM:
+    """``BundleRegistry._load_markdown_bundle`` — bundle.md files."""
+
+    def test_bom_prefixed_bundle_file(self, tmp_path: Path) -> None:
+        path = _write_with_bom(tmp_path / "bundle.md", BUNDLE_MD)
+        bundle = asyncio.run(BundleRegistry()._load_markdown_bundle(path))
+        assert bundle.name == "windows-bundle"
+        assert bundle.version == "1.0.0"
+        assert bundle.instruction == "Bundle instruction body."
+
+    def test_without_bom_unchanged(self, tmp_path: Path) -> None:
+        path = tmp_path / "bundle.md"
+        path.write_text(BUNDLE_MD, encoding="utf-8")
+        bundle = asyncio.run(BundleRegistry()._load_markdown_bundle(path))
+        assert bundle.name == "windows-bundle"
+
+
+class TestBundleDocsParseFrontmatterBOM:
+    """``bundle_docs.frontmatter.parse_frontmatter`` — reads the file itself."""
+
+    def test_bom_prefixed_markdown(self, tmp_path: Path) -> None:
+        path = _write_with_bom(tmp_path / "agent.md", AGENT_MD)
+        data, body = parse_path(path)
+        assert data["meta"]["name"] == "windows-agent"
+        assert "You are a helpful agent." in body
+
+    def test_bom_prefixed_yaml(self, tmp_path: Path) -> None:
+        path = tmp_path / "behavior.yaml"
+        path.write_bytes((BOM + "bundle:\n  name: windows-behavior\n").encode("utf-8"))
+        data, body = parse_path(path)
+        assert data["bundle"]["name"] == "windows-behavior"
+        assert body == ""
+
+    def test_without_bom_unchanged(self, tmp_path: Path) -> None:
+        path = tmp_path / "agent.md"
+        path.write_text(AGENT_MD, encoding="utf-8")
+        data, _body = parse_path(path)
+        assert data["meta"]["name"] == "windows-agent"


### PR DESCRIPTION
## The problem

Editors and shells on Windows write UTF-8 **with** a byte-order mark by default — Notepad, PowerShell `Set-Content`, PowerShell `Out-File`. Foundation reads markdown with `encoding="utf-8"`, which preserves that BOM as a leading `U+FEFF` character instead of stripping it.

That single invisible character pushes the opening `---` off position 0. Both frontmatter parsers anchor at the very start of the text:

- `amplifier_foundation/io/frontmatter.py` — `re.match(r"^---\s*\n(.*?)\n---\s*\n?", text, re.DOTALL)`
- `amplifier_foundation/bundle_docs/frontmatter.py` — `content.startswith("---")`

Neither matches, and both fall through to their "no frontmatter here" branch.

**The failure is silent.** Nothing raises. The parser returns an empty mapping and the file loads with none of its declared configuration:

| File authored on Windows | What actually happens |
|---|---|
| agent `.md` | `name` falls back to the filename, `description` empty, `model_role` / `tools` / `provider_preferences` all dropped |
| mode `.md` | `name` falls back, tool policies and `default_action` dropped — a mode declaring `default_action: block` silently enforces nothing |
| bundle `.md` | `name` and `version` empty, so the bundle does not resolve |

A user who authors any of these on Windows sees no error, only behaviour that does not match what they wrote. The mode case is the sharpest: a security-shaped declaration (`default_action: block`) evaporates without a word.

## The fix

**`io/frontmatter.py`** — strip a leading BOM before matching.

```python
text = text.lstrip("\ufeff")
```

This is the shared parser behind agent metadata, mode metadata, and markdown bundle loading, so one change covers all three entry points and any future caller. `lstrip` rather than `removeprefix` tolerates the repeated marks that accumulate when a file round-trips through BOM-adding tools.

**`bundle_docs/frontmatter.py`** — read with `utf-8-sig`.

```python
content = path.read_text(encoding="utf-8-sig")
```

This parser opens the file itself, so the fix belongs at the read. `utf-8-sig` decodes BOM-free UTF-8 identically, so existing files are unaffected.

Two different fixes because the two parsers sit at different layers: one receives already-decoded text and cannot control the read, the other performs the read.

## Why the BOM is not rejected instead

Rejecting would be defensible — but the file is valid UTF-8 and the author's intent is unambiguous. Every other consumer in the toolchain (`git`, `yaml.safe_load` on a `.yaml` path, most editors) handles it. Silently discarding configuration is the bug; refusing to open the file would trade one poor experience for another.

## Verification

Reproduced first on `main`, then re-run against the fix. The bug is confirmed to exist and confirmed to be gone — not inferred from reading the code.

- **On `main`:** 10 of 13 behavioural checks fail — agent metadata, mode metadata, and bundle metadata all silently empty when the source file carries a BOM.
- **With the fix:** 13 of 13 pass.

`tests/test_frontmatter_bom.py` adds 14 regression tests pinning BOM-tolerant parsing at every markdown entry point, and pinning that BOM-free files parse exactly as before.

```
tests/test_frontmatter_bom.py ..............                        [14 passed]
```

Full suite on this branch: **1608 passed, 1 skipped, 0 failed.**

Gate on the three files this PR touches: `ruff check` passes, `ruff format --check` reports 3 files already formatted, `pyright` reports 0 errors.

## Scope

Frontmatter parsing only. No change to how files are discovered, resolved, or composed. BOM-free files take exactly the same path they took before.
