### PR TITLE
fix(hooks): hooks-tool-dedupe fails protocol_compliance via top-level hooks block

### DIFF
--- a/behaviors/agents.yaml
+++ b/behaviors/agents.yaml
@@ -46,8 +46,8 @@ hooks:
   # above) so every sub-session in a delegation tree inherits it, since a
   # parallel tool batch -- the case this hook targets -- is always within
   # one session.
-  - module: hooks-tool-dedupe
-    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/hooks-tool-dedupe
+  - module: hooks-dedupe
+    source: git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=modules/hooks-dedupe
     config:
       enabled: false                       # Stage 1 ships default-OFF
       tools: ["read_file", "load_skill"]

--- a/modules/hooks-dedupe/amplifier_module_hooks_dedupe/__init__.py
+++ b/modules/hooks-dedupe/amplifier_module_hooks_dedupe/__init__.py
@@ -48,7 +48,7 @@ turn boundary in a way that could support them.
 Config surface (all keys optional; ships default-OFF):
 
     hooks:
-      - module: hooks-tool-dedupe
+      - module: hooks-dedupe
         config:
           enabled: false                       # Stage 1 ships default-OFF
           tools: ["read_file", "load_skill"]
@@ -87,7 +87,7 @@ from amplifier_core import HookResult
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["ToolDedupeHook", "mount"]
+__all__ = ["DedupeHook", "mount"]
 
 #: Default tool allowlist. Adding "load_skill" here *is* the entirety of the
 #: skill-load dedupe mechanism -- no separate code path exists for it.
@@ -163,7 +163,7 @@ def _build_key_and_target(tool_name: str, tool_input: Any) -> tuple[_Key, str] |
     return None
 
 
-class ToolDedupeHook:
+class DedupeHook:
     """Coalesces byte-identical repeated tool results within one parallel
     tool batch of one session. See module docstring for the full contract.
     """
