### PR TITLE
feat(delegate): plan-then-dispatch guidance — batch independent delegations in one turn

### DIFF
--- a/context/agents/delegation-instructions.md
+++ b/context/agents/delegation-instructions.md
@@ -276,21 +276,34 @@ Use session resumption when:
 
 ---
 
-## Scaling with Multiple Instances
+## Wave Discipline: Batch Everything Independent
 
-For large codebases or complex investigations, dispatch MULTIPLE instances of the same agent with different scopes:
+**Every delegate call in one turn runs concurrently. Every delegate call in a separate turn
+runs sequentially, and you block on the previous one first.**
+
+Plan your full delegation set before dispatching any of it. Emit every independently
+resolvable delegation in a single turn — different agents, same agent with different
+scopes, or both.
 
 ```python
-# Parallel dispatch - independent surveys
+# One turn, three concurrent agents - different specialists
+delegate(agent="foundation:explorer", instruction="Survey auth/", context_depth="none")
+delegate(agent="python-dev:code-intel", instruction="Trace authenticate() callers")
+delegate(agent="foundation:git-ops", instruction="Summarize recent auth/ commits")
+
+# One turn, three concurrent instances - same agent, split scope
 delegate(agent="foundation:explorer", instruction="Survey auth/", context_depth="none")
 delegate(agent="foundation:explorer", instruction="Survey api/", context_depth="none")
 delegate(agent="foundation:explorer", instruction="Survey models/", context_depth="none")
 ```
 
-**When to scale:**
-- Large codebase with distinct areas
-- Multiple independent questions to answer
-- Time-sensitive investigations where parallelism helps
+**Only a delegation that consumes another delegation's output belongs in a later turn.**
+Everything else goes now. Before you dispatch a second wave, ask whether it could have
+gone out with the first — if it could have, batch what remains rather than repeating the
+mistake.
+
+**When to scale out:** large codebase with distinct areas; multiple independent questions;
+any investigation where you would otherwise wait on one agent before starting the next.
 
 ---
 

--- a/context/agents/multi-agent-patterns.md
+++ b/context/agents/multi-agent-patterns.md
@@ -4,22 +4,39 @@ This context provides patterns for orchestrating multiple agents effectively.
 
 ---
 
-## Parallel Agent Dispatch
+## Plan the Whole Set, Then Dispatch
 
-**CRITICAL**: For non-trivial investigations or tasks, use MULTIPLE agents to get richer results. Different agents have different tools, perspectives, and context that complement each other.
+**Delegations emitted in ONE turn run concurrently. Delegations split across turns run
+sequentially — and you sit idle through each one.**
 
-When investigating or analyzing, dispatch multiple agents IN PARALLEL in a single message:
+Before your first delegate call, write down every delegation the task needs. Then emit,
+in a single turn, every one of them that does not consume another delegation's output.
 
 ```python
+# ONE turn - all three run at once, total time = the slowest one
 delegate(agent="foundation:explorer", instruction="Survey the authentication module structure")
 delegate(agent="python-dev:code-intel", instruction="Trace the call hierarchy of authenticate()")
-delegate(agent="foundation:zen-architect", instruction="Review auth module for design patterns")
+delegate(agent="foundation:git-ops", instruction="Summarize recent commits touching auth/")
 ```
 
-**Why parallel matters:**
-- Each agent brings different tools (LSP vs grep vs design analysis)
-- Deterministic tools (LSP) find actual code paths; text search finds references and docs
-- TOGETHER they reveal: actual behavior + dead code + documentation gaps + design issues
+**Two reasons this matters, and the second is the one usually missed:**
+
+1. **Richer results** — each agent brings different tools and perspective; together they
+   reveal actual behavior + dead code + documentation gaps + design issues.
+2. **Wall-clock** — a task delegated in three sequential waves takes roughly the sum of
+   those waves. The same agents batched into one wave take the length of the longest.
+   Sequential waves of independent work are pure waste.
+
+### The Independence Test
+
+Before dispatching a wave, ask: **would I write any of these instructions differently if I
+had the others' results first?**
+
+- **No** → they are independent. They belong in the SAME turn. Emit them now.
+- **Yes** → only the ones that consume a result wait. Everything else still goes now.
+
+And before dispatching wave N+1, ask: **could this have gone out with wave N?** If yes, you
+already paid for the mistake — batch the remainder.
 
 ---
 

--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -257,8 +257,21 @@ Special agent values:
         # Add usage notes
         base_description += """
 
+BATCH YOUR DELEGATIONS. Every delegate call you emit in a single turn runs
+CONCURRENTLY. Delegations you split across separate turns run SEQUENTIALLY, and
+you block on each one before planning the next.
+
+Before emitting any delegate call, enumerate every delegation this task needs.
+Emit ALL of them that do not consume another delegation's output in THIS turn.
+Only a delegation that literally needs a prior result as input belongs in a
+later turn.
+
+- Two independent delegations in one turn: finishes in the time of the slower one
+- The same two split across two turns: takes the sum, plus your own planning turn
+- "I'll see what the first one says first" is the failure mode - if you would not
+  change the second instruction based on the first result, it was independent
+
 Agent usage notes:
-- Launch multiple agents concurrently when tasks are independent
 - When an agent completes, it returns a single message back to you
 - Each agent invocation is stateless - provide complete context in your instruction
 - DEFAULT TO DELEGATION - only do simple single-step work yourself"""


