### PR TITLE
fix(bundles): drop descriptive prose from the system prompt

### DIFF
--- a/bundles/anchors-amp-dev/bundle.md
+++ b/bundles/anchors-amp-dev/bundle.md
@@ -136,10 +136,4 @@ agents:
     - foundation:session-analyst
 ---
 
-# Behavioral Anchor
-
-A lean, principle-driven experimental bundle. Behavior is shaped by a short set
-of named principles loaded once at the head of the system prompt, backed by thin
-purposeful agents and a standard tool roster.
-
 @anchors-amp-dev:context/system.md

--- a/bundles/anchors/bundle.md
+++ b/bundles/anchors/bundle.md
@@ -131,10 +131,4 @@ agents:
     - anchors:researcher
 ---
 
-# Anchors
-
-A lean, principle-driven bundle. Behavior is shaped by a short set
-of named principles loaded once at the head of the system prompt, backed by thin
-purposeful agents and a standard tool roster.
-
 @anchors:context/system.md

--- a/experiments/behavioral-anchor-amplifier-dev/behavioral-anchor-amplifier-dev.md
+++ b/experiments/behavioral-anchor-amplifier-dev/behavioral-anchor-amplifier-dev.md
@@ -132,10 +132,4 @@ agents:
     - foundation:session-analyst
 ---
 
-# Behavioral Anchor
-
-A lean, principle-driven experimental bundle. Behavior is shaped by a short set
-of named principles loaded once at the head of the system prompt, backed by thin
-purposeful agents and a standard tool roster.
-
 @behavioral-anchor-amplifier-dev:context/system.md

--- a/experiments/behavioral-anchor/behavioral-anchor.md
+++ b/experiments/behavioral-anchor/behavioral-anchor.md
@@ -127,10 +127,4 @@ agents:
     - behavioral-anchor:researcher
 ---
 
-# Behavioral Anchor
-
-A lean, principle-driven experimental bundle. Behavior is shaped by a short set
-of named principles loaded once at the head of the system prompt, backed by thin
-purposeful agents and a standard tool roster.
-
 @behavioral-anchor:context/system.md


### PR DESCRIPTION
## Problem

Everything below the YAML frontmatter in a bundle file is loaded verbatim as the session's **system instruction**, and it is placed **first** — ahead of every context file. Four bundle manifests in this repo carried a title and a descriptive paragraph there, so a session rooted on any of them opened by telling the model a third-person description of itself instead of an instruction.

The same three-line block had been copied across all four:

```markdown
---

# Anchors

A lean, principle-driven bundle. Behavior is shaped by a short set
of named principles loaded once at the head of the system prompt, backed by thin
purposeful agents and a standard tool roster.

@anchors:context/system.md
```

## Mechanism

This is all in this repo:

| Step | Location |
|---|---|
| Body below frontmatter becomes `instruction` | `amplifier_foundation/registry.py` — `bundle.instruction = body.strip()` |
| `instruction` becomes the main system prompt | `amplifier_foundation/bundle/_prepared.py` — `main_instruction = captured_bundle.instruction` |
| It is emitted first, before context | `_prepared.py` — `f"{main_instruction}\n\n---\n\n{all_context}"` |
| Registered as the prompt factory | `_prepared.py` — `context_manager.set_system_prompt_factory(factory)` |

Only instruction — or `@mention` pointers to instruction files — belongs below the frontmatter.

Note that `Bundle.compose()` applies "later replaces earlier" to `instruction`, and `registry.py` composes includes first and then the current bundle. So the body that reaches the system prompt is the **root** bundle's — which is exactly the case for all four of these.

## Change

| File | Removed |
|---|---|
| `bundles/anchors/bundle.md` | heading + descriptive paragraph |
| `bundles/anchors-amp-dev/bundle.md` | heading + descriptive paragraph |
| `experiments/behavioral-anchor/behavioral-anchor.md` | heading + descriptive paragraph |
| `experiments/behavioral-anchor-amplifier-dev/behavioral-anchor-amplifier-dev.md` | heading + descriptive paragraph |

Each file retains the `@mention` that loads its `context/system.md`, which is the actual instruction.

Nothing is lost: every one of these bundles already carries the same description in its frontmatter `bundle.description` field, which is manifest metadata and is never sent to the model.

## Scope

Deliberately narrow: four files, twenty deleted lines, no renames and no frontmatter changes. Two related follow-ups are separate PRs — a validator check that detects this pattern, and the authoring rule written into `docs/BUNDLE_GUIDE.md`.
