### PR TITLE
feat(delegate): flag-gated structured return contract (findings/not_covered/artifacts)

### DIFF
--- a/context/agents/delegation-instructions.md
+++ b/context/agents/delegation-instructions.md
@@ -132,6 +132,25 @@ Agents follow the **Honest Stopping** rule: when they can't satisfy a required i
 
 The agent's job is honest reporting; your job is to examine every "N/A" before it can pass for a satisfied requirement.
 
+### Reading a Structured Agent Return
+
+When the `return_contract` feature is enabled (see `tool-delegate`'s config), a delegate
+result may carry a `contract` field alongside `response`: `contract.findings` (each a
+`claim` + `evidence` + `confidence`), `contract.not_covered`, and `contract.artifacts`.
+This is the same doctrine above, given a machine-readable field instead of leaving it to
+be excavated from prose:
+
+- **Walk every entry in `contract.findings`** before you write your answer. A finding you
+  do not carry forward into your response text is one you have decided to discard —
+  decide that on purpose, not by running out of attention.
+- **`contract.not_covered` is the machine-readable form of the "N/A" doctrine above** —
+  it is the agent telling you, in a field instead of a sentence you might skim, exactly
+  what it did not examine. Read it the moment the result arrives: resuming that session
+  *now* is cheap; discovering the gap three turns later is not.
+- **`contract.conformant: false` means the agent returned unstructured prose.** Its
+  coverage is unknown — do not treat its silence on any topic as evidence it looked and
+  found nothing. Fall back to reading `response` the way you always have.
+
 ---
 
 ## Why Delegation Matters

--- a/modules/tool-delegate/README.md
+++ b/modules/tool-delegate/README.md
@@ -61,12 +61,80 @@ modules:
         max_turns: 10
       provider_selection:
         enabled: true
+      return_contract:
+        enabled: false        # default OFF; purely additive when on
+        strip_block: true     # remove the parsed json block from `response`
+        reask_on_nonconformance: false  # reserved for a future stage; inert today
     settings:
       exclude_tools:
         - delegate  # Default: spawned agents can't further delegate
       exclude_hooks: []
       timeout: 300
 ```
+
+### Structured Return Contract
+
+Flag-gated, default **off**. When `features.return_contract.enabled` is `true`, this
+tool appends a short instruction to every spawned/resumed agent's instruction, asking
+it to append a fenced ` ```json ` block to the end of its normal prose answer:
+
+```json
+{
+  "summary": "at most 3 sentences -- the answer in brief",
+  "findings": [
+    {"claim": "one assertion, carried forward verbatim",
+     "evidence": "file:line, command run, or URL -- empty string if genuinely none",
+     "confidence": "high | medium | low"}
+  ],
+  "not_covered": ["a thing in scope the agent did NOT examine"],
+  "artifacts": [{"path": "file written or modified", "description": "what changed"}]
+}
+```
+
+Only `findings` is required, and only `claim` within each finding -- everything else
+defaults on parse. The parser (`_parse_return_contract`) is tolerant: a partially-good
+block is normalized and kept, never discarded outright.
+
+On return, `ToolResult.output` gains one additive `contract` key:
+
+```jsonc
+{
+  "response": "...",        // the json block is stripped when parsing succeeded
+                             // and strip_block is enabled; untouched otherwise
+  "contract": {
+    "conformant": true,      // false on parse failure, null when the feature is off
+    "reason": null,          // populated string when conformant is false
+    "summary": "...",
+    "findings": [ /* ... */ ],
+    "not_covered": [ /* ... */ ],
+    "artifacts": [ /* ... */ ]
+  },
+  "session_id": "...", "agent": "...", "turn_count": 1, "status": "success", "metadata": {}
+}
+```
+
+**Non-conformance never fails the delegation.** If no fenced json block is found, it
+fails to parse, or it's missing the required `findings` array, `contract.conformant`
+is `false` with a `reason`, and `response` is byte-identical to what the agent
+actually returned -- the fallback is indistinguishable from this feature not existing.
+
+**Per-agent opt-out** -- an agent can opt out even when the feature is globally
+enabled, via its `meta:` frontmatter:
+
+```yaml
+meta:
+  name: git-ops
+  return_contract: false
+```
+
+This is an opt-**out** that defaults to inheriting the global flag, not a per-agent
+opt-in matrix.
+
+**Telemetry** -- no new events. `delegate:agent_completed` gains five additive fields:
+`contract_conformant` (`bool | None`, `None` when the feature is off),
+`findings_count`, `evidence_backed_count` (findings with a non-empty `evidence`),
+`not_covered_count`, and `artifacts_count` (all `int | None`, `None` alongside
+`contract_conformant is None`).
 
 ## Note
 

--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -41,7 +41,9 @@ Tool Parameters:
 __amplifier_module_type__ = "tool"
 
 import asyncio
+import json
 import logging
+import re
 from typing import Any
 
 from amplifier_core import ModuleCoordinator, ToolResult
@@ -61,6 +63,124 @@ class ModelRoleUnresolvedError(RuntimeError):
     behavior. See ``delegate:model_role_unresolved`` for the always-emitted
     observability event that accompanies both the strict and default paths.
     """
+
+
+# ---------------------------------------------------------------------------
+# Structured delegation return contract (flag-gated; see features.return_contract
+# in this module's config, and _parse_return_contract() below for the parser).
+#
+# A sub-agent may append a fenced ```json block, shaped per RETURN_CONTRACT_SCHEMA,
+# to the end of its normal prose response. Only "findings" is required, and only
+# "claim" within each finding -- everything else defaults on parse. The parser
+# never rejects a partially-good return; see _parse_return_contract's docstring.
+#
+# RETURN_CONTRACT_SCHEMA and RETURN_CONTRACT_INSTRUCTION are kept as pure
+# literals (no computed expressions) even though neither lives inside a tool
+# class -- foundation's static token-cost estimator
+# (amplifier_foundation.bundle_docs.tool_schema) locates the FIRST `return {`
+# after `def input_schema` inside this file's one class and ast.literal_eval's
+# it (see the docstring warning on DelegateTool.input_schema below). These two
+# module-level constants sit above the class entirely so they cannot interfere
+# with that scan, but keeping them literal keeps them inspectable by any future
+# tooling that walks this module the same way.
+RETURN_CONTRACT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["findings"],
+    "properties": {
+        "summary": {"type": "string"},
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["claim"],
+                "properties": {
+                    "claim": {"type": "string"},
+                    "evidence": {"type": "string"},
+                    "confidence": {
+                        "type": "string",
+                        "enum": ["high", "medium", "low"],
+                    },
+                },
+            },
+        },
+        "not_covered": {"type": "array", "items": {"type": "string"}},
+        "artifacts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["path"],
+                "properties": {
+                    "path": {"type": "string"},
+                    "description": {"type": "string"},
+                },
+            },
+        },
+    },
+}
+
+RETURN_CONTRACT_INSTRUCTION = """[STRUCTURED RETURN]
+After your normal prose answer, append ONE fenced json block as the LAST thing
+in your response:
+
+```json
+{
+  "summary": "at most 3 sentences -- the answer in brief",
+  "findings": [
+    {"claim": "one assertion, stated so it can be carried forward verbatim",
+     "evidence": "file:line, command run, or URL -- empty string if genuinely none",
+     "confidence": "high | medium | low"}
+  ],
+  "not_covered": ["a thing in scope you did NOT examine"],
+  "artifacts": [{"path": "file written or modified", "description": "what changed"}]
+}
+```
+
+Only "findings" is required, and only "claim" within each finding. If your task
+produced no investigative findings, return "findings": [] and describe the work
+done in "summary". Write your normal prose answer first, then this block."""
+
+
+def _return_contract_event_fields(contract: dict[str, Any]) -> dict[str, Any]:
+    """Five additive fields for the ``delegate:agent_completed`` event.
+
+    Shared by both the spawn and resume completion paths so the two emit
+    sites can never drift from each other.
+
+    ``contract_conformant`` and the four counts are all ``None`` together
+    when the return-contract feature is disabled -- this distinguishes
+    "feature off" from "feature on but the agent returned nothing usable"
+    (``False`` / ``0``), which a bare ``0`` would hide.
+    """
+    conformant = contract.get("conformant")
+    if conformant is None:
+        return {
+            "contract_conformant": None,
+            "findings_count": None,
+            "evidence_backed_count": None,
+            "not_covered_count": None,
+            "artifacts_count": None,
+        }
+
+    findings = contract.get("findings") or []
+    return {
+        "contract_conformant": conformant,
+        "findings_count": len(findings),
+        "evidence_backed_count": sum(
+            1 for f in findings if isinstance(f, dict) and f.get("evidence")
+        ),
+        "not_covered_count": len(contract.get("not_covered") or []),
+        "artifacts_count": len(contract.get("artifacts") or []),
+    }
+
+
+# Matches a fenced ```json ... ``` block, tolerant of ```JSON, surrounding
+# indentation, and trailing whitespace on the fence lines. The closing fence
+# must be alone on its own line so short "```" substrings inside the JSON
+# body's string values don't terminate the match early.
+_JSON_FENCE_PATTERN = re.compile(
+    r"^[ \t]*```[ \t]*json[ \t]*\r?\n(?P<body>.*?)\r?\n[ \t]*```[ \t]*$",
+    re.IGNORECASE | re.DOTALL | re.MULTILINE,
+)
 
 
 async def mount(coordinator: ModuleCoordinator, config: dict[str, Any] | None = None):
@@ -144,6 +264,20 @@ class DelegateTool:
             "enabled", True
         )
 
+        # Structured delegation return contract (flag-gated; default OFF).
+        # See RETURN_CONTRACT_INSTRUCTION / RETURN_CONTRACT_SCHEMA above and
+        # _parse_return_contract() below for the full mechanism. `return_contract_reask`
+        # is parsed now so the config surface is stable across stages, but it is
+        # inert in Stage 1 -- the re-ask loop is a Stage 2 deferral (see spec §4.4).
+        return_contract_config = features.get("return_contract", {})
+        self.return_contract_enabled = return_contract_config.get("enabled", False)
+        self.return_contract_strip_block = return_contract_config.get(
+            "strip_block", True
+        )
+        self.return_contract_reask = return_contract_config.get(
+            "reask_on_nonconformance", False
+        )
+
         # Settings
         self.exclude_tools: list[str] = settings.get("exclude_tools", ["tool-delegate"])
         self.exclude_hooks: list[str] = settings.get("exclude_hooks", [])
@@ -216,6 +350,24 @@ class DelegateTool:
                 "name": "provider_selection",
                 "enabled": self.provider_selection_enabled,
                 "description": "- Use provider_preferences to specify model/provider for the agent",
+                "disabled_note": None,
+            },
+            {
+                "name": "return_contract",
+                "enabled": self.return_contract_enabled,
+                "description": (
+                    "When a delegate result carries contract.findings, walk every "
+                    "finding before you write your answer, and carry each surviving "
+                    "claim into your response text with its evidence. A finding you "
+                    "do not mention is a finding you have decided to discard -- "
+                    "decide that deliberately, not by running out of attention.\n"
+                    "contract.not_covered is your resume decision list. Read it the "
+                    "moment the result arrives: resuming that session now is cheap; "
+                    "discovering the gap three turns later is not.\n"
+                    "contract.conformant: false means the agent returned "
+                    "unstructured prose. Its coverage is unknown -- do not treat "
+                    "its silence as completeness."
+                ),
                 "disabled_note": None,
             },
         ]
@@ -828,6 +980,159 @@ Agent usage notes:
 
         return inherited
 
+    def _parse_return_contract(self, response: str) -> tuple[dict[str, Any], str]:
+        """Parse an optional structured return contract from a sub-agent's response.
+
+        Looks for the LAST fenced ```json block in *response* (see
+        RETURN_CONTRACT_SCHEMA) and tolerantly normalizes it -- a partially-good
+        return is kept, never discarded outright. This is the single place that
+        decides whether a delegation "conformed" to the contract; both the spawn
+        and resume completion paths call it once and reuse the result for both
+        telemetry and the annotated ``ToolResult.output``.
+
+        Args:
+            response: The sub-agent's final text -- normal prose, optionally
+                followed by a fenced json block.
+
+        Returns:
+            A ``(contract, cleaned_response)`` tuple.
+
+            ``contract`` always has the shape::
+
+                {
+                    "conformant": bool | None,  # None only when the feature is disabled
+                    "reason": str | None,       # populated when conformant is False
+                    "summary": str | None,
+                    "findings": list[dict],
+                    "not_covered": list[str],
+                    "artifacts": list[dict],
+                }
+
+            ``cleaned_response`` is *response* with the parsed block removed
+            when parsing succeeded and ``return_contract_strip_block`` is
+            enabled; otherwise it is byte-identical to *response*. This is
+            the one non-purely-additive behavior in the contract (see the
+            module docstring / README) and only ever fires when both the
+            feature and strip_block are enabled and the block parsed cleanly.
+
+        Invariants:
+            - NEVER raises. Any unexpected failure degrades to
+              ``conformant=False`` with ``reason=repr(exception)``.
+            - NEVER mutates *response* when ``conformant`` is not ``True``.
+            - Pure function of (response, self.return_contract_enabled,
+              self.return_contract_strip_block). No I/O, no coordinator access.
+        """
+        empty_contract: dict[str, Any] = {
+            "conformant": None,
+            "reason": None,
+            "summary": None,
+            "findings": [],
+            "not_covered": [],
+            "artifacts": [],
+        }
+
+        if not self.return_contract_enabled:
+            return dict(empty_contract), response
+
+        try:
+            match = None
+            for match in _JSON_FENCE_PATTERN.finditer(response):
+                pass  # keep iterating -- the LAST fenced json block wins
+
+            if match is None:
+                contract = dict(empty_contract)
+                contract["conformant"] = False
+                contract["reason"] = "no fenced json block found in agent response"
+                return contract, response
+
+            try:
+                parsed = json.loads(match.group("body"))
+            except (ValueError, TypeError) as e:
+                contract = dict(empty_contract)
+                contract["conformant"] = False
+                contract["reason"] = f"json parse failed: {e}"
+                return contract, response
+
+            if not isinstance(parsed, dict):
+                contract = dict(empty_contract)
+                contract["conformant"] = False
+                contract["reason"] = "contract block is not a JSON object"
+                return contract, response
+
+            raw_findings = parsed.get("findings")
+            if not isinstance(raw_findings, list):
+                contract = dict(empty_contract)
+                contract["conformant"] = False
+                contract["reason"] = "missing required 'findings' array"
+                return contract, response
+
+            # Normalize, never reject -- a partially-good return is kept.
+            findings: list[dict[str, Any]] = []
+            for item in raw_findings:
+                if not isinstance(item, dict):
+                    continue
+                claim = item.get("claim")
+                if not isinstance(claim, str) or not claim.strip():
+                    continue
+                evidence = item.get("evidence")
+                if not isinstance(evidence, str):
+                    evidence = ""
+                confidence = item.get("confidence")
+                if confidence not in ("high", "medium", "low"):
+                    confidence = "unspecified"
+                findings.append(
+                    {"claim": claim, "evidence": evidence, "confidence": confidence}
+                )
+
+            raw_not_covered = parsed.get("not_covered")
+            not_covered = (
+                [item for item in raw_not_covered if isinstance(item, str)]
+                if isinstance(raw_not_covered, list)
+                else []
+            )
+
+            raw_artifacts = parsed.get("artifacts")
+            artifacts: list[dict[str, Any]] = []
+            if isinstance(raw_artifacts, list):
+                for item in raw_artifacts:
+                    if not isinstance(item, dict):
+                        continue
+                    path = item.get("path")
+                    if not isinstance(path, str) or not path:
+                        continue
+                    description = item.get("description")
+                    if not isinstance(description, str):
+                        description = ""
+                    artifacts.append({"path": path, "description": description})
+
+            summary = parsed.get("summary")
+            if not isinstance(summary, str):
+                summary = None
+
+            contract = {
+                "conformant": True,
+                "reason": None,
+                "summary": summary,
+                "findings": findings,
+                "not_covered": not_covered,
+                "artifacts": artifacts,
+            }
+
+            if self.return_contract_strip_block:
+                cleaned = response[: match.start()] + response[match.end() :]
+                # Collapse the blank lines left behind by removing the block.
+                cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+            else:
+                cleaned = response
+
+            return contract, cleaned
+
+        except Exception as e:  # defensive -- this method must never raise
+            contract = dict(empty_contract)
+            contract["conformant"] = False
+            contract["reason"] = repr(e)
+            return contract, response
+
     async def execute(self, input: dict) -> ToolResult:
         """Execute agent delegation with structured parameters.
 
@@ -1180,6 +1485,17 @@ Agent usage notes:
                 )
                 effective_instruction = f"{context_text}\n\n[YOUR TASK]\n{instruction}"
 
+            # Structured delegation return contract (flag-gated; additive).
+            # Per-agent opt-out: an agent's meta.return_contract: false (forwarded
+            # into agent config by _dataclass.py) suppresses injection even when
+            # the feature is globally enabled. Defaults to inheriting the global
+            # flag -- this is an opt-out, not a per-agent opt-in matrix (see spec §3.6).
+            agent_cfg = (agents or {}).get(agent_name, {})
+            if self.return_contract_enabled and agent_cfg.get("return_contract", True):
+                effective_instruction = (
+                    f"{effective_instruction}\n\n{RETURN_CONTRACT_INSTRUCTION}"
+                )
+
             # Extract orchestrator config from parent session for inheritance.
             # Guard with isinstance to handle non-dict orchestrator values gracefully
             # (e.g. when orchestrator is a string like "loop-basic").
@@ -1252,6 +1568,14 @@ Agent usage notes:
             else:
                 result = await spawn_coro
 
+            # Structured delegation return contract: parse the sub-agent's
+            # response once (no-op when the feature is disabled -- see
+            # _parse_return_contract). Reused below for both the completion
+            # telemetry and the annotated output.
+            contract, cleaned_response = self._parse_return_contract(
+                result.get("output", "")
+            )
+
             # Emit delegate:agent_completed event
             if hooks:
                 await hooks.emit(
@@ -1263,6 +1587,7 @@ Agent usage notes:
                         "success": True,
                         "tool_call_id": tool_call_id,
                         "parallel_group_id": parallel_group_id,
+                        **_return_contract_event_fields(contract),
                     },
                 )
 
@@ -1280,17 +1605,23 @@ Agent usage notes:
                     ),
                 }
 
-            # Return output with session_id for multi-turn capability
+            # Return output with session_id for multi-turn capability.
+            # "response" is `cleaned_response` -- byte-identical to
+            # result["output"] whenever the feature is disabled, parsing
+            # failed, or strip_block is off; the fenced json block is only
+            # ever removed from it on a successful, flag-enabled parse (see
+            # _parse_return_contract). "contract" is purely additive.
             session_id_result = result["session_id"]
             return ToolResult(
                 success=True,
                 output={
-                    "response": result["output"],
+                    "response": cleaned_response,
                     "session_id": session_id_result,
                     "agent": agent_name,
                     "turn_count": result.get("turn_count", 1),
                     "status": result.get("status", "success"),
                     "metadata": result.get("metadata", {}),
+                    "contract": contract,
                     **(
                         {"provider_routing": provider_routing}
                         if provider_routing
@@ -1466,16 +1797,40 @@ Agent usage notes:
                     },
                 )
 
+            # Structured delegation return contract (flag-gated; additive).
+            # Opt-out is resolved via `agent_name`, which is the same identity
+            # `_resolve_agent_for_session` computed above (before the try block)
+            # for event emission -- consistent with the spawn path's opt-out.
+            effective_instruction = instruction
+            if self.return_contract_enabled:
+                agents_cfg = self.coordinator.config.get("agents", {})
+                agent_cfg = (
+                    agents_cfg.get(agent_name, {})
+                    if isinstance(agents_cfg, dict)
+                    else {}
+                )
+                if agent_cfg.get("return_contract", True):
+                    effective_instruction = (
+                        f"{instruction}\n\n{RETURN_CONTRACT_INSTRUCTION}"
+                    )
+
             # Resume agent session (with optional session-level timeout)
             resume_coro = resume_fn(
                 sub_session_id=full_session_id,
-                instruction=instruction,
+                instruction=effective_instruction,
             )
             if self.timeout is not None:
                 async with asyncio.timeout(self.timeout):
                     result = await resume_coro
             else:
                 result = await resume_coro
+
+            # Structured delegation return contract (see the spawn path for
+            # the full explanation) -- computed once, reused for telemetry
+            # and the annotated output below.
+            contract, cleaned_response = self._parse_return_contract(
+                result.get("output", "")
+            )
 
             # Emit delegate:agent_completed event
             if hooks:
@@ -1488,20 +1843,24 @@ Agent usage notes:
                         "success": True,
                         "tool_call_id": tool_call_id,
                         "parallel_group_id": parallel_group_id,
+                        **_return_contract_event_fields(contract),
                     },
                 )
 
-            # Return output with session info
+            # Return output with session info. "response" is `cleaned_response`
+            # -- see the spawn path's comment for the exact byte-identity
+            # guarantee this preserves in the disabled/non-conformant paths.
             session_id_result = result["session_id"]
             return ToolResult(
                 success=True,
                 output={
-                    "response": result["output"],
+                    "response": cleaned_response,
                     "session_id": session_id_result,
                     "agent": agent_name,
                     "turn_count": result.get("turn_count", 1),
                     "status": result.get("status", "success"),
                     "metadata": result.get("metadata", {}),
+                    "contract": contract,
                 },
             )
 

--- a/modules/tool-delegate/tests/test_return_contract_disabled.py
+++ b/modules/tool-delegate/tests/test_return_contract_disabled.py
@@ -1,0 +1,260 @@
+"""Backward-compatibility guard for the structured delegation return contract.
+
+Pins Stage 0's success criterion (spec §12): with the feature off (the
+default), the delegate tool's behavior must be indistinguishable from before
+this change existed. This is the test suite that would fail loudly if the
+"purely additive" claim in the spec were ever violated.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from amplifier_module_tool_delegate import RETURN_CONTRACT_INSTRUCTION, DelegateTool
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_delegate_tool(
+    *,
+    spawn_fn=None,
+    resume_fn=None,
+    agents: dict | None = None,
+    hooks=None,
+    return_contract_config: dict | None = None,
+) -> DelegateTool:
+    coordinator = MagicMock()
+    coordinator.session_id = "parent-session-123"
+    coordinator.config = {"agents": agents or {}}
+    coordinator.session_state = {}
+    coordinator._tool_dispatch_context = {}
+    coordinator._tool_dispatch_contexts = {}
+
+    default_spawn_result = {
+        "output": "The answer is 42.",
+        "session_id": "child-001",
+        "status": "success",
+        "turn_count": 1,
+        "metadata": {},
+    }
+    default_resume_result = {
+        "output": "Still 42 on resume.",
+        "session_id": "child-001",
+        "status": "success",
+        "turn_count": 2,
+        "metadata": {},
+    }
+
+    capabilities: dict = {
+        "session.spawn": spawn_fn or AsyncMock(return_value=default_spawn_result),
+        "session.resume": resume_fn or AsyncMock(return_value=default_resume_result),
+        "self_delegation_depth": 0,
+    }
+    coordinator.get_capability = lambda name: capabilities.get(name)
+    coordinator.get = MagicMock(return_value=hooks)
+
+    parent_session = MagicMock()
+    parent_session.session_id = "parent-session-123"
+    parent_session.config = {"session": {"orchestrator": {}}}
+    coordinator.session = parent_session
+
+    features: dict = {}
+    if return_contract_config is not None:
+        features["return_contract"] = return_contract_config
+
+    config: dict = {"features": features, "settings": {"exclude_tools": []}}
+    return DelegateTool(coordinator, config)
+
+
+def _make_hooks() -> MagicMock:
+    hooks = MagicMock()
+    hooks.emit = AsyncMock()
+    return hooks
+
+
+# =============================================================================
+# Tests: feature off by default -- response byte-identical, contract inert
+# =============================================================================
+
+
+class TestFeatureOffByDefault:
+    @pytest.mark.asyncio
+    async def test_spawn_response_byte_identical_when_feature_off(self):
+        """With no return_contract config at all (the shipped default),
+        output["response"] is byte-identical to what spawn returned."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "The answer is 42.",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn, agents={"test-agent": {"description": "d"}}
+        )
+
+        result = await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Do something",
+                "context_depth": "none",
+            }
+        )
+
+        assert result.success
+        assert result.output["response"] == "The answer is 42."
+        assert result.output["contract"]["conformant"] is None
+
+    @pytest.mark.asyncio
+    async def test_resume_response_byte_identical_when_feature_off(self):
+        resume_fn = AsyncMock(
+            return_value={
+                "output": "Still 42 on resume.",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 2,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(resume_fn=resume_fn)
+
+        result = await tool.execute(
+            {"session_id": "child-001", "instruction": "Continue"}
+        )
+
+        assert result.success
+        assert result.output["response"] == "Still 42 on resume."
+        assert result.output["contract"]["conformant"] is None
+
+    @pytest.mark.asyncio
+    async def test_no_contract_instruction_injected_on_spawn_when_off(self):
+        """The instruction reaching session.spawn must NOT contain
+        RETURN_CONTRACT_INSTRUCTION when the feature is disabled."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn, agents={"test-agent": {"description": "d"}}
+        )
+
+        await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Do something",
+                "context_depth": "none",
+            }
+        )
+
+        spawn_fn.assert_called_once()
+        _, kwargs = spawn_fn.call_args
+        assert RETURN_CONTRACT_INSTRUCTION not in kwargs["instruction"]
+        assert kwargs["instruction"] == "Do something"
+
+    @pytest.mark.asyncio
+    async def test_no_contract_instruction_injected_on_resume_when_off(self):
+        resume_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(resume_fn=resume_fn)
+
+        await tool.execute({"session_id": "child-001", "instruction": "Continue"})
+
+        resume_fn.assert_called_once()
+        _, kwargs = resume_fn.call_args
+        assert RETURN_CONTRACT_INSTRUCTION not in kwargs["instruction"]
+        assert kwargs["instruction"] == "Continue"
+
+    @pytest.mark.asyncio
+    async def test_completed_event_carries_contract_conformant_none(self):
+        hooks = _make_hooks()
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            hooks=hooks,
+            agents={"test-agent": {"description": "d"}},
+        )
+
+        await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Do something",
+                "context_depth": "none",
+            }
+        )
+
+        emitted = {args[0]: args[1] for args, _ in hooks.emit.call_args_list}
+        completed = emitted["delegate:agent_completed"]
+        assert completed["contract_conformant"] is None
+        assert completed["findings_count"] is None
+        assert completed["evidence_backed_count"] is None
+        assert completed["not_covered_count"] is None
+        assert completed["artifacts_count"] is None
+
+
+# =============================================================================
+# Tests: per-agent opt-out overrides a globally-enabled feature
+# =============================================================================
+
+
+class TestPerAgentOptOut:
+    @pytest.mark.asyncio
+    async def test_per_agent_opt_out_suppresses_injection_with_feature_on(self):
+        """An agent config with return_contract: false suppresses injection
+        even though the tool-level feature is globally enabled."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            agents={
+                "git-ops": {"description": "d", "return_contract": False},
+            },
+            return_contract_config={"enabled": True},
+        )
+
+        result = await tool.execute(
+            {
+                "agent": "git-ops",
+                "instruction": "Commit this",
+                "context_depth": "none",
+            }
+        )
+
+        _, kwargs = spawn_fn.call_args
+        assert RETURN_CONTRACT_INSTRUCTION not in kwargs["instruction"]
+        # The parser still runs (feature is globally on), but since no agent
+        # opted-out response ever carries a fenced block, it degrades to a
+        # normal non-conformant parse -- never None, since the FEATURE
+        # itself is enabled (only this agent's injection was suppressed).
+        assert result.output["contract"]["conformant"] is False

--- a/modules/tool-delegate/tests/test_return_contract_injection.py
+++ b/modules/tool-delegate/tests/test_return_contract_injection.py
@@ -1,0 +1,276 @@
+"""Injection coverage tests for the structured delegation return contract.
+
+Pins spec §4.3's coverage claim: injecting RETURN_CONTRACT_INSTRUCTION at the
+tool level (rather than in 16+ agent .md files) covers every delegation
+target uniformly -- registered agents, agent="self", and bare bundle paths --
+none of which share a common agent file.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from amplifier_module_tool_delegate import RETURN_CONTRACT_INSTRUCTION, DelegateTool
+
+
+def _make_delegate_tool(
+    *,
+    spawn_fn=None,
+    resume_fn=None,
+    agents: dict | None = None,
+    return_contract_config: dict | None = None,
+) -> DelegateTool:
+    coordinator = MagicMock()
+    coordinator.session_id = "parent-session-123"
+    coordinator.config = {"agents": agents or {}}
+    coordinator.session_state = {}
+    coordinator._tool_dispatch_context = {}
+    coordinator._tool_dispatch_contexts = {}
+
+    default_spawn_result = {
+        "output": "done",
+        "session_id": "child-001",
+        "status": "success",
+        "turn_count": 1,
+        "metadata": {},
+    }
+    default_resume_result = {
+        "output": "done",
+        "session_id": "child-001",
+        "status": "success",
+        "turn_count": 2,
+        "metadata": {},
+    }
+    capabilities: dict = {
+        "session.spawn": spawn_fn or AsyncMock(return_value=default_spawn_result),
+        "session.resume": resume_fn or AsyncMock(return_value=default_resume_result),
+        "self_delegation_depth": 0,
+    }
+    coordinator.get_capability = lambda name: capabilities.get(name)
+    coordinator.get = MagicMock(return_value=None)
+
+    parent_session = MagicMock()
+    parent_session.session_id = "parent-session-123"
+    parent_session.config = {"session": {"orchestrator": {}}}
+    coordinator.session = parent_session
+
+    config: dict = {
+        "features": {"return_contract": return_contract_config or {"enabled": True}},
+        "settings": {"exclude_tools": []},
+    }
+    return DelegateTool(coordinator, config)
+
+
+class TestSpawnInjection:
+    @pytest.mark.asyncio
+    async def test_instruction_ends_with_contract_instruction(self):
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn, agents={"test-agent": {"description": "d"}}
+        )
+
+        await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Do something",
+                "context_depth": "none",
+            }
+        )
+
+        _, kwargs = spawn_fn.call_args
+        assert kwargs["instruction"].endswith(RETURN_CONTRACT_INSTRUCTION)
+
+    @pytest.mark.asyncio
+    async def test_your_task_composition_preserved_with_context_inheritance(self):
+        """When context inheritance is also on, the [YOUR TASK] composition
+        from the context-formatting step must still be present, with the
+        contract instruction appended after it (not replacing it)."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn, agents={"test-agent": {"description": "d"}}
+        )
+        # Force the parent-context-inheritance path to produce parent_messages.
+        tool._build_inherited_context = AsyncMock(
+            return_value=[{"role": "user", "content": "earlier turn"}]
+        )
+
+        await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "Do something",
+                "context_depth": "recent",
+            }
+        )
+
+        _, kwargs = spawn_fn.call_args
+        instruction = kwargs["instruction"]
+        assert "[YOUR TASK]" in instruction
+        assert "Do something" in instruction
+        assert instruction.endswith(RETURN_CONTRACT_INSTRUCTION)
+
+    @pytest.mark.asyncio
+    async def test_agent_self_receives_instruction(self):
+        """agent="self" has no shared agent .md file, but must still receive
+        the contract instruction via the tool-level injection point."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(spawn_fn=spawn_fn)
+
+        result = await tool.execute(
+            {
+                "agent": "self",
+                "instruction": "Recurse on this",
+                "context_depth": "none",
+            }
+        )
+
+        assert result.success
+        _, kwargs = spawn_fn.call_args
+        assert kwargs["instruction"].endswith(RETURN_CONTRACT_INSTRUCTION)
+
+    @pytest.mark.asyncio
+    async def test_bare_bundle_path_receives_instruction(self):
+        """A bare bundle path (e.g. "foundation:explorer") is not in the
+        agents registry and has no shared agent file, but must still
+        receive the contract instruction."""
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(spawn_fn=spawn_fn)
+
+        result = await tool.execute(
+            {
+                "agent": "foundation:explorer",
+                "instruction": "Explore the codebase",
+                "context_depth": "none",
+            }
+        )
+
+        assert result.success
+        _, kwargs = spawn_fn.call_args
+        assert kwargs["instruction"].endswith(RETURN_CONTRACT_INSTRUCTION)
+
+
+class TestResumeInjection:
+    @pytest.mark.asyncio
+    async def test_resume_instruction_carries_contract_instruction(self):
+        resume_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 2,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(resume_fn=resume_fn)
+
+        await tool.execute({"session_id": "child-001", "instruction": "Continue"})
+
+        _, kwargs = resume_fn.call_args
+        assert kwargs["instruction"].endswith(RETURN_CONTRACT_INSTRUCTION)
+        assert "Continue" in kwargs["instruction"]
+
+    @pytest.mark.asyncio
+    async def test_resume_respects_per_agent_opt_out_via_spawn_cache(self):
+        """A session originally spawned for an agent with return_contract:
+        false must not receive the instruction on resume either -- opt-out
+        is resolved via the same agent identity used at spawn time."""
+        spawn_fn = AsyncMock(
+            side_effect=lambda **kwargs: {
+                "output": "spawned",
+                "session_id": kwargs["sub_session_id"],
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        resume_fn = AsyncMock(
+            return_value={
+                "output": "resumed",
+                "session_id": "will-be-overwritten",
+                "status": "success",
+                "turn_count": 2,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            resume_fn=resume_fn,
+            agents={"git-ops": {"description": "d", "return_contract": False}},
+        )
+
+        spawn_result = await tool.execute(
+            {
+                "agent": "git-ops",
+                "instruction": "Commit this",
+                "context_depth": "none",
+            }
+        )
+        real_session_id = spawn_result.output["session_id"]
+
+        await tool.execute(
+            {"session_id": real_session_id, "instruction": "Now push it"}
+        )
+
+        _, resume_kwargs = resume_fn.call_args
+        assert RETURN_CONTRACT_INSTRUCTION not in resume_kwargs["instruction"]
+        assert resume_kwargs["instruction"] == "Now push it"
+
+
+class TestFeatureOffNoInjectionAnywhere:
+    @pytest.mark.asyncio
+    async def test_self_and_bundle_path_unaffected_when_feature_off(self):
+        spawn_fn = AsyncMock(
+            return_value={
+                "output": "done",
+                "session_id": "child-001",
+                "status": "success",
+                "turn_count": 1,
+                "metadata": {},
+            }
+        )
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn, return_contract_config={"enabled": False}
+        )
+
+        await tool.execute(
+            {
+                "agent": "self",
+                "instruction": "Recurse on this",
+                "context_depth": "none",
+            }
+        )
+
+        _, kwargs = spawn_fn.call_args
+        assert kwargs["instruction"] == "Recurse on this"

--- a/modules/tool-delegate/tests/test_return_contract_parse.py
+++ b/modules/tool-delegate/tests/test_return_contract_parse.py
@@ -1,0 +1,354 @@
+"""Pure-function tests for DelegateTool._parse_return_contract().
+
+Covers the structured delegation return contract (openai_improvement-q71):
+a sub-agent may append a fenced ```json block to its normal prose response,
+which this method parses tolerantly into a ``contract`` dict. See the spec
+(§10.2) for the exact algorithm this pins.
+
+These tests exercise the parser directly -- no coordinator, no spawn/resume
+plumbing -- since _parse_return_contract is documented as a pure function of
+(response, self.return_contract_enabled, self.return_contract_strip_block).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from amplifier_module_tool_delegate import DelegateTool
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_tool(*, enabled: bool = True, strip_block: bool = True) -> DelegateTool:
+    """Create a DelegateTool with only the return_contract feature configured.
+
+    No coordinator interaction is needed for these parser-only tests, so a
+    bare MagicMock is sufficient -- _parse_return_contract never touches it.
+    """
+    coordinator = MagicMock()
+    config = {
+        "features": {
+            "return_contract": {
+                "enabled": enabled,
+                "strip_block": strip_block,
+            }
+        },
+        "settings": {"exclude_tools": []},
+    }
+    return DelegateTool(coordinator, config)
+
+
+# =============================================================================
+# Tests: conformant parsing
+# =============================================================================
+
+
+class TestConformantParsing:
+    @pytest.mark.asyncio
+    async def test_well_formed_block_after_prose(self):
+        """A well-formed block after prose parses conformant, with the block
+        stripped from the cleaned response."""
+        tool = _make_tool()
+        response = (
+            "Here is my analysis of the issue.\n\n"
+            "```json\n"
+            '{"summary": "Found it.", '
+            '"findings": [{"claim": "X is broken", "evidence": "foo.py:12", "confidence": "high"}], '
+            '"not_covered": [], "artifacts": []}\n'
+            "```"
+        )
+
+        contract, cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is True
+        assert contract["reason"] is None
+        assert contract["summary"] == "Found it."
+        assert contract["findings"] == [
+            {"claim": "X is broken", "evidence": "foo.py:12", "confidence": "high"}
+        ]
+        assert "```json" not in cleaned
+        assert "Here is my analysis of the issue." in cleaned
+
+    def test_two_json_blocks_last_one_wins(self):
+        """When two fenced json blocks are present, the LAST one is used."""
+        tool = _make_tool()
+        response = (
+            "```json\n"
+            '{"findings": [{"claim": "first block, should be ignored"}]}\n'
+            "```\n\n"
+            "More prose in between.\n\n"
+            "```json\n"
+            '{"findings": [{"claim": "second block, should win"}]}\n'
+            "```"
+        )
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is True
+        assert len(contract["findings"]) == 1
+        assert contract["findings"][0]["claim"] == "second block, should win"
+
+    def test_case_insensitive_fence_info_string(self):
+        """```JSON (any case) is accepted, not just ```json."""
+        tool = _make_tool()
+        response = '```JSON\n{"findings": []}\n```'
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is True
+
+
+# =============================================================================
+# Tests: non-conformant fallbacks (never fail the delegation)
+# =============================================================================
+
+
+class TestNonConformantFallbacks:
+    def test_no_block_found(self):
+        """No fenced json block -> conformant False, byte-identical response."""
+        tool = _make_tool()
+        response = "Just plain prose, no structured block at all."
+
+        contract, cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is False
+        assert "no fenced json block" in contract["reason"]
+        assert cleaned == response
+
+    def test_malformed_json(self):
+        """Malformed JSON inside the fence -> conformant False, byte-identical."""
+        tool = _make_tool()
+        response = "Some prose.\n\n```json\n{not valid json,,,\n```"
+
+        contract, cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is False
+        assert "json parse failed" in contract["reason"]
+        assert cleaned == response
+
+    def test_block_is_array_not_object(self):
+        """A fenced block that parses to a JSON array (not object) is rejected
+        with a reason naming the problem."""
+        tool = _make_tool()
+        response = "```json\n[1, 2, 3]\n```"
+
+        contract, cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is False
+        assert "not a JSON object" in contract["reason"]
+        assert cleaned == response
+
+    def test_findings_missing(self):
+        """A well-formed object lacking the required 'findings' key is
+        non-conformant."""
+        tool = _make_tool()
+        response = '```json\n{"summary": "no findings key here"}\n```'
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is False
+        assert "findings" in contract["reason"]
+
+    def test_findings_not_a_list(self):
+        """'findings' present but not a list is also non-conformant."""
+        tool = _make_tool()
+        response = '```json\n{"findings": "not-a-list"}\n```'
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is False
+
+
+# =============================================================================
+# Tests: tolerant normalization (never reject a partially-good return)
+# =============================================================================
+
+
+class TestTolerantNormalization:
+    def test_finding_missing_claim_is_dropped_others_kept(self):
+        """A finding entry lacking 'claim' is dropped; other entries survive
+        and the overall contract is still conformant."""
+        tool = _make_tool()
+        response = (
+            "```json\n"
+            '{"findings": ['
+            '{"evidence": "no claim here"}, '
+            '{"claim": "valid claim", "evidence": "bar.py:5"}'
+            "]}\n"
+            "```"
+        )
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is True
+        assert len(contract["findings"]) == 1
+        assert contract["findings"][0]["claim"] == "valid claim"
+
+    def test_unknown_confidence_normalized_to_unspecified(self):
+        """confidence: "certain" (not in the enum) normalizes to "unspecified"
+        rather than being rejected."""
+        tool = _make_tool()
+        response = (
+            '```json\n{"findings": [{"claim": "x", "confidence": "certain"}]}\n```'
+        )
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is True
+        assert contract["findings"][0]["confidence"] == "unspecified"
+
+    def test_missing_evidence_defaults_to_empty_string(self):
+        tool = _make_tool()
+        response = '```json\n{"findings": [{"claim": "x"}]}\n```'
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["findings"][0]["evidence"] == ""
+
+    def test_not_covered_present_surfaced_verbatim(self):
+        tool = _make_tool()
+        response = '```json\n{"findings": [], "not_covered": ["auth flow", "rate limits"]}\n```'
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["not_covered"] == ["auth flow", "rate limits"]
+
+    def test_not_covered_malformed_items_dropped(self):
+        """Non-string items in not_covered are dropped, not fatal."""
+        tool = _make_tool()
+        response = '```json\n{"findings": [], "not_covered": ["ok", 42, null]}\n```'
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is True
+        assert contract["not_covered"] == ["ok"]
+
+    def test_artifacts_present_surfaced(self):
+        tool = _make_tool()
+        response = (
+            "```json\n"
+            '{"findings": [], "artifacts": [{"path": "src/foo.py", "description": "added retry"}]}\n'
+            "```"
+        )
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["artifacts"] == [
+            {"path": "src/foo.py", "description": "added retry"}
+        ]
+
+    def test_artifact_missing_path_dropped(self):
+        tool = _make_tool()
+        response = (
+            '```json\n{"findings": [], "artifacts": [{"description": "no path"}]}\n```'
+        )
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is True
+        assert contract["artifacts"] == []
+
+
+# =============================================================================
+# Tests: strip_block toggle
+# =============================================================================
+
+
+class TestStripBlockToggle:
+    def test_strip_block_false_leaves_response_byte_identical(self):
+        tool = _make_tool(strip_block=False)
+        response = 'Some prose.\n\n```json\n{"findings": []}\n```'
+
+        contract, cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is True
+        assert cleaned == response
+
+    def test_strip_block_true_removes_the_block(self):
+        tool = _make_tool(strip_block=True)
+        response = 'Some prose.\n\n```json\n{"findings": []}\n```'
+
+        _contract, cleaned = tool._parse_return_contract(response)
+
+        assert "```" not in cleaned
+        assert "Some prose." in cleaned
+
+
+# =============================================================================
+# Tests: pathological input -- must never raise
+# =============================================================================
+
+
+class TestPathologicalInputNeverRaises:
+    def test_unterminated_fence(self):
+        tool = _make_tool()
+        response = '```json\n{"findings": []'  # no closing fence at all
+
+        contract, cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is False
+        assert cleaned == response
+
+    def test_nested_fences_do_not_crash(self):
+        tool = _make_tool()
+        response = (
+            "```json\n"
+            '{"findings": [{"claim": "contains a nested fence marker below"}]}\n'
+            "```\n"
+            "```\n"
+            "some other unrelated fenced block\n"
+            "```"
+        )
+
+        # Must not raise regardless of what it parses to.
+        contract, _cleaned = tool._parse_return_contract(response)
+        assert contract["conformant"] in (True, False)
+
+    def test_large_1mb_string_does_not_raise(self):
+        tool = _make_tool()
+        padding = "x" * (1024 * 1024)
+        response = f'{padding}\n```json\n{{"findings": []}}\n```'
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is True
+
+    def test_empty_string_does_not_raise(self):
+        tool = _make_tool()
+
+        contract, cleaned = tool._parse_return_contract("")
+
+        assert contract["conformant"] is False
+        assert cleaned == ""
+
+    def test_non_dict_findings_items_do_not_raise(self):
+        tool = _make_tool()
+        response = (
+            '```json\n{"findings": ["not-a-dict", 42, null, {"claim": "ok"}]}\n```'
+        )
+
+        contract, _cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is True
+        assert len(contract["findings"]) == 1
+        assert contract["findings"][0]["claim"] == "ok"
+
+
+# =============================================================================
+# Tests: disabled feature short-circuits parsing entirely
+# =============================================================================
+
+
+class TestDisabledFeature:
+    def test_disabled_returns_none_conformant_and_untouched_response(self):
+        tool = _make_tool(enabled=False)
+        response = 'Some prose.\n\n```json\n{"findings": [{"claim": "x"}]}\n```'
+
+        contract, cleaned = tool._parse_return_contract(response)
+
+        assert contract["conformant"] is None
+        assert contract["findings"] == []
+        assert cleaned == response

--- a/modules/tool-delegate/tests/test_return_contract_telemetry.py
+++ b/modules/tool-delegate/tests/test_return_contract_telemetry.py
@@ -1,0 +1,164 @@
+"""Telemetry enrichment tests for the structured delegation return contract.
+
+`delegate:agent_completed` gains five additive fields (contract_conformant,
+findings_count, evidence_backed_count, not_covered_count, artifacts_count) --
+see spec §7. No new events are introduced; this suite pins that the existing
+event is enriched correctly on both the spawn and resume completion paths.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from amplifier_module_tool_delegate import DelegateTool
+
+_CONFORMANT_RESPONSE = (
+    "Here is what I found.\n\n"
+    "```json\n"
+    '{"summary": "done", '
+    '"findings": ['
+    '{"claim": "a", "evidence": "foo.py:1", "confidence": "high"}, '
+    '{"claim": "b", "evidence": "", "confidence": "low"}, '
+    '{"claim": "c", "evidence": "bar.py:9", "confidence": "medium"}'
+    "], "
+    '"not_covered": ["thing one", "thing two"], '
+    '"artifacts": [{"path": "src/x.py", "description": "edited"}]}\n'
+    "```"
+)
+
+
+def _make_delegate_tool(
+    *,
+    spawn_output: str | None = None,
+    resume_output: str | None = None,
+    hooks=None,
+    return_contract_enabled: bool = True,
+) -> DelegateTool:
+    coordinator = MagicMock()
+    coordinator.session_id = "parent-session-123"
+    coordinator.config = {"agents": {"test-agent": {"description": "d"}}}
+    coordinator.session_state = {}
+    coordinator._tool_dispatch_context = {}
+    coordinator._tool_dispatch_contexts = {}
+
+    spawn_fn = AsyncMock(
+        return_value={
+            "output": spawn_output if spawn_output is not None else "done",
+            "session_id": "child-001",
+            "status": "success",
+            "turn_count": 1,
+            "metadata": {},
+        }
+    )
+    resume_fn = AsyncMock(
+        return_value={
+            "output": resume_output if resume_output is not None else "done",
+            "session_id": "child-001",
+            "status": "success",
+            "turn_count": 2,
+            "metadata": {},
+        }
+    )
+    capabilities: dict = {
+        "session.spawn": spawn_fn,
+        "session.resume": resume_fn,
+        "self_delegation_depth": 0,
+    }
+    coordinator.get_capability = lambda name: capabilities.get(name)
+    coordinator.get = MagicMock(return_value=hooks)
+
+    parent_session = MagicMock()
+    parent_session.session_id = "parent-session-123"
+    parent_session.config = {"session": {"orchestrator": {}}}
+    coordinator.session = parent_session
+
+    config: dict = {
+        "features": {"return_contract": {"enabled": return_contract_enabled}},
+        "settings": {"exclude_tools": []},
+    }
+    return DelegateTool(coordinator, config)
+
+
+def _make_hooks() -> MagicMock:
+    hooks = MagicMock()
+    hooks.emit = AsyncMock()
+    return hooks
+
+
+class TestSpawnTelemetry:
+    @pytest.mark.asyncio
+    async def test_conformant_return_carries_correct_counts(self):
+        hooks = _make_hooks()
+        tool = _make_delegate_tool(spawn_output=_CONFORMANT_RESPONSE, hooks=hooks)
+
+        await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "investigate",
+                "context_depth": "none",
+            }
+        )
+
+        emitted = {args[0]: args[1] for args, _ in hooks.emit.call_args_list}
+        completed = emitted["delegate:agent_completed"]
+        assert completed["contract_conformant"] is True
+        assert completed["findings_count"] == 3
+        assert completed["not_covered_count"] == 2
+        assert completed["artifacts_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_evidence_backed_count_only_counts_non_empty_evidence(self):
+        """Of the 3 findings above, only 2 have non-empty evidence."""
+        hooks = _make_hooks()
+        tool = _make_delegate_tool(spawn_output=_CONFORMANT_RESPONSE, hooks=hooks)
+
+        await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "investigate",
+                "context_depth": "none",
+            }
+        )
+
+        emitted = {args[0]: args[1] for args, _ in hooks.emit.call_args_list}
+        completed = emitted["delegate:agent_completed"]
+        assert completed["evidence_backed_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_non_conformant_return_has_false_and_zero_counts(self):
+        hooks = _make_hooks()
+        tool = _make_delegate_tool(spawn_output="just plain prose", hooks=hooks)
+
+        await tool.execute(
+            {
+                "agent": "test-agent",
+                "instruction": "investigate",
+                "context_depth": "none",
+            }
+        )
+
+        emitted = {args[0]: args[1] for args, _ in hooks.emit.call_args_list}
+        completed = emitted["delegate:agent_completed"]
+        assert completed["contract_conformant"] is False
+        assert completed["findings_count"] == 0
+        assert completed["evidence_backed_count"] == 0
+        assert completed["not_covered_count"] == 0
+        assert completed["artifacts_count"] == 0
+
+
+class TestResumeTelemetry:
+    @pytest.mark.asyncio
+    async def test_resume_path_emits_same_enrichment_as_spawn(self):
+        hooks = _make_hooks()
+        tool = _make_delegate_tool(resume_output=_CONFORMANT_RESPONSE, hooks=hooks)
+
+        await tool.execute({"session_id": "child-001", "instruction": "continue"})
+
+        emitted = {args[0]: args[1] for args, _ in hooks.emit.call_args_list}
+        completed = emitted["delegate:agent_completed"]
+        assert completed["contract_conformant"] is True
+        assert completed["findings_count"] == 3
+        assert completed["evidence_backed_count"] == 2
+        assert completed["not_covered_count"] == 2
+        assert completed["artifacts_count"] == 1


### PR DESCRIPTION
## Summary

Stage 0/1 of `openai_improvement-q71` (structured delegation return contract). Ships **behind `features.return_contract.enabled` (default OFF)** — merging this changes nothing until the flag is flipped. Full design rationale, rejected alternatives, and the DTU measurement plan live in the approved spec (not included in this diff — internal design doc).

## Problem (measured, not assumed)

- The delegate return channel is **not bandwidth-starved**: ~17–22k tokens of sub-agent findings already cross back to the root per run, across 5 measured eval runs. Individual returns run up to ~5,300 tokens.
- Despite that, the root wrote only **46.6%** of what an inline (non-delegating) root wrote for the same task (7,849 vs 16,834 mean output tokens, confounded by provider — see caveat below). The work was done; the root transcribed a fraction of it.
- Three specific, measured defects, each with a field that fixes it:
  | Defect | Measured signature | Field |
  |---|---|---|
  | Undifferentiated prose | seeded credential-fallback finding survived in only **3/5** runs | `findings[]` (claim + evidence + confidence) |
  | No coverage honesty | **7/39** resumes fired late, one 19s after completion | `not_covered[]` |
  | No enumeration obligation | finding present in context, absent from final answer in **2/5** runs | root-side instruction in the tool description |

## Mechanism

The delegate tool injects a ~180-token contract instruction at both spawn and resume, asking the sub-agent to append a fenced ` ```json ` block (`findings[]`, `not_covered[]`, `artifacts[]`) after its normal prose. The tool parses the block tolerantly (only `findings` is required, only `claim` within it), annotates `ToolResult.output["contract"]` (purely additive), and enriches the tool description with an enumeration obligation for the root. **Non-conformance never fails the delegation** — it falls back to today's untouched `response`, byte-identical.

## Changes

**`modules/tool-delegate/amplifier_module_tool_delegate/__init__.py`**
- `RETURN_CONTRACT_SCHEMA` / `RETURN_CONTRACT_INSTRUCTION` module constants, `_return_contract_event_fields()` telemetry helper, and the compiled fenced-block regex — all placed above `class DelegateTool` so they cannot interfere with the static token-cost estimator's `return {` scan (see the existing docstring warning on `input_schema`).
- `__init__`: parses `features.return_contract.{enabled, strip_block, reask_on_nonconformance}` (defaults `False` / `True` / `False`).
- `_build_feature_registry()`: new `"return_contract"` entry carrying the root-side consumption text, surfaced in the tool description only when enabled.
- `_spawn_new_session()` / `_resume_existing_session()`: append `RETURN_CONTRACT_INSTRUCTION` to the instruction when enabled and the agent hasn't opted out (`agent_cfg.get("return_contract", True)` — opt-out only, not a per-agent matrix). Resume resolves opt-out via the same agent identity already used for event emission.
- New `_parse_return_contract()`: tolerant, **never-raising** parser. Malformed/missing fields degrade gracefully rather than rejecting the whole return (see the invariants in its docstring).
- Both completion paths: parse once, annotate `output["contract"]` and `output["response"]` (block stripped only on a successful, flag-enabled parse), and enrich the existing `delegate:agent_completed` event with five additive fields (`contract_conformant`, `findings_count`, `evidence_backed_count`, `not_covered_count`, `artifacts_count`). **No new events.**

**Docs**
- `context/agents/delegation-instructions.md`: new "Reading a Structured Agent Return" section, placed right after the existing "Scrutinize an Agent's N/A" doctrine — `not_covered[]` is that doctrine given a machine-readable field.
- `modules/tool-delegate/README.md`: full feature documentation (schema, config, per-agent opt-out, telemetry, non-conformant fallback).

## Explicitly NOT built

Per the spec's rejected/deferred list:
- **Provider-level `response_format` enforcement** — structurally blocked by the tool-calling loop (a turn is only final after the model declines a tool call) and not supported cross-provider (anthropic has none today).
- **The re-ask loop** — deferred to a future stage, gated on this stage's conformance data.
- **The shared blackboard file** — gated on measured return volume (>40k tokens/run) or duplicate-exploration (>15% of sub-agent tool calls) thresholds, neither of which has fired.

## Testing

- 4 new test files — parse (pure-function), backward-compat/disabled guard, telemetry enrichment, injection coverage (spawn/resume/self/bundle-path) — **102 tests, all passing** in `modules/tool-delegate/tests/`.
- Full `amplifier-foundation` suite: **1634 passed, 1 skipped** (pre-existing skip, unrelated).
- `python_check`: no new errors introduced; warning count matches the pre-existing baseline plus one additional blind-except required by the parser's "never raises" invariant (consistent with three identical pre-existing catches already in this file).
- Verified foundation's `bundle_docs` token-cost estimator still extracts `DelegateTool.input_schema` via `ast.literal_eval` (695 total tokens) — confirms the new module-level constants don't interfere with the estimator's `return {` scan.
- With the feature off (default), `ToolResult.output["response"]` is byte-identical to the pre-change payload for both spawn and resume, and `delegate:agent_completed` carries `contract_conformant: None` (pinned in `test_return_contract_disabled.py`).

## Rollout (next stage, not in this PR)

Flipping `enabled: true` in `behaviors/agents.yaml` is gated on a DTU measurement plan not run here: synthesis retention vs. an openai-inline control arm (baseline 46.6%, confounded by provider — target ≥65%), return-volume guard (baseline 12–16%, guard band 8–25%), late-resume rate (baseline 7/39 = 18% — target ≤8%), finding survival (baseline 3/5 — target 5/5), and conformance rate (target ≥90%, reported per model including anthropic).

**Not merging this PR** — opened for review per process; will hold pending explicit approval.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
