### PR TITLE
feat: guidance change — reject <example> blocks, behavior-first install convention, uv-not-pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Foundation provides:
 ## Quick Start
 
 ```bash
-pip install git+https://github.com/microsoft/amplifier-foundation
+uv pip install git+https://github.com/microsoft/amplifier-foundation
 ```
 
 ### Load, Compose, and Execute

--- a/context/shared/description-authoring-principles.md
+++ b/context/shared/description-authoring-principles.md
@@ -41,11 +41,23 @@ content masquerading as documentation, and cost tokens on every load.
 
 Every agent's `meta.description` is concatenated into the delegate tool's
 own description, which loads into context on **every turn**, not just when
-that agent is used. `<commentary>` blocks inside `<example>` blocks were
-validated for removal with no quality loss. Policy: **at most 2 examples**,
-**no `<commentary>` tags**, and any example that ships must reflect what the
-agent actually does today — an example is a claim about current behavior,
-and a stale one is V2's problem wearing a WHEN-to-delegate costume.
+that agent is used. Policy: **no `<example>` blocks at all**, in any
+description surface — agent `meta.description`, skill frontmatter
+`description`, mode `description`, or tool description strings. (Superseded:
+an earlier version of this policy allowed "at most 2 examples, no
+`<commentary>` tags" — the eval evidence below shows the cap was
+unnecessarily generous.)
+
+The P2 delegation-wave test (see "Settled" section below) stripped ALL
+`<example>` blocks and all `<commentary>` tags at assembly time — delegate
+description dropped from 14,562 → 8,060 chars — with **no reduction in
+delegation quality** across both providers tested. Full removal costs
+nothing measurable in quality and saves real per-turn tokens on every
+session that has the agent in its catalog, whether or not it's ever
+delegated to. If a trigger condition needs to reach the model, state it as a
+decision rule in the WHEN clause (V6) — a worked dialogue example is not
+required to communicate it, and a stale one is V2's problem wearing a
+WHEN-to-delegate costume.
 
 ## V4 — Delegation-pushing scaffolding hurts modern models
 
@@ -117,14 +129,22 @@ or silently override.
 
 ## Example policy (all description surfaces)
 
-- **≤2 examples.** A third example is rarely teaching a new case — audit
-  whether it's actually a duplicate before adding it.
-- **No `<commentary>` tags.** The example itself should be self-explanatory;
-  if it needs a footnote explaining why it triggers the agent, the trigger
-  condition belongs in the WHEN clause, not in prose bolted onto the example.
-- **Examples must match shipped reality.** An example describing a
-  capability, tool, or workflow the artifact no longer has is stale content
-  (V2) — delete or update it, don't leave it as aspirational documentation.
+- **No `<example>` blocks.** Not "at most 2" — zero. Trigger conditions
+  belong in the WHEN clause as a decision rule (V6), not as a worked
+  dialogue example. An example block does not teach the model anything a
+  clear WHEN clause can't state directly, and it is paid on every turn
+  regardless of whether the agent is ever delegated to.
+- **No `<commentary>` tags.** Subsumed by the no-examples rule (commentary
+  only ever appeared inside example blocks) — stated separately because a
+  stray `<commentary>` tag outside an example block is still a defect.
+- **If a worked example is genuinely useful for human authors** (teaching a
+  new bundle author how to phrase a description, say), it belongs in a body
+  doc — AGENT_AUTHORING.md, a README, or the artifact's own markdown body —
+  never in the `description` field itself. The description field is
+  metadata sent to the model every turn; a doc file is read on demand.
+- **Any example still present in a shipped description is stale content**
+  (V2), whether or not it matches current behavior — delete it, don't
+  archive it in place.
 
 ## Staleness and deletion
 

--- a/docs/AGENT_AUTHORING.md
+++ b/docs/AGENT_AUTHORING.md
@@ -36,11 +36,14 @@ bundle:                        meta:
 
 ### What Makes a Good Description
 
-Answer three questions:
+Answer two questions:
 1. **WHAT** does it do? (Core capability)
 2. **WHEN** should I delegate to it? (The deciding factor -- see
    description-authoring-principles.md V6 for phrasing)
-3. **HOW** do I invoke it? (≤2 examples)
+
+No third "HOW do I invoke it" question -- `<example>` blocks are rejected
+entirely (description-authoring-principles.md V3). A clear WHEN clause
+carries the trigger condition; no worked dialogue example is needed.
 
 ### Pattern
 
@@ -51,30 +54,23 @@ meta:
     [WHAT it does - core capability in 1-2 sentences]. [WHEN to delegate -
     the deciding factor, not a bare imperative -- see
     description-authoring-principles.md V6].
-
-    <example>
-    user: '[Example user request]'
-    assistant: 'I'll use my-agent to [action].'
-    </example>
 ```
 
 See `context/shared/description-authoring-principles.md` for trigger
-phrasing (decision rules over bare absolutes), the example cap (≤2, no
-`<commentary>`), and the token budget.
+phrasing (decision rules over bare absolutes), the example policy (no
+`<example>` blocks, no `<commentary>`), and the token budget.
 
 ### Real Example
 
-Matches the currently shipped `agents/bug-hunter.md` description:
+Illustrates the target shape under the current policy (no `<example>`
+block):
 
 ```yaml
 meta:
   name: bug-hunter
   description: "Specialized debugging expert focused on finding and fixing
-    bugs systematically. Use PROACTIVELY. It MUST BE USED when user has
-    reported or you are encountering errors, unexpected behavior, or test
-    failures. Examples: <example>user: 'The synthesis pipeline is throwing
-    a KeyError somewhere' assistant: 'I'll use the bug-hunter agent to
-    systematically track down and fix this KeyError.'</example>"
+    bugs systematically. Use when the user has reported or you are
+    encountering errors, unexpected behavior, or test failures."
 ```
 
 ### Anti-Patterns
@@ -84,20 +80,21 @@ meta:
 meta:
   description: "Helps with code stuff"
 
-# ❌ No examples - callers have to guess
+# ❌ <example> block - banned entirely, not just capped
 meta:
-  description: "Analyzes code for quality issues"
+  description: |
+    Analyzes code for quality issues.
 
-# ✅ Clear capability + trigger + example
+    <example>
+    user: 'Review this PR'
+    assistant: 'I'll use the reviewer agent.'
+    </example>
+
+# ✅ Clear capability + trigger, no example
 meta:
   description: |
     Systematic debugging with hypothesis-driven root cause analysis.
     Use when user reports errors, unexpected behavior, or test failures.
-
-    <example>
-    user: 'The build is failing'
-    assistant: 'I'll use bug-hunter to investigate.'
-    </example>
 ```
 
 ---
@@ -111,7 +108,7 @@ decide which agent to use.
 **How to write it is governed by the canonical
 [description-authoring-principles.md](../context/shared/description-authoring-principles.md)**
 -- trigger phrasing (decision rules over bare absolutes), the example policy
-(≤2 examples, no `<commentary>`), staleness/deletion, and provider
+(no `<example>` blocks, no `<commentary>`), staleness/deletion, and provider
 disposition all live there and are not restated here.
 
 ### Required Elements
