### PR TITLE
feat(tool-delegate): optional max_spawns_per_session cap on new sub-agent spawns

### DIFF
--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -240,6 +240,104 @@ def _validate_call_budget(value: Any) -> int | None:
     return value or None  # 0 -> None (explicit opt-out)
 
 
+# ---------------------------------------------------------------------------
+# SPAWN-BUDGET treatment (LOCAL PATCH -- not part of upstream
+# amplifier-foundation). See settings.max_spawns_per_session in this
+# module's docstring above. Distinct from the Layer 1 LLM-call budget
+# above: this caps the *count* of new sub-session spawns, not the number
+# of LLM calls within any one of them, and -- unlike
+# ``_validate_call_budget`` -- a bad value never raises. A misconfigured
+# spawn budget must never take down the whole delegate tool; it degrades
+# to unlimited (today's behavior) instead, with a logged warning.
+# ---------------------------------------------------------------------------
+
+
+def _parse_spawn_budget(value: Any) -> int | None:
+    """Defensively parse ``settings.max_spawns_per_session``.
+
+    Returns the parsed non-negative int budget, or ``None`` for
+    "unlimited" (no cap -- today's behavior, byte-identical when this
+    setting is absent). ``None`` is also returned -- with a logged
+    warning, never an exception -- for any value that cannot be
+    confidently parsed as a non-negative integer, so a typo or a bad
+    config value degrades to unlimited rather than either silently
+    blocking every new spawn or crashing tool construction.
+
+    Accepts:
+    - ``None`` -> ``None`` (unlimited; the default)
+    - ``int`` (not ``bool``) -> itself, when >= 0
+    - ``str`` -> ``int(value.strip())``, when that parses to a
+      non-negative int (e.g. ``"3"``, ``" 3 "``)
+
+    Rejects (warns, falls back to ``None`` / unlimited):
+    - ``bool`` (``bool`` is an ``int`` subclass in Python;
+      ``True``/``False`` must never silently become ``1``/``0`` here)
+    - a negative int, or a string that parses to a negative int
+    - ``float``, ``list``, ``dict``, or any other non-str/int type
+    - a string that does not parse as a base-10 integer (e.g. ``"lots"``)
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        logger.warning(
+            "max_spawns_per_session must be a non-negative integer (or a "
+            "numeric string), not a bool: %r. Falling back to unlimited "
+            "spawns.",
+            value,
+        )
+        return None
+    if isinstance(value, int):
+        if value < 0:
+            logger.warning(
+                "max_spawns_per_session must be >= 0, got %d. Falling back "
+                "to unlimited spawns.",
+                value,
+            )
+            return None
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = int(value.strip())
+        except ValueError:
+            logger.warning(
+                "max_spawns_per_session could not be parsed as an integer: "
+                "%r. Falling back to unlimited spawns.",
+                value,
+            )
+            return None
+        if parsed < 0:
+            logger.warning(
+                "max_spawns_per_session must be >= 0, got %d (from %r). "
+                "Falling back to unlimited spawns.",
+                parsed,
+                value,
+            )
+            return None
+        return parsed
+    logger.warning(
+        "max_spawns_per_session must be an integer, a numeric string, or "
+        "null; got %s: %r. Falling back to unlimited spawns.",
+        type(value).__name__,
+        value,
+    )
+    return None
+
+
+def _spawn_budget_message(used: int, limit: int) -> str:
+    """The judgment-respecting decline message for a budget-exceeded spawn.
+
+    Deliberately factual and non-scolding: states the cap, names the
+    caller's remaining tools, and reminds that resuming an existing
+    session is still unmetered. Kept short by design (<=60 words).
+    """
+    return (
+        f"Delegation budget reached ({used}/{limit} new agent sessions "
+        "used). Complete the remaining work directly with your own tools "
+        "-- you have filesystem, search, and bash. Resuming an existing "
+        "agent session (session_id=...) is still allowed."
+    )
+
+
 class _DelegateTimeoutExpired(Exception):
     """Internal signal that the delegate-owned timeout expired."""
 
@@ -394,6 +492,17 @@ class DelegateTool:
             settings.get("max_llm_calls")
         )
         self.budget_warn_ratio: float = float(settings.get("budget_warn_ratio", 0.8))
+
+        # SPAWN-BUDGET treatment (LOCAL PATCH). Hard cap on NEW sub-session
+        # spawns for the lifetime of this DelegateTool instance (one parent
+        # session). Resumes are never metered -- see execute()'s routing
+        # and _spawn_new_session's counter increment. Ships DARK: default
+        # None means "no cap at all", today's behavior, byte-identical,
+        # unless settings.max_spawns_per_session is explicitly set.
+        self.max_spawns_per_session: int | None = _parse_spawn_budget(
+            settings.get("max_spawns_per_session")
+        )
+        self._new_spawns_used: int = 0
 
         # Build feature registry for dynamic description composition
         self._feature_registry = self._build_feature_registry()
@@ -571,6 +680,15 @@ Special agent values:
         # Add self-delegation if enabled
         if self.self_delegation_enabled:
             base_description += '\n- agent="self": Spawn yourself as a sub-agent (maximum token conservation)'
+
+        # SPAWN-BUDGET treatment (LOCAL PATCH): one factual line, only when
+        # a budget is actually configured. No line at all when unlimited
+        # (today's behavior) -- see self.max_spawns_per_session.
+        if self.max_spawns_per_session is not None:
+            base_description += (
+                f"\n\nThis session has a budget of {self.max_spawns_per_session} "
+                "new agent sessions; resuming existing sessions is unmetered."
+            )
 
         # Add feature-based sections
         base_description += f"\n\n{feature_desc}"
@@ -1459,6 +1577,23 @@ Agent usage notes:
                 },
             )
 
+        # SPAWN-BUDGET treatment (LOCAL PATCH): reject at/over the cap with
+        # a normal ToolResult, never an exception. Resumes never reach this
+        # branch (handled above, by session_id). None means unlimited.
+        if (
+            self.max_spawns_per_session is not None
+            and self._new_spawns_used >= self.max_spawns_per_session
+        ):
+            return ToolResult(
+                success=False,
+                error={
+                    "message": _spawn_budget_message(
+                        self._new_spawns_used, self.max_spawns_per_session
+                    ),
+                    "code": "SPAWN_BUDGET_EXCEEDED",
+                },
+            )
+
         # Check agent exists in registry (with special handling for "self" and bundle paths)
         agents = self.coordinator.config.get("agents", {})
 
@@ -1851,6 +1986,22 @@ Agent usage notes:
             output_metadata = dict(result_metadata)
             if call_budget is not None:
                 output_metadata["budget_enforced"] = budget_enforced
+
+            # SPAWN-BUDGET treatment (LOCAL PATCH): count this new spawn --
+            # at the point it actually succeeded, not at the point it was
+            # merely requested (see execute()'s pre-spawn check above) and
+            # not on the timeout/error exception paths below (an infra
+            # failure should not cost the caller a slot) -- and append a
+            # remaining-budget footer so the caller can plan ahead. No-op,
+            # no footer, when unlimited (today's behavior).
+            if self.max_spawns_per_session is not None:
+                self._new_spawns_used += 1
+                remaining = max(self.max_spawns_per_session - self._new_spawns_used, 0)
+                cleaned_response = (
+                    f"{cleaned_response}\n\n"
+                    f"(new-session budget: {remaining} of "
+                    f"{self.max_spawns_per_session} remaining)"
+                )
 
             # Return output with session_id for multi-turn capability.
             # "response" is `cleaned_response` -- byte-identical to

--- a/modules/tool-delegate/tests/test_delegate_spawn_budget.py
+++ b/modules/tool-delegate/tests/test_delegate_spawn_budget.py
@@ -1,0 +1,324 @@
+"""Tests for the SPAWN-BUDGET treatment (LOCAL PATCH, not upstream).
+
+Covers the test plan from the treatment's own construction task:
+  B1  Default (unset) -> unlimited, zero behavior change vs. today
+  B2  budget=3 -> 3 spawns succeed with footers; 4th is rejected and
+      spawns nothing
+  B3  Resume calls never decrement the budget
+  B4  String "3" coerces to int 3
+  B5  Garbage value warns and falls back to unlimited
+  B6  The description gets exactly one factual budget line, iff configured
+
+Mirrors the helper pattern established in test_delegate_call_budget.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from amplifier_module_tool_delegate import DelegateTool, _parse_spawn_budget
+
+# ---------------------------------------------------------------------------
+# Helpers (pattern mirrors tests/test_delegate_call_budget.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_tool(
+    *,
+    settings: dict | None = None,
+    spawn_result: dict | None = None,
+    resume_result: dict | None = None,
+) -> tuple[DelegateTool, AsyncMock, AsyncMock]:
+    """Create a DelegateTool wired for execute()-level spawn/resume tests.
+
+    Returns (tool, spawn_fn, resume_fn) so tests can inspect call counts.
+    Each call to spawn_fn returns a FRESH copy of spawn_result so mutating
+    one call's dict (e.g. via output_metadata = dict(result_metadata))
+    never leaks into another call's assertions.
+    """
+    default_spawn_result = {
+        "output": "done",
+        "session_id": "child-001",
+        "status": "success",
+        "turn_count": 1,
+        "metadata": {},
+    }
+    base_spawn_result = spawn_result or default_spawn_result
+
+    async def _spawn_side_effect(*_args, **_kwargs):
+        return dict(base_spawn_result)
+
+    spawn_fn = AsyncMock(side_effect=_spawn_side_effect)
+
+    default_resume_result = {
+        "output": "continued",
+        "session_id": "child-001",
+        "status": "success",
+        "turn_count": 2,
+        "metadata": {},
+    }
+    resume_fn = AsyncMock(return_value=resume_result or default_resume_result)
+
+    coordinator = MagicMock()
+    coordinator.session_id = "parent-session-123"
+    coordinator.config = {"agents": {}}
+    coordinator.session_state = {}
+    coordinator._tool_dispatch_context = {}
+
+    def _get_capability(name: str):
+        if name == "session.spawn":
+            return spawn_fn
+        if name == "session.resume":
+            return resume_fn
+        return None
+
+    coordinator.get_capability = _get_capability
+    coordinator.get = MagicMock(return_value=None)
+
+    parent_session = MagicMock()
+    parent_session.session_id = "parent-session-123"
+    parent_session.config = {"session": {"orchestrator": {}}}
+    coordinator.session = parent_session
+
+    config: dict = {"features": {}, "settings": settings or {"exclude_tools": []}}
+    tool = DelegateTool(coordinator, config)
+    return tool, spawn_fn, resume_fn
+
+
+# ---------------------------------------------------------------------------
+# B1 -- Default (unset) -> unlimited, zero behavior change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDefaultUnlimited:
+    async def test_default_is_none(self) -> None:
+        tool, _spawn_fn, _resume_fn = _make_tool()
+        assert tool.max_spawns_per_session is None
+
+    async def test_no_footer_on_response_when_unlimited(self) -> None:
+        tool, _spawn_fn, _resume_fn = _make_tool()
+        result = await tool.execute({"agent": "self", "instruction": "do it"})
+        assert result.success is True
+        assert result.output is not None
+        assert "new-session budget" not in result.output["response"]
+
+    async def test_no_description_line_when_unlimited(self) -> None:
+        tool, _spawn_fn, _resume_fn = _make_tool()
+        assert "budget of" not in tool.description
+        assert "new agent sessions" not in tool.description
+
+    async def test_many_spawns_never_rejected(self) -> None:
+        """Zero behavior change: an unset budget never rejects a spawn,
+        no matter how many new sessions this tool instance has spawned."""
+        tool, spawn_fn, _resume_fn = _make_tool()
+        for _ in range(10):
+            result = await tool.execute({"agent": "self", "instruction": "go"})
+            assert result.success is True
+        assert spawn_fn.call_count == 10
+
+
+# ---------------------------------------------------------------------------
+# B2 -- budget=3: 3 succeed with footers, 4th rejected, spawns nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestBudgetEnforcement:
+    async def test_three_succeed_with_footers_fourth_rejected(self) -> None:
+        tool, spawn_fn, _resume_fn = _make_tool(
+            settings={"exclude_tools": [], "max_spawns_per_session": 3}
+        )
+
+        expected_footers = [
+            "(new-session budget: 2 of 3 remaining)",
+            "(new-session budget: 1 of 3 remaining)",
+            "(new-session budget: 0 of 3 remaining)",
+        ]
+        for expected_footer in expected_footers:
+            result = await tool.execute({"agent": "self", "instruction": "go"})
+            assert result.success is True
+            assert result.output is not None
+            assert expected_footer in result.output["response"]
+
+        assert spawn_fn.call_count == 3
+        assert tool._new_spawns_used == 3
+
+        # 4th call: rejected, and spawn_fn must NOT be called at all.
+        result = await tool.execute({"agent": "self", "instruction": "go"})
+        assert result.success is False
+        assert result.error is not None
+        assert (
+            "Delegation budget reached (3/3 new agent sessions used)"
+            in (result.error["message"])
+        )
+        assert result.error["code"] == "SPAWN_BUDGET_EXCEEDED"
+        assert spawn_fn.call_count == 3  # unchanged -- nothing was spawned
+        assert tool._new_spawns_used == 3  # unchanged -- rejection doesn't count
+
+    async def test_rejection_message_is_not_scolding_and_mentions_resume(
+        self,
+    ) -> None:
+        tool, _spawn_fn, _resume_fn = _make_tool(
+            settings={"exclude_tools": [], "max_spawns_per_session": 0}
+        )
+        result = await tool.execute({"agent": "self", "instruction": "go"})
+        assert result.success is False
+        assert result.error is not None
+        message = result.error["message"]
+        assert len(message.split()) <= 60
+        assert "session_id=" in message
+        assert "filesystem" in message
+
+
+# ---------------------------------------------------------------------------
+# B3 -- Resume calls never decrement the budget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestResumeDoesNotCountAgainstBudget:
+    async def test_resume_does_not_consume_a_spawn_slot(self) -> None:
+        tool, spawn_fn, resume_fn = _make_tool(
+            settings={"exclude_tools": [], "max_spawns_per_session": 1}
+        )
+
+        # Resume an "existing" session several times -- none of this should
+        # touch the new-spawn counter or ever be rejected by the budget.
+        resume_results = []
+        for _ in range(5):
+            resume_result = await tool.execute(
+                {
+                    "session_id": "abc123-def456_self",
+                    "instruction": "continue please",
+                }
+            )
+            assert resume_result.success is True
+            resume_results.append(resume_result)
+
+        assert resume_fn.call_count == 5
+        assert tool._new_spawns_used == 0
+        # No footer on resume responses -- footer is a spawn-only feature.
+        last_resume = resume_results[-1]
+        assert last_resume.output is not None
+        assert "new-session budget" not in last_resume.output["response"]
+
+        # The budget is still fully available for a genuine new spawn.
+        spawn_result = await tool.execute({"agent": "self", "instruction": "go"})
+        assert spawn_result.success is True
+        assert spawn_fn.call_count == 1
+        assert tool._new_spawns_used == 1
+
+        # And now it's exhausted for a second new spawn.
+        second_spawn = await tool.execute({"agent": "self", "instruction": "go"})
+        assert second_spawn.success is False
+        assert second_spawn.error["code"] == "SPAWN_BUDGET_EXCEEDED"
+        assert spawn_fn.call_count == 1  # still just the one real spawn
+
+
+# ---------------------------------------------------------------------------
+# B4 / B5 -- Defensive parsing: string coercion, garbage -> warn + unlimited
+# ---------------------------------------------------------------------------
+
+
+class TestDefensiveParsing:
+    def test_string_int_coerces(self) -> None:
+        assert _parse_spawn_budget("3") == 3
+        assert _parse_spawn_budget(" 3 ") == 3
+
+    def test_none_is_unlimited(self) -> None:
+        assert _parse_spawn_budget(None) is None
+
+    def test_int_passes_through(self) -> None:
+        assert _parse_spawn_budget(3) == 3
+        assert _parse_spawn_budget(0) == 0
+
+    def test_garbage_string_warns_and_falls_back_to_unlimited(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level("WARNING"):
+            result = _parse_spawn_budget("lots")
+        assert result is None
+        assert any(
+            "max_spawns_per_session" in record.message for record in caplog.records
+        )
+
+    def test_negative_warns_and_falls_back_to_unlimited(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level("WARNING"):
+            result = _parse_spawn_budget(-1)
+        assert result is None
+        assert any("max_spawns_per_session" in r.message for r in caplog.records)
+
+    def test_bool_warns_and_falls_back_to_unlimited(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level("WARNING"):
+            result = _parse_spawn_budget(True)
+        assert result is None
+        assert any("max_spawns_per_session" in r.message for r in caplog.records)
+
+    def test_float_warns_and_falls_back_to_unlimited(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level("WARNING"):
+            result = _parse_spawn_budget(3.5)
+        assert result is None
+        assert any("max_spawns_per_session" in r.message for r in caplog.records)
+
+    async def _unused(self) -> None:  # pragma: no cover
+        """Keeps this class importable if a runner assumes async collection."""
+
+
+@pytest.mark.asyncio
+class TestGarbageBudgetEndToEnd:
+    async def test_garbage_config_value_degrades_to_unlimited_behavior(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A misconfigured max_spawns_per_session must not crash tool
+        construction, must not silently block every spawn, and must warn."""
+        with caplog.at_level("WARNING"):
+            tool, spawn_fn, _resume_fn = _make_tool(
+                settings={
+                    "exclude_tools": [],
+                    "max_spawns_per_session": "banana",
+                }
+            )
+        assert tool.max_spawns_per_session is None
+        assert any(
+            "max_spawns_per_session" in record.message for record in caplog.records
+        )
+
+        for _ in range(5):
+            result = await tool.execute({"agent": "self", "instruction": "go"})
+            assert result.success is True
+            assert "new-session budget" not in result.output["response"]
+        assert spawn_fn.call_count == 5
+
+
+# ---------------------------------------------------------------------------
+# B6 -- Description line present iff a budget is configured
+# ---------------------------------------------------------------------------
+
+
+class TestDescriptionBudgetLine:
+    def test_line_present_when_configured(self) -> None:
+        tool, _spawn_fn, _resume_fn = _make_tool(
+            settings={"exclude_tools": [], "max_spawns_per_session": 5}
+        )
+        assert (
+            "This session has a budget of 5 new agent sessions; resuming "
+            "existing sessions is unmetered." in tool.description
+        )
+
+    def test_line_absent_when_unconfigured(self) -> None:
+        tool, _spawn_fn, _resume_fn = _make_tool()
+        assert "This session has a budget of" not in tool.description
+
+    def test_line_absent_when_garbage(self) -> None:
+        tool, _spawn_fn, _resume_fn = _make_tool(
+            settings={"exclude_tools": [], "max_spawns_per_session": "nonsense"}
+        )
+        assert "This session has a budget of" not in tool.description


### PR DESCRIPTION
## Summary

Adds an optional, defensively-parsed `settings.max_spawns_per_session` cap to
`DelegateTool` (`modules/tool-delegate`): once a parent session has spawned
that many **new** sub-agent sessions, further new-spawn requests get a normal
(non-exception) declined `ToolResult` naming the cap and pointing at the
caller's own tools, while session **resumes** remain completely unmetered.
Default (absent/`None`) is **unlimited — byte-identical to today's behavior**.

## Why

Models with a strong intrinsic delegation habit (gpt-5.6-sol-class) over-delegate
regardless of tool-description wording:

- On an identical background task, **claude-opus** solved it single-session
  with **zero** delegation, while **sol** spawned **6–11** sub-agents.
- Two prior treatments targeted only the tool description's *framing*:
  - T-dg: a relaxed decision-rule rewrite → median **7** spawns
  - T-strip: full advocacy+example strip (description 14,562 → 8,060 chars) → median **9** spawns
  - Both against a control median of **6**, with quality held at **18/18** in both.
- **Rewording the description did not move the needle.** That is the evidence
  this is model-intrinsic, not a fixable-by-better-prose problem — the
  pre-registered fallback for a model-intrinsic behavior is a mechanical
  constraint, not a fourth wording attempt.
- OpenAI's own hosted multi-agent documentation recommends a max concurrency
  of 3, which is the reference value used throughout validation below (the
  actual value is fully operator-configured, not hardcoded in the patch).

## Validation (DTU A/B, dial-in wave, `max_spawns_per_session: 3`)

- Root new-spawns stayed **≤ 3** on every capped run (vs **11** and **5**
  uncapped) — and the model **voluntarily stopped at or below the cap**: the
  budget-reached decline path never actually fired across the wave.
- Quality fully held: single-turn **2/2** correct; multi-turn **2/2** at
  **100/100** grader score.
- Session count dropped **12 → 4**.
- **claude-opus unaffected**: 0 delegations with and without the cap — it
  never binds, consistent with T-strip's earlier finding that opus is
  largely insensitive to the tool description's specific content.

**Honest framing:** the cap is a *construction guarantee* (mechanically true
once configured), not a claimed change in model behavior — the model chose to
respect it early, which is a genuinely interesting secondary result but not
the point of the feature. Cost savings are **secondary and roughly a wash**
(capped runs did the remaining work in-root at similar cost); the real value
is bounded fan-out, fewer sessions, and cache-friendlier session trees —
structural discipline, not a cost play.

## What changed

`modules/tool-delegate/amplifier_module_tool_delegate/__init__.py` (+151/-0, 5 hunks):

- `_parse_spawn_budget(value)` — defensive parser. `None` → unlimited (default).
  `int` (not `bool`) ≥ 0 → itself. `str` → coerces via `int(value.strip())`
  when non-negative. Anything else (negative, `bool`, `float`, unparseable
  string, any other type) **warns and falls back to unlimited — never raises**.
  (Deliberately different from the sibling `max_llm_calls` budget, which
  raises at construction — a misconfigured spawn budget must never take down
  the whole delegate tool.)
- `DelegateTool.__init__`: parses the setting once; `self._new_spawns_used = 0`.
- `DelegateTool.execute()`: in the SPAWN branch only (resumes are routed away
  earlier via `session_id` and never reach this check) — at/over the cap,
  returns `ToolResult(success=False, error={"message": ..., "code":
  "SPAWN_BUDGET_EXCEEDED"})` and **spawns nothing** (`session.spawn` is never
  called on this path).
- `DelegateTool._spawn_new_session()`: counts **only on the success path**
  (never on the `_DelegateTimeoutExpired` or generic-exception paths, so an
  infra failure never costs the caller a slot) and appends a
  `"(new-session budget: X of Y remaining)"` footer to the response.
- `DelegateTool.description`: one factual sentence appended when a budget is
  configured; nothing added when unlimited.
- `0` is a valid, literal budget (blocks every new spawn) — **not** collapsed
  to "unlimited" the way `0` is for the sibling `max_llm_calls` budget, since
  the task spec only treats *absent/None* as unlimited for this key.
- Decline message is 32 words (asserted `<=60` by test), names the caller's
  own remaining tools (filesystem, search, bash), and explicitly says
  resuming an existing session is still allowed.

`modules/tool-delegate/tests/test_delegate_spawn_budget.py` (new, +324/-0):
18 tests / 6 classes — default-unlimited zero-behavior-change,
budget-enforcement (3 succeed w/ footers, 4th rejected + spawns nothing),
resume-never-counts, defensive parsing (string coercion, garbage → warn +
unlimited), garbage-value end-to-end, and description-line presence.

**Known, disclosed limitation:** the pre-spawn check and the post-spawn
counter increment are not atomic across concurrent invocations, so a burst of
simultaneous delegate calls (e.g. an orchestrator's own `asyncio.gather`) could
allow limited overshoot beyond the configured cap. This mirrors an existing,
already-accepted pattern in the same file (the self-delegation-depth check
reads a capability with no lock either) and is a mechanical backstop, not a
hard security boundary.

## Test evidence

Run against this exact branch, both before (`git stash -u`) and after
(`git stash pop`) on the same checkout — not assumed from the diff:

| Suite | Before | After | Delta |
|---|---|---|---|
| `modules/tool-delegate/tests` | 150 passed | **168 passed** | +18 (new), 0 regressions |
| Full repo (`uv run pytest`) | 1793 passed, 1 skipped | **1811 passed, 1 skipped** | +18 (new), 0 regressions |

`python_check` (ruff format / ruff lint / pyright) on both touched files:
10 pre-existing warnings on `__init__.py`, identical codes at shifted line
positions (confirmed via the same stash/pop comparison — this patch is a
pure insertion, `+151/-0`); 0 new lint/format issues. The new test file's
one `pyright reportMissingImports` (`amplifier_module_tool_delegate`) is the
same pre-existing false positive already present on the neighboring,
untouched `test_delegate_call_budget.py` (confirmed directly) — `pytest`'s
own `pythonpath` setting resolves it at runtime; the 168-pass run above is
the real signal.

## Config (opt-in, no default behavior change)

```yaml
modules:
  tool-delegate:
    settings:
      max_spawns_per_session: 3  # optional; absent/null = unlimited (today's behavior)
```

## Drift / rebase note

Built against `amplifier-foundation@3a43b29`. `main` has since moved to
`4d22a3a` ("fix: preserve git source subdirectories") — confirmed that commit
does not touch `modules/tool-delegate/` at all (`git log
3a43b29..HEAD -- modules/tool-delegate/` is empty), so the patch applied
cleanly with `git apply`, zero fuzz, no manual rebase needed.

---
🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
