### PR TITLE
chore(context): remove legacy scaffolding shown to cause over-delegation (-27% tokens, quality preserved)

### DIFF
--- a/bundles/anchors-amp-dev/agents/explorer.md
+++ b/bundles/anchors-amp-dev/agents/explorer.md
@@ -26,13 +26,6 @@ tools:
 
 You survey code and report findings. You do not modify anything.
 
-## Method
-
-1. Start broad: locate relevant files with search and glob.
-2. Read the files that matter. Follow imports and references.
-3. Trace the actual flow -- don't assume.
-4. Report concisely: what exists, how it connects, where the relevant logic lives.
-
 ## Output
 
 - **Summary** -- the answer to the question asked, up front.

--- a/bundles/anchors-amp-dev/agents/git-ops.md
+++ b/bundles/anchors-amp-dev/agents/git-ops.md
@@ -27,10 +27,9 @@ You handle all git and GitHub CLI operations.
 
 ## Rules
 
-1. Always check `git status` and `git diff` before committing.
-2. Write conventional commit messages (`feat:`, `fix:`, `refactor:`, `docs:`).
-3. Never force-push to main.
-4. End every commit message with:
+1. Write conventional commit messages (`feat:`, `fix:`, `refactor:`, `docs:`).
+2. Never force-push to main.
+3. End every commit message with:
 
 ```
 Generated with Amplifier

--- a/bundles/anchors-amp-dev/context/amplifier-dev/testing-patterns.md
+++ b/bundles/anchors-amp-dev/context/amplifier-dev/testing-patterns.md
@@ -80,8 +80,6 @@ Then run Amplifier normally - it will use your local sources.
 
 For changes that span multiple repos or need isolation, use the **amplifier-tester** bundle. It launches a Digital Twin Universe with your local repos mirrored via Gitea, installs Amplifier from those mirrors, and runs validation checks.
 
-Always delegate — don't drive the CLI directly:
-
 ```
 delegate(agent="amplifier-tester:setup-digital-twin",
          instruction="Set up a DTU validating my changes to <repo-paths>",

--- a/bundles/anchors-amp-dev/context/system.md
+++ b/bundles/anchors-amp-dev/context/system.md
@@ -13,9 +13,7 @@ These principles govern every action you take:
 
 2. **Minimum viable change** -- Nothing speculative. No premature abstractions. Every line of code, every file, every abstraction must earn its place. Start with the simplest thing that works.
 
-3. **Verify at every step** -- Run tests, check types, validate assumptions. After modifying 3 files, pause and verify. Evidence before assertions. Never claim "done" without proof.
-
-4. **Delegate complex work** -- Use `delegate` for multi-file exploration, architecture decisions, implementation, debugging, and git operations. Agents absorb token cost and return summaries. Your context window is finite; protect it.
+3. **Verify at every step** -- Never claim "done" without proof.
 
 ## Operating Rules
 
@@ -44,8 +42,4 @@ Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.co
 
 **Safe multi-repo push order.** Push core-side first; wait for merge and CI; then push module/bundle/app. A module pushed before its core dep merges can break downstream consumers.
 
-**Delegate dev-ecosystem questions.** "How does Amplifier work?" and "how do I author a bundle?" both go to the amplifier-dev-expert agent — it holds the authoritative knowledge.
-
-**Delegate session analysis.** Analyzing, debugging, searching, or repairing Amplifier sessions — and any reading of `events.jsonl` — goes to the `foundation:session-analyst` agent. Never read `events.jsonl` directly; its lines can exceed 100k tokens and will crash the session.
-
-Ecosystem and bundle-authoring knowledge lives in the **amplifier-dev-expert** agent.
+Never read `events.jsonl` directly; its lines can exceed 100k tokens and will crash the session.

--- a/context/shared/common-agent-base.md
+++ b/context/shared/common-agent-base.md
@@ -4,23 +4,6 @@ Operational guidance: See foundation:context/IMPLEMENTATION_PHILOSOPHY.md, found
 
 Problem-solving methodology: See foundation:context/shared/PROBLEM_SOLVING_PHILOSOPHY.md (loaded by specialist agents)
 
-## 💎 CRITICAL: Respect User Time - Test Before Presenting
-
-**The user's time is their most valuable resource.** When you present work as "ready" or "done", you must have:
-
-1. **Tested it yourself thoroughly** - QA is your job, completed before the user sees the work
-2. **Fixed obvious issues** - Syntax errors, import problems, broken logic
-3. **Verified it actually works** - Run tests, check structure, validate logic
-4. **Only then present it** - "This is ready for your review" means YOU'VE already validated it
-
-**User's role:** Strategic decisions, design approval, business context, stakeholder judgment
-**Your role:** Implementation, testing, debugging, fixing issues before engaging user
-
-**Anti-pattern**: "I've implemented X, can you test it and let me know if it works?"
-**Correct pattern**: "I've implemented and tested X. Tests pass, structure verified, logic validated. Ready for your review. Here is how you can verify."
-
-**Remember**: Every time you ask the user to debug something you could have caught, you're wasting their time on non-stakeholder work. Be thorough BEFORE engaging them.
-
 ## CRITICAL: Honest Stopping - Complete Tasks Only With Real Evidence
 
 When an instruction, or a required item you've been asked to produce or attest, cannot be satisfied with **real, verified evidence**, STOP and report - completing the item waits until real evidence exists. Finishing a task is authorized only by the parts you actually have.
@@ -95,21 +78,11 @@ The `source` attribute identifies which component generated the reminder.
 
 # Tool Usage Policy
 
-## Tool Selection Philosophy
-
-**Prefer specialized capabilities over primitives.** Before using low-level tools like bash, check if specialized options exist:
-
-1. **Specialized agents first** - Agents carry domain expertise, safety guardrails, and best practices
-2. **Purpose-built tools second** - Provide structured output, validation, and error handling
-3. **Primitive tools as fallback** - Use bash only when specialized options don't exist
-
 **Specific guidance:**
 - **File operations**: Use read_file (not cat/head/tail), edit_file (not sed/awk), write_file (not echo/heredoc)
 - **Search**: Use grep tool (not bash grep/rg) - it has output limits and smart exclusions
 - **Web content**: Use web_fetch tool (not curl/wget)
 - **Bash timeouts**: Commands time out after 30 seconds by default. Pass `timeout` to increase for long-running commands like builds, tests, or monitoring (e.g., `bash(command="cargo test", timeout=300)`). For truly indefinite processes (dev servers, watchers), use `run_in_background: true` — this returns a PID immediately; poll with separate bash calls (`ps`, `cat logfile`, etc.). For long waits, use `timeout` for finite waits or `run_in_background` + polling for observation.
-
-**Direct execution exception**: Single-command operations with known outcomes (e.g., `git status`, `ls`, `pwd`, reading a single known file) may be executed directly. Multi-step work, exploration, or any task matching an agent's domain MUST be delegated.
 
 ## Parallel Tool Execution
 

--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -458,24 +458,6 @@ class DelegateTool:
 
         base_description = """Spawn a specialized agent to handle tasks autonomously.
 
-CRITICAL: Delegation is your PRIMARY operating mode, not an optimization.
-
-ALWAYS use this tool when:
-- Task requires reading more than 2 files
-- Task requires exploration or investigation
-- Task matches any agent's specialty (check Available agents below)
-- Task would benefit from specialized context or tools
-- You're about to use grep, glob, or read_file more than twice
-- User asks you to "look into", "investigate", "explore", or "analyze" something
-
-NEVER do these yourself - ALWAYS delegate:
-- Codebase exploration → foundation:explorer
-- Git commits/PRs → foundation:git-ops  
-- Session/conversation analysis → foundation:session-analyst
-- Debugging errors → foundation:bug-hunter
-- Architecture decisions → foundation:zen-architect
-- Implementation work → foundation:modular-builder
-
 Why delegate: Every tool call YOU make consumes YOUR context window permanently.
 Agents absorb that cost and return only summaries (~500 tokens vs ~20,000 tokens).
 Delegation = longer, more effective sessions.
@@ -509,8 +491,7 @@ later turn.
 
 Agent usage notes:
 - When an agent completes, it returns a single message back to you
-- Each agent invocation is stateless - provide complete context in your instruction
-- DEFAULT TO DELEGATION - only do simple single-step work yourself"""
+- Each agent invocation is stateless - provide complete context in your instruction"""
 
         if agents_list:
             agent_desc = "\n".join(


### PR DESCRIPTION
## Summary

Deletes legacy prompt scaffolding that a controlled A/B showed **causes** over-delegation and over-verification in modern models, rather than preventing it.

## Evidence

A 5-vs-5 DTU A/B on an identical real task (same foundation commit both arms, this deletion set the only delta):

| Metric | Control | Deletion | Delta |
|---|---:|---:|---:|
| Total tree tokens (mean) | 42.5M | 31.1M | **-27%** |
| Total tree tokens (median) | -- | -- | **-26%** |
| Task correctness | 5/5 | 5/5 | unchanged |
| Delegate calls | -- | -- | **-27%** |

Captures: `.amplifier/evaluation/first-turn-ab/20260826-225820/6d6-deletion/`

**Mechanism:** modern models (observed on gpt-5.6) interpret prompt instructions literally. Legacy verify/delegate scaffolding -- "ALWAYS delegate when...", "NEVER do these yourself", MUST-delegate tables, numbered step-by-step process recipes -- is read as a literal, mandatory trigger. Deleting it lets the root session inline more work itself instead of spawning redundant sub-agent waves, each of which drags in a 6k-30k-token sub-agent system prompt. The delegate tool description itself was measured byte-identical across arms in the source experiment; the behavior difference is attributable to how the two model families treat the same imperative text.

## Deletions applied in this repo (verbatim removals, no rewording)

| ID | File | What was removed | What was retained |
|---|---|---|---|
| D1 | `modules/tool-delegate/amplifier_module_tool_delegate/__init__.py` | `CRITICAL: Delegation is your PRIMARY operating mode...` + the `ALWAYS use this tool when:` / `NEVER do these yourself` block | The `Why delegate:` context-economy rationale (kept once, declaratively) |
| D2 | same file | `- DEFAULT TO DELEGATION - only do simple single-step work yourself` | -- |
| D3 (partial) | `bundles/anchors-amp-dev/context/system.md` | `Run tests, check types, validate assumptions. After modifying 3 files, pause and verify. Evidence before assertions.` | `**Verify at every step** -- Never claim "done" without proof.` (anti-fabrication) |
| D4 | same file | `**Delegate complex work** -- Use \`delegate\` for multi-file exploration...` | -- |
| D6 | same file | `**Delegate dev-ecosystem questions.**...` | -- |
| D7 (partial) | same file | `**Delegate session analysis.** Analyzing, debugging, searching...goes to the \`foundation:session-analyst\` agent.` | `Never read events.jsonl directly; its lines can exceed 100k tokens and will crash the session.` (real crash guard) |
| D8 | same file | `Ecosystem and bundle-authoring knowledge lives in the **amplifier-dev-expert** agent.` (duplicate of D6) | -- |
| D14 | `bundles/anchors-amp-dev/agents/explorer.md` | `## Method` numbered 4-step recipe | `## Output` response contract |
| D15 | `bundles/anchors-amp-dev/agents/git-ops.md` | `Always check git status and git diff before committing.` | `Never force-push to main.` (destructive-action guard); commit-format convention |
| D16 | `context/shared/common-agent-base.md` | `## 💎 CRITICAL: Respect User Time - Test Before Presenting` section | `## CRITICAL: Honest Stopping` (anti-fabrication, untouched) |
| D17 (minimal safe cut) | same file | `## Tool Selection Philosophy` heading + ranked delegate-first list; the MUST-delegate clause of `**Direct execution exception**` | `**Specific guidance:**` bullets incl. the bash `timeout`/`run_in_background` contract |
| D18 | `bundles/anchors-amp-dev/context/amplifier-dev/testing-patterns.md` | `Always delegate — don't drive the CLI directly:` | the two `delegate(...)` call-shape examples |

**D5** ("Prove cross-repo changes in isolation") is **excluded** per the experiment plan — it is genuine engineering policy, not scaffolding, and is retained verbatim.

**Explicitly not touched:** safety/approval gates, destructive-action confirmations, the Honest Stopping anti-fabrication rules, and all tool-usage mechanics (schemas, arg semantics, capability discovery, the bash timeout contract).

## Testing

```
uv run pytest tests/
1642 passed, 1 skipped
```
Unchanged from main — this change only touches prompt/context markdown and one Python string literal (no logic).

## Not merging yet

Opened for review per the standard multi-repo push order (core → foundation → modules → bundles → apps). Do not merge without review.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