@@ -314,7 +314,7 @@ async def mount(
     """
     config = config or {}
 
-    hook = ToolDedupeHook(
+    hook = DedupeHook(
         hooks=coordinator.hooks,
         enabled=bool(config.get("enabled", False)),
         tools=config.get("tools", list(DEFAULT_TOOLS)),
@@ -327,7 +327,7 @@ async def mount(
     # already-short marker and no-ops, rather than dedupe hashing an
     # already-truncated string.
     coordinator.hooks.register(
-        "tool:post", hook.handle_tool_post, priority=5, name="hooks-tool-dedupe"
+        "tool:post", hook.handle_tool_post, priority=5, name="hooks-dedupe"
     )
 
     # Declare the events we emit so the session capture hooks (hooks-logging
@@ -337,12 +337,12 @@ async def mount(
     # hooks-deprecation.
     coordinator.register_contributor(
         "observability.events",
-        "hooks-tool-dedupe",
+        "hooks-dedupe",
         lambda: ["dedupe:coalesced", "dedupe:divergent"],
     )
 
     return {
-        "name": "hooks-tool-dedupe",
+        "name": "hooks-dedupe",
         "version": "0.1.0",
         "description": "Coalesces byte-identical repeated tool results within one parallel tool batch",
         "config": {

--- a/modules/hooks-dedupe/pyproject.toml
+++ b/modules/hooks-dedupe/pyproject.toml
@@ -1,16 +1,16 @@
 [project]
-name = "amplifier-module-hooks-tool-dedupe"
+name = "amplifier-module-hooks-dedupe"
 version = "0.1.0"
 description = "Coalesces byte-identical repeated tool results within one parallel tool batch"
 requires-python = ">=3.11"
 dependencies = ["amplifier-core>=1.0.10"]
 
 [project.entry-points."amplifier.modules"]
-hooks-tool-dedupe = "amplifier_module_hooks_tool_dedupe:mount"
+hooks-dedupe = "amplifier_module_hooks_dedupe:mount"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["amplifier_module_hooks_tool_dedupe"]
+packages = ["amplifier_module_hooks_dedupe"]

--- a/modules/hooks-dedupe/tests/test_batch_dedupe.py
+++ b/modules/hooks-dedupe/tests/test_batch_dedupe.py
@@ -1,4 +1,4 @@
-"""Tests for hooks-tool-dedupe: the same-batch read coalescer.
+"""Tests for hooks-dedupe: the same-batch read coalescer.
 
 Pure-function and hook-level tests only -- no session, no network, no
 provider. Mirrors the test plan in the implementation spec (yoc-dedup-spec.md
@@ -15,10 +15,10 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
-from amplifier_module_hooks_tool_dedupe import (
+from amplifier_module_hooks_dedupe import (
     DEFAULT_MAX_BATCHES,
     DEFAULT_MIN_BYTES,
-    ToolDedupeHook,
+    DedupeHook,
 )
 
 
@@ -32,7 +32,7 @@ class FakeHooks:
         self.emitted.append((event, dict(data)))
 
 
-def make_hook(**overrides) -> tuple[ToolDedupeHook, FakeHooks]:
+def make_hook(**overrides) -> tuple[DedupeHook, FakeHooks]:
     hooks = FakeHooks()
     kwargs = {
         "hooks": hooks,
@@ -42,7 +42,7 @@ def make_hook(**overrides) -> tuple[ToolDedupeHook, FakeHooks]:
         "max_batches": DEFAULT_MAX_BATCHES,
     }
     kwargs.update(overrides)
-    return ToolDedupeHook(**kwargs), hooks
+    return DedupeHook(**kwargs), hooks
 
 
 def read_post_data(
@@ -453,7 +453,7 @@ async def test_mount_registers_tool_post_at_priority_5():
     """priority=5 is load-bearing: must run before hooks-tool-truncation's
     priority=10 (spec Section 4.3)."""
     coordinator = FakeCoordinator()
-    result = await __import__("amplifier_module_hooks_tool_dedupe").mount(
+    result = await __import__("amplifier_module_hooks_dedupe").mount(
         coordinator, {"enabled": True}
     )
 
@@ -461,21 +461,21 @@ async def test_mount_registers_tool_post_at_priority_5():
     event, _handler, priority, name = coordinator.registered[0]
     assert event == "tool:post"
     assert priority == 5
-    assert name == "hooks-tool-dedupe"
-    assert result["name"] == "hooks-tool-dedupe"
+    assert name == "hooks-dedupe"
+    assert result["name"] == "hooks-dedupe"
 
 
 @pytest.mark.asyncio
 async def test_mount_declares_observability_events():
     coordinator = FakeCoordinator()
-    from amplifier_module_hooks_tool_dedupe import mount
+    from amplifier_module_hooks_dedupe import mount
 
     await mount(coordinator, {"enabled": True})
 
     assert len(coordinator.contributors) == 1
     channel, name = coordinator.contributors[0]
     assert channel == "observability.events"
-    assert name == "hooks-tool-dedupe"
+    assert name == "hooks-dedupe"
     assert coordinator._contributor_callback is not None
     assert coordinator._contributor_callback() == [
         "dedupe:coalesced",
@@ -488,7 +488,7 @@ async def test_mount_defaults_to_disabled():
     """Stage 1 ships default-OFF: mounting with no config must be a total
     no-op at runtime."""
     coordinator = FakeCoordinator()
-    from amplifier_module_hooks_tool_dedupe import mount
+    from amplifier_module_hooks_dedupe import mount
 
     result = await mount(coordinator, None)
     assert result["config"]["enabled"] is False

--- a/modules/hooks-dedupe/uv.lock
+++ b/modules/hooks-dedupe/uv.lock
@@ -23,7 +23,7 @@ wheels = [
 ]
 
 [[package]]
-name = "amplifier-module-hooks-tool-dedupe"
+name = "amplifier-module-hooks-dedupe"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [

--- a/tests/test_hook_module_classification.py
+++ b/tests/test_hook_module_classification.py
@@ -1,0 +1,114 @@
+"""Regression tests for hook module classification via amplifier-core's real
+module loader.
+
+Root cause this guards against: amplifier-core's `ModuleLoader._get_module_metadata`
+falls back to `_guess_from_naming()` for any module that doesn't declare an
+explicit `__amplifier_module_type__` attribute (none of foundation's in-tree
+hook modules do). `_guess_from_naming()` does a first-match substring scan over
+a fixed keyword order (`orchestrat`, `loop`, `provider`, `tool`, `hook`,
+`context`) -- so a hook module whose id contains an *earlier* keyword than
+"hook" is silently misclassified.
+
+`hooks-tool-dedupe` tripped exactly this: it contains "tool" (an earlier
+keyword) as well as "hook", so it was classified as a `tool` module and
+validated with `ToolValidator` instead of `HookValidator`, which then failed
+`protocol_compliance` with "No tool was mounted and mount() did not return a
+Tool instance" -- even though the module loaded and mounted correctly as a
+hook. The fix renamed the module to `hooks-dedupe` (no competing keyword);
+this test exercises the *actual* amplifier-core loader classification and
+validation path (not just `mount()` called directly against a fake
+coordinator, which every module's own test suite already covers and which
+would NOT catch this class of bug) so a future hook module with a colliding
+substring in its name fails CI instead of silently never activating.
+
+See: amplifier-core python/amplifier_core/loader.py, `_guess_from_naming()`
+and `_get_module_metadata()`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from amplifier_core.loader import ModuleLoader, ModuleValidationError
+
+MODULES_DIR = Path(__file__).parent.parent / "modules"
+
+# Every in-tree module that follows foundation's `hooks-*` naming convention.
+# Discovered dynamically so a newly added hook module is automatically
+# covered by this regression guard without needing to update this list.
+HOOK_MODULE_IDS = sorted(
+    p.name for p in MODULES_DIR.iterdir() if p.is_dir() and p.name.startswith("hooks-")
+)
+
+
+@pytest.fixture
+def loader() -> ModuleLoader:
+    return ModuleLoader()
+
+
+def test_hook_modules_were_discovered() -> None:
+    """Sanity check: the dynamic discovery above must find at least the
+    modules known to exist at the time this test was written, otherwise the
+    parametrized tests below would silently pass on an empty set."""
+    assert "hooks-dedupe" in HOOK_MODULE_IDS
+    assert len(HOOK_MODULE_IDS) >= 5
+
+
+@pytest.mark.parametrize("module_id", HOOK_MODULE_IDS)
+def test_hook_module_classifies_as_hook(loader: ModuleLoader, module_id: str) -> None:
+    """Every `hooks-*` module must classify as type='hook' via the same
+    `_get_module_metadata()` amplifier-core's real loader calls at bundle
+    composition time (both the top-level `hooks:` block and a behavior's
+    `hooks:` block resolve modules through this exact method).
+
+    A module classified as anything else (e.g. 'tool', because its id
+    contains a keyword the naming-fallback checks before 'hook') will be
+    validated with the wrong protocol validator and fail to load.
+    """
+    module_path = MODULES_DIR / module_id
+    module_type, mount_point = loader._get_module_metadata(module_id, module_path)
+
+    assert module_type == "hook", (
+        f"'{module_id}' classified as type='{module_type}' instead of 'hook' -- "
+        "its module id likely contains a keyword ('tool', 'loop', 'provider', "
+        "'orchestrat', or 'context') that amplifier-core's naming-fallback "
+        "heuristic matches before 'hook'. Rename the module so its id does not "
+        "contain a competing keyword (see hooks-tool-dedupe -> hooks-dedupe)."
+    )
+    assert mount_point == "hooks"
+
+
+@pytest.mark.asyncio
+async def test_hooks_dedupe_passes_real_validation(loader: ModuleLoader) -> None:
+    """`hooks-dedupe` must pass amplifier-core's real load-time validation
+    (`ModuleLoader._validate_module`) -- the exact call site (loader.py,
+    inside `load()`) whose failure produced:
+
+        ModuleValidationError: protocol_compliance: No tool was mounted and
+        mount() did not return a Tool instance
+
+    for `hooks-tool-dedupe` (this module's pre-rename id) when it was
+    misclassified as a tool module. This is a true end-to-end reproduction:
+    it imports the real module from its real on-disk path, resolves its
+    classification the same way `load()` does, and calls its real `mount()`
+    via the validator appropriate to that classification -- asserting the
+    whole thing does not raise, unlike calling `mount()` directly against a
+    fake coordinator (which every module's own test suite, including this
+    one's, already does and which would NOT have caught this bug, since the
+    bug is in classification/validator selection *before* `mount()` is ever
+    reached).
+
+    Not parametrized across every `hooks-*` module: some (e.g.
+    hooks-deprecation) require module-specific config to mount successfully,
+    which is a property of their own contract, unrelated to this
+    classification bug. `test_hook_module_classifies_as_hook` above already
+    covers the classification step -- the part of the pipeline this bug was
+    actually in -- for every hook module generically without needing to know
+    each one's required config.
+    """
+    module_path = MODULES_DIR / "hooks-dedupe"
+    try:
+        await loader._validate_module("hooks-dedupe", module_path, config=None)
+    except ModuleValidationError as exc:
+        pytest.fail(f"'hooks-dedupe' failed real module-load validation: {exc}")


### PR DESCRIPTION
## Root cause

Confirmed at `amplifier-core` 1.6.1, `python/amplifier_core/loader.py`:

- `ModuleLoader._get_module_metadata()` (loader.py:504-566) tries an explicit `__amplifier_module_type__` attribute on the module first; when absent (true of every in-tree foundation hook module — none declare it), it falls back to `_guess_from_naming()` (loader.py:568-602).
- `_guess_from_naming()` does a **first-match substring scan** over a fixed keyword insertion order (loader.py:586-599): `orchestrat`, `loop`, `provider`, `tool`, `hook`, `context`.
- `hooks-tool-dedupe` contains **both** `"tool"` and `"hook"` as substrings. Because `"tool"` is checked before `"hook"` in that dict, the module was classified as `type="tool"` and validated by `ToolValidator` instead of `HookValidator`.
- `ToolValidator._check_protocol_compliance` (validation/tool.py:277-284) requires `mount()` to either populate `coordinator.mount_points["tools"]` or return an object with `.name`/`.description`/`.execute`. `hooks-tool-dedupe.mount()` correctly does neither (it registers a `tool:post` hook handler and returns a plain descriptor dict, exactly like its 5 working siblings) — so validation fails with exactly the reported error:

  ```
  ModuleValidationError: protocol_compliance: No tool was mounted and mount() did not return a Tool instance
  ```

Empirical proof (against amplifier-core 1.6.1's real loader):

```python
>>> loader._guess_from_naming('hooks-tool-dedupe')
('tool', 'tools')
>>> loader._guess_from_naming('hooks-dedupe')
('hook', 'hooks')
```

None of the 5 working siblings (`hooks-deprecation`, `hooks-process-guard`, `hooks-progress-monitor`, `hooks-session-naming`, `hooks-todo-display`) contain a keyword the scan checks before `"hook"`, which is why only this module was affected — and why it affects **both** composition paths that reference it (the top-level `hooks:` block and `behaviors/agents.yaml`'s `hooks:` block): both resolve the module id through the identical `loader.load() -> _validate_module() -> _get_module_metadata()` call chain, so there is only one code path to fix, not two.

## Fix

Renamed the module `hooks-tool-dedupe` -> **`hooks-dedupe`** rather than touching amplifier-core's naming heuristic — the heuristic is a documented, working fallback that every other hook module in this repo relies on correctly; this module's own name was the defect (per the discovered-root-cause guidance: prefer a rename when a name trips a core name-heuristic, over changing core).

Changed, via `git mv` + reference updates (no functional/behavioral changes):
- `modules/hooks-tool-dedupe/` -> `modules/hooks-dedupe/`
- Python package `amplifier_module_hooks_tool_dedupe` -> `amplifier_module_hooks_dedupe`
- `pyproject.toml`: package name, entry-point name (`hooks-tool-dedupe` -> `hooks-dedupe`), wheel package list
- `uv.lock`: self-referential package name
- Internal `ToolDedupeHook` class -> `DedupeHook` (not part of the classification surface, but kept consistent with the module's new name)
- `mount()` registration name, contributor-channel name, and returned descriptor's `"name"` field
- `behaviors/agents.yaml`: module id and git source `subdirectory=` path
- The module's own 25 tests (imports, class name, assertions on registered/returned names)

**Not a core bug** in the sense of needing a core fix: the naming heuristic works correctly for every other hook module in this repo. It's a real footgun worth flagging upstream, though — see "Core follow-up" below.

## Regression test

Added `tests/test_hook_module_classification.py` (new — no loader-classification test existed in foundation before this):
- `test_hook_module_classifies_as_hook` — parametrized across every `hooks-*` module directory (discovered dynamically), calls amplifier-core's real `ModuleLoader._get_module_metadata()` against each module's actual on-disk path and asserts `type == "hook"`. This is the generic guard against a future hook module picking a name with a colliding keyword.
- `test_hooks_dedupe_passes_real_validation` — the specific end-to-end reproduction of the reported bug: calls the real `ModuleLoader._validate_module()` (the exact call site inside `load()` that raised `ModuleValidationError`) against `hooks-dedupe`'s real on-disk module, and asserts it does not raise. This exercises the actual classification -> validator-selection -> `mount()` chain, unlike the module's existing tests (which call `mount()` directly against a fake coordinator and would not have caught this class of bug, since the bug is in classification/validator-selection *before* `mount()` is ever reached).

## Smoke-test evidence (the original failure, reproduced pre-fix)

```
$ uv run python -c "
from amplifier_core.loader import ModuleLoader
loader = ModuleLoader()
print(loader._guess_from_naming('hooks-tool-dedupe'))
print(loader._guess_from_naming('hooks-dedupe'))
"
('tool', 'tools')   # pre-rename id: misclassified as a tool
('hook', 'hooks')   # post-rename id: classified correctly
```

## Test results

- `tests/test_hook_module_classification.py` (new, 8 tests): **8 passed**
- `modules/hooks-dedupe/tests/` (existing 25 tests, updated for rename): **25 passed**
- Full repo suite (`uv run pytest tests/ -q --tb=short`, matches CI's `.github/workflows/ci.yml` invocation): **1642 passed, 1 skipped** (1634 pre-existing + 8 new)
- `python_check` (ruff format/lint, pyright, stub-check) on all changed files: clean

## Core follow-up (not fixed here, per scope)

`ModuleLoader._guess_from_naming()`'s first-match-wins keyword scan (loader.py:586-599) is a latent footgun for *any* hook (or context/provider) module whose id happens to contain `"tool"`, `"loop"`, `"provider"`, or `"orchestrat"` as a substring before `"hook"`/`"context"` is reached — this PR works around it for this one module by renaming, but the underlying ambiguity in amplifier-core remains. Worth an upstream fix (e.g. require modules to declare `__amplifier_module_type__` explicitly, or make the scan match on hyphen-delimited tokens instead of raw substrings) tracked separately in amplifier-core.

Fixes: openai_improvement-j3t
