### PR TITLE
chore: refresh Anthropic provider presets to current models

### DIFF
--- a/providers/anthropic-opus.yaml
+++ b/providers/anthropic-opus.yaml
@@ -7,5 +7,5 @@ providers:
   - module: provider-anthropic
     source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
     config:
-      default_model: claude-opus-4-6
+      default_model: claude-opus-5
       raw: true

--- a/providers/anthropic-sonnet.yaml
+++ b/providers/anthropic-sonnet.yaml
@@ -7,5 +7,5 @@ providers:
   - module: provider-anthropic
     source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
     config:
-      default_model: claude-sonnet-4-5
+      default_model: claude-sonnet-5
       raw: true


### PR DESCRIPTION
## Summary

Refresh the two Anthropic provider presets to the current models.

| File | Before | After |
|---|---|---|
| `providers/anthropic-sonnet.yaml:10` | `claude-sonnet-4-5` | `claude-sonnet-5` |
| `providers/anthropic-opus.yaml:10` | `claude-opus-4-6` | `claude-opus-5` |

Two lines. Nothing else changes.

## Why

Housekeeping, not a fix. Both old pins still resolve and work — they are simply two to three releases behind. These presets are what a caller composes when they want "the Anthropic Sonnet provider" without writing the block themselves, so the name they carry should be the current model.

## Verification

- `claude-sonnet-5` — live on the Models API, created 2026-06-29
- `claude-opus-5` — live on the Models API, created 2026-07-24
- Both have cost rates in `provider-anthropic`'s pricing table, so cost reporting stays accurate

## Note

`claude-opus-5` is a more expensive tier than `claude-opus-4-6` was at the time these were written ($5/$25 per MTok). Anyone composing `providers/anthropic-opus.yaml` gets that rate. That is the intent of an "Opus" preset, but it is a real cost change and worth being explicit about.

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)
