### PR TITLE
feat(validation): detect documentation prose below bundle/agent frontmatter

### DIFF
--- a/amplifier_foundation/validator.py
+++ b/amplifier_foundation/validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -303,3 +304,104 @@ def validate_bundle_completeness_or_raise(bundle: Bundle) -> None:
     """
     validator = BundleValidator()
     validator.validate_completeness_or_raise(bundle)
+
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n.*?\n---\s*\n(.*)$", re.DOTALL)
+_BARE_MENTION_RE = re.compile(r"^\s*@[\w.-]+:[\w./-]+\s*$")
+_SECOND_PERSON_RE = re.compile(r"\b(you|your|yours|yourself)\b", re.IGNORECASE)
+_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+
+# Markdown scaffolding: headings and horizontal rules. These carry no prose --
+# a body of "# LLM Wiki Bundle" and a divider says nothing to the model, so
+# there is nothing there to classify as instruction or as documentation.
+_SCAFFOLDING_RE = re.compile(r"^\s{0,3}(#{1,6}\s|-{3,}\s*$|\*{3,}\s*$|_{3,}\s*$)")
+
+
+def check_body_is_instruction(content: str) -> dict[str, Any]:
+    """Classify the markdown body of a bundle/agent/mode file.
+
+    Everything below the YAML frontmatter is sent to the model as system
+    instruction. Only instruction -- or @mention pointers to instruction
+    files -- belongs there. Descriptive prose about the artifact is a defect.
+
+    The discriminator is whether the remaining text addresses the model
+    (second person). Fenced code blocks are excluded before that test: they are
+    examples, and a placeholder such as "your-server" inside a sample config is
+    not the body addressing the model.
+
+    Args:
+        content: Full text of the .md file, including frontmatter.
+
+    Returns:
+        Dict with keys:
+          verdict: "OK" | "FLAG" | "NO_FRONTMATTER"
+          prose_chars: int, characters of body text left after removing
+            fenced code, @mention lines, HTML comments, and markdown
+            scaffolding (headings, horizontal rules)
+          prose_preview: str, first 200 chars of that prose ("" when none)
+          reason: str, short human-readable explanation
+    """
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        return {
+            "verdict": "NO_FRONTMATTER",
+            "prose_chars": 0,
+            "prose_preview": "",
+            "reason": "no frontmatter",
+        }
+
+    # Fenced code blocks are examples, not the body speaking to the model.
+    body = _CODE_FENCE_RE.sub("", match.group(1))
+
+    prose_lines: list[str] = []
+    in_html_comment = False
+    for line in body.split("\n"):
+        stripped = line.strip()
+
+        if in_html_comment:
+            if "-->" in stripped:
+                in_html_comment = False
+            continue
+
+        if not stripped:
+            continue
+
+        if stripped.startswith("<!--"):
+            if "-->" not in stripped:
+                in_html_comment = True
+            continue
+
+        if _BARE_MENTION_RE.match(line):
+            continue
+
+        if _SCAFFOLDING_RE.match(line):
+            continue
+
+        prose_lines.append(line)
+
+    prose_text = "\n".join(prose_lines)
+    prose_chars = len(prose_text)
+    prose_preview = prose_text[:200]
+
+    if not prose_text.strip():
+        return {
+            "verdict": "OK",
+            "prose_chars": prose_chars,
+            "prose_preview": prose_preview,
+            "reason": "body carries no prose (mentions/scaffolding only)",
+        }
+
+    if _SECOND_PERSON_RE.search(prose_text):
+        return {
+            "verdict": "OK",
+            "prose_chars": prose_chars,
+            "prose_preview": prose_preview,
+            "reason": "addresses the model (second person)",
+        }
+
+    return {
+        "verdict": "FLAG",
+        "prose_chars": prose_chars,
+        "prose_preview": prose_preview,
+        "reason": "no second-person address -- reads as documentation, not instruction",
+    }

--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -244,6 +244,17 @@ steps:
           }))
           exit(0)
 
+      # amplifier_foundation is not guaranteed to be importable in every
+      # environment this recipe runs in (it is run against third-party bundle
+      # repos). Degrade to a no-op rather than killing the whole run: an
+      # unhandled ImportError here produces no JSON, and quality-classification
+      # parses this step's output unguarded with on_error: "fail".
+      try:
+          from amplifier_foundation.validator import check_body_is_instruction
+      except ImportError:
+          def check_body_is_instruction(content):
+              return {"verdict": "SKIPPED", "prose_chars": 0, "prose_preview": "", "reason": "amplifier_foundation not available"}
+
       # Valid model roles per role taxonomy v2 (2026-03-01)
       # Update when roles are added/removed from the routing matrix schema
       VALID_MODEL_ROLES = {
@@ -530,6 +541,18 @@ steps:
           else:
               result["example_count"] = 0
               result["examples_with_context"] = 0
+
+          # Check whether the body (below frontmatter) reads as instruction, not
+          # documentation -- everything below frontmatter is sent to the model
+          # as system instruction (WARNING level, not ERROR)
+          body_check = check_body_is_instruction(content)
+          if body_check["verdict"] == "FLAG":
+              result["warnings"].append({
+                  "severity": "WARNING",
+                  "code": "PROSE_BELOW_FRONTMATTER",
+                  "message": f"{Path(file_path).name}: body has {body_check['prose_chars']} chars of documentation-style prose below the frontmatter: \"{body_check['prose_preview']}\"",
+                  "remediation": "Everything below the frontmatter is sent to the model as system instruction. Move descriptive prose into the frontmatter description field (metadata, never sent) or delete it. Keep @mention pointers to instruction files."
+              })
 
           return result
 

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -1,9 +1,17 @@
 # validate-bundle-repo.yaml
-# Repository-Wide Bundle Validator Recipe v3.6.1
+# Repository-Wide Bundle Validator Recipe v3.7.0
 # Validates an entire bundle repository against structural requirements, conventions,
 # and Amplifier bundle philosophy (context sink pattern, thin behaviors, tool placement)
 #
 # CHANGELOG:
+# v3.7.0 - NEW PHASE 2.55: Body Instruction Check
+#        - Everything below a bundle.md / agents/*.md YAML frontmatter is loaded
+#          verbatim as the session's system instruction and emitted FIRST, ahead
+#          of every context file. Documentation prose there is a defect.
+#        - Emits PROSE_BELOW_FRONTMATTER at WARNING level; never fails the build.
+#        - Scope is bundle.md + agents/*.md. modes/*.md are NOT covered.
+#        - Skips test fixtures; degrades to a clean skip when amplifier_foundation
+#          is not importable.
 # v3.6.1 - Fix two false-positive defects
 #        - Standalone completeness (Phase 3): Bundle.session is dict[str, Any],
 #          but the check used getattr(session, 'orchestrator'/'context'), which
@@ -204,7 +212,7 @@ description: |
   - All measurements use TOKENS (len/4), never line counts
   
   For single bundle validation, use validate-bundle.yaml instead.
-version: "3.6.1"
+version: "3.7.0"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "repository", "packaging", "hygiene", "context-sink"]
 
@@ -2854,6 +2862,124 @@ steps:
     depends_on: ["repo-discovery"]
 
   # ============================================================================
+  # PHASE 2.55: Body Instruction Check (v3.7.0)
+  # Everything below a bundle.md / agent.md file's YAML frontmatter is loaded
+  # verbatim as the session's system instruction. Descriptive/documentation
+  # prose there is a defect -- only instruction (or @mention pointers to
+  # instruction files) belongs below the frontmatter. WARNING level (not
+  # ERROR) -- a large fraction of the current ecosystem trips this check.
+  #
+  # Scope: bundle.md and agents/*.md. Mode files (modes/*.md) are NOT covered.
+  # The mode-validation step above checks a mode's frontmatter description
+  # budget and its advertising references -- it does not inspect the body for
+  # prose. Extending this check to modes is deliberately left for a follow-up.
+  # ============================================================================
+
+  - id: "body-instruction-check"
+    type: "bash"
+    command: |
+      python3 << 'EOF'
+      import json
+      import sys
+      from pathlib import Path
+
+      # amplifier_foundation is not guaranteed to be importable in every
+      # environment this recipe runs in. Report a clean skip rather than
+      # dying silently into the downstream json.loads fallback.
+      try:
+          from amplifier_foundation.validator import check_body_is_instruction
+      except ImportError:
+          print(json.dumps({
+              "phase": "body_instruction_check",
+              "skipped": True,
+              "passed": True,
+              "reason": "amplifier_foundation not importable",
+              "files_checked": 0,
+              "errors": [],
+              "warnings": []
+          }))
+          sys.exit(0)
+
+      repo_path = "{{repo_path}}"
+      path = Path(repo_path).resolve()
+
+      results = {
+          "phase": "body_instruction_check",
+          "files_checked": 0,
+          "errors": [],
+          "warnings": []
+      }
+
+      # Find all bundle.md files (root + nested behaviors/providers/etc.) and
+      # agent definition files anywhere in the repo.
+      bundle_files = list(path.rglob("bundle.md"))
+      agent_files = list(path.rglob("*/agents/*.md")) + list(path.glob("agents/*.md"))
+
+      # Test fixtures are deliberately synthetic -- they exist to exercise the
+      # validators and are not shipped instruction. Flagging them is noise.
+      EXCLUDED_DIRS = {"test-fixtures", "tests", "node_modules", ".git", ".venv"}
+
+      # Deduplicate (rglob/glob patterns can overlap)
+      seen = set()
+      unique_files = []
+      for f in bundle_files + agent_files:
+          if EXCLUDED_DIRS & set(f.parts):
+              continue
+          resolved = f.resolve()
+          if resolved not in seen:
+              seen.add(resolved)
+              unique_files.append(f)
+
+      if not unique_files:
+          results["skipped"] = True
+          results["passed"] = True
+          results["reason"] = "No bundle.md or agents/*.md files found"
+          print(json.dumps(results))
+          sys.exit(0)
+
+      for file_path in sorted(unique_files):
+          try:
+              content = file_path.read_text(encoding="utf-8", errors="replace")
+          except Exception:
+              continue
+
+          results["files_checked"] += 1
+          rel_path = str(file_path.relative_to(path))
+
+          check = check_body_is_instruction(content)
+          if check["verdict"] == "FLAG":
+              results["warnings"].append({
+                  "type": "prose_below_frontmatter",
+                  "file": rel_path,
+                  "message": (
+                      f"{rel_path}: body has {check['prose_chars']} chars of "
+                      f"documentation-style prose below the frontmatter: "
+                      f"\"{check['prose_preview']}\""
+                  ),
+                  "severity": "WARNING",
+                  "fix": (
+                      "Everything below the frontmatter is sent to the model as "
+                      "system instruction. Move descriptive prose into the "
+                      "frontmatter description field (metadata, never sent) or "
+                      "delete it. Keep @mention pointers to instruction files."
+                  )
+              })
+
+      results["passed"] = True  # WARNING-only check -- never fails the build
+      results["summary"] = {
+          "files_checked": results["files_checked"],
+          "warnings": len(results["warnings"])
+      }
+
+      print(json.dumps(results))
+      EOF
+    output: "body_instruction_check_results"
+    parse_json: true
+    timeout: 120
+    on_error: "continue"
+    depends_on: ["repo-discovery"]
+
+  # ============================================================================
   # PHASE 2.6: Quality Classification (Deterministic)
   # Enhanced in v3.0.0 to incorporate all new validation phases
   # ============================================================================
@@ -2940,6 +3066,13 @@ steps:
           mode_validation = json.loads(mode_validation_raw)
       except (json.JSONDecodeError, ValueError):
           mode_validation = {"passed": True, "skipped": True, "errors": [], "warnings": []}
+
+      # v3.7.0: Parse body instruction check results
+      body_instruction_raw = '''{{body_instruction_check_results}}'''
+      try:
+          body_instruction = json.loads(body_instruction_raw)
+      except (json.JSONDecodeError, ValueError):
+          body_instruction = {"passed": True, "skipped": True, "errors": [], "warnings": []}
 
       # Handle case where individual validation was skipped
       if individual.get("skipped", False):
@@ -3054,6 +3187,7 @@ steps:
               "structure_lint_issues": [],  # v3.4.0
               "behavior_reference_hygiene_issues": [],  # v3.5.0
               "mode_validation_issues": [],  # v3.6.0
+              "body_instruction_issues": [],  # v3.7.0
               # v3.2.0: Environment status tracking
               "environment_status": {
                   "validation_mode": env_check.get("validation_mode", "unknown"),
@@ -3239,6 +3373,17 @@ steps:
                       "fix": warning.get("fix", "")
                   })
 
+          # v3.7.0: Body instruction check warnings (prose below frontmatter)
+          if not body_instruction.get("skipped", False):
+              for warning in body_instruction.get("warnings", []):
+                  results["body_instruction_issues"].append({
+                      "type": warning.get("type"),
+                      "file": warning.get("file"),
+                      "message": warning.get("message"),
+                      "severity": "WARNING",
+                      "fix": warning.get("fix", "")
+                  })
+
           # Determine overall quality level
           # Priority: critical > needs_work > polish > good
           
@@ -3266,6 +3411,7 @@ steps:
           warning_count += len([i for i in results["experiment_issues"] if i.get("severity") == "WARNING"])
           warning_count += len(results["behavior_reference_hygiene_issues"])  # v3.5.0: all are WARNING
           warning_count += len([i for i in results["mode_validation_issues"] if i.get("severity") == "WARNING"])  # v3.6.0
+          warning_count += len(results["body_instruction_issues"])  # v3.7.0: all are WARNING
           if recipe_quality == "polish":
               warning_count += 1
           
@@ -3310,7 +3456,8 @@ steps:
               "structure_lint_errors": len(results["structure_lint_issues"]),
               "behavior_ref_hygiene_warnings": len(results["behavior_reference_hygiene_issues"]),  # v3.5.0
               "mode_validation_errors": len([i for i in results["mode_validation_issues"] if i.get("severity") == "ERROR"]),  # v3.6.0
-              "mode_validation_warnings": len([i for i in results["mode_validation_issues"] if i.get("severity") == "WARNING"])  # v3.6.0
+              "mode_validation_warnings": len([i for i in results["mode_validation_issues"] if i.get("severity") == "WARNING"]),  # v3.6.0
+              "body_instruction_warnings": len(results["body_instruction_issues"])  # v3.7.0
           }
 
           # v3.3.0: Recipe validation summary
@@ -3337,7 +3484,7 @@ steps:
     parse_json: true
     timeout: 60
     on_error: "fail"
-    depends_on: ["validate-all-bundles", "behavior-hygiene-validation", "behavior-reference-hygiene", "standalone-completeness-validation", "experiments-validation", "context-sink-compliance", "tool-placement-analysis", "validate-recipes", "set-default-recipe-validation", "yaml-structure-lint", "mode-validation"]
+    depends_on: ["validate-all-bundles", "behavior-hygiene-validation", "behavior-reference-hygiene", "standalone-completeness-validation", "experiments-validation", "context-sink-compliance", "tool-placement-analysis", "validate-recipes", "set-default-recipe-validation", "yaml-structure-lint", "mode-validation", "body-instruction-check"]
 
   # ============================================================================
   # PHASE 2.75: Initialize Optional Outputs
@@ -3989,6 +4136,11 @@ steps:
       {{mode_validation_results}}
       ```
 
+      **Body Instruction Check (v3.7.0):**
+      ```json
+      {{body_instruction_check_results}}
+      ```
+
       **Bundle Doc Freshness (Phase 6 v3):**
       ```json
       {{bundle_doc_freshness}}
@@ -4108,6 +4260,19 @@ steps:
         - Per mode-design-discipline §4 advertising rule: the LLM infers modes by name
       - If no issues: "Mode validation: all N modes passed description budget and advertising checks"
       - If mode_validation_results.skipped == true: "Mode validation: skipped (no modes/*.md files found)"
+
+      ### Body Instruction Check (v3.7.0)
+      Use body_instruction_check_results to report:
+      - files_checked: total number of bundle.md and agents/*.md files checked
+      - For each WARNING of type prose_below_frontmatter:
+        - [WARNING] the file's message (names the file, prose char count, and a preview)
+        - The fix: everything below the frontmatter is sent to the model as system
+          instruction -- move descriptive prose into the frontmatter description
+          field (metadata, never sent) or delete it; keep @mention pointers to
+          instruction files
+      - If no issues: "Body instruction check: all N files have instruction-only bodies"
+      - If body_instruction_check_results.skipped == true: "Body instruction check: skipped (no bundle.md or agents/*.md files found)"
+      - This is WARNING-level only -- it never fails the build on its own
 
       ### Standalone Completeness
       | Bundle | Orchestrator | Context | Provider | Status |

--- a/recipes/validate-single-bundle.yaml
+++ b/recipes/validate-single-bundle.yaml
@@ -9,6 +9,13 @@
 # CHANGELOG
 # =============================================================================
 #
+# v2.2.0:
+#   - NEW: Body Instruction Check (Step 1.5) - warns when the bundle body below
+#     the frontmatter reads as documentation rather than instruction. The body
+#     is sent to the model as system instruction, emitted ahead of all context.
+#     WARNING level only; degrades to a clean skip if amplifier_foundation is
+#     not importable.
+#
 # v2.1.0 (2026-04-20):
 #   - NEW FEATURE: YAML Structure Lint (Step 0) — runs BEFORE dependency tracing
 #     * Detects 'includes:' nested under 'bundle:' (silently dropped by parser)
@@ -44,7 +51,7 @@ description: |
   
   For example, if a behavior is not in this bundle's includes chain,
   its context files won't be counted.
-version: "2.1.0"
+version: "2.2.0"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "single", "dependency-tracing", "yaml-lint"]
 
@@ -466,6 +473,75 @@ steps:
     depends_on: ["yaml-structure-lint"]
 
   # ============================================================================
+  # STEP 1.5: Body Instruction Check
+  # Everything below the bundle's YAML frontmatter is loaded verbatim as the
+  # session's system instruction. Descriptive/documentation prose there is a
+  # defect -- only instruction (or @mention pointers to instruction files)
+  # belongs below the frontmatter. WARNING level (not ERROR).
+  # ============================================================================
+
+  - id: "body-instruction-check"
+    type: "bash"
+    command: |
+      python3 << 'EOF'
+      import json
+      import sys
+      from pathlib import Path
+
+      # amplifier_foundation is not guaranteed to be importable in every
+      # environment this recipe runs in. Report a clean skip so generate-report
+      # sees valid JSON instead of a crashed step's output.
+      try:
+          from amplifier_foundation.validator import check_body_is_instruction
+      except ImportError:
+          print(json.dumps({
+              "phase": "body_instruction_check",
+              "skipped": True,
+              "reason": "amplifier_foundation not importable",
+              "warnings": [],
+              "errors": []
+          }))
+          sys.exit(0)
+
+      def check_bundle_body(bundle_path: str) -> dict:
+          results = {
+              "phase": "body_instruction_check",
+              "bundle_path": bundle_path,
+              "warnings": [],
+              "errors": []
+          }
+
+          path = Path(bundle_path).resolve()
+          try:
+              content = path.read_text(encoding="utf-8")
+          except Exception as e:
+              results["errors"].append({
+                  "severity": "ERROR",
+                  "code": "READ_ERROR",
+                  "message": f"Failed to read bundle file: {e}"
+              })
+              return results
+
+          check = check_body_is_instruction(content)
+          if check["verdict"] == "FLAG":
+              results["warnings"].append({
+                  "severity": "WARNING",
+                  "code": "PROSE_BELOW_FRONTMATTER",
+                  "message": f"{path.name}: body has {check['prose_chars']} chars of documentation-style prose below the frontmatter: \"{check['prose_preview']}\"",
+                  "remediation": "Everything below the frontmatter is sent to the model as system instruction. Move descriptive prose into the frontmatter description field (metadata, never sent) or delete it. Keep @mention pointers to instruction files."
+              })
+
+          return results
+
+      print(json.dumps(check_bundle_body("{{bundle_path}}")))
+      EOF
+    output: "body_instruction_results"
+    parse_json: true
+    timeout: 30
+    on_error: "continue"
+    depends_on: ["trace-dependencies"]
+
+  # ============================================================================
   # STEP 2: Context analysis using ONLY traced dependencies
   # ============================================================================
 
@@ -680,7 +756,7 @@ steps:
     parse_json: true
     timeout: 60
     on_error: "fail"
-    depends_on: ["trace-dependencies"]
+    depends_on: ["trace-dependencies", "body-instruction-check"]
 
   # ============================================================================
   # STEP 3: Generate validation report for this bundle
@@ -708,6 +784,11 @@ steps:
       **Context Analysis:**
       ```json
       {{context_results}}
+      ```
+
+      **Body Instruction Check:**
+      ```json
+      {{body_instruction_results}}
       ```
 
       **Generate a report with:**
@@ -745,6 +826,9 @@ steps:
       
       **Issues:**
       List any errors or warnings found, with recommended fixes.
+      Include any warnings from body_instruction_results (PROSE_BELOW_FRONTMATTER) --
+      the bundle body below the frontmatter is sent to the model as system
+      instruction, so documentation-style prose there is a WARNING-level issue.
       
       **Key Files:**
       List the top 5 largest context files with their token counts and source category.

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -8,6 +8,7 @@ from amplifier_foundation.exceptions import BundleValidationError
 from amplifier_foundation.validator import (
     BundleValidator,
     ValidationResult,
+    check_body_is_instruction,
     validate_bundle,
     validate_bundle_completeness,
     validate_bundle_completeness_or_raise,
@@ -252,3 +253,125 @@ class TestStrictMode:
         assert result.valid is True
         assert result.errors == []
         assert result.warnings == []
+
+
+class TestCheckBodyIsInstruction:
+    """Tests for check_body_is_instruction()."""
+
+    def test_mentions_only_body_is_ok(self) -> None:
+        """A body containing only @mentions is OK (nothing to flag)."""
+        content = (
+            "---\nname: test\n---\n@foundation:context/FOO.md\n@core:docs/BAR.md\n"
+        )
+        result = check_body_is_instruction(content)
+        assert result["verdict"] == "OK"
+        assert result["reason"] == "body carries no prose (mentions/scaffolding only)"
+        assert result["prose_chars"] == 0
+        assert result["prose_preview"] == ""
+
+    def test_second_person_body_is_ok(self) -> None:
+        """A body that addresses the model in second person is OK (instruction)."""
+        content = (
+            "---\nname: test\n---\n"
+            "You are a helpful assistant. Your job is to help the user work through "
+            "their task. Delegate research to the explorer agent, and keep your "
+            "own responses short and concrete rather than exhaustive.\n"
+        )
+        result = check_body_is_instruction(content)
+        assert result["verdict"] == "OK"
+        assert result["reason"] == "addresses the model (second person)"
+        assert result["prose_chars"] > 0
+
+    def test_third_person_prose_with_trailing_mention_is_flagged(self) -> None:
+        """Heading + third-person descriptive paragraph + trailing @mention is FLAG."""
+        content = (
+            "---\nname: test\n---\n"
+            "# About This Bundle\n\n"
+            "This bundle provides tools for working with documents. "
+            "It was created by the team to simplify document processing, and "
+            "collects the conventions the team settled on for that work.\n\n"
+            "@foundation:context/FOO.md\n"
+        )
+        result = check_body_is_instruction(content)
+        assert result["verdict"] == "FLAG"
+        assert result["reason"] == (
+            "no second-person address -- reads as documentation, not instruction"
+        )
+        assert result["prose_chars"] > 0
+        # the heading is scaffolding and is stripped; the paragraph is the prose
+        assert result["prose_preview"].startswith("This bundle provides tools")
+
+    def test_second_person_inside_code_fence_does_not_rescue_prose(self) -> None:
+        """A placeholder like "your-server" in a sample config is not instruction.
+
+        Regression test for the real defect this missed: amplifier-foundation's
+        own root bundle.md is documentation prose that passed as OK solely
+        because of the string "your-server" inside a fenced JSON example.
+        """
+        content = (
+            "---\nname: test\n---\n"
+            "# Foundation Bundle\n\n"
+            "This bundle provides the standard Amplifier foundation with the "
+            "enhanced delegate tool for agent orchestration. It bundles the "
+            "common tool roster and the default orchestrator.\n\n"
+            "## MCP Configuration\n\n"
+            "```json\n"
+            '{\n  "mcpServers": {\n    "your-server": {\n      "url": "https://example.com/mcp"\n    }\n  }\n}\n'
+            "```\n"
+        )
+        result = check_body_is_instruction(content)
+        assert result["verdict"] == "FLAG"
+        assert "your-server" not in result["prose_preview"]
+
+    def test_bare_heading_body_is_not_flagged(self) -> None:
+        """A body that is only a title heading carries no prose."""
+        content = "---\nname: test\n---\n# LLM Wiki Bundle\n"
+        result = check_body_is_instruction(content)
+        assert result["verdict"] == "OK"
+        assert result["prose_chars"] == 0
+
+    def test_scaffolding_and_mentions_only_body_is_not_flagged(self) -> None:
+        """Headings, horizontal rules and @mentions are scaffolding, not prose."""
+        content = (
+            "---\nname: test\n---\n"
+            "# Design Intelligence\n\n"
+            "@design-intelligence:context/design-instructions.md\n\n"
+            "---\n\n"
+            "## Design Philosophy\n\n"
+            "@design-intelligence:context/philosophy/DESIGN-PHILOSOPHY.md\n"
+        )
+        result = check_body_is_instruction(content)
+        assert result["verdict"] == "OK"
+        assert result["prose_chars"] == 0
+
+    def test_no_frontmatter_returns_no_frontmatter_verdict(self) -> None:
+        """A file without YAML frontmatter returns NO_FRONTMATTER."""
+        content = "# Just a markdown file\n\nNo frontmatter here.\n"
+        result = check_body_is_instruction(content)
+        assert result["verdict"] == "NO_FRONTMATTER"
+        assert result["prose_chars"] == 0
+        assert result["prose_preview"] == ""
+        assert result["reason"] == "no frontmatter"
+
+    def test_html_comment_only_body_is_ok(self) -> None:
+        """A body containing only an HTML comment is OK (mentions-only equivalent)."""
+        content = "---\nname: test\n---\n<!-- This is just a note for maintainers -->\n"
+        result = check_body_is_instruction(content)
+        assert result["verdict"] == "OK"
+        assert result["reason"] == "body carries no prose (mentions/scaffolding only)"
+        assert result["prose_chars"] == 0
+
+    def test_multiline_html_comment_is_skipped(self) -> None:
+        """A multi-line HTML comment is fully skipped, not counted as prose."""
+        content = (
+            "---\nname: test\n---\n"
+            "<!--\n"
+            "This is a long internal note.\n"
+            "It spans multiple lines and describes the bundle.\n"
+            "-->\n"
+            "@foundation:context/FOO.md\n"
+        )
+        result = check_body_is_instruction(content)
+        assert result["verdict"] == "OK"
+        assert result["reason"] == "body carries no prose (mentions/scaffolding only)"
+        assert result["prose_chars"] == 0

--- a/tests/test_yaml_structure_lint.py
+++ b/tests/test_yaml_structure_lint.py
@@ -358,11 +358,11 @@ class TestLintLogicEdgeCases:
 class TestSingleBundleRecipeStructure:
     """Verify validate-single-bundle.yaml has the yaml-structure-lint step."""
 
-    def test_version_is_2_1_0(self, single_bundle_recipe):
-        """Version must be bumped to 2.1.0."""
+    def test_version_is_current(self, single_bundle_recipe):
+        """Version must match the recipe's current release."""
         data, _ = single_bundle_recipe
