### PR TITLE
fix(delegate): structured event + optional strict mode for unresolved model_role

### DIFF
--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -20,6 +20,12 @@ Config Options:
 - settings.exclude_tools: Tools spawned agents should NOT inherit (default: ["tool-delegate"])
 - settings.exclude_hooks: Hooks spawned agents should NOT inherit (default: [])
 - settings.timeout: Maximum total execution time for child session in seconds (default: None/disabled)
+- settings.strict_model_role: When True, a model_role that resolves to no
+  candidates raises ModelRoleUnresolvedError instead of silently falling
+  back to the session default model (default: False). Regardless of this
+  setting, the no-candidates case always emits a
+  "delegate:model_role_unresolved" event so the silent substitution is
+  observable.
 
 Tool Parameters:
 - agent: Agent to delegate to (e.g., 'foundation:explorer', 'self')
@@ -43,6 +49,18 @@ from amplifier_foundation import ProviderPreference
 from amplifier_foundation.tracing import generate_sub_session_id
 
 logger = logging.getLogger(__name__)
+
+
+class ModelRoleUnresolvedError(RuntimeError):
+    """Raised when ``model_role`` resolves to no candidates under strict mode.
+
+    Only raised when ``settings.strict_model_role`` is ``True``. Signals
+    that the requested ``model_role`` could not be resolved to any
+    provider/model candidate against the installed providers, and the
+    caller has opted out of the default silent-fallback-to-session-default
+    behavior. See ``delegate:model_role_unresolved`` for the always-emitted
+    observability event that accompanies both the strict and default paths.
+    """
 
 
 async def mount(coordinator: ModuleCoordinator, config: dict[str, Any] | None = None):
@@ -70,6 +88,7 @@ async def mount(coordinator: ModuleCoordinator, config: dict[str, Any] | None = 
             "delegate:agent_completed",
             "delegate:agent_cancelled",
             "delegate:error",
+            "delegate:model_role_unresolved",
         ],
     )
 
@@ -129,6 +148,12 @@ class DelegateTool:
         self.exclude_tools: list[str] = settings.get("exclude_tools", ["tool-delegate"])
         self.exclude_hooks: list[str] = settings.get("exclude_hooks", [])
         self.timeout: int | None = settings.get("timeout", None)
+        # When True, model_role resolving to no candidates raises
+        # ModelRoleUnresolvedError instead of silently falling back to the
+        # session default model. Default False preserves existing behavior
+        # for every caller that currently relies on the quiet fallback; the
+        # "delegate:model_role_unresolved" event is emitted either way.
+        self.strict_model_role: bool = settings.get("strict_model_role", False)
 
         # Build feature registry for dynamic description composition
         self._feature_registry = self._build_feature_registry()
@@ -883,12 +908,54 @@ Agent usage notes:
                     # Resolver returns list[ProviderPreference] (foundation public type).
                     provider_preferences = list(resolved)
                 else:
+                    resolver_name = getattr(resolver, "name", type(resolver).__name__)
                     logger.warning(
                         "model_role '%s' resolved to no candidates against "
                         "installed providers (resolver=%s)",
                         raw_model_role,
-                        getattr(resolver, "name", type(resolver).__name__),
+                        resolver_name,
                     )
