### PR TITLE
Encode description-authoring evidence into canonical guidance and validators

### DIFF
--- a/agents/bundle-design-expert.md
+++ b/agents/bundle-design-expert.md
@@ -107,6 +107,10 @@ The bundles reference is loaded here since it's not in the intro list:
 
 @foundation:docs/AGENT_AUTHORING.md
 
+### Description Authoring Principles
+
+@foundation:context/shared/description-authoring-principles.md
+
 ---
 
 ## Context Architecture Patterns

--- a/bundles/anchors-amp-dev/agents/amplifier-dev-expert.md
+++ b/bundles/anchors-amp-dev/agents/amplifier-dev-expert.md
@@ -12,7 +12,6 @@ meta:
     Context: A change spans amplifier-core and a dependent module.
     user: 'I need to update a kernel contract and the modules that consume it.'
     assistant: 'I'll consult amplifier-dev-expert for the correct change and push order across repos.'
-    <commentary>Cross-repo dependency ordering is this agent's core domain.</commentary>
     </example>
 
 model_role: [reasoning, general]

--- a/bundles/anchors-amp-dev/agents/architect.md
+++ b/bundles/anchors-amp-dev/agents/architect.md
@@ -10,7 +10,6 @@ meta:
     Context: A feature needs design before code exists.
     user: 'Add a caching layer to the measurement harness.'
     assistant: 'I'll use architect to analyze options and produce a spec before any code is written.'
-    <commentary>Under-specified work needs design first -- architect produces the spec builder implements.</commentary>
     </example>
 
 model_role: [reasoning, general]

--- a/bundles/anchors-amp-dev/agents/builder.md
+++ b/bundles/anchors-amp-dev/agents/builder.md
@@ -9,7 +9,6 @@ meta:
     Context: A complete spec exists.
     user: 'Implement the CacheService from specs/cache-spec.md.'
     assistant: 'I'll use builder to implement it from the spec.'
-    <commentary>Spec with file paths and success criteria exists -- builder implements directly.</commentary>
     </example>
 
 model_role: [coding, general]

--- a/bundles/anchors-amp-dev/agents/debugger.md
+++ b/bundles/anchors-amp-dev/agents/debugger.md
@@ -9,7 +9,6 @@ meta:
     Context: A test is failing for unknown reasons.
     user: 'usage.py throws a KeyError after the last change.'
     assistant: 'I'll delegate to debugger to find the root cause systematically.'
-    <commentary>Errors with unknown cause trigger debugger's hypothesis-driven diagnosis.</commentary>
     </example>
 
 model_role: [coding, general]

--- a/bundles/anchors-amp-dev/agents/explorer.md
+++ b/bundles/anchors-amp-dev/agents/explorer.md
@@ -10,7 +10,6 @@ meta:
     Context: User wants to understand a flow spanning several files.
     user: 'How does the fingerprint run.sh pipe results into the report?'
     assistant: 'I'll delegate to explorer to trace the flow across run.sh and the report scripts.'
-    <commentary>Multi-file survey -- explorer maps it without burning parent context.</commentary>
     </example>
 
 model_role: [general, fast]

--- a/bundles/anchors-amp-dev/agents/git-ops.md
+++ b/bundles/anchors-amp-dev/agents/git-ops.md
@@ -9,7 +9,6 @@ meta:
     Context: Work is complete and needs committing.
     user: 'Commit this and open a PR.'
     assistant: 'I'll delegate to git-ops to create the commit and open the PR.'
-    <commentary>Any git/gh operation routes to git-ops for consistent commits and safety.</commentary>
     </example>
 
 model_role: [fast, general]

--- a/bundles/anchors-amp-dev/agents/researcher.md
+++ b/bundles/anchors-amp-dev/agents/researcher.md
@@ -9,7 +9,6 @@ meta:
     Context: Answer requires external docs.
     user: 'What are the rate limits on the Anthropic API?'
     assistant: 'I'll use researcher to look up the current Anthropic API limits.'
-    <commentary>External documentation lookup -- not in the local codebase -- routes to researcher.</commentary>
     </example>
 
 model_role: [research, general]

--- a/context/CONTEXT_POISONING.md
+++ b/context/CONTEXT_POISONING.md
@@ -154,6 +154,10 @@ Use --local flag to override provider per project.
 
 **Rule**: Each concept lives in exactly ONE place.
 
+> Applied to description fields (agent `meta.description`, skill/mode
+> `description`, tool descriptions) specifically: see
+> `context/shared/description-authoring-principles.md`.
+
 **Good organization**:
 - ✅ Command syntax → `docs/USER_ONBOARDING.md#quick-reference`
 - ✅ Architecture → `docs/ARCHITECTURE.md`

