### PR TITLE
docs: drop the enforcement claim the validators do not yet back

### DIFF
--- a/docs/BUNDLE_GUIDE.md
+++ b/docs/BUNDLE_GUIDE.md
@@ -181,8 +181,6 @@ The second form costs tokens in every turn of every session and tells the model 
 
 `Bundle.compose()` applies *later replaces earlier* to `instruction`, and the registry composes includes first, then the current bundle. So the body that becomes the system prompt is the **root** bundle's. An included bundle's body is discarded — unless the root has no body of its own, in which case the last included body with content survives. Don't rely on that fallback; keep every body correct on its own terms.
 
-**Enforced by** `foundation:recipes/validate-bundle-repo.yaml`, `validate-single-bundle.yaml`, and `validate-agents.yaml`, which emit a `PROSE_BELOW_FRONTMATTER` warning.
-
 ---
 
 ## The Behavior Pattern


### PR DESCRIPTION
## Problem

The *What Goes Below the Frontmatter* section added in #313 closed with:

> **Enforced by** `foundation:recipes/validate-bundle-repo.yaml`, `validate-single-bundle.yaml`, and `validate-agents.yaml`, which emit a `PROSE_BELOW_FRONTMATTER` warning.

**No such check exists on `main`.** It is in #312, which is still open. I wrote the two changes as a pair and #313 landed first, so the guide is currently asserting a safety net that will not catch anyone.

## Change

Removes the sentence. The rule itself — and the mechanism, the read-it-aloud test, and the compose semantics — is unaffected and stands on its own.

The sentence has been moved into #312, so the claim and the code that makes it true land in the same commit.

## Why not just merge #312 instead

That would also resolve it, but the ordering dependency shouldn't be load-bearing. A doc claim should be true on the commit that introduces it, regardless of what else merges and when.