+
+                    # Silent-substitution hazard: with provider_preferences
+                    # left None, the delegation proceeds and quietly lands
+                    # on the session's default model -- indistinguishable
+                    # from a caller who never asked for routing at all. This
+                    # can also occur after list_models retry-exhaustion
+                    # (persistent provider outage) leaves the resolver with
+                    # nothing to match. Always emit a structured event here,
+                    # regardless of strict_model_role, so operators can
+                    # detect the substitution even when they haven't opted
+                    # into fail-loud mode.
+                    unresolved_hooks = (
+                        self.coordinator.get("hooks")
+                        if hasattr(self.coordinator, "get")
+                        else None
+                    )
+                    if unresolved_hooks:
+                        await unresolved_hooks.emit(
+                            "delegate:model_role_unresolved",
+                            {
+                                "model_role": raw_model_role,
+                                "agent": agent_name,
+                                "resolver": resolver_name,
+                                "fallback_behavior": "session_default",
+                            },
+                        )
+
+                    # Default behavior (preserved for every existing caller):
+                    # warn + emit the event above, then fall through with
+                    # provider_preferences left None -- session default
+                    # model is used. Only when the operator has explicitly
+                    # opted into strict_model_role do we fail loud instead.
+                    if self.strict_model_role:
+                        raise ModelRoleUnresolvedError(
+                            f"model_role '{raw_model_role}' resolved to no "
+                            f"candidates against installed providers "
+                            f"(resolver={resolver_name}). strict_model_role "
+                            "is enabled, so this delegation is refused "
+                            "instead of silently substituting the session "
+                            "default model."
+                        )
 
         # Validate instruction (always required)
         if not instruction:

--- a/modules/tool-delegate/tests/test_delegate_contribution_channel.py
+++ b/modules/tool-delegate/tests/test_delegate_contribution_channel.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import pytest
 from amplifier_core.testing import MockCoordinator
