### PR TITLE
Add resource-hygiene norm to shared agent base

### DIFF
--- a/context/shared/common-agent-base.md
+++ b/context/shared/common-agent-base.md
@@ -18,6 +18,12 @@ For each required item, exactly one of three cases applies - handle each explici
 
 **A fabricated attestation is worse than an honest gap.** It tells the next person a gate passed when it didn't, and quietly defeats the system that gate exists to protect. An honest "I couldn't satisfy X - here's why" is recoverable; a hidden one is not.
 
+## Resource Hygiene — Clean Up What You Create
+
+Any long-lived resource you provision (container, VM, environment, background server, tmux session) is yours until you either destroy it or hand its ID to a named owner in your completion report. Silent survivors are a defect.
+
+For fan-out work: stateless sub-agents cannot see the running total - the **orchestrator** owns a cumulative ledger and a ceiling. Before each wave: count what exists, compare to budget, clean up before launching more. Blanket approval of an activity is not approval of unbounded resource accumulation.
+
 ## Git Commit Message Guidelines
 
 When creating git commit messages, always insert the following at the end of your commit message:


### PR DESCRIPTION
## Summary

Post-incident hardening. Adds a **Resource Hygiene — Clean Up What You Create** section to `context/shared/common-agent-base.md`, placed right after the "Honest Stopping" section.

## Why

On 2026-08-29 a runaway occurred: an eval orchestration **batch-launched 126 containers over 3 days** with no teardown, no cumulative ledger, and no cap. The host hit **100% disk and stalled**.

The root cause was structural, not a one-off slip: the orchestration fanned out to **stateless sub-agent delegations**, so the running total of provisioned resources lived in **no agent's context** — no single agent could see how many resources existed, so nobody was positioned to stop.

## What this changes

Establishes the generic clean-up-after-yourself norm at the one layer **every agent inherits** (the shared agent base):

- Any long-lived resource you provision (container, VM, environment, background server, tmux session) is yours until you destroy it or hand its ID to a named owner in your completion report. Silent survivors are a defect.
- For fan-out work, the **orchestrator** owns a cumulative ledger and a ceiling — because stateless sub-agents cannot see the running total. Count before each wave, compare to budget, clean up before launching more. Blanket approval of an activity is not approval of unbounded resource accumulation.

Deliberately generic: this file ships to every agent from the foundation library, so the language names only generic resource classes — no specific repos, bundles, or tools.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>