### PR TITLE
docs(anchors-amp-dev): drop the stale behavioral-anchor naming

### DIFF
--- a/bundles/anchors-amp-dev/README.md
+++ b/bundles/anchors-amp-dev/README.md
@@ -1,11 +1,11 @@
-# Experimental Behavioral-Anchor Bundle — Amplifier-Dev Variant
+# Anchors Bundle — Amplifier-Dev Variant
 
 A lean experimental bundle that shapes the agent's conduct with a short, explicit
 set of **behavioral principles** at the top of the system prompt — specialized for
 developing **on the Amplifier ecosystem itself** (multi-repo coordination, bundle
 authoring, DTU validation).
 
-This is the [`anchors`](../anchors/) experiment extended with an
+This is the [`anchors`](../anchors/) bundle extended with an
 amplifier-dev domain: one additional expert agent and a small set of dev-domain
 context files, layered on the same principle-driven core.
 
@@ -28,7 +28,7 @@ amplifier bundle use anchors-amp-dev
 
 ## The idea
 
-Same bet as the base behavioral-anchor experiment: a handful of sharp, named
+Same bet as the base `anchors` bundle: a handful of sharp, named
 principles — re-read on every turn — steer conduct more cheaply and reliably than
 verbose policy text. This variant asks whether that same lean core can carry
 **domain-specialized** work (developing Amplifier) by adding only a thin domain
@@ -46,6 +46,6 @@ The principle core:
 - **`amplifier-dev-expert`** agent — authority for multi-repo development, dependency/push order, DTU validation, and bundle/agent authoring.
 - **`context/amplifier-dev/`** — `ecosystem-map.md`, `dev-workflows.md`, `testing-patterns.md`, loaded by the expert agent on demand.
 
-Everything else mirrors the base experiment: a minimal system prompt and the same
+Everything else mirrors the base `anchors` bundle: a minimal system prompt and the same
 thin, delegation-aware agent roster (explorer, architect, builder, debugger,
 researcher, git-ops).

--- a/bundles/anchors-amp-dev/bundle.md
+++ b/bundles/anchors-amp-dev/bundle.md
@@ -3,7 +3,7 @@ bundle:
   name: anchors-amp-dev
   version: 0.1.0
   description: |
-    Experimental lean bundle driven by a small set of behavioral principles.
+    Lean bundle driven by a small set of behavioral principles.
     A minimal system prompt, thin purposeful agents, and a standard tool roster.
     Explores how far concise behavior-shaping -- principles loaded once at the
     head of the system prompt -- can carry an Amplifier session at a fraction of


### PR DESCRIPTION
## Why

`bundles/anchors-amp-dev/` still describes itself as the "Behavioral-Anchor" experiment. That name is two renames out of date.

The bundle it varies was `behavioral-anchor` when `anchors-amp-dev` was written. #259 promoted it to the published `anchors` bundle on 2026-06-23, and #278 dropped the stale "experimental" framing from `anchors`' own manifest on 2026-07-22. `anchors-amp-dev` was carried along by neither.

The bundle's `name:` field is already correct (`anchors-amp-dev`) — this is prose only. Nothing resolvable changes.

## Change

| File:line | Before | After |
|---|---|---|
| `README.md:1` | `# Experimental Behavioral-Anchor Bundle — Amplifier-Dev Variant` | `# Anchors Bundle — Amplifier-Dev Variant` |
| `README.md:8` | "This is the [`anchors`](../anchors/) **experiment** extended with…" | "…the [`anchors`](../anchors/) **bundle** extended with…" |
| `README.md:31` | "Same bet as the base **behavioral-anchor experiment**:" | "Same bet as the base **`anchors` bundle**:" |
| `README.md:49` | "Everything else mirrors the base **experiment**:" | "…mirrors the base **`anchors` bundle**:" |
| `bundle.md:6` | "**Experimental** lean bundle driven by a small set of behavioral principles." | "Lean bundle driven by a small set of behavioral principles." |

`bundle.md:6` now matches `bundles/anchors/bundle.md:6` verbatim, which is what #278 established.

Lines 8 and 49 weren't in the original scope, but they call the promoted `anchors` bundle an "experiment" — the same factual staleness as line 31, in the same file. Fixing three of five instances of one wrong thing is worse than fixing all five.

## Deliberately unchanged

`README.md:3` — "A lean **experimental** bundle that shapes the agent's conduct…" — is left alone. It is verbatim identical to `bundles/anchors/README.md:3`. That sentence characterizes the *approach* as experimental, which is still upstream's own current wording; changing it here would make the two READMEs inconsistent in the opposite direction. If that framing should go, it should go from both, in its own change.

"**behavioral principles**" also stays throughout — that is the concept the bundle is built on, and it appears identically in `bundles/anchors/`, both `context/system.md` files, and upstream.

`experiments/behavioral-anchor/` and `experiments/behavioral-anchor-amplifier-dev/` keep their names. Those are the experiments' actual names.

## Scope

Two files, prose only. No frontmatter keys, no `@mentions`, no module or agent changes.