@@ -129,10 +126,12 @@ The condition that should cause delegation, phrased as a decision rule
 Domain terms this agent owns, so questions in that domain route here.
 Pattern: `**Authoritative on:** term1, term2, "multi-word concept"`
 
-#### 4. Examples
-Up to 2 `<example>` blocks (no `<commentary>`) showing a real request and
-the resulting delegation. Each example must reflect what the agent
-actually does today.
+#### 4. Examples -- Not Permitted
+`<example>` blocks are rejected entirely (description-authoring-
+principles.md V3) -- do not add one. If a worked example is genuinely
+useful for a human reading the docs, put it in a body doc (this guide, a
+README, or the agent's own markdown body), never in the `description`
+field.
 
 ### Template
 
@@ -145,11 +144,6 @@ meta:
     Use when [the deciding factor -- context shape, not a bare imperative].
 
     **Authoritative on:** [comma-separated domain terms/keywords]
-
-    <example>
-    user: '[Example user request]'
-    assistant: 'I'll delegate to [agent] because [reason].'
-    </example>
 ```
 
 ### Anti-Patterns
@@ -157,10 +151,8 @@ meta:
 ❌ One-liner descriptions: `"Helps with debugging"`
 ❌ No indication of WHEN to delegate
 ❌ No taxonomy terms: LLM can't match domain questions
-❌ No examples: LLM doesn't learn delegation patterns
-❌ More than 2 examples, or any `<commentary>` tag
-❌ An example describing a capability the agent no longer has (stale --
-see description-authoring-principles.md V2)
+❌ Any `<example>` block, or any `<commentary>` tag -- both are banned
+entirely (description-authoring-principles.md V3), not merely capped
 
 ### Description Token Budget
 
@@ -467,7 +459,9 @@ Only put a file in behavior `context.include` if you can clearly defend "this mu
 ## Common Mistakes
 
 ### 1. Vague Description
-Callers don't know when to use the agent. Add activation triggers and examples.
+Callers don't know when to use the agent. Add a concrete WHEN clause
+(decision rule, not a worked example -- `<example>` blocks are rejected
+entirely, see description-authoring-principles.md V3).
 
 ### 2. Missing @mention Base
 Forgetting `@foundation:context/shared/common-agent-base.md` causes inconsistent behavior.

--- a/docs/BUNDLE_GUIDE.md
+++ b/docs/BUNDLE_GUIDE.md
@@ -712,6 +712,54 @@ Create README.md documenting:
 - The architecture (thin bundle + behavior pattern)
 - How to load/use it
 
+#### Install-Instructions Convention
+
+If your README shows install commands, follow these conventions
+(enforced by `foundation:recipes/validate-bundle-repo.yaml`'s
+`readme_install_recommendation` and `tool_install_convention` checks):
+
+**Recommend a behavior over the root bundle, unless this repo's purpose
+is to produce root bundles for users.** Most bundle repos are capability
+providers, not root-bundle sources -- their README's PRIMARY install
+example should target the repo's own behavior:
+
+```bash
+amplifier bundle add "git+https://github.com/org/my-repo#subdirectory=behaviors/my-capability.yaml" --app
+```
+
+not the bare root bundle:
+
+```bash
+# Only lead with this if THIS repo's purpose is to ship ready-to-run root
+# bundles for end users -- uncommon. Most repos provide a capability
+# others compose onto their OWN bundle, via the behavior pattern above.
+amplifier bundle add "git+https://github.com/org/my-repo" --app
+```
+
+If your repo genuinely exists to produce root bundles for users, leading
+with the root-bundle install is correct -- just make it a deliberate
+choice, not the unexamined default.
+
+**Always include `--app` on install commands targeting the Amplifier
+CLI.** `--app` is what makes `amplifier bundle add <uri>` compose into an
+installed CLI's configuration; omitting it is the most common README
+defect this convention exists to catch.
+
+**Tool install commands: `uv tool install`, not `pip install`.** If your
+bundle also ships a standalone CLI (see [Bundle with Root Python
+Package](#root-python-package)), show:
+
+```bash
+uv tool install "git+https://github.com/org/my-repo"
+```
+
+Always show the `git+https://` form, even when the package is also
+published to PyPI -- PyPI is an *additional* convenience form, never a
+replacement for the git+https instructions (a consumer who hasn't waited
+for a PyPI release still needs a working install path). Libraries (not
+standalone CLI tools) use `uv pip install` in place of `pip install` --
+see the Quick Start examples above.
+
 ---
 
 ## Creating Tool Modules

--- a/docs/DOMAIN_VALIDATOR_GUIDE.md
+++ b/docs/DOMAIN_VALIDATOR_GUIDE.md
@@ -59,11 +59,15 @@ Every validator MUST define what "passing" means:
 # ✅ Description token budget respected (provisional WARN >300 / ERROR >600
 #   tokens -- see foundation:context/shared/description-authoring-principles.md V5)
 #
-# NOTE: MUST/ALWAYS/REQUIRED/PROACTIVELY keyword presence and <example> count
-# are reported as METRICS, not gates -- a measured eval campaign found
-# requiring them harmed compliant models (description-authoring-principles.md
-# V1, V3, V6). An earlier version of this example incorrectly required them;
-# see the PR that fixed validate-agents.yaml's own inverted thresholds.
+# NOTE: MUST/ALWAYS/REQUIRED/PROACTIVELY keyword presence is reported as a
+# METRIC, not a gate -- a measured eval campaign found requiring it harmed
+# compliant models (description-authoring-principles.md V1, V6). An earlier
+# version of this example incorrectly required it; see the PR that fixed
+# validate-agents.yaml's own inverted thresholds.
+#
+# <example> blocks, however, ARE a gate: any <example> (or <commentary>)
+# block in a description is an ERROR (description-authoring-principles.md
+# V3 -- examples are banned entirely, not merely capped at 2).
 ```
 
 ### Domain-Specific Thresholds
@@ -79,7 +83,9 @@ Different domains have different PASS criteria. What makes an agent "good" diffe
 ```yaml
 # Behavioral quality criteria
 - Has strong trigger (MUST, ALWAYS, REQUIRED, PROACTIVELY, DO NOT)
-- Has at least one <example> block
+  -- reported as a metric, not a gate (see NOTE above)
+- Has NO <example> or <commentary> blocks -- ERROR if present
+  (description-authoring-principles.md V3: examples are banned entirely)
 - Has explicit tools: section
 - Description ≥ 100 characters
 ```

--- a/experiments/bundle-configurator/README.md
+++ b/experiments/bundle-configurator/README.md
@@ -18,13 +18,13 @@ A few terms used throughout this README:
 ## Install
 
 ```bash
-pip install "git+https://github.com/microsoft/amplifier-foundation@feat/bundle-configurator-experiment#subdirectory=experiments/bundle-configurator"
+uv pip install "git+https://github.com/microsoft/amplifier-foundation@feat/bundle-configurator-experiment#subdirectory=experiments/bundle-configurator"
 ```
 
 After this branch is merged to main:
 
 ```bash
-pip install "git+https://github.com/microsoft/amplifier-foundation#subdirectory=experiments/bundle-configurator"
+uv pip install "git+https://github.com/microsoft/amplifier-foundation#subdirectory=experiments/bundle-configurator"
 ```
 
 ## Using This in an Amplifier Chat Session
@@ -182,7 +182,7 @@ Test coverage:
 
 ```bash
 # Install dependencies
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 
 # Unit tests only (fast, no network calls)
 pytest tests/ -k "not integration"

--- a/recipes/generate-bundle-docs.yaml
+++ b/recipes/generate-bundle-docs.yaml
@@ -46,7 +46,7 @@ steps:
           from amplifier_foundation.bundle_docs import bundle_repo_dot
       except ImportError:
           print(json.dumps({
-              "error": "amplifier_foundation not installed — pip install amplifier-foundation",
+              "error": "amplifier_foundation not installed — uv pip install amplifier-foundation",
               "bundle_dot": "",
               "needs_regen": False,
           }))

--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -1,8 +1,31 @@
 # validate-agents.yaml
-# Agent Definition Validator Recipe v1.3.1
+# Agent Definition Validator Recipe v1.4.0
 # Validates agent definitions in a bundle repository for quality, tool access, and structural requirements
 #
 # CHANGELOG:
+# v1.4.0 - Example-policy tightening: <example> blocks REJECTED ENTIRELY
+#        - Guidance changed from "at most 2 examples, no <commentary>" to
+#          "no <example> blocks at all" (foundation:context/shared/
+#          description-authoring-principles.md V3). The eval evidence
+#          (P2 delegation wave: stripping ALL examples + commentary did
+#          not reduce delegation quality) supports full removal, not just
+#          a cap.
+#        - Any <example> block in meta.description is now a structural
+#          ERROR (was: only >2 blocks warned). New code EXAMPLE_BLOCK_PRESENT.
+#        - <commentary> tag presence is now ERROR (was WARNING) --
+#          consistency: it only ever occurs inside a now-banned example.
+#        - Removed the EXAMPLES_MISSING_CONTEXT / TOO_MANY_EXAMPLES checks
+#          (moot once examples are banned outright, not merely capped).
+#        - Both new/changed ERRORs feed into the existing has_errors ->
+#          "critical" classification path -- no classify_agent changes
+#          needed, the severity mapping already treats any ERROR as
+#          critical.
+#        - Description Quality (Phase 4) prompt updated to stop treating
+#          "1-2 examples, no commentary" as a target shape, and to note
+#          example/commentary presence is now caught deterministically in
+#          Phase 2 (structural-validation), not judged by the LLM.
+#        - Report synthesis (Phase 6) severity guide and metadata updated
+#          to match.
 # v1.3.1 - BUG 2(i) fix: honor the injected AMPLIFIER_PYTHON interpreter
 #          (NOTE: patch bump of the authoritative `version:` field, which was
 #          already at 1.3.0 — ahead of this changelog's prior 1.2.x entries,
@@ -47,17 +70,20 @@
 #
 # PASS THRESHOLDS (explicit criteria for "good enough"):
 # - No structural errors (valid YAML, has meta.name, meta.description)
+# - No <example> or <commentary> blocks in the description (v1.4.0: ERROR --
+#   description-authoring-principles.md V3 bans them entirely, not just >2)
 # - Has explicit tools section (even if empty [])
 # - Description >= 100 characters
 # - Description token budget respected (provisional: WARN >300 tok,
 #   ERROR >600 tok -- see foundation:context/shared/
 #   description-authoring-principles.md V5)
 #
-# NOTE: presence of MUST/ALWAYS/REQUIRED/PROACTIVELY keywords and
-# <example> blocks are reported as METRICS, not pass/fail gates. A
-# measured eval campaign found these keywords/examples do not by
-# themselves indicate quality, and requiring them measurably harmed
-# compliant models (see description-authoring-principles.md V1, V3, V6).
+# NOTE: presence of MUST/ALWAYS/REQUIRED/PROACTIVELY keywords is reported
+# as a METRIC, not a pass/fail gate. A measured eval campaign found these
+# keywords do not by themselves indicate quality, and requiring them
+# measurably harmed compliant models (see description-authoring-
+# principles.md V1, V6). <example>/<commentary> blocks, by contrast, ARE a
+# gate as of v1.4.0 -- see PASS THRESHOLDS above and V3.
 #
 # Usage:
 #   amplifier tool invoke recipes operation=execute \
@@ -68,9 +94,10 @@ name: validate-agents
 description: |
   Validates Amplifier agent definitions in a bundle repository against:
   
-  - **Structural Requirements** (ERROR): Valid YAML frontmatter, required meta fields
+  - **Structural Requirements** (ERROR): Valid YAML frontmatter, required meta fields,
+    no `<example>`/`<commentary>` blocks in the description (v1.4.0)
   - **Tool Access** (WARNING): Explicit tools section, appropriate tools for role
-  - **Description Quality** (SUGGESTION): Activation triggers, examples, WHY/WHEN/WHAT guidance
+  - **Description Quality** (SUGGESTION): Activation triggers, WHY/WHEN/WHAT guidance
   
   Produces a validation report with findings categorized by severity and actionable remediation.
   
@@ -120,7 +147,7 @@ steps:
           results["errors"].append({
               "type": "import_error",
               "message": "PyYAML not available - required for parsing agent frontmatter",
-              "suggestion": "pip install pyyaml"
+              "suggestion": "uv pip install pyyaml"
           })
 
       # Check repo path exists
@@ -556,43 +583,35 @@ steps:
                   "remediation": "Expand description to explain WHAT the agent does and WHEN to delegate to it"
               })
 
