### PR TITLE
fix(delegate): carry agent identity through resume completions + emit agent_resumed

### DIFF
--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -133,6 +133,27 @@ class DelegateTool:
         # Build feature registry for dynamic description composition
         self._feature_registry = self._build_feature_registry()
 
+        # Maps sub_session_id -> the raw (un-sanitized) agent_name recorded at
+        # spawn time. This is the authoritative source for agent identity on
+        # resume: it is the exact same string emitted in delegate:agent_spawned,
+        # so counters that pair spawned/resumed/completed events by "agent"
+        # stay correct. Populated in _spawn_new_session(); consulted in
+        # _resume_existing_session() via _resolve_agent_for_session().
+        #
+        # Scope: this cache lives on the DelegateTool instance, which is
+        # constructed once per mounted session (see mount()) and persists for
+        # the lifetime of the parent session/coordinator. It does NOT survive
+        # across process restarts or a resume issued from a *different*
+        # parent session than the one that spawned the sub-session -- that
+        # cold-cache case falls back to parsing the agent name out of the
+        # session_id suffix (see _resolve_agent_for_session), which is lossy
+        # (sanitized: lowercased, non-alphanumeric chars collapsed to hyphens)
+        # but always available since
+        # amplifier_foundation.tracing.generate_sub_session_id guarantees the
+        # "{parent_span}-{child_span}_{sanitized_agent_name}" shape for every
+        # sub-session id this tool creates.
+        self._session_agents: dict[str, str] = {}
+
     def _build_feature_registry(self) -> list[dict[str, Any]]:
         """Build registry of features with their descriptions.
 
@@ -995,6 +1016,12 @@ Agent usage notes:
             parent_session_id=parent_session_id,
         )
 
+        # Record the raw agent_name for this sub-session so a later resume
+        # (via _resume_existing_session) can recover the exact identity used
+        # here, instead of re-deriving a lossy, sanitized approximation from
+        # the session_id suffix. See _resolve_agent_for_session().
+        self._session_agents[sub_session_id] = agent_name
+
         # Resolve agents from coordinator config if not provided directly
         if agents is None:
             try:
@@ -1255,6 +1282,44 @@ Agent usage notes:
                 )
             return ToolResult(success=False, error={"message": error_msg})
 
+    def _resolve_agent_for_session(self, session_id: str) -> str:
+        """Resolve the agent identity for a (possibly resumed) sub-session.
+
+        Source priority (most to least reliable):
+        1. ``self._session_agents`` -- the raw agent_name recorded by THIS
+           tool instance when it originally spawned ``session_id``. Exact
+           match to the ``agent`` field emitted in ``delegate:agent_spawned``,
+           so spawned/resumed/completed events pair correctly under the same
+           agent identity.
+        2. The session_id suffix -- ``generate_sub_session_id`` always
+           produces IDs shaped ``{parent_span}-{child_span}_{sanitized_name}``
+           (see amplifier_foundation.tracing). The sanitizer maps every
+           non-alphanumeric character -- including "_" itself -- to "-", so
+           the suffix after the LAST "_" is unambiguous and always present.
+           This is a deterministic parse of a documented format, not a guess,
+           but it is lossy: the sanitized name is lowercased and punctuation
+           (e.g. the ":" in "foundation:explorer") is collapsed to hyphens.
+           Used when the cache misses -- e.g. resuming a sub-session spawned
+           by a different parent session/process than the one calling this
+           method now.
+
+        Args:
+            session_id: Full sub-session ID to resolve.
+
+        Returns:
+            The agent name, or "unknown" if neither source yields one.
+        """
+        cached = self._session_agents.get(session_id)
+        if cached:
+            return cached
+
+        if "_" in session_id:
+            suffix = session_id.rsplit("_", 1)[-1]
+            if suffix:
+                return suffix
+
+        return "unknown"
+
     async def _resume_existing_session(
         self,
         session_id: str,
@@ -1278,15 +1343,32 @@ Agent usage notes:
         """
         parent_session_id = self.coordinator.session_id
 