-
 from amplifier_module_tool_delegate import mount
 
 EXPECTED_DELEGATE_EVENTS = [
@@ -18,6 +17,7 @@ EXPECTED_DELEGATE_EVENTS = [
     "delegate:agent_completed",
     "delegate:agent_cancelled",
     "delegate:error",
+    "delegate:model_role_unresolved",
 ]
 
 
@@ -25,7 +25,7 @@ EXPECTED_DELEGATE_EVENTS = [
 async def test_delegate_events_discoverable_via_collect_contributions():
     """Events registered by tool-delegate are discoverable via collect_contributions.
 
-    After mount(), all 5 delegate events must appear when collect_contributions
+    After mount(), all 6 delegate events must appear when collect_contributions
     is called for the 'observability.events' channel.
     """
     coordinator = MockCoordinator()

--- a/modules/tool-delegate/tests/test_delegate_model_role.py
+++ b/modules/tool-delegate/tests/test_delegate_model_role.py
@@ -6,10 +6,8 @@ import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from amplifier_foundation.spawn_utils import ProviderPreference
 from amplifier_module_tool_delegate import DelegateTool
-
 
 # =============================================================================
 # Helpers
@@ -21,6 +19,7 @@ def _make_delegate_tool(
     spawn_fn=None,
     agents: dict | None = None,
     model_role_resolver=None,
+    settings: dict | None = None,
 ) -> DelegateTool:
     """Create a DelegateTool with mocked coordinator for model_role testing.
 
@@ -69,7 +68,10 @@ def _make_delegate_tool(
     parent_session.config = {"session": {"orchestrator": {}}}
     coordinator.session = parent_session
 
-    config: dict = {"features": {}, "settings": {"exclude_tools": []}}
+    config: dict = {
+        "features": {},
+        "settings": {"exclude_tools": [], **(settings or {})},
+    }
     return DelegateTool(coordinator, config)
 
 
@@ -86,7 +88,9 @@ def _make_resolver(
     """
     resolver = MagicMock()
     resolver.name = name
-    resolver.resolve = AsyncMock(return_value=return_value if return_value is not None else [])
+    resolver.resolve = AsyncMock(
+        return_value=return_value if return_value is not None else []
+    )
     return resolver
 
 
@@ -114,7 +118,9 @@ class TestDelegateModelRole:
         # Mock the resolver to return a resolved preference
         resolver = _make_resolver(
             return_value=[
-                ProviderPreference(provider="anthropic", model="claude-haiku-3.5", config={}),
+                ProviderPreference(
+                    provider="anthropic", model="claude-haiku-3.5", config={}
+                ),
             ]
         )
         tool = _make_delegate_tool(
@@ -156,6 +162,7 @@ class TestDelegateModelRole:
         resolver.resolve.assert_called_once()
         call_args = resolver.resolve.call_args
         assert call_args[0][0] == "fast"  # raw_model_role
+
     @pytest.mark.asyncio
     async def test_provider_preferences_overrides_model_role(self):
         """Explicit provider_preferences wins over model_role when both provided."""
@@ -200,6 +207,7 @@ class TestDelegateModelRole:
 
         # Resolver should NOT have been called
         resolver.resolve.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_model_role_resolution_includes_config(self):
         """Config from resolved model_role is preserved in ProviderPreference."""
@@ -216,9 +224,11 @@ class TestDelegateModelRole:
         # Resolver returns a result with non-empty config
         resolver = _make_resolver(
             return_value=[
-                ProviderPreference(provider="anthropic",
+                ProviderPreference(
+                    provider="anthropic",
                     model="claude-sonnet-4-6",
-                    config={"reasoning_effort": "high"}),
+                    config={"reasoning_effort": "high"},
+                ),
             ]
         )
         tool = _make_delegate_tool(
@@ -255,6 +265,7 @@ class TestDelegateModelRole:
         assert prefs[0].config == {"reasoning_effort": "high"}, (
             f"Expected config={{'reasoning_effort': 'high'}}, got {prefs[0].config!r}"
         )
+
     @pytest.mark.asyncio
     async def test_model_role_without_matrix_falls_through(self):
         """model_role with no routing matrix falls through gracefully."""
@@ -327,9 +338,7 @@ class TestModelRoleObservabilityWarnings:
             )
         )
 
-        with caplog.at_level(
-            logging.WARNING, logger="amplifier_module_tool_delegate"
-        ):
+        with caplog.at_level(logging.WARNING, logger="amplifier_module_tool_delegate"):
             result = await tool.execute(
                 {
                     "agent": "test-agent",
@@ -359,6 +368,7 @@ class TestModelRoleObservabilityWarnings:
         assert any("coding" in str(m) for m in warning_messages), (
             f"Expected WARNING mentioning 'coding' role; got: {warning_messages}"
         )
+
     @pytest.mark.asyncio
     async def test_model_role_without_matrix_logs_warning(self, caplog):
         """model_role with no model_role_resolver capability logs WARNING (not just DEBUG)."""
@@ -411,6 +421,208 @@ class TestModelRoleObservabilityWarnings:
 
 
 # =============================================================================
+# Tests: openai_improvement-doc — fail loud when model_role resolves to no
+# candidates. Covers:
+#   (a) default mode: "delegate:model_role_unresolved" event emitted AND the
+#       existing quiet-fallback behavior (provider_preferences stays None,
+#       delegation still succeeds) is preserved.
+#   (b) strict mode (settings.strict_model_role=True): raises
+#       ModelRoleUnresolvedError naming the role and the resolver, instead
+#       of falling back.
+#   (c) normal resolution: no "delegate:model_role_unresolved" event is
+#       emitted when the resolver returns candidates.
+# =============================================================================
+
+
+def _hooks_returning(mock_hooks):
+    """Build a coordinator.get side_effect that returns mock_hooks for "hooks"."""
+
+    def _get(key):
+        if key == "hooks":
+            return mock_hooks
+        if key == "providers":
+            return {"provider-anthropic": MagicMock()}
+        return None
+
+    return _get
+
+
+class TestModelRoleUnresolvedEvent:
+    """delegate:model_role_unresolved must be emitted whenever model_role
+    resolves to no candidates -- regardless of strict_model_role -- and the
+    quiet fallback must remain the default behavior (event is additive,
+    not a behavior change) unless strict_model_role is explicitly enabled.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_mode_emits_event_and_preserves_fallback(self):
+        """(a) Default mode: event emitted, and the delegation still
+        succeeds with provider_preferences left None (quiet fallback to the
+        session default model is preserved -- only its observability
+        changes). This assertion on the emitted event fails against
+        unpatched main, which never emits any event on this path.
+        """
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        resolver = _make_resolver(return_value=[], name="test-matrix")
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={"test-agent": {"description": "A test agent"}},
+            model_role_resolver=resolver,
+            # strict_model_role omitted -- must default to False
+        )
+        mock_hooks = MagicMock()
+        mock_hooks.emit = AsyncMock()
+        tool.coordinator.get = MagicMock(side_effect=_hooks_returning(mock_hooks))
+
+        result = await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Write some code",
+                "context_depth": "none",
+                "model_role": "coding",
+            }
+        )
+
+        # Fallback behavior preserved: delegation succeeds, no provider pin.
+        assert result.success is True
+        spawn_fn.assert_called_once()
+        _, kwargs = spawn_fn.call_args
+        assert kwargs["provider_preferences"] is None
+
+        # The new structured event was emitted with the documented payload.
+        unresolved_calls = [
+            call
+            for call in mock_hooks.emit.call_args_list
+            if call.args[0] == "delegate:model_role_unresolved"
+        ]
+        assert len(unresolved_calls) == 1, (
+            f"Expected exactly one delegate:model_role_unresolved event; "
+            f"got {len(unresolved_calls)}. All emit calls: "
+            f"{[c.args[0] for c in mock_hooks.emit.call_args_list]}"
+        )
+        payload = unresolved_calls[0].args[1]
+        assert payload["model_role"] == "coding"
+        assert payload["agent"] == "test-agent"
+        assert payload["resolver"] == "test-matrix"
+        assert payload["fallback_behavior"] == "session_default"
+
+    @pytest.mark.asyncio
+    async def test_strict_mode_raises_instead_of_falling_back(self):
+        """(b) strict_model_role=True: raises ModelRoleUnresolvedError
+        naming the role and the resolver, instead of silently falling back.
+        """
+        from amplifier_module_tool_delegate import ModelRoleUnresolvedError
+
+        spawn_fn = AsyncMock()
+        resolver = _make_resolver(return_value=[], name="test-matrix")
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={"test-agent": {"description": "A test agent"}},
+            model_role_resolver=resolver,
+            settings={"strict_model_role": True},
+        )
+        mock_hooks = MagicMock()
+        mock_hooks.emit = AsyncMock()
+        tool.coordinator.get = MagicMock(side_effect=_hooks_returning(mock_hooks))
+
+        with pytest.raises(ModelRoleUnresolvedError) as exc_info:
+            await tool.execute(
+                {
+                    "agent": "test-agent",
+                    "instruction": "Write some code",
+                    "context_depth": "none",
+                    "model_role": "coding",
+                }
+            )
+
+        # Error message must name both the role and the resolver.
+        message = str(exc_info.value)
+        assert "coding" in message, f"Expected role 'coding' in message: {message}"
+        assert "test-matrix" in message, (
+            f"Expected resolver 'test-matrix' in message: {message}"
+        )
+
+        # Fail loud means no spawn happened at all.
+        spawn_fn.assert_not_called()
+
+        # The event is still emitted -- strict mode adds a raise, it doesn't
+        # replace the observability event.
+        unresolved_calls = [
+            call
+            for call in mock_hooks.emit.call_args_list
+            if call.args[0] == "delegate:model_role_unresolved"
+        ]
+        assert len(unresolved_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_normal_resolution_emits_no_unresolved_event(self):
+        """(c) When model_role resolves normally (candidates found), no
+        delegate:model_role_unresolved event is emitted.
+        """
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        resolver = _make_resolver(
+            return_value=[
+                ProviderPreference(
+                    provider="anthropic", model="claude-haiku-3.5", config={}
+                ),
+            ],
+            name="test-matrix",
+        )
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={"test-agent": {"description": "A test agent"}},
+            model_role_resolver=resolver,
+        )
+        mock_hooks = MagicMock()
+        mock_hooks.emit = AsyncMock()
+        tool.coordinator.get = MagicMock(side_effect=_hooks_returning(mock_hooks))
+
+        result = await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Write some code",
+                "context_depth": "none",
+                "model_role": "coding",
+            }
+        )
+
+        assert result.success is True
+        unresolved_calls = [
+            call
+            for call in mock_hooks.emit.call_args_list
+            if call.args[0] == "delegate:model_role_unresolved"
+        ]
+        assert unresolved_calls == [], (
+            f"Expected no delegate:model_role_unresolved event on normal "
+            f"resolution; got {len(unresolved_calls)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_strict_mode_defaults_to_false(self):
+        """strict_model_role defaults to False when settings omit it entirely,
+        preserving the fallback behavior for every existing caller/config.
+        """
+        tool = _make_delegate_tool(model_role_resolver=None)
+        assert tool.strict_model_role is False
+
+
+# =============================================================================
 # Tests: Fix 3 — provider_routing in ToolResult output
 # =============================================================================
 
@@ -433,7 +645,9 @@ class TestProviderRoutingInResult:
 
         resolver = _make_resolver(
             return_value=[
-                ProviderPreference(provider="anthropic", model="claude-sonnet-4-6", config={}),
+                ProviderPreference(
+                    provider="anthropic", model="claude-sonnet-4-6", config={}
+                ),
             ]
         )
         tool = _make_delegate_tool(
@@ -469,6 +683,7 @@ class TestProviderRoutingInResult:
         )
         assert len(routing["resolved"]) >= 1
         assert routing["resolved"][0]["provider"] == "anthropic"
+
     @pytest.mark.asyncio
     async def test_provider_routing_in_result_on_failure(self):
         """Failed model_role resolution returns provider_routing with resolved=None."""
@@ -516,6 +731,7 @@ class TestProviderRoutingInResult:
             "Empty resolution should produce resolved=None"
         )
 
+
 # =============================================================================
 # Tests: Fix 2 — delegate:agent_spawned event includes routing intent
 # =============================================================================
@@ -539,7 +755,9 @@ class TestAgentSpawnedEventIncludesRouting:
 
         resolver = _make_resolver(
             return_value=[
-                ProviderPreference(provider="anthropic", model="claude-haiku-3.5", config={}),
+                ProviderPreference(
+                    provider="anthropic", model="claude-haiku-3.5", config={}
+                ),
             ]
         )
         tool = _make_delegate_tool(
@@ -561,9 +779,7 @@ class TestAgentSpawnedEventIncludesRouting:
                 mock_hooks
                 if key == "hooks"
                 else (
-                    {"provider-anthropic": MagicMock()}
-                    if key == "providers"
-                    else None
+                    {"provider-anthropic": MagicMock()} if key == "providers" else None
                 )
             )
         )
@@ -604,6 +820,7 @@ class TestAgentSpawnedEventIncludesRouting:
         )
         assert len(payload["provider_preferences"]) >= 1
         assert payload["provider_preferences"][0]["provider"] == "anthropic"
+
 
 # =============================================================================
 # Tests: input_schema shaping of the model_role parameter


### PR DESCRIPTION
## Summary

`resolver.resolve(raw_model_role)` returning no candidates was silently
absorbed: `tool-delegate` logged a single WARNING and proceeded with
`provider_preferences=None`, so the delegation quietly landed on the
session's default model with no signal an operator could act on — including
after `list_models` retry-exhaustion during a persistent provider outage
(the resolver has nothing to match against once the provider stops
answering).

This is the **third member of the silent-substitution family** found in
this codebase, after:
- #318 — sub-agent provider override losing a priority-0 tie-break (fixed by
  strictly demoting other instances instead of merely tying)
- the `list_models` retry work — transient provider failures previously
  looked identical to "provider has zero models" from the caller's side

All three share the same shape: a resolution step fails or comes back
empty, and the system falls back to *some* default without telling anyone
it did. This fix is cross-provider by construction — nothing here is
Anthropic/OpenAI/Gemini-specific; any `model_role_resolver` capability hits
the same code path.

## Changes

`modules/tool-delegate/amplifier_module_tool_delegate/__init__.py`

1. **Structured event, always emitted.** On the no-candidates path, in
   addition to the existing WARNING log, we now emit
   `delegate:model_role_unresolved` via the same `hooks.emit()` mechanism
   used for `delegate:agent_spawned` (registered in the module's
   `observability.events` contribution list at mount time):

   ```python
   {
       "model_role": raw_model_role,
       "agent": agent_name,
       "resolver": resolver_name,   # class/name of the resolver instance
       "fallback_behavior": "session_default",
   }
   ```

   This is unconditional — emitted regardless of `strict_model_role` — so
   the substitution is observable even for callers who haven't opted into
   fail-loud mode.

2. **New `settings.strict_model_role` (bool, default `False`).** When
   `True`, the no-candidates path raises `ModelRoleUnresolvedError` (a new
   `RuntimeError` subclass) naming both the role and the resolver, instead
   of falling back:

   ```
   model_role 'coding' resolved to no candidates against installed
   providers (resolver=test-matrix). strict_model_role is enabled, so this
   delegation is refused instead of silently substituting the session
   default model.
   ```

   Default `False` preserves the exact current behavior for every existing
   caller that relies on the quiet fallback — this is additive, not a
   breaking change.

## Sibling path investigated (caller-passed `provider_preferences` glob)

Per the task, I traced the other place a "resolves to nothing" silent
substitution could occur: a caller passing `provider_preferences` directly
with a glob `model` (e.g. `"gpt-9-*"`) that matches no installed model.
That path lives in `amplifier_foundation/spawn_utils.py`
(`resolve_model_pattern` / `apply_provider_preferences_with_resolution`),
not in `tool-delegate` itself — `tool-delegate` just parses and forwards
`ProviderPreference` objects; resolution happens deeper in the spawn
pipeline (`amplifier_foundation/bundle/_prepared.py`).

Verdict: **for a single preference, this already fails loud** — a
non-matching glob returns an explicit `resolved_model=None` sentinel (never
substitutes the raw/broken pattern) and the caller deliberately advances to
the *next* preference in the ordered fallback list (correct semantics for
an ordered list, and already carefully commented as intentional). Per the
task's instruction ("if it already fails loud, note it and leave it"), I
left this untouched.

One narrower residual gap, noted here rather than folded into this PR: if
**every** preference in the caller's list fails to resolve (or none of
their providers are present in the mount plan), the function falls back to
the *unmodified* mount plan with a warning-only log — the same
class of silent fallback as the bug this PR fixes, but in a much
lower-level, broadly-shared utility (used by every `session.spawn` /
`prepared.spawn()` caller, not just delegate) with no existing `hooks`/
`agent` parameter threading. Extending the same event+strict-mode
treatment there is a reasonable follow-up but is a separate, larger-blast-
radius change than this module-scoped fix warrants on its own.

## Tests

`modules/tool-delegate/tests/test_delegate_model_role.py` —
new `TestModelRoleUnresolvedEvent` class:

- `test_default_mode_emits_event_and_preserves_fallback` — event emitted
  with the documented payload, delegation still succeeds,
  `provider_preferences` stays `None` (fallback preserved). **Fails on
  unpatched main**, which never emits any event on this path.
- `test_strict_mode_raises_instead_of_falling_back` — raises
  `ModelRoleUnresolvedError` naming both the role (`coding`) and the
  resolver (`test-matrix`); `spawn_fn` never called; event still emitted.
- `test_normal_resolution_emits_no_unresolved_event` — resolver returning
  candidates emits no `delegate:model_role_unresolved` event.
- `test_strict_mode_defaults_to_false` — confirms the default.

Also updated `test_delegate_contribution_channel.py`'s exact-event-count
assertion (5 → 6) since the module now legitimately contributes one more
observability event.

### Results

```
# Full repo suite (uv run pytest tests/ -q --tb=short)
1634 passed, 1 skipped   (unchanged from baseline on this main)

# tool-delegate module suite
66 passed   (was 62 before this change; +4 new tests)
```

## Not merging

Per instructions, opening for review only — not merging.