-          # Check for <commentary> tags -- validated for removal with no
-          # quality loss (description-authoring-principles.md V3). WARNING,
-          # not ERROR: existing agents carrying these still load fine.
+          # Check for <commentary> tags -- v1.4.0: ERROR, not WARNING.
+          # <commentary> only ever occurs inside an <example> block, and
+          # example blocks are now rejected entirely (see below), so this
+          # is treated with the same severity for consistency.
           result["commentary_count"] = description.lower().count("<commentary>") if description else 0
           if result["commentary_count"] > 0:
-              result["warnings"].append({
-                  "severity": "WARNING",
+              result["errors"].append({
+                  "severity": "ERROR",
                   "code": "COMMENTARY_TAG_PRESENT",
-                  "message": f"Description contains {result['commentary_count']} <commentary> tag(s) -- validated for removal with no quality loss",
-                  "remediation": "Delete <commentary> tags; the example itself should be self-explanatory (see description-authoring-principles.md V3)"
+                  "message": f"Description contains {result['commentary_count']} <commentary> tag(s) -- <commentary> tags are rejected entirely",
+                  "remediation": "Delete <commentary> tags (and the <example> block containing them -- see description-authoring-principles.md V3)"
               })
 
-          # Check if examples have Context labels (quality check)
+          # Check for <example> blocks -- v1.4.0: REJECTED ENTIRELY, not
+          # merely capped at 2. description-authoring-principles.md V3: the
+          # eval evidence (P2 delegation wave) showed removing ALL examples
+          # does not reduce delegation quality, so any occurrence is now a
+          # structural ERROR, not a metric.
           if result["has_examples"]:
               example_blocks = re.findall(r'<example>(.*?)</example>', description, re.DOTALL | re.IGNORECASE)
-              examples_with_context = sum(1 for ex in example_blocks if 'Context:' in ex or 'context:' in ex)
               result["example_count"] = len(example_blocks)
-              result["examples_with_context"] = examples_with_context
-              
-              if example_blocks and examples_with_context < len(example_blocks):
-                  result["warnings"].append({
-                      "severity": "WARNING",
-                      "code": "EXAMPLES_MISSING_CONTEXT",
-                      "message": f"Only {examples_with_context}/{len(example_blocks)} examples have 'Context:' labels",
-                      "remediation": "Add 'Context: [situation]' line at start of each <example> block to help LLM understand when to match"
-                  })
-
-              if len(example_blocks) > 2:
-                  result["warnings"].append({
-                      "severity": "WARNING",
-                      "code": "TOO_MANY_EXAMPLES",
-                      "message": f"Description has {len(example_blocks)} <example> blocks (>2) -- validated cap is 2",
-                      "remediation": "Trim to at most 2 examples (description-authoring-principles.md V3)"
-                  })
+              result["errors"].append({
+                  "severity": "ERROR",
+                  "code": "EXAMPLE_BLOCK_PRESENT",
+                  "message": f"Description has {len(example_blocks)} <example> block(s) -- example blocks are rejected entirely, not merely capped",
+                  "remediation": "Delete all <example> blocks. State the trigger condition as a decision rule in the WHEN clause instead (description-authoring-principles.md V6). If a worked example is genuinely useful for human authors, put it in a body doc, not the description field (see V3)."
+              })
           else:
               result["example_count"] = 0
-              result["examples_with_context"] = 0
 
           # Check whether the body (below frontmatter) reads as instruction, not
           # documentation -- everything below frontmatter is sent to the model
@@ -676,12 +695,18 @@ steps:
       # 4. Description token budget respected (provisional: WARN >300 tok,
       #    ERROR >600 tok -- description-authoring-principles.md V5)
       #
-      # has_strong_trigger / has_examples / commentary_count /
-      # absolute_keyword_count are reported as METRICS below, not gates.
-      # A measured eval campaign found these do not by themselves indicate
-      # quality, and requiring them measurably harmed compliant models
-      # (see foundation:context/shared/description-authoring-principles.md
-      # V1, V3, V6). Do not reintroduce them as pass/fail criteria.
+      # has_strong_trigger / absolute_keyword_count are reported as METRICS
+      # below, not gates. A measured eval campaign found these do not by
+      # themselves indicate quality, and requiring them measurably harmed
+      # compliant models (see foundation:context/shared/
+      # description-authoring-principles.md V1, V6). Do not reintroduce
+      # them as pass/fail criteria.
+      #
+      # has_examples / commentary_count, by contrast, ARE gates as of
+      # v1.4.0: any <example>/<commentary> in the description is a
+      # structural ERROR (see structural-validation above), which already
+      # routes through has_errors -> "critical" below -- no separate
+      # classify_agent branch needed for them.
 
       # Provisional token thresholds (see description-authoring-principles.md V5)
       DESCRIPTION_TOKEN_WARN = 300
@@ -963,9 +988,14 @@ steps:
       **`foundation:context/shared/description-authoring-principles.md`** --
       this prompt does not restate it. In summary: trigger phrasing should
       state the deciding factor (a decision rule), not lean on bare
-      imperatives; examples are capped at 2 with no `<commentary>` tags;
-      stale examples (describing a capability the agent no longer has) are
-      a defect.
+      imperatives; `<example>`/`<commentary>` blocks are rejected entirely
+      (not merely capped -- see V3).
+
+      **Note on examples/commentary:** `<example>` and `<commentary>`
+      presence is already caught as a structural ERROR by Phase 2
+      (structural-validation), deterministically, before this LLM phase
+      ever runs. Do not re-judge it here -- this phase is about the WHEN
+      clause and WHAT/WHEN guidance only.
 
       **What is NOT an Issue (do not flag these):**
       - Whether the description happens to use MUST/ALWAYS/REQUIRED/
@@ -975,16 +1005,11 @@ steps:
       - Reasonable alternative approaches to documentation
       - "Could be slightly better" items for agents that meet thresholds
       - Personal preferences about wording or structure
-      - Exactly 1-2 examples with no `<commentary>` -- this is the target
-        shape, not a gap
+      - Absence of examples -- this is the required shape, not a gap
 
       **Only flag genuine issues:**
       - A WHEN clause that gives no deciding factor at all (not "weak
         phrasing" -- literally no signal for when to delegate)
-      - Complete absence of examples in agents that need them
-      - More than 2 examples, or any `<commentary>` tag (see V3)
-      - An example describing a capability the agent no longer has (stale,
-        see V2)
       - Critical missing guidance that would confuse users
 
       **Quality Criteria to Check (for agents needing work only):**
@@ -997,12 +1022,7 @@ steps:
       supporting context? See description-authoring-principles.md V6 for
       the before/after example.
 
-      ### 2. Example Blocks (SUGGESTION if missing, or if >2/has <commentary>)
-
-      Check: Does the description have 1-2 `<example>` blocks, with no
-      `<commentary>` tags, that reflect what the agent actually does today?
-
-      ### 3. WHAT/WHEN Guidance (SUGGESTION if incomplete)
+      ### 2. WHAT/WHEN Guidance (SUGGESTION if incomplete)
 
       Good descriptions answer:
       - **WHAT**: What does this agent do? What are its capabilities?
@@ -1259,18 +1279,20 @@ steps:
 
       ## Metadata
       - **Validated**: [timestamp]
-      - **Recipe**: validate-agents v1.3.0
+      - **Recipe**: validate-agents v1.4.0
       - **Quality Thresholds**: see
         `foundation:context/shared/description-authoring-principles.md`
-        (canonical -- not restated here). Gates: no structural errors,
+        (canonical -- not restated here). Gates: no structural errors
+        (including any `<example>`/`<commentary>` block in the
+        description -- rejected entirely per V3, not merely capped),
         explicit tools section, description >= 100 chars, description
         token budget (provisional WARN >300 / ERROR >600 tok).
-        MUST/ALWAYS/REQUIRED/PROACTIVELY keyword presence and <example>
-        count are reported as metrics, not gates.
+        MUST/ALWAYS/REQUIRED/PROACTIVELY keyword presence is reported as
+        a metric, not a gate.
       - **Severity Guide**:
-        - ERROR (critical): Invalid YAML, missing required fields (will break)
+        - ERROR (critical): Invalid YAML, missing required fields, or any `<example>`/`<commentary>` block in the description (will break, or is rejected per V3)
         - WARNING (needs_work): No explicit tools, relying on inheritance, or description over budget (may break or bloat every session)
-        - SUGGESTION (polish): Missing WHEN deciding factor, missing examples, >2 examples, or <commentary> tags present (quality improvement)
+        - SUGGESTION (polish): Missing WHEN deciding factor (quality improvement)
 
       Make the report actionable with clear next steps and concrete examples.
       

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -1,9 +1,40 @@
 # validate-bundle-repo.yaml
-# Repository-Wide Bundle Validator Recipe v3.9.0
+# Repository-Wide Bundle Validator Recipe v3.10.0
 # Validates an entire bundle repository against structural requirements, conventions,
 # and Amplifier bundle philosophy (context sink pattern, thin behaviors, tool placement)
 #
 # CHANGELOG:
+# v3.10.0 - Example-policy tightening + NEW README install-convention checks
+#        - Phase 2.8 (agent description budget): <example> and <commentary>
+#          presence are now ERROR (was WARNING at >2 examples / any
+#          commentary). description-authoring-principles.md V3: examples
+#          are rejected entirely, not merely capped -- the eval evidence
+#          (P2 delegation wave) showed removing ALL examples does not
+#          reduce delegation quality. New/renamed codes:
+#          example_block_present (was too_many_examples), commentary_present
+#          (severity changed WARNING -> ERROR).
+#        - NEW PHASE 2.85: readme-install-convention-check. Two deterministic
+#          checks against the root README.md:
+#          Check A (readme_install_recommendation): the PRIMARY
+#          `amplifier bundle add` command should target a behavior
+#          (#subdirectory=behaviors/<name>.yaml), not the bare root bundle,
+#          unless context var root_bundle_repo: "true" (repo's own purpose
+#          is to ship root bundles for users). Findings:
+#          readme_recommends_root_bundle, readme_missing_app_flag (both
+#          severity needs_work).
+#          Check B (tool_install_convention): bare `pip install` in
+#          README.md instructional text is readme_pip_install (needs_work);
+#          docs/*.md are scanned at INFO level only (docs_pip_install). A
+#          repo shipping a CLI ([project.scripts] in pyproject.toml) with
+#          an install command but no git+https:// form anywhere is
+#          readme_missing_git_install (needs_work).
+#          No README, or a README with no bundle-add commands, is INFO
+#          only (no_readme, no_bundle_add_commands) -- not a defect.
+#        - quality-classification incorporates readme_convention_issues
+#          (severity "needs_work", counted like structural_issues, not
+#          ERROR/WARNING like the other v3.x checks)
+#        - synthesize-report includes README Install-Instructions
+#          Convention Check section
 # v3.9.0 - BUG 2 fix (interpreter injection) + NEW composable-surface check
 #        - BUG 2(i) (CRITICAL FIX): all 24 python3 heredocs used a BARE `python3`,
 #          ignoring the AMPLIFIER_PYTHON interpreter the executor injects into
@@ -226,6 +257,7 @@ description: |
   - **NEW in v3.5.0:** Behavior name collision detection (behavior vs root bundle name)
   - **NEW in v3.6.0:** Mode description token budget validation (WARNING >500, ERROR >800 tokens)
   - **NEW in v3.6.0:** Mode advertising-rule enforcement (unadvertised modes must not be named in agent-readable files)
+  - **NEW in v3.10.0:** README install-instructions convention (behavior-over-root recommendation, `--app` flag, `uv tool install`/`uv pip install` over bare `pip install`, git+https availability for shipped CLIs)
   - Deterministic quality classification with explicit PASS thresholds
   - Quick-approval path for clean repos (no unnecessary LLM analysis)
   - Repository composition analysis (do pieces fit together correctly?)
@@ -250,10 +282,10 @@ description: |
       context='{"repo_path": "/path/to/repo"}'
   ```
   
-  Or install directly (if pip works):
+  Or install directly with uv:
   ```bash
-  pip install hatchling
-  pip install git+https://github.com/microsoft/amplifier-foundation@main
+  uv pip install hatchling
+  uv pip install git+https://github.com/microsoft/amplifier-foundation@main
   ```
   
   **v3.1.0 Enhancements:**
@@ -269,7 +301,7 @@ description: |
   - All measurements use TOKENS (len/4), never line counts
   
   For single bundle validation, use validate-bundle.yaml instead.
-version: "3.9.0"
+version: "3.10.0"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "repository", "packaging", "hygiene", "context-sink"]
 
@@ -281,6 +313,9 @@ context:
   recipes_dir: "recipes"  # Optional: Subdirectory containing recipes (default: 'recipes')
   known_agents: ""  # Optional: JSON list of known external namespace:agent patterns for recipe validation
   enhance_diagrams: "true"  # Optional: LLM-enhanced DOT labels (true/false, default: true)
+  root_bundle_repo: "false"  # Optional (v3.10.0): set "true" if this repo's own purpose is to
+    # produce root bundles for users (uncommon) -- suppresses the
+    # readme_recommends_root_bundle finding
 
 steps:
   # ============================================================================
@@ -364,28 +399,30 @@ steps:
               "pep668": []
           }
           
-          # Standard pip commands (in correct order)
+          # Standard uv pip commands (in correct order)
           if not hatchling_available:
-              results["install_instructions"]["standard"].append("pip install hatchling")
+              results["install_instructions"]["standard"].append("uv pip install hatchling")
           if not foundation_available:
               results["install_instructions"]["standard"].append(
-                  "pip install git+https://github.com/microsoft/amplifier-core@main"
+                  "uv pip install git+https://github.com/microsoft/amplifier-core@main"
               )
               results["install_instructions"]["standard"].append(
-                  "pip install git+https://github.com/microsoft/amplifier-foundation@main"
+                  "uv pip install git+https://github.com/microsoft/amplifier-foundation@main"
               )
           
-          # PEP 668 commands (with --break-system-packages)
+          # PEP 668 commands (uv's --system flag targets the externally-managed
+          # interpreter directly; unlike bare pip, uv does not need
+          # --break-system-packages for this)
           if not hatchling_available:
               results["install_instructions"]["pep668"].append(
-                  "pip install --break-system-packages hatchling"
+                  "uv pip install --system hatchling"
               )
           if not foundation_available:
               results["install_instructions"]["pep668"].append(
-                  "pip install --break-system-packages git+https://github.com/microsoft/amplifier-core@main"
+                  "uv pip install --system git+https://github.com/microsoft/amplifier-core@main"
               )
               results["install_instructions"]["pep668"].append(
-                  "pip install --break-system-packages git+https://github.com/microsoft/amplifier-foundation@main"
+                  "uv pip install --system git+https://github.com/microsoft/amplifier-foundation@main"
               )
 
       # Check 3: pip wheel capability
@@ -628,7 +665,7 @@ steps:
               "type": "build_tools_unavailable",
               "message": "Build check skipped: hatchling not installed",
               "severity": "INFO",
-              "suggestion": "Install hatchling for full build validation: pip install hatchling"
+              "suggestion": "Install hatchling for full build validation: uv pip install hatchling"
           })
           result["environment_limitation"] = True
           print(json.dumps(result))
@@ -3059,32 +3096,44 @@ steps:
               })
               detail["issues"].append("agent_description_high")
 
+          # v3.10.0: <commentary> presence is now ERROR, not WARNING --
+          # consistency with <example> below (commentary only ever occurs
+          # inside a now-banned example block).
           commentary_count = description.lower().count("<commentary>") if description else 0
           detail["commentary_count"] = commentary_count
           if commentary_count > 0:
-              results["warnings"].append({
+              results["errors"].append({
                   "type": "commentary_present",
                   "file": rel_path,
-                  "severity": "WARNING",
-                  "message": f"{rel_path}: description has {commentary_count} <commentary> tag(s)",
+                  "severity": "ERROR",
+                  "message": f"{rel_path}: description has {commentary_count} <commentary> tag(s) -- rejected entirely",
                   "fix": (
-                      "Delete <commentary> tags -- validated for removal with no "
-                      "quality loss. See description-authoring-principles.md V3."
+                      "Delete <commentary> tags (and the <example> block containing "
+                      "them). See description-authoring-principles.md V3."
                   )
               })
               detail["issues"].append("commentary_present")
 
+          # v3.10.0: ANY <example> block is now ERROR (was WARNING at >2).
+          # description-authoring-principles.md V3: examples are rejected
+          # entirely, not merely capped -- the eval evidence (P2 delegation
+          # wave) showed removing ALL examples does not reduce delegation
+          # quality.
           example_count = len(re.findall(r'<example>', description, re.IGNORECASE)) if description else 0
           detail["example_count"] = example_count
-          if example_count > 2:
-              results["warnings"].append({
-                  "type": "too_many_examples",
+          if example_count > 0:
+              results["errors"].append({
+                  "type": "example_block_present",
                   "file": rel_path,
-                  "severity": "WARNING",
-                  "message": f"{rel_path}: description has {example_count} <example> blocks (>2)",
-                  "fix": "Trim to at most 2 examples. See description-authoring-principles.md V3."
+                  "severity": "ERROR",
+                  "message": f"{rel_path}: description has {example_count} <example> block(s) -- example blocks are rejected entirely, not merely capped",
+                  "fix": (
+                      "Delete all <example> blocks. State the trigger condition as "
+                      "a decision rule in the WHEN clause instead (V6). See "
+                      "description-authoring-principles.md V3."
+                  )
               })
-              detail["issues"].append("too_many_examples")
+              detail["issues"].append("example_block_present")
 
           results["agent_details"].append(detail)
 
@@ -3100,6 +3149,182 @@ steps:
     output: "agent_description_validation_results"
     parse_json: true
     timeout: 120
+    on_error: "continue"
+    depends_on: ["repo-discovery"]
+
+  # ============================================================================
+  # PHASE 2.85: README Install-Instructions Convention Check (v3.10.0)
+  #
+  # Scans the ROOT README.md for two conventions:
+  #
+  # Check A -- readme_install_recommendation:
+  #   The PRIMARY `amplifier bundle add` command should target a behavior
+  #   (`#subdirectory=behaviors/<name>.yaml`), not the bare root bundle --
+  #   UNLESS this repo's own purpose is to produce root bundles for users
+  #   (uncommon; set context var root_bundle_repo: "true" to suppress).
+  #   Every `amplifier bundle add` command should include --app.
+  #   Findings: readme_recommends_root_bundle, readme_missing_app_flag
+  #   (both severity needs_work).
+  #
+  # Check B -- tool_install_convention:
+  #   `pip install` in README.md instructional text is a needs_work finding
+  #   (readme_pip_install) -- should be `uv tool install git+https://...`
+  #   for CLI tools, or `uv pip install` for libraries. docs/*.md are
+  #   scanned too, but only at INFO level (docs_pip_install). A repo that
+  #   ships a CLI ([project.scripts] in pyproject.toml) and shows an
+  #   install command but no git+https:// form anywhere is
+  #   readme_missing_git_install (needs_work) -- pypi MAY be offered in
+  #   addition to git+https, never as a replacement for it.
+  #
+  # No README, or a README with no `amplifier bundle add` commands at all,
+  # is reported at INFO level only -- absence of install docs is not
+  # itself the defect this check exists to catch.
+  # ============================================================================
+
+  - id: "readme-install-convention-check"
+    type: "bash"
+    command: |
+      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
+      import json
+      import re
+      from pathlib import Path
+
+      repo_path = "{{repo_path}}"
+      root_bundle_repo = "{{root_bundle_repo}}".strip().lower() == "true"
+      path = Path(repo_path).resolve()
+
+      results = {
+          "phase": "readme_install_convention",
+          "skipped": False,
+          "root_bundle_repo": root_bundle_repo,
+          "errors": [],
+          "warnings": [],
+          "info": []
+      }
+
+      readme_path = path / "README.md"
+      readme_text = ""
+      if not readme_path.exists():
+          results["skipped"] = True
+          results["info"].append({
+              "type": "no_readme",
+              "message": "No root README.md found -- install-instructions convention check skipped.",
+              "severity": "INFO"
+          })
+      else:
+          try:
+              readme_text = readme_path.read_text(encoding="utf-8", errors="replace")
+          except Exception as exc:
+              results["skipped"] = True
+              results["info"].append({
+                  "type": "readme_unreadable",
+                  "message": f"Could not read README.md: {exc}",
+                  "severity": "INFO"
+              })
+
+      # `amplifier bundle add <uri> [flags]` -- capture the URI and the rest
+      # of the line (where --app would appear).
+      bundle_add_pattern = re.compile(
+          r'amplifier\s+bundle\s+add\s+["\']?([^\s"\'`]+)["\']?([^\n]*)',
+          re.IGNORECASE
+      )
+      bundle_add_matches = list(bundle_add_pattern.finditer(readme_text)) if readme_text else []
+
+      if readme_text and not bundle_add_matches:
+          results["info"].append({
+              "type": "no_bundle_add_commands",
+              "message": "README.md has no `amplifier bundle add` commands -- nothing to evaluate for the install-recommendation check.",
+              "severity": "INFO"
+          })
+      elif bundle_add_matches:
+          first_uri, first_rest = bundle_add_matches[0].group(1), bundle_add_matches[0].group(2)
+          recommends_root = (
+              "#subdirectory=behaviors/" not in first_uri
+              and "#subdirectory=behaviors/" not in first_rest
+          )
+          if recommends_root and not root_bundle_repo:
+              results["warnings"].append({
+                  "type": "readme_recommends_root_bundle",
+                  "severity": "needs_work",
+                  "message": (
+                      "README.md's primary `amplifier bundle add` command installs "
+                      "the root bundle, not a behavior. Most repos are capability "
+                      "providers -- lead with `amplifier bundle add "
+                      "\"<repo>#subdirectory=behaviors/<name>.yaml\" --app` instead, "
+                      "unless this repo's own purpose IS to produce root bundles for "
+                      "users."
+                  ),
+                  "fix": "Recommend a behaviors/<name>.yaml install as the primary path, or set context var root_bundle_repo: \"true\" if this repo genuinely ships root bundles for users."
+              })
+
+          missing_app = [m.group(0) for m in bundle_add_matches if "--app" not in m.group(2)]
+          if missing_app:
+              results["warnings"].append({
+                  "type": "readme_missing_app_flag",
+                  "severity": "needs_work",
+                  "message": f"{len(missing_app)}/{len(bundle_add_matches)} `amplifier bundle add` command(s) in README.md are missing the --app flag.",
+                  "fix": "Add --app to every `amplifier bundle add` command shown in README.md."
+              })
+
+      if readme_text:
+          pip_install_count = len(re.findall(r'(?<!uv )pip install', readme_text))
+          if pip_install_count:
+              results["warnings"].append({
+                  "type": "readme_pip_install",
+                  "severity": "needs_work",
+                  "message": f"README.md shows `pip install` {pip_install_count} time(s) in instructional text.",
+                  "fix": "Use `uv tool install git+https://...` for CLI tools, or `uv pip install` for libraries, instead of bare `pip install`."
+              })
+
+          docs_dir = path / "docs"
+          if docs_dir.is_dir():
+              doc_pip_hits = []
+              for doc_file in sorted(docs_dir.rglob("*.md")):
+                  try:
+                      doc_text = doc_file.read_text(encoding="utf-8", errors="replace")
+                  except Exception:
+                      continue
+                  if re.search(r'(?<!uv )pip install', doc_text):
+                      doc_pip_hits.append(str(doc_file.relative_to(path)))
+              if doc_pip_hits:
+                  results["info"].append({
+                      "type": "docs_pip_install",
+                      "message": f"{len(doc_pip_hits)} doc file(s) under docs/ show `pip install`: {', '.join(doc_pip_hits[:10])}",
+                      "severity": "INFO"
+                  })
+
+          pyproject_path = path / "pyproject.toml"
+          ships_cli = False
+          if pyproject_path.exists():
+              try:
+                  ships_cli = "[project.scripts]" in pyproject_path.read_text(encoding="utf-8", errors="replace")
+              except Exception:
+                  ships_cli = False
+
+          has_install_command = bool(re.search(r'(uv tool install|uv pip install|pip install)', readme_text))
+          has_git_install = "git+https://" in readme_text
+
+          if ships_cli and has_install_command and not has_git_install:
+              results["warnings"].append({
+                  "type": "readme_missing_git_install",
+                  "severity": "needs_work",
+                  "message": "Repo ships a CLI ([project.scripts] in pyproject.toml) and README.md shows an install command, but no git+https:// form is shown anywhere.",
+                  "fix": "Always show a `uv tool install git+https://...` form, even when the package is also on PyPI -- PyPI is an additional convenience form, never a replacement."
+              })
+
+      results["passed"] = len(results["errors"]) == 0
+      results["summary"] = {
+          "bundle_add_commands_found": len(bundle_add_matches),
+          "warnings": len(results["warnings"]),
+          "errors": len(results["errors"]),
+          "info": len(results["info"])
+      }
+
+      print(json.dumps(results))
+      EOF
+    output: "readme_install_convention_results"
+    parse_json: true
+    timeout: 60
     on_error: "continue"
     depends_on: ["repo-discovery"]
 
@@ -3327,6 +3552,13 @@ steps:
       except (json.JSONDecodeError, ValueError):
           agent_description_validation = {"passed": True, "skipped": True, "errors": [], "warnings": []}
 
+      # v3.10.0: Parse README install-instructions convention check results
+      readme_convention_raw = '''{{readme_install_convention_results}}'''
+      try:
+          readme_convention = json.loads(readme_convention_raw)
+      except (json.JSONDecodeError, ValueError):
+          readme_convention = {"passed": True, "skipped": True, "errors": [], "warnings": [], "info": []}
+
       # Handle case where individual validation was skipped
       if individual.get("skipped", False):
           # v3.2.0: Check if this is an environment limitation (not a bundle problem)
@@ -3442,6 +3674,7 @@ steps:
               "mode_validation_issues": [],  # v3.6.0
               "body_instruction_issues": [],  # v3.7.0
               "agent_description_issues": [],  # Phase 2.8
+              "readme_convention_issues": [],  # v3.10.0
               # v3.2.0: Environment status tracking
               "environment_status": {
                   "validation_mode": env_check.get("validation_mode", "unknown"),
@@ -3676,6 +3909,25 @@ steps:
                       "fix": warning.get("fix", "")
                   })
 
+          # v3.10.0: README install-instructions convention findings.
+          # Severity is "needs_work" (not ERROR/WARNING) -- these are
+          # structural/convention findings, same tier as orphan_agents /
+          # no_composable_surface above, not blocking errors.
+          if not readme_convention.get("skipped", False):
+              for warning in readme_convention.get("warnings", []):
+                  results["readme_convention_issues"].append({
+                      "type": warning.get("type"),
+                      "message": warning.get("message"),
+                      "severity": warning.get("severity", "needs_work"),
+                      "fix": warning.get("fix", "")
+                  })
+              for info in readme_convention.get("info", []):
+                  results["readme_convention_issues"].append({
+                      "type": info.get("type"),
+                      "message": info.get("message"),
+                      "severity": "INFO"
+                  })
+
           # Determine overall quality level
           # Priority: critical > needs_work > polish > good
           
@@ -3695,6 +3947,7 @@ steps:
           
           needs_work_count = results["summary"]["needs_work"]
           needs_work_count += len([i for i in results["structural_issues"] if i.get("severity") == "needs_work"])
+          needs_work_count += len([i for i in results["readme_convention_issues"] if i.get("severity") == "needs_work"])  # v3.10.0
           if recipe_quality == "needs_work":
               needs_work_count += 1
           
@@ -3753,7 +4006,8 @@ steps:
               "mode_validation_warnings": len([i for i in results["mode_validation_issues"] if i.get("severity") == "WARNING"]),  # v3.6.0
               "body_instruction_warnings": len(results["body_instruction_issues"]),  # v3.7.0
               "agent_description_errors": len([i for i in results["agent_description_issues"] if i.get("severity") == "ERROR"]),  # Phase 2.8
-              "agent_description_warnings": len([i for i in results["agent_description_issues"] if i.get("severity") == "WARNING"])  # Phase 2.8
+              "agent_description_warnings": len([i for i in results["agent_description_issues"] if i.get("severity") == "WARNING"]),  # Phase 2.8
+              "readme_convention_needs_work": len([i for i in results["readme_convention_issues"] if i.get("severity") == "needs_work"])  # v3.10.0
           }
 
           # v3.3.0: Recipe validation summary
@@ -3780,7 +4034,7 @@ steps:
     parse_json: true
     timeout: 60
     on_error: "fail"
-    depends_on: ["validate-all-bundles", "behavior-hygiene-validation", "behavior-reference-hygiene", "standalone-completeness-validation", "experiments-validation", "context-sink-compliance", "tool-placement-analysis", "validate-recipes", "set-default-recipe-validation", "yaml-structure-lint", "mode-validation", "body-instruction-check"]
+    depends_on: ["validate-all-bundles", "behavior-hygiene-validation", "behavior-reference-hygiene", "standalone-completeness-validation", "experiments-validation", "context-sink-compliance", "tool-placement-analysis", "validate-recipes", "set-default-recipe-validation", "yaml-structure-lint", "mode-validation", "body-instruction-check", "agent-description-validation", "readme-install-convention-check"]
 
   # ============================================================================
   # PHASE 2.75: Initialize Optional Outputs
@@ -4442,6 +4696,11 @@ steps:
       {{agent_description_validation_results}}
       ```
 
+      **README Install-Instructions Convention Check (v3.10.0):**
+      ```json
+      {{readme_install_convention_results}}
+      ```
+
       **Bundle Doc Freshness (Phase 6 v3):**
       ```json
       {{bundle_doc_freshness}}
@@ -4498,7 +4757,7 @@ steps:
       
       Install missing dependencies, then **re-run this recipe** for complete validation.
       
-      **Standard pip (if allowed):**
+      **Standard uv pip install:**
       ```bash
       [commands from install_instructions.standard]
       ```
@@ -4582,14 +4841,33 @@ steps:
       - For each WARNING of type agent_description_high (>300 tokens, provisional):
         - [WARNING] "Agent description in <file> is N tokens -- consider trimming toward <300"
         - Same reference as above
-      - For each WARNING of type commentary_present:
-        - [WARNING] "<file>: description has N <commentary> tag(s) -- delete them (V3)"
-      - For each WARNING of type too_many_examples:
-        - [WARNING] "<file>: description has N <example> blocks (>2) -- trim to 2 (V3)"
-      - If no issues: "Agent description validation: all N agents within budget, no commentary/example bloat"
+      - For each ERROR of type commentary_present (v3.10.0 -- was WARNING):
+        - [ERROR] "<file>: description has N <commentary> tag(s) -- rejected entirely (V3)"
+      - For each ERROR of type example_block_present (v3.10.0 -- replaces too_many_examples, was WARNING at >2):
+        - [ERROR] "<file>: description has N <example> block(s) -- example blocks are rejected entirely, not merely capped (V3)"
+      - If no issues: "Agent description validation: all N agents within budget, no commentary/example blocks"
       - If agent_description_validation_results.skipped == true: "Agent description validation: skipped (no agents/*.md files found)"
       - If body_instruction_check_results.skipped == true: "Body instruction check: skipped (no bundle.md or agents/*.md files found)"
-      - This is WARNING-level only -- it never fails the build on its own
+      - commentary_present and example_block_present ARE blocking (ERROR); the token-budget findings above stay WARNING/ERROR per their own thresholds
+
+      ### README Install-Instructions Convention Check (v3.10.0)
+      Use readme_install_convention_results to report:
+      - If skipped == true: "README install-instructions convention check: skipped (<reason from info>)"
+      - For each finding of type readme_recommends_root_bundle:
+        - [NEEDS WORK] the finding's message (README's primary install recommends the root bundle, not a behavior)
+        - The fix: lead with `amplifier bundle add "<repo>#subdirectory=behaviors/<name>.yaml" --app`, or set context var root_bundle_repo: "true" if this repo genuinely ships root bundles for users
+      - For each finding of type readme_missing_app_flag:
+        - [NEEDS WORK] the finding's message (N/M bundle-add commands missing --app)
+        - The fix: add --app to every `amplifier bundle add` command in README.md
+      - For each finding of type readme_pip_install:
+        - [NEEDS WORK] the finding's message (README shows bare `pip install`)
+        - The fix: `uv tool install git+https://...` for CLI tools, `uv pip install` for libraries
+      - For each finding of type readme_missing_git_install:
+        - [NEEDS WORK] the finding's message (repo ships a CLI, README shows an install command, but no git+https:// form anywhere)
+        - The fix: always show a git+https:// install form; PyPI may be offered additionally, never as a replacement
+      - INFO findings (no_readme, no_bundle_add_commands, docs_pip_install) are informational only -- do not treat as defects
+      - If no warnings: "README install-instructions convention: no findings"
+      - Severity is "needs_work" for all warnings here -- these feed needs_work_count, not critical_count
 
       ### Standalone Completeness
       | Bundle | Orchestrator | Context | Provider | Status |