--- a/context/shared/description-authoring-principles.md
+++ b/context/shared/description-authoring-principles.md
@@ -1,0 +1,149 @@
+# Description Authoring Principles
+
+> **Canonical source.** This is the ONE place that states how to write a
+> *description* field — agent `meta.description`, skill frontmatter
+> `description`, mode `description`, and tool description strings. Every
+> other doc that touches this topic (AGENT_AUTHORING.md, BUNDLE_GUIDE.md,
+> DOMAIN_VALIDATOR_GUIDE.md, skill authoring guides, validator recipes)
+> **points here** instead of restating it. If you find yourself copying a
+> paragraph from this file into another doc, stop — link instead (see V1/V2
+> below, and don't make this file the exception to its own rule).
+
+Evidence base: a measured eval campaign (A/B testing across paired runs)
+found the patterns this file discourages measurably harm compliant modern
+models. Citations are inline per principle. The campaign is ongoing — see
+"Provisional" markers for findings still being calibrated.
+
+---
+
+## V1 — State each rule once
+
+A mandate stated 4 ways in one system prompt (2 of the 4 contradictory)
+measurably destabilized a compliant model's behavior; removing the
+duplication was validated in a 12-run A/B (same task, same seed set,
+duplication present vs. removed). **One canonical statement, cross-referenced
+everywhere else.** A rule repeated "for emphasis" is not redundant safety
+margin — it is a second copy that can drift from the first and force the
+model to arbitrate between two versions of your own instructions.
+
+## V2 — Delete stale and fabricated content
+
+The "1e2 deletion pass" removed stale/fabricated system-prompt content:
+−11.3% system-prompt bytes, quality unchanged across 12/12 paired runs.
+Deletion, not archival-in-place — see `CONTEXT_POISONING.md` §"Aggressive
+Deletion" (this file does not restate that guidance; go read it there).
+Applied to descriptions specifically: an example that no longer matches the
+shipped agent, a trigger condition for a capability that was removed, a
+"WHY" paragraph justifying a design that changed — all of these are stale
+content masquerading as documentation, and cost tokens on every load.
+
+## V3 — Agent-catalog examples are expensive and always visible
+
+Every agent's `meta.description` is concatenated into the delegate tool's
+own description, which loads into context on **every turn**, not just when
+that agent is used. `<commentary>` blocks inside `<example>` blocks were
+validated for removal with no quality loss. Policy: **at most 2 examples**,
+**no `<commentary>` tags**, and any example that ships must reflect what the
+agent actually does today — an example is a claim about current behavior,
+and a stale one is V2's problem wearing a WHEN-to-delegate costume.
+
+## V4 — Delegation-pushing scaffolding hurts modern models
+
+Scaffolding designed to push the orchestrator toward delegating (verbose
+"why you should use this agent" framing, redundant WHY/WHEN/WHAT/HOW
+templates repeated per-agent) measured **−27% tokens and −27% delegate
+calls** on deletion, with quality unchanged across 5/5 paired runs. Modern
+models do not need to be sold on delegating — they need a clear, minimal
+statement of what the agent does and when it applies. Persuasive framing is
+overhead, not signal.
+
+## V5 — Description budgets are real and must be enforced
+
+One real tool description was measured at **15,271 characters — 56% of the
+entire tool-description budget** for that session, and drove 7-8x
+over-delegation on gpt-5.6-sol: 60% of that model's spawns quoted the
+tool's own imperative language verbatim back at it. A description that large
+is not thorough — it is a second system prompt smuggled into a metadata
+field, read on every turn whether or not the tool is ever called.
+
+**Budgets (token count via the same tokenizer the validators use):**
+
+| Surface | WARN | ERROR | Status |
+|---|---|---|---|
+| Mode `description` | > 500 tokens | > 800 tokens | Established (validate-bundle-repo.yaml Phase 2.7) |
+| Agent `meta.description` | > 300 tokens | > 600 tokens | **Provisional** — pending wave calibration |
+| Skill frontmatter `description` | see skills authoring guide | see skills authoring guide | Shared cap: `max_skills_visible` bounds total visible-catalog cost |
+| Tool description | no fixed ceiling yet | no fixed ceiling yet | Flag any single tool >10% of a typical tool-description budget as a design smell |
+
+Agent tiers are lower than mode tiers because agent descriptions are paid
+**by every session that has the agent in its catalog**, regardless of
+whether it's ever delegated to — mode descriptions are paid only by sessions
+that load that mode. Treat the agent-tier numbers as provisional until the
+in-flight A/B wave (P1-P3, see below) reports.
+
+## V6 — Provider disposition: absolutes for invariants, decision rules for judgment
+
+Compliant models (measured: "sol complies") execute literal imperatives —
+MUST, ALWAYS, PROACTIVELY, NEVER — even when a case-by-case judgment call
+would serve the task better. Judgment-oriented models (measured: "opus
+judges") already weigh trade-offs and don't need to be shouted at; absolutes
+aimed at them just add noise. OpenAI's own GPT-5.6 guidance independently
+concurs: reserve hard imperatives for things that are actually invariant,
+and give everything else a decision rule the model can apply to the
+situation in front of it.
+
+**Rule:** Use ALWAYS / MUST / NEVER / PROACTIVELY only for conditions that
+are true 100% of the time with no legitimate exception. For anything that
+depends on context, state the deciding factor, not the verdict.
+
+**Before / after:**
+
+```
+BEFORE (absolute applied to a judgment call):
+  "ALWAYS delegate multi-file exploration tasks. NEVER read more than
+  2 files yourself — delegate to this agent instead."
+
+AFTER (decision rule):
+  "Delegate when the exploration spans more files than you can hold in
+  working context at once, or when the caller needs a structured survey
+  rather than a single answer. Reading 1-2 files directly to answer a
+  narrow question is fine and does not need delegation."
+```
+
+The AFTER version gives the model the actual factor to weigh (context cost,
+answer shape) instead of a bright line the model must either obey literally
+or silently override.
+
+## Example policy (all description surfaces)
+
+- **≤2 examples.** A third example is rarely teaching a new case — audit
+  whether it's actually a duplicate before adding it.
+- **No `<commentary>` tags.** The example itself should be self-explanatory;
+  if it needs a footnote explaining why it triggers the agent, the trigger
+  condition belongs in the WHEN clause, not in prose bolted onto the example.
+- **Examples must match shipped reality.** An example describing a
+  capability, tool, or workflow the artifact no longer has is stale content
+  (V2) — delete or update it, don't leave it as aspirational documentation.
+
+## Staleness and deletion
+
+Governed by `CONTEXT_POISONING.md` §"Aggressive Deletion" and §"Maximum
+DRY" — this file does not restate that guidance. The short version: find the
+canonical source, delete the duplicate, update cross-references. Applies to
+descriptions exactly as it applies to any other doc content.
+
+---
+
+## Provisional — in-flight A/B wave (do not treat as settled)
+
+An A/B wave is in progress evaluating:
+
+- **P1** — relaxed delegate-tool language (softening imperative framing in
+  the delegate tool's own description, not just the agents it lists)
+- **P2** — assembly-time example stripping (dropping `<example>` blocks
+  from the catalog view entirely, keeping them only in the agent's own file)
+- **P3** — negative examples (showing a case where delegation should
+  *not* happen, alongside the positive trigger cases)
+
+Do not cite P1-P3 as settled findings. When the wave reports, update the
+provisional tiers in the V5 table and remove this section.

--- a/context/understanding-mechanisms/mechanisms/agents.md
+++ b/context/understanding-mechanisms/mechanisms/agents.md
@@ -97,6 +97,22 @@ model_role at call time.
 | test-coverage | coding | Test coverage analysis |
 | integration-specialist | general | External API/MCP integration |
 | post-task-cleanup | fast | Codebase hygiene after tasks |
+| bundle-design-expert | general | Bundle design, mechanism selection, behavioral modeling |
+| ecosystem-expert | general | Multi-repo coordination across core/foundation/modules/bundles |
+| foundation-expert | general | Foundation ecosystem navigation, examples, patterns, philosophy |
+| shell-exec | fast | Shell command execution with output capture |
+
+### Agent Catalog Cost
+
+The delegate tool's own description is `base description + sum(each available
+agent's meta.description)`, concatenated verbatim -- measured at 15,688
+characters for foundation's current 16 agents. This is loaded into context on
+**every turn**, not only when an agent is actually delegated to. Every
+character added to any agent's `meta.description` is therefore an every-turn
+cost paid by every session that has that agent in its catalog, not a
+one-time cost paid only by callers. See
+`context/shared/description-authoring-principles.md` for the token budgets
+and phrasing guidance this implies.
 
 ### Key Implementation Files
 

--- a/docs/AGENT_AUTHORING.md
+++ b/docs/AGENT_AUTHORING.md
@@ -37,9 +37,10 @@ bundle:                        meta:
 ### What Makes a Good Description
 
 Answer three questions:
-1. **WHEN** should I use this agent? (Activation triggers)
-2. **WHAT** does it do? (Core capability)
-3. **HOW** do I invoke it? (Examples)
+1. **WHAT** does it do? (Core capability)
+2. **WHEN** should I delegate to it? (The deciding factor -- see
+   description-authoring-principles.md V6 for phrasing)
+3. **HOW** do I invoke it? (≤2 examples)
 
 ### Pattern
 
@@ -47,41 +48,33 @@ Answer three questions:
 meta:
   name: my-agent
   description: |
-    [WHEN to use - activation triggers]. Use PROACTIVELY when [condition].
-    
-    [WHAT it does - core capability in 1-2 sentences].
-    
-    Examples:
-    
+    [WHAT it does - core capability in 1-2 sentences]. [WHEN to delegate -
+    the deciding factor, not a bare imperative -- see
+    description-authoring-principles.md V6].
+
     <example>
     user: '[Example user request]'
     assistant: 'I'll use my-agent to [action].'
-    <commentary>[Why this agent is the right choice]</commentary>
     </example>
 ```
 
+See `context/shared/description-authoring-principles.md` for trigger
+phrasing (decision rules over bare absolutes), the example cap (≤2, no
+`<commentary>`), and the token budget.
+
 ### Real Example
+
+Matches the currently shipped `agents/bug-hunter.md` description:
 
 ```yaml
 meta:
   name: bug-hunter
-  description: |
-    Specialized debugging expert. Use PROACTIVELY when user reports errors,
-    unexpected behavior, or test failures.
-    
-    Examples:
-    
-    <example>
-    user: 'The pipeline is throwing a KeyError somewhere'
-    assistant: 'I'll use bug-hunter to systematically track down this KeyError.'
-    <commentary>Bug reports trigger bug-hunter delegation.</commentary>
-    </example>
-    
-    <example>
-    user: 'Tests are failing after the recent changes'
-    assistant: 'Let me use bug-hunter to investigate the test failures.'
-    <commentary>Test failures are a clear debugging task.</commentary>
-    </example>
+  description: "Specialized debugging expert focused on finding and fixing
+    bugs systematically. Use PROACTIVELY. It MUST BE USED when user has
+    reported or you are encountering errors, unexpected behavior, or test
+    failures. Examples: <example>user: 'The synthesis pipeline is throwing
+    a KeyError somewhere' assistant: 'I'll use the bug-hunter agent to
+    systematically track down and fix this KeyError.'</example>"
 ```
 
 ### Anti-Patterns
@@ -95,12 +88,12 @@ meta:
 meta:
   description: "Analyzes code for quality issues"
 
-# ✅ Clear triggers + capability + examples
+# ✅ Clear capability + trigger + example
 meta:
   description: |
-    Use PROACTIVELY when user reports errors or test failures.
     Systematic debugging with hypothesis-driven root cause analysis.
-    
+    Use when user reports errors, unexpected behavior, or test failures.
+
     <example>
     user: 'The build is failing'
     assistant: 'I'll use bug-hunter to investigate.'
@@ -109,34 +102,37 @@ meta:
 
 ---
 
-## Description Requirements (Critical)
+## Description Requirements
 
 The `meta.description` field is the **ONLY** discovery mechanism for agents. When the
 task tool presents available agents to the LLM, this description is all it sees to
 decide which agent to use.
 
-**Poor descriptions cause delegation failures.** One-liner descriptions are unacceptable.
+**How to write it is governed by the canonical
+[description-authoring-principles.md](../context/shared/description-authoring-principles.md)**
+-- trigger phrasing (decision rules over bare absolutes), the example policy
+(≤2 examples, no `<commentary>`), staleness/deletion, and provider
+disposition all live there and are not restated here.
 
 ### Required Elements
 
-Every agent description MUST include:
+Every agent description should cover:
 
-#### 1. WHY - The Purpose
-What problem does this agent solve? What value does it provide?
+#### 1. WHAT - The Capability
+What does this agent do? What value does it provide?
 
-#### 2. WHEN - Activation Triggers  
-Explicit conditions that should cause delegation to this agent.
-Use keywords: MUST, REQUIRED, ALWAYS, PROACTIVELY, "Use when..."
+#### 2. WHEN - The Deciding Factor
+The condition that should cause delegation, phrased as a decision rule
+(see description-authoring-principles.md V6) rather than a bare imperative.
 
-#### 3. WHAT - Domain/Taxonomy Terms
-Keywords and concepts this agent is authoritative on.
-Pattern: `**Authoritative on:** term1, term2, term3, "multi-word concept"`
+#### 3. Authoritative On (optional)
+Domain terms this agent owns, so questions in that domain route here.
+Pattern: `**Authoritative on:** term1, term2, "multi-word concept"`
 
-This serves as the agent's "taxonomy" - terms that should trigger delegation.
-
-#### 4. HOW - Usage Examples
-Concrete examples showing user request → delegation rationale.
-Use `<example>` blocks with `<commentary>` tags.
+#### 4. Examples
+Up to 2 `<example>` blocks (no `<commentary>`) showing a real request and
+the resulting delegation. Each example must reflect what the agent
+actually does today.
 
 ### Template
 
@@ -144,40 +140,34 @@ Use `<example>` blocks with `<commentary>` tags.
 meta:
   name: my-agent
   description: |
-    [ONE SENTENCE: What this agent does and why it matters]
-    
-    Use PROACTIVELY when [primary trigger condition].
-    
+    [ONE SENTENCE: What this agent does]
+
+    Use when [the deciding factor -- context shape, not a bare imperative].
+
     **Authoritative on:** [comma-separated domain terms/keywords]
-    
-    **MUST be used for:**
-    - [Condition 1]
-    - [Condition 2]
-    
+
     <example>
     user: '[Example user request]'
     assistant: 'I'll delegate to [agent] because [reason].'
-    <commentary>
-    [Why this triggers the agent - helps LLMs learn the pattern]
-    </commentary>
     </example>
 ```
 
 ### Anti-Patterns
 
 ❌ One-liner descriptions: `"Helps with debugging"`
-❌ No trigger conditions: Missing WHEN to use
+❌ No indication of WHEN to delegate
 ❌ No taxonomy terms: LLM can't match domain questions
 ❌ No examples: LLM doesn't learn delegation patterns
+❌ More than 2 examples, or any `<commentary>` tag
+❌ An example describing a capability the agent no longer has (stale --
+see description-authoring-principles.md V2)
 
-### Audit Your Agents
+### Description Token Budget
 
-Check each agent's description against these criteria:
-- [ ] >100 words (not a one-liner)
-- [ ] Has explicit trigger conditions
-- [ ] Lists domain terms ("Authoritative on:")
-- [ ] Includes at least one example
-- [ ] Explains the value proposition
+**Provisional** (pending A/B calibration -- see
+description-authoring-principles.md V5): WARN above 300 tokens, ERROR
+above 600 tokens. Enforced by `foundation:recipes/validate-agents.yaml`
+and `foundation:recipes/validate-bundle-repo.yaml`.
 
 ---
 

--- a/docs/BUNDLE_GUIDE.md
+++ b/docs/BUNDLE_GUIDE.md
@@ -669,7 +669,8 @@ Place agent files in `agents/` with proper frontmatter:
 ---
 meta:
   name: my-agent
-  description: "Description shown when listing agents. Include usage examples..."
+  description: "Description shown when listing agents. See AGENT_AUTHORING.md
+    and context/shared/description-authoring-principles.md for how to write it."
 ---
 
 # My Agent
@@ -1605,10 +1606,11 @@ Extract to separate repo only when:
 
 ### Use Descriptive Agent Metadata
 
-The `meta.description` is shown when listing agents. Include:
-- What the agent does
-- When to use it
-- Usage examples in the description string
+The `meta.description` is shown when listing agents. For what to include
+and how to phrase it (capability, deciding factor, up to 2 examples, no
+`<commentary>`, token budget), see
+[AGENT_AUTHORING.md](AGENT_AUTHORING.md#description-requirements) and the
+canonical `context/shared/description-authoring-principles.md`.
 
 ### No Root pyproject.toml
 

--- a/docs/DOMAIN_VALIDATOR_GUIDE.md
+++ b/docs/DOMAIN_VALIDATOR_GUIDE.md
@@ -56,8 +56,14 @@ Every validator MUST define what "passing" means:
 # ✅ No structural errors
 # ✅ Has explicit `tools:` section (even if empty)
 # ✅ Description ≥ 100 characters
-# ✅ Has at least ONE strong trigger (MUST, ALWAYS, REQUIRED, PROACTIVELY, DO NOT)
-# ✅ Has at least ONE `<example>` block
+# ✅ Description token budget respected (provisional WARN >300 / ERROR >600
+#   tokens -- see foundation:context/shared/description-authoring-principles.md V5)
+#
+# NOTE: MUST/ALWAYS/REQUIRED/PROACTIVELY keyword presence and <example> count
+# are reported as METRICS, not gates -- a measured eval campaign found
+# requiring them harmed compliant models (description-authoring-principles.md
+# V1, V3, V6). An earlier version of this example incorrectly required them;
+# see the PR that fixed validate-agents.yaml's own inverted thresholds.
 ```
 
 ### Domain-Specific Thresholds
@@ -663,7 +669,7 @@ Reference these as working examples:
 
 The **gold standard** for domain validators, demonstrating:
 - ✅ Deterministic quality classification (Phase 2.5)
-- ✅ Explicit PASS thresholds (trigger + examples + tools + 100 chars)
+- ✅ Explicit PASS thresholds (structural + tools + 100 chars + description token budget)
 - ✅ Conditional execution (skip LLM when all agents good)
 - ✅ Quick-approval path (uses claude-haiku for speed)
 - ✅ "Not an issue" guidance in LLM prompts
@@ -680,10 +686,12 @@ The **gold standard** for domain validators, demonstrating:
     # Explicit thresholds - code, not LLM judgment
     thresholds = {
         "min_description_length": 100,
-        "requires_trigger": True,
-        "requires_examples": True,
-        "requires_explicit_tools": True
+        "requires_explicit_tools": True,
+        "description_token_warn": 300,   # provisional, see V5
+        "description_token_error": 600,  # provisional, see V5
     }
+    # has_strong_trigger / has_examples are reported as metrics, not gates
+    # -- see description-authoring-principles.md V1, V3, V6
     # ... classification logic ...
     EOF
 
@@ -712,7 +720,7 @@ Validates a single bundle file for:
 
 **Recipe**: `@foundation:recipes/validate-bundle-repo.yaml`
 
-The **second gold standard** for domain validators, demonstrating all the patterns from validate-agents plus infrastructure handling:
+The **second gold standard** for domain validators, demonstrating all the patterns from validate-agents (including its own Phase 2.8 agent-description budget check) plus infrastructure handling:
 
 - ✅ Graceful degradation when `amplifier_foundation` unavailable
 - ✅ Domain-specific structural thresholds (loads + entry point + no orphans)

--- a/experiments/behavioral-anchor-amplifier-dev/agents/amplifier-dev-expert.md
+++ b/experiments/behavioral-anchor-amplifier-dev/agents/amplifier-dev-expert.md
@@ -12,7 +12,6 @@ meta:
     Context: A change spans amplifier-core and a dependent module.
     user: 'I need to update a kernel contract and the modules that consume it.'
     assistant: 'I'll consult amplifier-dev-expert for the correct change and push order across repos.'
-    <commentary>Cross-repo dependency ordering is this agent's core domain.</commentary>
     </example>
 
 model_role: [reasoning, general]

--- a/experiments/behavioral-anchor-amplifier-dev/agents/architect.md
+++ b/experiments/behavioral-anchor-amplifier-dev/agents/architect.md
@@ -10,7 +10,6 @@ meta:
     Context: A feature needs design before code exists.
     user: 'Add a caching layer to the measurement harness.'
     assistant: 'I'll use architect to analyze options and produce a spec before any code is written.'
-    <commentary>Under-specified work needs design first -- architect produces the spec builder implements.</commentary>
     </example>
 
 model_role: [reasoning, general]

--- a/experiments/behavioral-anchor-amplifier-dev/agents/builder.md
+++ b/experiments/behavioral-anchor-amplifier-dev/agents/builder.md
@@ -9,7 +9,6 @@ meta:
     Context: A complete spec exists.
     user: 'Implement the CacheService from specs/cache-spec.md.'
     assistant: 'I'll use builder to implement it from the spec.'
-    <commentary>Spec with file paths and success criteria exists -- builder implements directly.</commentary>
     </example>
 
 model_role: [coding, general]

--- a/experiments/behavioral-anchor-amplifier-dev/agents/debugger.md
+++ b/experiments/behavioral-anchor-amplifier-dev/agents/debugger.md
@@ -9,7 +9,6 @@ meta:
     Context: A test is failing for unknown reasons.
     user: 'usage.py throws a KeyError after the last change.'
     assistant: 'I'll delegate to debugger to find the root cause systematically.'
-    <commentary>Errors with unknown cause trigger debugger's hypothesis-driven diagnosis.</commentary>
     </example>
 
 model_role: [coding, general]

--- a/experiments/behavioral-anchor-amplifier-dev/agents/explorer.md
+++ b/experiments/behavioral-anchor-amplifier-dev/agents/explorer.md
@@ -10,7 +10,6 @@ meta:
     Context: User wants to understand a flow spanning several files.
     user: 'How does the fingerprint run.sh pipe results into the report?'
     assistant: 'I'll delegate to explorer to trace the flow across run.sh and the report scripts.'
-    <commentary>Multi-file survey -- explorer maps it without burning parent context.</commentary>
     </example>
 
 model_role: [general, fast]

--- a/experiments/behavioral-anchor-amplifier-dev/agents/git-ops.md
+++ b/experiments/behavioral-anchor-amplifier-dev/agents/git-ops.md
@@ -9,7 +9,6 @@ meta:
     Context: Work is complete and needs committing.
     user: 'Commit this and open a PR.'
     assistant: 'I'll delegate to git-ops to create the commit and open the PR.'
-    <commentary>Any git/gh operation routes to git-ops for consistent commits and safety.</commentary>
     </example>
 
 model_role: [fast, general]

--- a/experiments/behavioral-anchor-amplifier-dev/agents/researcher.md
+++ b/experiments/behavioral-anchor-amplifier-dev/agents/researcher.md
@@ -9,7 +9,6 @@ meta:
     Context: Answer requires external docs.
     user: 'What are the rate limits on the Anthropic API?'
     assistant: 'I'll use researcher to look up the current Anthropic API limits.'
-    <commentary>External documentation lookup -- not in the local codebase -- routes to researcher.</commentary>
     </example>
 
 model_role: [research, general]

--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -36,10 +36,18 @@
 # - Implicit tool dependencies
 #
 # PASS THRESHOLDS (explicit criteria for "good enough"):
-# - Has at least ONE of: MUST, ALWAYS, REQUIRED, PROACTIVELY, DO NOT (activation trigger)
-# - Has at least ONE <example> block
-# - Description >= 100 characters
+# - No structural errors (valid YAML, has meta.name, meta.description)
 # - Has explicit tools section (even if empty [])
+# - Description >= 100 characters
+# - Description token budget respected (provisional: WARN >300 tok,
+#   ERROR >600 tok -- see foundation:context/shared/
+#   description-authoring-principles.md V5)
+#
+# NOTE: presence of MUST/ALWAYS/REQUIRED/PROACTIVELY keywords and
+# <example> blocks are reported as METRICS, not pass/fail gates. A
+# measured eval campaign found these keywords/examples do not by
+# themselves indicate quality, and requiring them measurably harmed
+# compliant models (see description-authoring-principles.md V1, V3, V6).
 #
 # Usage:
 #   amplifier tool invoke recipes operation=execute \
@@ -64,7 +72,7 @@ description: |
   
   This recipe helps maintain agent quality across the Amplifier ecosystem by codifying
   the audit criteria discovered in manual reviews.
-version: "1.2.4"
+version: "1.3.0"
 author: "Amplifier Foundation Team"
 tags: ["agents", "validation", "quality", "audit", "tools", "descriptions"]
 
@@ -500,13 +508,27 @@ steps:
           description = meta.get("description", "")
           result["description_length"] = len(description) if description else 0
           result["has_examples"] = "<example>" in description.lower() if description else False
-          
-          # Check for strong activation triggers
+
+          # Description token budget estimate (Foundation's standard formula:
+          # len(content) // 4 -- see experiments/bundle-configurator/
+          # amplifier_configurator/tokens.py). Reported as a metric; see
+          # quality-classification for the WARN/ERROR gate.
+          result["description_tokens"] = len(description) // 4 if description else 0
+
+          # Track activation-keyword usage as a METRIC, not a pass/fail gate.
+          # A measured eval campaign found requiring these keywords does not
+          # by itself indicate quality and measurably harmed compliant models
+          # (see foundation:context/shared/description-authoring-principles.md
+          # V1, V3, V6). has_strong_trigger/triggers_found are reported for
+          # visibility only.
           STRONG_TRIGGERS = ["MUST", "ALWAYS", "REQUIRED", "PROACTIVELY", "DO NOT"]
           result["has_strong_trigger"] = any(
               trigger in description.upper() 
               for trigger in STRONG_TRIGGERS
           ) if description else False
+          result["absolute_keyword_count"] = sum(
+              description.upper().count(trigger) for trigger in STRONG_TRIGGERS
+          ) if description else 0
           
           # Track which triggers were found (for reporting)
           result["triggers_found"] = [
@@ -521,7 +543,19 @@ steps:
                   "severity": "WARNING",
                   "code": "SHORT_DESCRIPTION",
                   "message": f"Description is too short ({result['description_length']} chars, minimum {MIN_DESCRIPTION_LENGTH})",
-                  "remediation": "Expand description to include WHY/WHEN/WHAT guidance and activation triggers"
+                  "remediation": "Expand description to explain WHAT the agent does and WHEN to delegate to it"
+              })
+
+          # Check for <commentary> tags -- validated for removal with no
+          # quality loss (description-authoring-principles.md V3). WARNING,
+          # not ERROR: existing agents carrying these still load fine.
+          result["commentary_count"] = description.lower().count("<commentary>") if description else 0
+          if result["commentary_count"] > 0:
+              result["warnings"].append({
+                  "severity": "WARNING",
+                  "code": "COMMENTARY_TAG_PRESENT",
+                  "message": f"Description contains {result['commentary_count']} <commentary> tag(s) -- validated for removal with no quality loss",
+                  "remediation": "Delete <commentary> tags; the example itself should be self-explanatory (see description-authoring-principles.md V3)"
               })
 
           # Check if examples have Context labels (quality check)
@@ -537,6 +571,14 @@ steps:
                       "code": "EXAMPLES_MISSING_CONTEXT",
                       "message": f"Only {examples_with_context}/{len(example_blocks)} examples have 'Context:' labels",
                       "remediation": "Add 'Context: [situation]' line at start of each <example> block to help LLM understand when to match"
+                  })
+
+              if len(example_blocks) > 2:
+                  result["warnings"].append({
+                      "severity": "WARNING",
+                      "code": "TOO_MANY_EXAMPLES",
+                      "message": f"Description has {len(example_blocks)} <example> blocks (>2) -- validated cap is 2",
+                      "remediation": "Trim to at most 2 examples (description-authoring-principles.md V3)"
                   })
           else:
               result["example_count"] = 0
@@ -621,8 +663,19 @@ steps:
       # 1. No structural errors (valid YAML, has meta.name, meta.description)
       # 2. Has explicit tools section (even if empty)
       # 3. Description >= 100 characters
-      # 4. Has at least ONE strong trigger (MUST, ALWAYS, REQUIRED, PROACTIVELY, DO NOT)
-      # 5. Has at least ONE <example> block
+      # 4. Description token budget respected (provisional: WARN >300 tok,
+      #    ERROR >600 tok -- description-authoring-principles.md V5)
+      #
+      # has_strong_trigger / has_examples / commentary_count /
+      # absolute_keyword_count are reported as METRICS below, not gates.
+      # A measured eval campaign found these do not by themselves indicate
+      # quality, and requiring them measurably harmed compliant models
+      # (see foundation:context/shared/description-authoring-principles.md
+      # V1, V3, V6). Do not reintroduce them as pass/fail criteria.
+
+      # Provisional token thresholds (see description-authoring-principles.md V5)
+      DESCRIPTION_TOKEN_WARN = 300
+      DESCRIPTION_TOKEN_ERROR = 600
 
       def classify_agent(agent: dict) -> dict:
           """Classify a single agent's quality level."""
@@ -636,6 +689,7 @@ steps:
           has_strong_trigger = agent.get("has_strong_trigger", False)
           has_examples = agent.get("has_examples", False)
           description_length = agent.get("description_length", 0)
+          description_tokens = agent.get("description_tokens", 0)
           has_model_role = agent.get("has_model_role", False)
           model_role_issues = agent.get("model_role_issues", [])
           has_model_role_errors = any(i.startswith("ERROR:") for i in model_role_issues)
@@ -650,15 +704,12 @@ steps:
           elif description_length < 100:
               quality = "needs_work"
               reason = f"Description too short ({description_length} chars)"
-          elif not has_strong_trigger and not has_examples:
+          elif description_tokens > DESCRIPTION_TOKEN_ERROR:
               quality = "needs_work"
-              reason = "Missing both strong triggers AND examples"
-          elif not has_strong_trigger:
+              reason = f"Description is {description_tokens} tokens (>{DESCRIPTION_TOKEN_ERROR} threshold -- must shorten)"
+          elif description_tokens > DESCRIPTION_TOKEN_WARN:
               quality = "polish"
-              reason = "Has examples but missing strong triggers (MUST/ALWAYS/REQUIRED)"
-          elif not has_examples:
-              quality = "polish"
-              reason = "Has strong triggers but missing <example> blocks"
+              reason = f"Description is {description_tokens} tokens (>{DESCRIPTION_TOKEN_WARN} threshold -- consider trimming)"
           elif has_model_role_errors:
               quality = "needs_work"
               reason = "Invalid or deprecated model_role values"
@@ -898,70 +949,56 @@ steps:
       
       Agents classified as "good" have ALREADY PASSED. Do NOT suggest improvements for them.
 
+      **How to judge description quality is governed by the canonical**
+      **`foundation:context/shared/description-authoring-principles.md`** --
+      this prompt does not restate it. In summary: trigger phrasing should
+      state the deciding factor (a decision rule), not lean on bare
+      imperatives; examples are capped at 2 with no `<commentary>` tags;
+      stale examples (describing a capability the agent no longer has) are
+      a defect.
+
       **What is NOT an Issue (do not flag these):**
-      - Minor style differences (e.g., "MUST be used" vs "ALWAYS use" - both are strong)
+      - Whether the description happens to use MUST/ALWAYS/REQUIRED/
+        PROACTIVELY -- their presence or absence is not itself a quality
+        signal (a measured eval campaign found requiring them harmed
+        compliant models; see description-authoring-principles.md V1, V6)
       - Reasonable alternative approaches to documentation
       - "Could be slightly better" items for agents that meet thresholds
       - Personal preferences about wording or structure
-      - Agents that have strong triggers but use different words than the examples
-      
+      - Exactly 1-2 examples with no `<commentary>` -- this is the target
+        shape, not a gap
+
       **Only flag genuine issues:**
-      - Truly weak/passive triggers ("Use when..." with no imperative language)
+      - A WHEN clause that gives no deciding factor at all (not "weak
+        phrasing" -- literally no signal for when to delegate)
       - Complete absence of examples in agents that need them
+      - More than 2 examples, or any `<commentary>` tag (see V3)
+      - An example describing a capability the agent no longer has (stale,
+        see V2)
       - Critical missing guidance that would confuse users
 
       **Quality Criteria to Check (for agents needing work only):**
-      
-      ### 1. Activation Triggers (SUGGESTION if weak)
-      
-      **Strong triggers** use imperative language that COMPELS action:
-      - "MUST be used when..."
-      - "ALWAYS use this agent for..."
-      - "REQUIRED for..."
-      - "Use PROACTIVELY when..."
-      - "DO NOT attempt this yourself..."
-      
-      **Weak triggers** (need improvement):
-      - "Use when..." (passive)
-      - "Can be used for..." (ambiguous)
-      - "Helpful for..." (vague)
-      - "This agent helps with..." (passive description)
-      
-      **CONCRETE BEFORE/AFTER EXAMPLES:**
-      
-      ❌ WEAK: "This agent helps with security reviews"
-      ✅ STRONG: "MUST be used when reviewing authentication code, handling user data, or before production deployments"
-      
-      ❌ WEAK: "Use when you need to explore code"
-      ✅ STRONG: "ALWAYS delegate multi-file exploration tasks. NEVER read more than 2 files yourself - delegate to this agent instead."
-      
-      Check: Does the description clearly tell the LLM WHEN to delegate to this agent?
 
-      ### 2. Example Blocks (SUGGESTION if missing)
-      
-      Good agent descriptions include `<example>` blocks showing:
-      ```
-      <example>
-      Context: [situation]
-      user: '[example request]'
-      assistant: '[how assistant should respond]'
-      <commentary>
-      [why this triggers this agent]
-      </commentary>
-      </example>
-      ```
-      
-      Check: Does the description have at least one `<example>` block?
+      ### 1. WHEN Clause Quality (SUGGESTION if missing a deciding factor)
 
-      ### 3. WHY/WHEN/WHAT Guidance (SUGGESTION if incomplete)
-      
+      Check: Does the description state a concrete condition or context
+      shape that should cause delegation (a decision rule), rather than
+      either (a) nothing at all, or (b) a bare imperative with no
+      supporting context? See description-authoring-principles.md V6 for
+      the before/after example.
+
+      ### 2. Example Blocks (SUGGESTION if missing, or if >2/has <commentary>)
+
+      Check: Does the description have 1-2 `<example>` blocks, with no
+      `<commentary>` tags, that reflect what the agent actually does today?
+
+      ### 3. WHAT/WHEN Guidance (SUGGESTION if incomplete)
+
       Good descriptions answer:
-      - **WHY**: Why does this agent exist? What problem does it solve?
-      - **WHEN**: When should this agent be invoked? What triggers it?
       - **WHAT**: What does this agent do? What are its capabilities?
-      - **HOW**: How does it work? What tools/approach does it use?
-      
-      Check: Are these four aspects covered in the description?
+      - **WHEN**: What's the deciding factor for delegating to it?
+
+      Check: Are both aspects covered in the description?
 
       **Read the actual agent files** at {{repo_path}} to analyze the full descriptions.
 
@@ -1212,16 +1249,18 @@ steps:
 
       ## Metadata
       - **Validated**: [timestamp]
-      - **Recipe**: validate-agents v1.2.1
-      - **Quality Thresholds**:
-        - Strong trigger: MUST, ALWAYS, REQUIRED, PROACTIVELY, or DO NOT
-        - Examples: At least one <example> block
-        - Description: >= 100 characters
-        - Tools: Explicit tools: section (even if empty)
+      - **Recipe**: validate-agents v1.3.0
+      - **Quality Thresholds**: see
+        `foundation:context/shared/description-authoring-principles.md`
+        (canonical -- not restated here). Gates: no structural errors,
+        explicit tools section, description >= 100 chars, description
+        token budget (provisional WARN >300 / ERROR >600 tok).
+        MUST/ALWAYS/REQUIRED/PROACTIVELY keyword presence and <example>
+        count are reported as metrics, not gates.
       - **Severity Guide**:
         - ERROR (critical): Invalid YAML, missing required fields (will break)
-        - WARNING (needs_work): No explicit tools, relying on inheritance (may break)
-        - SUGGESTION (polish): Weak triggers, missing examples (quality improvement)
+        - WARNING (needs_work): No explicit tools, relying on inheritance, or description over budget (may break or bloat every session)
+        - SUGGESTION (polish): Missing WHEN deciding factor, missing examples, >2 examples, or <commentary> tags present (quality improvement)
 
       Make the report actionable with clear next steps and concrete examples.
       

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -1,9 +1,30 @@
 # validate-bundle-repo.yaml
-# Repository-Wide Bundle Validator Recipe v3.7.0
+# Repository-Wide Bundle Validator Recipe v3.8.0
 # Validates an entire bundle repository against structural requirements, conventions,
 # and Amplifier bundle philosophy (context sink pattern, thin behaviors, tool placement)
 #
 # CHANGELOG:
+# v3.8.0 - NEW PHASE 2.8: Agent Description Budget Validation
+#        - Walks agents/*.md files and applies the same description-budget +
+#          example/commentary checks validate-agents.yaml enforces, so a
+#          repo-wide scan catches agent description bloat on its own.
+#        - Check A: description token budget (PROVISIONAL -- see foundation:
+#          context/shared/description-authoring-principles.md V5):
+#          WARNING >300 tokens (agent_description_high)
+#          ERROR   >600 tokens (agent_description_excessive)
+#          Tighter than the mode-tier thresholds (500/800) because agent
+#          descriptions are paid by every session with the agent in its
+#          catalog, not only sessions that use it.
+#        - Check B: <example>/<commentary> detection (description-authoring-
+#          principles.md V3): WARNING on any <commentary> tag, WARNING on
+#          >2 <example> blocks.
+#        - quality-classification incorporates agent_description_issues
+#        - synthesize-report includes Agent Description Budget Validation section
+#        - Remediation pointers throughout the recipe now point to the
+#          canonical context/shared/description-authoring-principles.md
+#          instead of AGENT_AUTHORING.md's old "Description Requirements
+#          (Critical)" section header (renamed, and no longer states the
+#          thresholds inline -- see foundation PR de-inverting validate-agents.yaml)
 # v3.7.0 - NEW PHASE 2.55: Body Instruction Check
 #        - Everything below a bundle.md / agents/*.md YAML frontmatter is loaded
 #          verbatim as the session's system instruction and emitted FIRST, ahead
@@ -138,7 +159,7 @@
 #     <500 tokens    OK     (concise, on-point)
 #     500-800        WARNING (mode_description_high — consider trimming)
 #     >800           ERROR  (mode_description_excessive — must shorten)
-#     See foundation:docs/AGENT_AUTHORING.md §"Description Requirements (Critical)"
+#     See foundation:context/shared/description-authoring-principles.md (V5)
 # 14. Unadvertised modes (advertised: false) are not referenced by name in agent-readable files
 #     (.md files in context/, agents/, behaviors/, skills/, modes/ — excluding the mode's own file)
 #     Patterns checked: /<mode-name> and name="<mode-name>"/name='<mode-name>'
@@ -212,7 +233,7 @@ description: |
   - All measurements use TOKENS (len/4), never line counts
   
   For single bundle validation, use validate-bundle.yaml instead.
-version: "3.7.0"
+version: "3.8.0"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "repository", "packaging", "hygiene", "context-sink"]
 
@@ -2786,9 +2807,8 @@ steps:
                   ),
                   "fix": (
                       "Shorten the description to <500 tokens. "
-                      "See foundation:docs/AGENT_AUTHORING.md "
-                      "\u00a7'Description Requirements (Critical)' and "
-                      "modes/.../mode-design-discipline skill."
+                      "See foundation:context/shared/description-authoring-principles.md "
+                      "(V5) and modes/.../mode-design-discipline skill."
                   )
               })
               detail["issues"].append("mode_description_excessive")
@@ -2805,9 +2825,8 @@ steps:
                   ),
                   "fix": (
                       "Trim description toward <500 tokens. "
-                      "See foundation:docs/AGENT_AUTHORING.md "
-                      "\u00a7'Description Requirements (Critical)' and "
-                      "modes/.../mode-design-discipline skill."
+                      "See foundation:context/shared/description-authoring-principles.md "
+                      "(V5) and modes/.../mode-design-discipline skill."
                   )
               })
               detail["issues"].append("mode_description_high")
@@ -2856,6 +2875,171 @@ steps:
       print(json.dumps(results))
       EOF
     output: "mode_validation_results"
+    parse_json: true
+    timeout: 120
+    on_error: "continue"
+    depends_on: ["repo-discovery"]
+
+  # ============================================================================
+  # PHASE 2.8: Agent Description Budget Validation
+  #
+  # Walks all agents/*.md files in the repo and applies the same description
+  # budget + example/commentary checks validate-agents.yaml enforces, so a
+  # bundle-repo-wide scan catches agent description bloat even when
+  # validate-agents.yaml is not run separately.
+  #
+  # Check A -- Description token budget (PROVISIONAL, see foundation:context/
+  # shared/description-authoring-principles.md V5)
+  #   For each agent file's meta.description:
+  #   WARNING >300 tokens  (agent_description_high)
+  #   ERROR   >600 tokens  (agent_description_excessive)
+  #   Token estimate: len(description) // 4 -- same formula as Phase 2.7
+  #   Check A (mode descriptions), applied at the tighter agent-tier ceiling
+  #   because agent descriptions are paid by every session with the agent
+  #   in its catalog, not only sessions that use it.
+  #
+  # Check B -- <example>/<commentary> detection (description-authoring-
+  # principles.md V3)
+  #   WARNING: any <commentary> tag present (commentary_present)
+  #   WARNING: more than 2 <example> blocks (too_many_examples)
+  # ============================================================================
+
+  - id: "agent-description-validation"
+    type: "bash"
+    command: |
+      python3 << 'EOF'
+      import json
+      import re
+      from pathlib import Path
+
+      repo_path = "{{repo_path}}"
+      path = Path(repo_path).resolve()
+
+      results = {
+          "phase": "agent_description_validation",
+          "agents_checked": 0,
+          "errors": [],
+          "warnings": [],
+          "agent_details": []
+      }
+
+      EXCLUDED_DIRS = {"test-fixtures", "tests", "node_modules", ".git", ".venv"}
+
+      agent_files = list(path.rglob("*/agents/*.md")) + list(path.glob("agents/*.md"))
+      seen = set()
+      unique_agent_files = []
+      for f in agent_files:
+          if EXCLUDED_DIRS & set(f.parts):
+              continue
+          resolved = f.resolve()
+          if resolved not in seen:
+              seen.add(resolved)
+              unique_agent_files.append(f)
+
+      def extract_description(agent_file: Path) -> str:
+          try:
+              content = agent_file.read_text(encoding="utf-8", errors="replace")
+          except Exception:
+              return ""
+          match = re.match(r'^---\s*\n(.*?)\n---\s*\n', content, re.DOTALL)
+          if not match:
+              return ""
+          try:
+              import yaml
+              fm = yaml.safe_load(match.group(1))
+          except Exception:
+              return ""
+          if not isinstance(fm, dict):
+              return ""
+          meta = fm.get("meta", {})
+          if not isinstance(meta, dict):
+              return ""
+          description = meta.get("description", "")
+          return description if isinstance(description, str) else str(description or "")
+
+      for agent_file in sorted(unique_agent_files):
+          description = extract_description(agent_file)
+          rel_path = str(agent_file.relative_to(path))
+          results["agents_checked"] += 1
+          detail = {"file": rel_path, "issues": []}
+
+          token_count = len(description) // 4
+          detail["description_tokens"] = token_count
+
+          if token_count > 600:
+              results["errors"].append({
+                  "type": "agent_description_excessive",
+                  "file": rel_path,
+                  "tokens": token_count,
+                  "severity": "ERROR",
+                  "message": (
+                      f"Agent description in {rel_path} is {token_count} tokens "
+                      f"(>600 threshold -- must shorten)."
+                  ),
+                  "fix": (
+                      "Shorten the description to <300 tokens. See "
+                      "foundation:context/shared/description-authoring-principles.md "
+                      "V5 (provisional tier)."
+                  )
+              })
+              detail["issues"].append("agent_description_excessive")
+          elif token_count > 300:
+              results["warnings"].append({
+                  "type": "agent_description_high",
+                  "file": rel_path,
+                  "tokens": token_count,
+                  "severity": "WARNING",
+                  "message": (
+                      f"Agent description in {rel_path} is {token_count} tokens "
+                      f"(>300 threshold -- consider trimming)."
+                  ),
+                  "fix": (
+                      "Trim description toward <300 tokens. See "
+                      "foundation:context/shared/description-authoring-principles.md "
+                      "V5 (provisional tier)."
+                  )
+              })
+              detail["issues"].append("agent_description_high")
+
+          commentary_count = description.lower().count("<commentary>") if description else 0
+          detail["commentary_count"] = commentary_count
+          if commentary_count > 0:
+              results["warnings"].append({
+                  "type": "commentary_present",
+                  "file": rel_path,
+                  "severity": "WARNING",
+                  "message": f"{rel_path}: description has {commentary_count} <commentary> tag(s)",
+                  "fix": (
+                      "Delete <commentary> tags -- validated for removal with no "
+                      "quality loss. See description-authoring-principles.md V3."
+                  )
+              })
+              detail["issues"].append("commentary_present")
+
+          example_count = len(re.findall(r'<example>', description, re.IGNORECASE)) if description else 0
+          detail["example_count"] = example_count
+          if example_count > 2:
+              results["warnings"].append({
+                  "type": "too_many_examples",
+                  "file": rel_path,
+                  "severity": "WARNING",
+                  "message": f"{rel_path}: description has {example_count} <example> blocks (>2)",
+                  "fix": "Trim to at most 2 examples. See description-authoring-principles.md V3."
+              })
+              detail["issues"].append("too_many_examples")
+
+          results["agent_details"].append(detail)
+
+      results["passed"] = len(results["errors"]) == 0
+      results["summary"] = {
+          "agents_checked": results["agents_checked"],
+          "errors": len(results["errors"]),
+          "warnings": len(results["warnings"])
+      }
+
+      print(json.dumps(results))
+      EOF
+    output: "agent_description_validation_results"
     parse_json: true
     timeout: 120
     on_error: "continue"
@@ -3074,6 +3258,13 @@ steps:
       except (json.JSONDecodeError, ValueError):
           body_instruction = {"passed": True, "skipped": True, "errors": [], "warnings": []}
 
+      # Phase 2.8: Parse agent description budget validation results
+      agent_description_raw = '''{{agent_description_validation_results}}'''
+      try:
+          agent_description_validation = json.loads(agent_description_raw)
+      except (json.JSONDecodeError, ValueError):
+          agent_description_validation = {"passed": True, "skipped": True, "errors": [], "warnings": []}
+
       # Handle case where individual validation was skipped
       if individual.get("skipped", False):
           # v3.2.0: Check if this is an environment limitation (not a bundle problem)
@@ -3188,6 +3379,7 @@ steps:
               "behavior_reference_hygiene_issues": [],  # v3.5.0
               "mode_validation_issues": [],  # v3.6.0
               "body_instruction_issues": [],  # v3.7.0
+              "agent_description_issues": [],  # Phase 2.8
               # v3.2.0: Environment status tracking
               "environment_status": {
                   "validation_mode": env_check.get("validation_mode", "unknown"),
@@ -3384,6 +3576,25 @@ steps:
                       "fix": warning.get("fix", "")
                   })
 
+          # Phase 2.8: Agent description budget errors and warnings
+          if not agent_description_validation.get("skipped", False):
+              for error in agent_description_validation.get("errors", []):
+                  results["agent_description_issues"].append({
+                      "type": error.get("type"),
+                      "file": error.get("file"),
+                      "message": error.get("message"),
+                      "severity": "ERROR",
+                      "fix": error.get("fix", "")
+                  })
+              for warning in agent_description_validation.get("warnings", []):
+                  results["agent_description_issues"].append({
+                      "type": warning.get("type"),
+                      "file": warning.get("file"),
+                      "message": warning.get("message"),
+                      "severity": "WARNING",
+                      "fix": warning.get("fix", "")
+                  })
+
           # Determine overall quality level
           # Priority: critical > needs_work > polish > good
           
@@ -3394,6 +3605,7 @@ steps:
           critical_count += len([i for i in results["completeness_issues"] if i.get("severity") == "ERROR"])
           critical_count += len([i for i in results["experiment_issues"] if i.get("severity") == "ERROR"])
           critical_count += len([i for i in results["mode_validation_issues"] if i.get("severity") == "ERROR"])  # v3.6.0
+          critical_count += len([i for i in results["agent_description_issues"] if i.get("severity") == "ERROR"])  # Phase 2.8
 
           # Recipe validation impact
           recipe_quality = recipe_validation.get("quality_level", "good")
@@ -3412,6 +3624,7 @@ steps:
           warning_count += len(results["behavior_reference_hygiene_issues"])  # v3.5.0: all are WARNING
           warning_count += len([i for i in results["mode_validation_issues"] if i.get("severity") == "WARNING"])  # v3.6.0
           warning_count += len(results["body_instruction_issues"])  # v3.7.0: all are WARNING
+          warning_count += len([i for i in results["agent_description_issues"] if i.get("severity") == "WARNING"])  # Phase 2.8
           if recipe_quality == "polish":
               warning_count += 1
           
@@ -3457,7 +3670,9 @@ steps:
               "behavior_ref_hygiene_warnings": len(results["behavior_reference_hygiene_issues"]),  # v3.5.0
               "mode_validation_errors": len([i for i in results["mode_validation_issues"] if i.get("severity") == "ERROR"]),  # v3.6.0
               "mode_validation_warnings": len([i for i in results["mode_validation_issues"] if i.get("severity") == "WARNING"]),  # v3.6.0
-              "body_instruction_warnings": len(results["body_instruction_issues"])  # v3.7.0
+              "body_instruction_warnings": len(results["body_instruction_issues"]),  # v3.7.0
+              "agent_description_errors": len([i for i in results["agent_description_issues"] if i.get("severity") == "ERROR"]),  # Phase 2.8
+              "agent_description_warnings": len([i for i in results["agent_description_issues"] if i.get("severity") == "WARNING"])  # Phase 2.8
           }
 
           # v3.3.0: Recipe validation summary
@@ -4141,6 +4356,11 @@ steps:
       {{body_instruction_check_results}}
       ```
 
+      **Agent Description Budget Validation (Phase 2.8):**
+      ```json
+      {{agent_description_validation_results}}
+      ```
+
       **Bundle Doc Freshness (Phase 6 v3):**
       ```json
       {{bundle_doc_freshness}}
@@ -4249,7 +4469,7 @@ steps:
       - modes_checked: total number of modes/*.md files with a mode: block
       - For each ERROR of type mode_description_excessive (>800 tokens):
         - [ERROR] "Mode '<name>' description is N tokens — must shorten to <500"
-        - Refer author to foundation:docs/AGENT_AUTHORING.md §"Description Requirements (Critical)"
+        - Refer author to foundation:context/shared/description-authoring-principles.md (V5)
           and modes/.../mode-design-discipline skill
       - For each WARNING of type mode_description_high (>500 tokens):
         - [WARNING] "Mode '<name>' description is N tokens — consider trimming toward <500"
@@ -4271,6 +4491,22 @@ steps:
           field (metadata, never sent) or delete it; keep @mention pointers to
           instruction files
       - If no issues: "Body instruction check: all N files have instruction-only bodies"
+
+      ### Agent Description Budget Validation (Phase 2.8)
+      Use agent_description_validation_results to report:
+      - agents_checked: total number of agents/*.md files with a meta.description
+      - For each ERROR of type agent_description_excessive (>600 tokens, provisional):
+        - [ERROR] "Agent description in <file> is N tokens -- must shorten to <300"
+        - Refer author to foundation:context/shared/description-authoring-principles.md V5
+      - For each WARNING of type agent_description_high (>300 tokens, provisional):
+        - [WARNING] "Agent description in <file> is N tokens -- consider trimming toward <300"
+        - Same reference as above
+      - For each WARNING of type commentary_present:
+        - [WARNING] "<file>: description has N <commentary> tag(s) -- delete them (V3)"
+      - For each WARNING of type too_many_examples:
+        - [WARNING] "<file>: description has N <example> blocks (>2) -- trim to 2 (V3)"
+      - If no issues: "Agent description validation: all N agents within budget, no commentary/example bloat"
+      - If agent_description_validation_results.skipped == true: "Agent description validation: skipped (no agents/*.md files found)"
       - If body_instruction_check_results.skipped == true: "Body instruction check: skipped (no bundle.md or agents/*.md files found)"
       - This is WARNING-level only -- it never fails the build on its own
 


### PR DESCRIPTION
## Summary

An eval campaign measured that several patterns our own docs and validators *actively required* — MUST/ALWAYS/REQUIRED/PROACTIVELY keywords, `<commentary>` tags inside `<example>` blocks, unbounded description length — measurably harm compliant modern models. `recipes/validate-agents.yaml`'s own PASS thresholds were **inverted** relative to this evidence: an agent needed at least one strong-trigger keyword and at least one `<example>` block to be classified "good".

This PR encodes the evidence-backed principles into one canonical doc and de-inverts every validator/guide that contradicted it.

## The inversion

`validate-agents.yaml` required exactly the patterns the campaign found harmful:

```
# OLD (inverted) PASS THRESHOLDS
# - Has at least ONE of: MUST, ALWAYS, REQUIRED, PROACTIVELY, DO NOT
# - Has at least ONE <example> block
# - Description >= 100 characters
# - Has explicit tools section (even if empty [])
```

```
# NEW (de-inverted) PASS THRESHOLDS
# - No structural errors
# - Has explicit tools section (even if empty [])
# - Description >= 100 characters
# - Description token budget respected (provisional WARN >300 / ERROR >600 tok)
#
# NOTE: MUST/ALWAYS/REQUIRED/PROACTIVELY keyword presence and <example> count
# are reported as METRICS, not pass/fail gates.
```

## Evidence cited (see `context/shared/description-authoring-principles.md`)

- **V1** — a mandate stated 4 ways (2 contradictory) measurably destabilized a compliant model; removal validated in a 12-run A/B.
- **V2** — the "1e2 deletion pass": −11.3% system-prompt bytes, quality unchanged 12/12.
- **V3** — `<commentary>` blocks validated for removal; examples capped at ≤2, must reflect shipped reality.
- **V4** — delegation-pushing scaffolding: −27% tokens / −27% delegate calls on deletion, quality unchanged 5/5.
- **V5** — one tool description measured at 15,271 chars (56% of the tool-description budget), drove 7-8x over-delegation on gpt-5.6-sol (60% of spawns quoted it verbatim).
- **V6** — provider disposition: "sol complies; opus judges" — absolutes reserved for true invariants, decision rules for judgment calls (concurs with OpenAI's own 5.6 guidance).

P1-P3 (relaxed delegate-tool language, assembly-time example stripping, negative examples) are marked **provisional** — an A/B wave is in flight and not yet settled.

## Changes (10 commits, guidance and validators move together)

1. **NEW** `context/shared/description-authoring-principles.md` — the one canonical statement of V1-V6, applied to descriptions (agent `meta.description`, skill/mode `description`, tool descriptions). Every other file below points here instead of restating.
2. `context/CONTEXT_POISONING.md` — one-line back-reference (closes its previously zero-inbound-reference orphan status).
3. `docs/AGENT_AUTHORING.md` — de-inverts "Description Requirements (Critical)" → "Description Requirements": drops the MUST/ALWAYS/REQUIRED/PROACTIVELY keyword instruction, the "MUST be used for:" template line, the `<commentary>` requirement, and the ">100 words" floor. Replaces with a P0 pointer + provisional token ceiling. Refreshes the bug-hunter exemplar to match currently shipped `agents/bug-hunter.md` (it had drifted).
4. `recipes/validate-agents.yaml` — de-inverts PASS thresholds (see above). `has_strong_trigger`/`has_examples` become reported metrics, not gates; `description_tokens` (provisional WARN >300/ERROR >600) now drives classification in their place. Adds `commentary_count`/`absolute_keyword_count`/`TOO_MANY_EXAMPLES` detection. Version 1.2.4 → 1.3.0.
5. `recipes/validate-bundle-repo.yaml` — new Phase 2.8 (agent-description budget + example/commentary detection), cloned from the working Phase 2.7 Check A (mode descriptions) shape, wired into quality-classification and synthesize-report the same way. Retargets 4 remediation pointers that cited AGENT_AUTHORING's renamed section to the new canonical doc. Version 3.7.0 → 3.8.0.
6. `docs/DOMAIN_VALIDATOR_GUIDE.md` — updates the validate-agents exemplar (comment block, gold-standard bullet, code sample) in lockstep with #4, so it stops re-manufacturing the old thresholds.
7. `docs/BUNDLE_GUIDE.md` — replaces "Include usage examples in the description string" (both spots) with pointers to the canonical guidance.
8. `agents/bundle-design-expert.md` — adds an `@`-mention to the new canonical doc alongside the existing AGENT_AUTHORING.md reference (its own `meta.description` is untouched, held for the in-flight wave).
9. `context/understanding-mechanisms/mechanisms/agents.md` — fixes "16 agents" heading vs. 12-listed staleness (adds the 4 missing rows); adds an "Agent Catalog Cost" note (delegate tool description = base + Σ(agent descriptions), measured 15,688 chars for foundation's 16 agents, loaded every turn).
10. `bundles/anchors-amp-dev/agents/*` + `experiments/behavioral-anchor-amplifier-dev/agents/*` — deletes the 14 byte-identical `<commentary>` blocks (the only non-fixture commentary left in the repo). Each file's frontmatter re-verified with `yaml.safe_load` after editing.

## Testing

- Both touched recipes validate: `recipes(operation="validate")` reports `status: valid` for both (`validate-agents` v1.3.0, `validate-bundle-repo` v3.8.0).
- Full test suite: **1639 passed, 1 pre-existing failure, 1 skipped** (baseline ~1640). The one failure (`tests/test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes`) is unrelated to this change — confirmed pre-existing (this PR touches zero `.py` files) and reproduces identically with this branch's own commits checked out.
- `tests/test_validate_agents_model_role.py` (18 tests) — unaffected, all pass. It only tests `model_role` validation logic and constants, which this PR does not touch.
- No test pins the old (inverted) trigger/example thresholds as pass/fail gates, so no test updates were required alongside #4.

## Out of scope (pending wave)

P1-P3 are explicitly marked provisional in `description-authoring-principles.md` and not implemented here — they await the in-flight A/B wave's results.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>