### PR TITLE
docs: teach self-referential git+#subdirectory= module sources, not ./modules

### DIFF
--- a/docs/BUNDLE_GUIDE.md
+++ b/docs/BUNDLE_GUIDE.md
@@ -287,7 +287,7 @@ agents:
     instructions: my-bundle:agents/my-agent.md
     tools:
       - module: tool-special    # This agent gets specific tools
-        source: ./modules/tool-special
+        source: git+https://github.com/org/repo@main#subdirectory=modules/tool-special
 ```
 
 **Use when**: Agent needs bundle-specific tool configurations that differ from the parent bundle.
@@ -854,10 +854,10 @@ packages = ["amplifier_module_tool_{name}"]
 ```yaml
 tools:
   - module: tool-{name}
-    source: ./modules/tool-{name}    # local path
-    # OR for published modules:
-    # source: git+https://github.com/org/repo@main#subdirectory=modules/tool-{name}
+    source: git+https://github.com/org/repo@main#subdirectory=modules/tool-{name}
 ```
+
+Use this self-referential git URL form even when the module lives in the bundle's own repo — it works regardless of which file (`bundle.md`, a `behaviors/*.yaml`, etc.) declares it. A bare relative path (`./modules/tool-{name}`) resolves relative to whichever bundle file is active at activation time, not the file that declares it, so it breaks silently when used from anywhere other than the root bundle file.
 
 ---
 
@@ -1277,7 +1277,7 @@ includes:
 # Only declare tools NOT inherited from includes
 tools:
   - module: tool-name
-    source: ./modules/tool-name     # Local path
+    source: git+https://github.com/my-org/my-bundle@main#subdirectory=modules/tool-name
     config:
       setting: value
 
@@ -1317,12 +1317,12 @@ Bundles support multiple source formats for modules:
 
 | Format | Example | Use Case |
 |--------|---------|----------|
-| Local path | `./modules/my-module` | Modules within the bundle |
-| Relative path | `../shared-module` | Sibling directories |
 | Git URL | `git+https://github.com/org/repo@main` | External modules |
-| Git with subpath | `git+https://github.com/org/repo@main#subdirectory=modules/foo` | Module within larger repo |
+| Git with subpath | `git+https://github.com/org/repo@main#subdirectory=modules/foo` | Module within larger bundle repo (including the bundle's own modules) |
 
-**Local paths are resolved relative to the bundle's location.**
+**For modules that live in the bundle's own repo, use a self-referential git URL with `#subdirectory=`** — the same form used for every module in this repo (see `bundle.md`, `behaviors/*.yaml`). It is the one canonical form: it names the module the same way no matter which file in the bundle declares it.
+
+**Avoid bare relative paths** (`source: ./modules/foo`). They're still technically accepted, but they resolve relative to whichever bundle file is active when the module is activated — not necessarily the file that declares it. That makes them position-sensitive: they work from a root `bundle.md`/`bundle.yaml`, but silently resolve to the wrong directory (and fail with "File not found") when the same `source:` line lives in a file loaded via `includes:`, such as `behaviors/*.yaml`. The self-referential git URL form above has no such position-dependence.
 
 ---
 

--- a/skills/creating-amplifier-modules/SKILL.md
+++ b/skills/creating-amplifier-modules/SKILL.md
@@ -208,13 +208,7 @@ tools:
     source: git+https://github.com/org/repo@main#subdirectory=modules/tool-{name}
 ```
 
-For local development (relative path from bundle root):
-
-```yaml
-tools:
-  - module: tool-{name}
-    source: ./modules/tool-{name}
-```
+Use this self-referential git URL form even for modules that live in the bundle's own repo — it resolves the same way no matter which file declares it. A bare relative path (`source: ./modules/tool-{name}`) resolves relative to whichever bundle file is active at activation time, not the file that declares it, so it only works from a root `bundle.md`/`bundle.yaml` and breaks silently when the same line is used in a `behaviors/*.yaml` or other included file.
 
 ---
 


### PR DESCRIPTION
## Problem

`docs/BUNDLE_GUIDE.md` and `skills/creating-amplifier-modules/SKILL.md` taught
`source: ./modules/tool-x` as a recommended way to reference a module living
in the bundle's own repo. That form is **position-sensitive**, not
bundle-root-relative, and it silently breaks when used anywhere other than a
root `bundle.md`/`bundle.yaml`.

### Real-world failure this caused

`amplifier-engram`'s `behaviors/engram-session.yaml` used exactly this taught
form (`source: ./modules/<m>`). On a clean install, all three session-plane
modules failed to activate:

```
File not found: <cache>/behaviors/modules/<m>
```

The entire session plane silently never activated. Multiple independent
agents made the identical mistake in earlier work, because the docs taught
it as correct — a textbook case of the context-poisoning failure mode this
repo's own `CONTEXT_POISONING.md` describes (stale/misleading teaching
confidently followed to a wrong implementation).

## Root cause (confirmed against this repo's own resolver code)

- `amplifier_foundation/sources/file.py:65-66` resolves a `./`/`../` source
  against `self.base_path` of whichever `Bundle` object is active at
  activation time:
  ```python
  if path_str.startswith("./") or path_str.startswith("../"):
      resolved_path = self.base_path / path_str
  ```
- `amplifier_foundation/registry.py:676` / `:687` set `base_path =
  path.parent` **per loaded file** — the directory containing whichever YAML/MD
  file was loaded, not the bundle root:
  ```python
  bundle = Bundle.from_dict(frontmatter, base_path=path.parent)
  ...
  return Bundle.from_dict(data, base_path=path.parent)
  ```
- `amplifier_foundation/bundle/_dataclass.py:364-366` builds the
  `ModuleActivator` from `self.base_path` at `prepare()` time, and the
  bundle-compose merge (`_dataclass.py:262-266`) sets the composed bundle's
  `base_path` to the *last-merged* bundle's own `base_path` — so a relative
  `source:` declared inside an included file (e.g. `behaviors/*.yaml`) can
  resolve against that file's own directory instead of the bundle root,
  yielding paths like `behaviors/modules/<name>` that don't exist.

## What I checked before writing the fix

Per the ask, I did **not** write a replacement syntax I hadn't verified the
resolver accepts. I confirmed:

- Module `source:` fields are resolved by `SimpleSourceResolver` ->
  `parse_uri()` (`amplifier_foundation/paths/resolution.py:231-302`), which
  recognizes only: `git+`, `zip+`, `http(s)://`, `file://`, absolute paths,
  and `./`/`../` relative paths. **There is no colon-based namespace/`@mention`
  form** (e.g. `@bundle:modules/x` or `bundle:modules/x`) supported for
  module sources — that syntax exists only for `includes:` bundle
  composition, via `BundleRegistry._resolve_include_source()`
  (`registry.py:930-1029`), a completely different code path.
- Every real, loadable module source in this repo already uses a
  self-referential `git+https://...#subdirectory=modules/<name>` URL — this
  works for the bundle's *own* modules, not just external ones — see
  `bundle.md`, `bundles/anchors/bundle.md`, `behaviors/redaction.yaml`,
  `behaviors/agents.yaml`, `behaviors/todo-reminder.yaml`, etc. Zero
  exceptions across the repo. This form doesn't depend on `base_path` at all
  (`GitSourceHandler` clones by URL), so it's immune to the position bug.

## Fix (docs only, no code changes)

- `docs/BUNDLE_GUIDE.md`:
  - Inline-agent-tools example and "Bundle File Structure" example: replaced
    `./modules/...` with a `git+...#subdirectory=modules/...` example.
  - "Behavior YAML Reference": dropped the `./modules` alternative, kept the
    git URL form as the only example, added a short explanation.
  - "Source URI Formats" table: removed the "Local path" / "Relative path"
    rows (no longer taught as recommended forms), added canonical-form
    guidance and an explicit warning about the position-sensitivity and the
    exact `behaviors/*.yaml` failure mode.
- `skills/creating-amplifier-modules/SKILL.md`: dropped the "for local
  development" relative-path example, replaced with the same warning.

Relative paths are **not** removed from the resolver — this is a docs-only
retcon per the repo's own `CONTEXT_POISONING.md` doctrine (one canonical
form, no "old way"/"new way" both presented). They remain technically legal
but are no longer taught as safe or recommended.

## Verification

- Re-confirmed all 5 poisoned lines still existed on latest `origin/main`
  (`400bda2`) before branching.
- `grep -rn "\./modules/"` across the whole repo (docs/, skills/, context/,
  examples/, experiments/) after the edit: the only remaining matches are the
  resolver's own code comments describing the (still-real) behavior, not
  documentation recommending it.
- Docs-only change; no code, tests, or behavior touched.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)