@@ -4662,7 +4940,7 @@ steps:
 
       ## Metadata
       - Validated: [timestamp]
-      - Recipe: validate-bundle-repo v3.6.0
+      - Recipe: validate-bundle-repo v3.10.0
       - Validation Mode: [mode from env_check]
       - Foundation: [version or "not available"]
       - Quality Thresholds:


### PR DESCRIPTION
Three owner guidance changes, applied to BOTH the development-time authoring docs and the validation recipes (so the ecosystem teaches the rules at authoring time, not just enforces them after):

## 1. `<example>` blocks in agent descriptions are now REJECTED (was: ≤2 allowed)
- `context/shared/description-authoring-principles.md` — V3 + "Example policy" rewritten to "no `<example>` blocks at all"; the existing P2 eval evidence (stripping ALL examples didn't hurt delegation) now cited as support for full removal.
- `docs/AGENT_AUTHORING.md` — template, required-elements, and anti-pattern sections rewritten to no-examples.
- `docs/DOMAIN_VALIDATOR_GUIDE.md` — metric-vs-gate note split (keywords stay metrics; examples/commentary now a gate); stale "has at least one `<example>`" bullet removed.
- `recipes/validate-agents.yaml` **v1.3.1 → 1.4.0** — any `<example>` → `EXAMPLE_BLOCK_PRESENT` ERROR; `<commentary>` → ERROR; moot `TOO_MANY_EXAMPLES`/`EXAMPLES_MISSING_CONTEXT` checks removed.
- `recipes/validate-bundle-repo.yaml` **v3.9.0 → 3.10.0** — Phase 2.8 mirrors the same errors.

## 2. README install convention: behavior bundle over root, with `--app`
- `docs/BUNDLE_GUIDE.md` — new "Install-Instructions Convention" subsection: recommend `#subdirectory=behaviors/<name>.yaml` installs with `--app`; recommending the root bundle is reserved for repos whose intent is producing root bundles (usually not the case).
- `validate-bundle-repo.yaml` — new deterministic **Phase 2.85**: `readme_recommends_root_bundle` + `readme_missing_app_flag` findings (needs_work), with new `root_bundle_repo` context opt-out for intentionally-root-bundle repos.

## 3. Tool installs: `uv tool install` + always support git+https
- Foundation's own `README.md` + `experiments/bundle-configurator/README.md` switched off bare pip.
- Recipes' own remediation text fixed (`pip install hatchling` → `uv pip install`; PEP-668 variant → `uv pip install --system`).
- `validate-bundle-repo.yaml` Phase 2.85 Check B: `readme_pip_install` (needs_work) + `readme_missing_git_install` (needs_work when repo ships a CLI but README lacks a `git+https://` install form).

## Verification
- `yaml.safe_load` clean on all touched recipes; every new/modified python heredoc compiles.
- New checks dry-run against 3 fixture READMEs: root-bundle/no-app → both findings; behavior+--app → clean; pip/no-git → both findings.
- Zero remaining "≤2 examples" contradictions repo-wide.

## Known consequence (intentional, follow-up work)
**16 of foundation's own agents** currently carry 2 `<example>` blocks each and will now fail validate-agents (bug-hunter, explorer, git-ops, zen-architect, modular-builder, …). Rewriting them to the new no-examples style is deliberately out of scope for this PR.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)