### PR DESCRIPTION
## Summary

Stage 1 ("Option A", guidance-only) of the approved `pg1-parallel-delegation` spec. Text-only guidance edits — no code, schema, or behavior changes.

## Measured evidence

A measured eval showed root sessions delegating in **3–4 sequential waves**, idle **91–94% of wall time**, with **~57% of wall structurally recoverable** by batching independent delegations into a single turn. One eval run's wave 2 was `[explorer, explorer, git-ops]` — none of which consumed wave 1's output. The root had all the information needed to batch those into wave 1 and did not.

## Why guidance, not machinery

The parallel-dispatch machinery already works end-to-end and needed no changes:

- The orchestrator mints one `parallel_group_id` per assistant turn and runs every tool call from that turn concurrently via `asyncio.gather` (`amplifier_module_loop_streaming`).
- The OpenAI provider already sets `parallel_tool_calls=True` by default; Anthropic never disables it.
- Concurrent delegates don't race on dispatch context (task-keyed, not session-keyed).

**There is no mechanical serialization to remove.** A root that emits three `delegate` calls in one turn already gets three concurrent sub-sessions. The measured idle time is the machinery faithfully executing a *one-delegation-per-turn plan* — a planning-policy defect, not an execution-machinery defect. Per `KERNEL_PHILOSOPHY.md` §1, policy belongs at the edges (instructions, tool descriptions), not in new kernel-adjacent code.

Every existing mention of parallelism in this repo argued **quality** ("different agents bring different tools") — none argued **wall-clock**, and none told the model to enumerate its full delegation set before dispatching. This PR fixes that gap directly at its source.

A companion approach (a `delegations[]` array with explicit dependency edges) was evaluated and rejected in the spec: it asks the model for exactly the judgment whose absence is the defect, re-implements `asyncio.gather` one layer below where it already exists correctly, and its marginal wall-clock gain over a correctly-batched guidance fix is under 1%.

## Changes (3 verbatim text replacements, +175 tokens/request budgeted)

- `modules/tool-delegate/amplifier_module_tool_delegate/__init__.py` — replaced the delegate tool's "Agent usage notes" block (re-rendered into every request's tool spec, last thing read before a `delegate` call) with explicit batching guidance and an independence heuristic.
- `context/agents/multi-agent-patterns.md` — replaced "## Parallel Agent Dispatch" (framed only as "richer results") with "## Plan the Whole Set, Then Dispatch", adding the wall-clock framing and an explicit independence test.
- `context/agents/delegation-instructions.md` — replaced "## Scaling with Multiple Instances" (same-agent only) with "## Wave Discipline: Batch Everything Independent", covering both same-agent and cross-agent batching.

Each edit *replaces* its section rather than appending, per `ISSUE_HANDLING.md`'s guidance on not growing files without cause. No file grows a section count.

## Verification

- `uv run pytest tests/ -q --tb=short` (the exact CI command): **1634 passed, 1 skipped**
- `modules/tool-delegate/tests/` (62 tests, editable-installed locally to resolve the package): **62 passed** — the existing description/schema tests are unaffected by the wording change
- `python_check` on the touched `.py` file: clean except 8 pre-existing warnings elsewhere in the file (confirmed present before this change via `git stash`), none introduced by this edit
- Confirmed no `return` + `{` substring was introduced — `amplifier_foundation.bundle_docs.tool_schema._extract_input_schema` still successfully `ast.literal_eval`-extracts the tool's static input schema after the edit
- Grepped `tests/` and `modules/*/tests/` repo-wide for the replaced phrases (`"Launch multiple agents concurrently"`, `"Parallel Agent Dispatch"`, `"Scaling with Multiple Instances"`, etc.) — no test asserts the old wording, so no test updates were needed

## Deferred (not in this PR)

**Stage 2** (`hooks-delegation-batching`, a nudge hook that reinforces this guidance at the actual decision point — after wave N's results land, before wave N+1 is planned) is fully specified in the spec but **not implemented here**. Per the spec's rollout plan, it ships only if Stage 1's DTU measurement (median wall-time reduction) misses the ≥40% target. If Stage 1 alone hits target, Stage 2 never ships.

**B′** (a flat `delegations[]` array, no dependency edges) is kept on the shelf as a contingency, gated on a specific signature (a backend whose tool-call parser structurally emits at most one call per turn) that has not been observed. Not scheduled.

## Post-merge note

After merge, `amplifier reset --remove cache -y` is required before the new guidance is loaded by a running Amplifier process — foundation context files are read from the bundle cache, and the guidance is prose read at composition time, not code.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
