### PR TITLE
docs: state the rule that only instruction goes below the frontmatter

### DIFF
--- a/docs/AGENT_AUTHORING.md
+++ b/docs/AGENT_AUTHORING.md
@@ -183,12 +183,14 @@ Check each agent's description against these criteria:
 
 ## Instruction Structure
 
-The markdown body after frontmatter becomes the agent's system prompt. Recommended structure:
+The markdown body after frontmatter becomes the agent's system prompt. It is instruction addressed to the agent — never a description of the agent for a human reader. That belongs in the frontmatter `meta.description`, which is metadata and is never sent to the model. See [What Goes Below the Frontmatter](BUNDLE_GUIDE.md#what-goes-below-the-frontmatter) for the general rule and the enforcing validators.
+
+Recommended structure:
 
 ```markdown
 # Agent Name
 
-[One-line role description]
+You are [role]. You [what you do, in one line].
 
 **Execution model:** You run as a one-shot sub-session. Work with what 
 you're given and return complete results.

--- a/docs/BUNDLE_GUIDE.md
+++ b/docs/BUNDLE_GUIDE.md
@@ -129,7 +129,59 @@ includes:
 - No `tools:`, `session:`, or `hooks:` declarations (inherited from foundation)
 - Uses behavior pattern for its unique capabilities
 - References consolidated instructions file
-- Minimal markdown body
+- Minimal markdown body — see [What Goes Below the Frontmatter](#what-goes-below-the-frontmatter)
+
+---
+
+## What Goes Below the Frontmatter
+
+**Everything below the frontmatter is sent to the model as system instruction.** It is not documentation, and it is not free.
+
+The loader assigns the markdown body to `bundle.instruction` (`amplifier_foundation/registry.py`), and the prepared bundle emits it **first** — ahead of every context file:
+
+```python
+# amplifier_foundation/bundle/_prepared.py
+main_instruction = captured_bundle.instruction or ""
+...
+return f"{main_instruction}\n\n---\n\n{all_context}"
+```
+
+Agent files (`agents/*.md`) and mode files (`modes/*.md`) take the same path.
+
+### The rule
+
+Below the frontmatter, write **only**:
+
+- instruction addressed to the model, and/or
+- `@mention` pointers to instruction files.
+
+Do **not** write a description of the bundle. That is what the frontmatter `description:` field is for — it is manifest metadata and is never sent to the model.
+
+### The test
+
+Read the body aloud as though you are the model receiving it. Instruction addresses the model:
+
+```markdown
+✅ You have access to the recipe system for multi-step orchestration.
+   Delegate all recipe authoring to `recipes:recipe-author`.
+```
+
+Documentation describes the artifact to a human reader:
+
+```markdown
+❌ # Recipe Bundle
+
+   A lean, principle-driven bundle. Behavior is shaped by a short set of
+   named principles loaded once at the head of the system prompt.
+```
+
+The second form costs tokens in every turn of every session and tells the model a third-person description of itself instead of what to do. If you want that text for humans, put it in `README.md` or in the frontmatter `description:`.
+
+### Which body actually reaches the prompt
+
+`Bundle.compose()` applies *later replaces earlier* to `instruction`, and the registry composes includes first, then the current bundle. So the body that becomes the system prompt is the **root** bundle's. An included bundle's body is discarded — unless the root has no body of its own, in which case the last included body with content survives. Don't rely on that fallback; keep every body correct on its own terms.
+
+**Enforced by** `foundation:recipes/validate-bundle-repo.yaml`, `validate-single-bundle.yaml`, and `validate-agents.yaml`, which emit a `PROSE_BELOW_FRONTMATTER` warning.
 
 ---
 


### PR DESCRIPTION
## Problem

Everything below the YAML frontmatter in a bundle, agent, or mode file is loaded verbatim as the session's **system instruction**, and it is emitted **first** — ahead of every context file. **This rule is not written down anywhere for bundles.**

`docs/BUNDLE_GUIDE.md` never states that the body becomes the system prompt. Its only nod to the constraint is an incidental bullet — "Minimal markdown body" — in the list of observations about an exemplar bundle. An author reading the guide has no way to learn that a title and a paragraph of description in that position cost tokens in every turn of every session and read to the model as an instruction.

Worse, `docs/AGENT_AUTHORING.md` states the rule correctly ("The markdown body after frontmatter becomes the agent's system prompt") and then hands the author a template that opens with exactly the shape the rule forbids:

```markdown
# Agent Name

[One-line role description]
```

A third-person role description is documentation, not instruction. In practice every agent in this repo ignores the template and opens in second person ("You are a specialized…") — the template has simply been wrong.

## Change

**`docs/BUNDLE_GUIDE.md`** — new section, *What Goes Below the Frontmatter*, placed after the thin-bundle exemplar and before the behavior pattern. It covers:

- the mechanism, with the actual code path (`registry.py` → `_prepared.py`) and the line that puts the instruction first;
- the rule — below the frontmatter write only instruction addressed to the model, and/or `@mention` pointers to instruction files;
- a read-it-aloud test with a good and a bad example;
- which body actually reaches the prompt — `Bundle.compose()` applies *later replaces earlier* to `instruction` and the registry composes includes first, so the **root** bundle's body wins and an included body is normally discarded;
- a pointer to the validators that enforce it.

The "Minimal markdown body" bullet now links to the new section instead of leaving the reader to guess what "minimal" means.

**`docs/AGENT_AUTHORING.md`** — the template's third-person placeholder becomes second person, and the section now states plainly that the body is instruction addressed to the agent, never a description for a human reader (that is what `meta.description` is for), with a cross-link to the general rule.

## Scope

Two documentation files. No code, no bundles, no recipes. Companion PRs remove the prose from the bundles that have it and add the validator check that emits `PROSE_BELOW_FRONTMATTER`.