-        assert data["version"] == "2.1.0", (
-            f"Expected version '2.1.0', got '{data['version']}'"
+        assert data["version"] == "2.2.0", (
+            f"Expected version '2.2.0', got '{data['version']}'"
         )
 
     def test_yaml_structure_lint_step_exists(self, single_bundle_steps):


### PR DESCRIPTION
## Problem

Everything below the YAML frontmatter in a bundle, agent, or mode file is loaded verbatim as the session's **system instruction**, and it is emitted **first** — ahead of every context file. Only instruction, or `@mention` pointers to instruction files, belongs there. Descriptive documentation prose in that position burns system-prompt tokens on every turn of every session and reads to the model as an instruction.

The rule is now stated in `docs/BUNDLE_GUIDE.md` (#313) and the known offenders in this repo were fixed (#311). Nothing enforces it. This PR is the enforcement leg.

**No existing validation recipe checks this.** All three read the file, regex-match the frontmatter, and then never look at the body again — except `validate-bundle-repo.yaml`'s `mode-validation`, which isolates the body of `modes/*.md` solely to regex out `@mentions`. Every token/description check that exists today operates on either `context.include` targets or a field *inside* the frontmatter, never on the body.

## Mechanism (verified in this repo)

| Step | Location |
|---|---|
| Body below frontmatter becomes `instruction` | `amplifier_foundation/registry.py` — `bundle.instruction = body.strip()` |
| `instruction` becomes the main system prompt | `amplifier_foundation/bundle/_prepared.py` — `main_instruction = captured_bundle.instruction` |
| Emitted first, before context | `_prepared.py` — `f"{main_instruction}\n\n---\n\n{all_context}"` |
| Registered as prompt factory | `_prepared.py` — `context_manager.set_system_prompt_factory(factory)` |

Agent and mode files take the same path (`bundle/_dataclass.py` — `result["instruction"] = body.strip()`).

## Change

**One library function, three thin call sites.**

`amplifier_foundation/validator.py` gains `check_body_is_instruction(content) -> dict` returning `verdict` (`OK` / `FLAG` / `NO_FRONTMATTER`), `prose_chars`, `prose_preview`, and `reason`.

The discriminator, in order:

1. Strip fenced code blocks. They are examples — a placeholder like `"your-server"` in a sample config is not the body addressing the model.
2. Strip blank lines, bare `@mention` lines, and HTML comments.
3. Strip markdown scaffolding — headings and horizontal rules. A body of `# LLM Wiki Bundle` and a divider says nothing to the model; there is no prose there to classify either way. If nothing remains, pass.
4. Otherwise: does the remaining text address the model (`you` / `your` / `yours` / `yourself`)? Instruction addresses the model. Documentation describes the artifact.

Wired into all three recipes at **WARNING** severity, issue code `PROSE_BELOW_FRONTMATTER`:

| Recipe | Where |
|---|---|
| `recipes/validate-agents.yaml` | inside `parse_agent_frontmatter()`, appended to `result["warnings"]` in the same dict shape as the existing `SHORT_DESCRIPTION` warning |
| `recipes/validate-single-bundle.yaml` | new step `body-instruction-check` between `trace-dependencies` and `context-analysis`; surfaced in `generate-report` |
| `recipes/validate-bundle-repo.yaml` | new step `body-instruction-check` modelled on `mode-validation`; wired into `quality-classification` and given a section in `synthesize-report` |

Both bundle recipes are needed because `validate-bundle-repo.yaml` does not delegate to `validate-single-bundle.yaml` — they are independent code paths with duplicated discovery and linting.

All three guard the import: `amplifier_foundation` is not importable in every environment these recipes run in (they are run against third-party bundle repos), and they degrade to a clean skip rather than a crash. In `validate-agents.yaml` this matters more than elsewhere — an unhandled `ImportError` there produces no JSON, and the downstream `quality-classification` step parses that output unguarded with `on_error: "fail"`, taking the whole run down. Verified reproducible in a clean venv.

## Scope

`bundle.md` and `agents/*.md`. **`modes/*.md` are NOT covered** — `mode-validation` checks a mode's frontmatter description budget and its advertising references, never the body. Extending the check to modes is left for a follow-up.

Test fixtures are excluded from repo-wide discovery; they are deliberately synthetic and flagging them is noise.

## Why WARNING and not ERROR

13 distinct bundles across a resolved cache trip this check. ERROR would turn essentially every bundle repo red on first run. WARNING surfaces the class for a human to judge, which is the right call for a heuristic.

## Test evidence

Run against a 321-file corpus (this repo plus a fully resolved bundle cache; test fixtures excluded): **289 OK, 16 FLAG, 16 no-frontmatter.** The 16 flags cover 13 distinct bundles — browser-tester, filesystem, modes, recipes, redaction, routing-matrix, stories, terminal-tester, both anchors bundles, and this repo's own root `bundle.md`. Manual review of the flag list found no false positives.

Ground-truth check against the four files #311 fixed: all four FLAG in their pre-fix form, all four clear post-fix.

Note on the code-fence rule: without it, this repo's own root `bundle.md` — 578 chars of third-person documentation, loaded into effectively every session — passed as clean, on the strength of the string `"your-server"` inside a fenced JSON example. That was the only false negative in the corpus, and it was the highest-token-leverage file in it.

Caveat worth stating plainly: `you`/`your` is a proxy for "addresses the model," not the thing itself. It holds across this corpus in both directions, but it is a heuristic, which is why this ships at WARNING.

Second caveat, on this repo's own root `bundle.md`: it is flagged, but it is not a clean-cut defect. #311 fixed four bundle manifests and deliberately left this one alone, on the stated grounds that the four it fixed duplicated their description in the frontmatter and so lost nothing. The root bundle's body is mixed — an opening description and a features table that are pure waste, alongside delegate-tool reference and MCP setup guidance that are not duplicated in the frontmatter. It is flagged here because the previous behaviour cleared it by accident (a `"your-server"` placeholder in a fenced example), and an accidental pass is not an exemption. Whether to trim it, or to accept one standing warning, is a separate call. There is deliberately **no opt-out mechanism** in this PR — one file wanting an exemption is one file, not yet a feature.

Plus unit tests in `tests/test_validator.py` covering mentions-only, second-person, heading-plus-third-person-paragraph, missing frontmatter, single- and multi-line HTML comments, the code-fence false negative, and scaffolding-only bodies. `pytest tests/test_validator.py` — 32 passed. All three recipes parse cleanly under `yaml.safe_load`.

## Recipe versions

`validate-bundle-repo.yaml` → v3.7.0, `validate-single-bundle.yaml` → v2.2.0, both with changelog entries.

## Not in scope

No bundle, agent, or mode content files are touched — recipes, `validator.py`, and tests only. Severity is WARNING everywhere. Fixing the 13 bundles that trip this is a separate PR; extending the check to `modes/*.md` is another.