+        # Resolve agent identity BEFORE the try block (and before emitting
+        # any events), from the most reliable in-repo source available
+        # (spawn-time cache, or the session_id suffix convention as
+        # fallback). This is what lets delegate:agent_resumed -- and every
+        # delegate:error / delegate:agent_cancelled / delegate:agent_completed
+        # event on this path -- carry a real "agent" value instead of
+        # omitting the field entirely. Computed outside the try/except so it
+        # is unconditionally bound in every except branch below (pyright:
+        # a name only assigned inside a try body is "possibly unbound" in
+        # its except clauses, since any earlier statement could have raised
+        # first).
+        agent_name = self._resolve_agent_for_session(session_id)
+
         try:
             # Use session_id as-is (no short ID resolution - LLMs can handle full IDs)
             full_session_id = session_id
 
-            # Emit delegate:agent_resumed event
+            # Emit delegate:agent_resumed event.
+            # Payload shape is kept consistent with delegate:agent_spawned's
+            # "agent" field (see _spawn_new_session) so downstream counters
+            # can pair spawned/resumed/completed events by agent identity.
             if hooks:
                 await hooks.emit(
                     "delegate:agent_resumed",
                     {
+                        "agent": agent_name,
                         "session_id": full_session_id,
                         "parent_session_id": parent_session_id,
                         "tool_call_id": tool_call_id,
@@ -1320,6 +1402,7 @@ Agent usage notes:
                 await hooks.emit(
                     "delegate:agent_completed",
                     {
+                        "agent": agent_name,
                         "sub_session_id": full_session_id,
                         "parent_session_id": parent_session_id,
                         "success": True,
@@ -1327,11 +1410,6 @@ Agent usage notes:
                         "parallel_group_id": parallel_group_id,
                     },
                 )
-
-            # Extract agent name from session ID if possible
-            agent_name = "unknown"
-            if "_" in full_session_id:
-                agent_name = full_session_id.split("_")[-1]
 
             # Return output with session info
             session_id_result = result["session_id"]
@@ -1353,6 +1431,7 @@ Agent usage notes:
                 await hooks.emit(
                     "delegate:error",
                     {
+                        "agent": agent_name,
                         "session_id": session_id,
                         "parent_session_id": parent_session_id,
                         "error": str(e),
@@ -1368,6 +1447,7 @@ Agent usage notes:
                 await hooks.emit(
                     "delegate:error",
                     {
+                        "agent": agent_name,
                         "session_id": session_id,
                         "parent_session_id": parent_session_id,
                         "error": f"Session not found: {str(e)}",
@@ -1391,6 +1471,7 @@ Agent usage notes:
                 await hooks.emit(
                     "delegate:agent_cancelled",
                     {
+                        "agent": self._resolve_agent_for_session(session_id),
                         "session_id": session_id,
                         "parent_session_id": parent_session_id,
                         "tool_call_id": tool_call_id,
@@ -1399,10 +1480,9 @@ Agent usage notes:
             raise
 
         except TimeoutError:
-            # Extract agent name for the message
-            resume_agent = "unknown"
-            if "_" in session_id:
-                resume_agent = session_id.split("_")[-1]
+            # Resolve agent name for the message the same way as everywhere
+            # else on this path (cache first, session_id suffix fallback).
+            resume_agent = self._resolve_agent_for_session(session_id)
             timeout_msg = (
                 f"Resumed agent '{resume_agent}' timed out after {self.timeout}s "
                 f"(delegate tool session-level timeout). "
@@ -1414,6 +1494,7 @@ Agent usage notes:
                 await hooks.emit(
                     "delegate:error",
                     {
+                        "agent": resume_agent,
                         "session_id": session_id,
                         "parent_session_id": parent_session_id,
                         "error": timeout_msg,
@@ -1432,6 +1513,7 @@ Agent usage notes:
                 await hooks.emit(
                     "delegate:error",
                     {
+                        "agent": self._resolve_agent_for_session(session_id),
                         "session_id": session_id,
                         "parent_session_id": parent_session_id,
                         "error": error_msg,

--- a/modules/tool-delegate/tests/test_delegate_event_enrichment.py
+++ b/modules/tool-delegate/tests/test_delegate_event_enrichment.py
@@ -568,3 +568,134 @@ class TestResumeEventEnrichment:
         assert "parallel_group_id" in resumed_payload
         assert resumed_payload["tool_call_id"] == ""
         assert resumed_payload["parallel_group_id"] is None
+
+
+# =============================================================================
+# Tests: agent identity on resume (regression tests for openai_improvement-9n6)
+#
+# Production symptom: when a delegation is RESUMED via session_id, the parent
+# stream got delegate:agent_completed with agent: null and NO agent_resumed
+# event at all. Fan-out counted from agent_spawned undercounted ~18%, and
+# completions on the resumed leg could not be attributed to an agent.
+# =============================================================================
+
+
+class TestResumeAgentIdentity:
+    """delegate:agent_resumed and delegate:agent_completed carry a real,
+    non-null "agent" identity on the resume path -- sourced from the
+    spawn-time cache when available, or the session_id suffix convention
+    as a fallback (see DelegateTool._resolve_agent_for_session).
+    """
+
+    @pytest.mark.asyncio
+    async def test_resumed_and_completed_events_carry_agent_from_spawn_cache(self):
+        """Resuming a session this DelegateTool instance previously spawned
+        must emit agent_resumed AND agent_completed with "agent" equal to
+        the exact agent_name used at spawn time (the most reliable source:
+        an in-memory cache keyed by sub_session_id, populated in
+        _spawn_new_session). On unpatched main, agent_resumed has no
+        "agent" key at all (KeyError) and agent_completed's "agent" key is
+        likewise absent -- this test fails loudly on unpatched main.
+        """
+        hooks = _make_hooks()
+
+        async def spawn_side_effect(**kwargs):
+            # Echo back the real generated sub_session_id, like the
+            # production spawn capability does (PreparedBundle.spawn()
+            # returns child_session.session_id, which is seeded from the
+            # sub_session_id this tool generated).
+            return {
+                "output": "spawned",
+                "session_id": kwargs["sub_session_id"],
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+
+        async def resume_side_effect(**kwargs):
+            return {
+                "output": "resumed",
+                "session_id": kwargs["sub_session_id"],
+                "status": "success",
+                "turn_count": 2,
+                "metadata": {},
+            }
+
+        spawn_fn = AsyncMock(side_effect=spawn_side_effect)
+        resume_fn = AsyncMock(side_effect=resume_side_effect)
+
+        tool = _make_delegate_tool(
+            hooks=hooks,
+            spawn_fn=spawn_fn,
+            resume_fn=resume_fn,
+            agents={"test-agent": {"description": "A test agent"}},
+        )
+
+        spawn_result = await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Do something",
+                "context_depth": "none",
+            }
+        )
+        assert spawn_result.success
+        real_session_id = spawn_result.output["session_id"]
+
+        hooks.emit.reset_mock()
+
+        resume_result = await tool.execute(
+            {
+                "session_id": real_session_id,
+                "instruction": "Continue",
+            }
+        )
+        assert resume_result.success
+
+        emitted = {args[0]: args[1] for args, _ in hooks.emit.call_args_list}
+
+        assert "delegate:agent_resumed" in emitted
+        resumed_payload = emitted["delegate:agent_resumed"]
+        assert resumed_payload["agent"] == "test-agent"
+        assert resumed_payload["agent"] is not None
+
+        assert "delegate:agent_completed" in emitted
+        completed_payload = emitted["delegate:agent_completed"]
+        assert completed_payload["agent"] == "test-agent"
+        assert completed_payload["agent"] is not None
+
+        # Result output should also carry the correct agent identity.
+        assert resume_result.output["agent"] == "test-agent"
+
+    @pytest.mark.asyncio
+    async def test_resume_falls_back_to_session_id_suffix_when_cache_misses(self):
+        """Resuming a session_id this DelegateTool instance never spawned
+        (cold cache -- e.g. a different parent session/process originally
+        spawned it) still resolves a real agent identity from the
+        session_id's sanitized suffix (the format guaranteed by
+        amplifier_foundation.tracing.generate_sub_session_id), rather than
+        silently emitting "unknown" or omitting "agent" entirely.
+        """
+        hooks = _make_hooks()
+        cold_session_id = "0000000000000000-fedcba0987654321_foundation-explorer"
+        resume_fn = AsyncMock(
+            return_value={
+                "output": "resumed",
+                "session_id": cold_session_id,
+                "status": "success",
+                "turn_count": 5,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(hooks=hooks, resume_fn=resume_fn)
+
+        result = await tool.execute(
+            {
+                "session_id": cold_session_id,
+                "instruction": "Continue",
+            }
+        )
+        assert result.success
+
+        emitted = {args[0]: args[1] for args, _ in hooks.emit.call_args_list}
+        assert emitted["delegate:agent_resumed"]["agent"] == "foundation-explorer"
+        assert emitted["delegate:agent_completed"]["agent"] == "foundation-explorer"


### PR DESCRIPTION
## What

Fixes delegate resume telemetry (work item `openai_improvement-9n6`).

When a delegation is **resumed** via `session_id` (the delegate tool's
resume path in `_resume_existing_session`), the parent stream got
`delegate:agent_completed` with no usable agent identity, and
`delegate:agent_resumed` was emitted without an `agent` field either.

Measured across 5 production eval runs:
- Fan-out counted from `agent_spawned` undercounted 18% (32 spawns vs
  39 delegate calls — the missing 7 were resumes).
- Completions on the resumed leg couldn't be attributed to an agent.
- Downstream context-intelligence graph ingestion mislabeled healthy
  resumed sub-sessions (see investigation notes below).

## Root cause

`DelegateTool._resume_existing_session()` emitted
`delegate:agent_resumed` and `delegate:agent_completed` with no
`"agent"` key at all. An agent name *was* derived from the session_id
(naive `split("_")[-1]`), but only **after both events had already
been emitted** — too late to matter, and never plumbed into either
payload.

## Fix

`modules/tool-delegate/amplifier_module_tool_delegate/__init__.py`:

- `DelegateTool.__init__`: add `self._session_agents`, an in-memory
  `sub_session_id -> raw agent_name` cache.
- `_spawn_new_session`: record `{sub_session_id: agent_name}` in the
  cache right after generating `sub_session_id` — this is the exact
  string later emitted in `delegate:agent_spawned`'s `"agent"` field,
  so spawned/resumed/completed events pair correctly under one
  identity for downstream counters.
- New `_resolve_agent_for_session()`: resolves agent identity for a
  `sub_session_id`. Priority:
  1. The spawn-time cache (exact match to `agent_spawned`'s value).
  2. Fallback: the session_id's sanitized suffix, per
     `amplifier_foundation.tracing.generate_sub_session_id`'s
     documented `{parent_span}-{child_span}_{sanitized_agent_name}`
     format — deterministic, not a guess, but lossy (lowercased,
     punctuation collapsed to hyphens). Used when the cache misses,
     e.g. a resume issued from a different parent session/process
     than the one that spawned the sub-session.
- `_resume_existing_session`: resolve `agent_name` up front (before
  the `try` block, so it stays bound in every `except` clause —
  pyright flagged this when I first computed it inside `try`) and
  include it in `delegate:agent_resumed`, `delegate:agent_completed`,
  `delegate:agent_cancelled`, and `delegate:error` payloads on this
  path.

Confined to `modules/tool-delegate/` — does not touch
`amplifier_foundation/spawn_utils.py` (reserved for another
in-flight PR).

## Tests

`modules/tool-delegate/tests/test_delegate_event_enrichment.py` —
new `TestResumeAgentIdentity`:
- `test_resumed_and_completed_events_carry_agent_from_spawn_cache`:
  full spawn → resume flow through `DelegateTool.execute()`, asserts
  `delegate:agent_resumed` and `delegate:agent_completed` both carry
  the real agent identity (not null/missing). **Fails with
  `KeyError: 'agent'` on unpatched main.**
- `test_resume_falls_back_to_session_id_suffix_when_cache_misses`:
  covers the cold-cache fallback path (session_id suffix parsing).
  Also fails on unpatched main.

## Test results

- `modules/tool-delegate/tests`: **62 passed** (60 pre-existing + 2 new).
- Repo suite (`uv run pytest tests/ -q --tb=short`): **1631 passed, 1 skipped**.
- `python_check` (ruff lint/format, pyright, stub check): clean —
  0 new warnings vs. unpatched main (verified via diff), 0 errors.

## Investigation: context-intelligence ingestion (secondary, no PR)

Per the request, I investigated whether the context-intelligence
server's session-completeness classification (`IncompleteSession` /
"has_terminal: false") mislabels resumed sub-sessions as a *local,
small* classification bug. It does not look like one:

- The classifier (`context_intelligence_server/handlers/data_layer_2/session.py`,
  `SessionHandler._handle_end` + `SessionLabelStateMachine.classify`)
  only marks `IncompleteSession` when `session:end` arrives and the
  node has **no prior type label** (`RootSession`/`SubSession`/`ForkedSession`)
  — i.e. its `session:start`/`session:fork` was never seen *in that
  same graph scope*.
- `session:resume` is **intentionally** excluded from
  `SessionHandler.handled_events` and routed to `DefaultHandler`
  instead — pinned by `tests/handlers/data_layer_2/test_session.py::TestSessionResumeNotClaimed`
  (`assert "session:resume" not in SessionHandler.handled_events`).
  A prior investigation (commit `8acdb3e`, "no bug in the label state
  machine") already audited a similarly-shaped anomaly and left this
  exclusion in place deliberately.
- I reproduced both shapes directly against the handlers: when
  `session:start` **is** seen before a `session:resume` + `session:end`
  sequence, the node correctly stays `SubSession` throughout (no
  `IncompleteSession`). Only when `session:resume` + `session:end`
  arrive with **no prior start/fork ever recorded** does the node get
  `IncompleteSession` — which is the classifier working exactly as
  documented, not a rule bug.

So the false positive isn't in the local classification rule; it
requires establishing *why* the resumed sub-session's original
`session:start`/`session:fork` never reached the same graph scope
before its `session:end` was processed — e.g. cross-run/cross-workspace
ingestion boundaries in the eval harness, or a gap in how a resumed
child session's own lifecycle hooks are wired in `amplifier-app-cli`'s
resume implementation (outside this repo). That's not a small,
confidently-scoped fix I can safely make without tracing production
event delivery across those boundaries, so I'm reporting it rather
than opening a second PR. Pointers for whoever picks this up:

- `context_intelligence_server/handlers/data_layer_2/session.py:118-136`
  (`SessionLabelStateMachine.classify`, `"end"` branch)
- `context_intelligence_server/handlers/data_layer_2/session.py:139-152`
  (`SessionHandler.handled_events` — deliberately excludes `session:resume`)
- `tests/handlers/data_layer_2/test_session.py:517-524`
  (`TestSessionResumeNotClaimed` — the pinned exclusion)

## Not included

- `amplifier-context-intelligence` PR — investigated, not opened (see above).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
