### PR TITLE
chore: remove <example> blocks from all 16 agent descriptions (new V3 policy)

### DIFF
--- a/agents/bug-hunter.md
+++ b/agents/bug-hunter.md
@@ -1,7 +1,7 @@
 ---
 meta:
   name: bug-hunter
-  description: "Specialized debugging expert focused on finding and fixing bugs systematically. Use PROACTIVELY. It MUST BE USED when user has reported or you are encountering errors, unexpected behavior, or test failures. Examples: <example>user: 'The synthesis pipeline is throwing a KeyError somewhere' assistant: 'I'll use the bug-hunter agent to systematically track down and fix this KeyError.'</example> <example>user: 'Tests are failing after the recent changes' assistant: 'Let me use the bug-hunter agent to investigate and fix the test failures.'</example>"
+  description: "Specialized debugging expert focused on finding and fixing bugs systematically. Use PROACTIVELY. It MUST BE USED when user has reported or you are encountering errors, unexpected behavior, or test failures."
 
 model_role: [coding, general]
 

--- a/agents/bundle-design-expert.md
+++ b/agents/bundle-design-expert.md
@@ -7,18 +7,6 @@ meta:
       Use PROACTIVELY when: designing a new bundle, selecting mechanisms, writing bundle YAML or behaviors, authoring agent files (meta.description, WHY/WHEN/WHAT/HOW), making context architecture decisions (context sink, thin pointer, zero poisoning), or running behavioral modeling recipes.
 
       **Authoritative on:** bundle design, mechanism selection, behavioral modeling, YAML authoring, behaviors, agent file authoring, context sink pattern, thin pointer, zero poisoning, bundle lifecycle, bundle anti-patterns, objectives-to-model recipes
-
-      <example>
-      <context>User is planning a new bundle</context>
-      <user>I want to create a bundle that provides code review with different strictness modes</user>
-      <assistant>I'll delegate to the bundle-design-expert who owns the full design-through-implementation lifecycle.</assistant>
-      </example>
-
-      <example>
-      <context>User wants to author an agent description</context>
-      <user>How do I write a good agent description?</user>
-      <assistant>Delegating to bundle-design-expert for agent authoring guidance — it knows the WHY/WHEN/WHAT/HOW framework and context sink pattern.</assistant>
-      </example>
 model_role: general
 
 tools:

--- a/agents/ecosystem-expert.md
+++ b/agents/ecosystem-expert.md
@@ -10,20 +10,6 @@ meta:
     - Cross-repo workflows and dependency management
     - Working memory patterns for long sessions
     - Understanding ecosystem architecture and dependencies
-
-    Examples:
-
-    <example>
-    Context: User needs to test changes across multiple repos
-    user: 'How do I test my amplifier-core changes with amplifier-foundation?'
-    assistant: 'I'll delegate to foundation:ecosystem-expert for multi-repo testing patterns.'
-    </example>
-
-    <example>
-    Context: User is making coordinated changes
-    user: 'I need to update a kernel contract and all affected modules'
-    assistant: 'Let me consult foundation:ecosystem-expert for the correct change and push order across repos.'
-    </example>
 model_role: general
 
 provider_preferences:

--- a/agents/explorer.md
+++ b/agents/explorer.md
@@ -1,7 +1,7 @@
 ---
 meta:
   name: explorer
-  description: "Deep local-context reconnaissance agent. IMPORTANT: This agent has zero prior context—every invocation must include the full objective, scope hints (directories, file types, keywords), and any constraints the agent should respect. Without that information it will not be aware of such. MUST be used for multi-file exploration. Use this agent whenever the user needs a comprehensive survey of local code, documentation, configuration, or user-provided content (not a precise single-file lookup). Examples:\n\n<example>\nuser: 'What does the overall event handling flow look like?'\nassistant: 'I'll delegate to the foundation:explorer agent to map the event handling modules and summarize the flow.'\n</example>\n\n<example>\nuser: 'Gather everything we have about client-facing SLAs across docs and configs.'\nassistant: |\n  delegate(\n      agent=\"foundation:explorer\",\n      instruction=\"Survey docs/ and config/ for client-facing SLA definitions, thresholds, and owners. Report path:line for each.\",\n      context_depth=\"none\",\n      context_scope=\"conversation\",\n  )\n</example>"
+  description: "Deep local-context reconnaissance agent. IMPORTANT: This agent has zero prior context—every invocation must include the full objective, scope hints (directories, file types, keywords), and any constraints the agent should respect. Without that information it will not be aware of such. MUST be used for multi-file exploration. Use this agent whenever the user needs a comprehensive survey of local code, documentation, configuration, or user-provided content (not a precise single-file lookup)."
 
 model_role: general
 

--- a/agents/file-ops.md
+++ b/agents/file-ops.md
@@ -1,19 +1,7 @@
 ---
 meta:
   name: file-ops
-  description: "Focused file operations agent for reading, writing, editing, and searching files. ALWAYS use for targeted file operations when you need precise file system operations without the broader exploration scope. This agent handles: reading file contents, writing new files, making targeted edits, finding files by pattern (glob), and searching file contents (grep). Best for: single-file operations, batch file changes, content search, and file discovery tasks.
-
-<example>
-Context: User needs specific files read or written
-user: 'Read the config files in src/config/ and update the timeout values'
-assistant: 'I'll delegate to foundation:file-ops to read those config files and make the targeted edits.'
-</example>
-
-<example>
-Context: User needs to find files matching a pattern
-user: 'Find all Python test files in the project'
-assistant: 'I'll use foundation:file-ops to glob for **/*test*.py files across the project.'
-</example>"
+  description: "Focused file operations agent for reading, writing, editing, and searching files. ALWAYS use for targeted file operations when you need precise file system operations without the broader exploration scope. This agent handles: reading file contents, writing new files, making targeted edits, finding files by pattern (glob), and searching file contents (grep). Best for: single-file operations, batch file changes, content search, and file discovery tasks."
 
 model_role: fast
 

--- a/agents/foundation-expert.md
+++ b/agents/foundation-expert.md
@@ -8,19 +8,6 @@ meta:
 
     **Authoritative on:** foundation inventory, examples catalog, behaviors, agents, philosophy docs, concepts (CONCEPTS.md), configuration, ecosystem navigation, foundation patterns, @mention system, contribution channels
 
-    <example>
-    Context: Finding working examples
-    user: 'Show me how to set up a multi-provider configuration'
-    assistant: 'Let me ask foundation:foundation-expert — it has access to all the working examples and can point to the right pattern.'
-    </example>
-
-    <example>
-    Context: Philosophy question
-    user: 'Should I inline my instructions or create separate context files?'
-    assistant: 'I\'ll consult foundation:foundation-expert for the recommended approach based on modular design philosophy.'
-    </example>
-
-
 model_role: general
 
 provider_preferences:

--- a/agents/git-ops.md
+++ b/agents/git-ops.md
@@ -8,19 +8,6 @@ meta:
 
     **Authoritative on:** commits, conventional commits, co-author attribution, PRs, branches, merge, rebase, conflicts, GitHub Issues, GitHub Releases, GitHub Actions, gh CLI, repo discovery
 
-    <example>
-    Context: Agent completed a multi-file implementation task.
-    user: 'Commit this work'
-    assistant: 'I\'ll delegate to git-ops with a summary of what we accomplished and context_depth=recent so it has conversation history for a quality commit message.'
-    </example>
-
-    <example>
-    Context: Feature branch complete, ready for PR.
-    user: 'Create a PR for this feature'
-    assistant: 'I\'ll delegate to git-ops with the full summary and context_depth=all, context_scope=agents so it can write a comprehensive PR description.'
-    </example>
-
-
 model_role: fast
 
 provider_preferences:

--- a/agents/integration-specialist.md
+++ b/agents/integration-specialist.md
@@ -1,7 +1,7 @@
 ---
 meta:
   name: integration-specialist
-  description: "Expert at integrating with external services, APIs, and MCP servers while maintaining simplicity. Also analyzes and manages dependencies for security, compatibility, and technical debt. MUST be used when connecting to external services, setting up MCP servers, handling API integrations, or analyzing project dependencies. Examples: <example>user: 'Set up integration with the new payment API' assistant: 'I'll use the integration-specialist agent to create a simple, direct integration with the payment API.'</example> <example>user: 'Connect our system to the MCP notification server' assistant: 'Let me use the integration-specialist agent to set up the MCP server connection properly.'</example>"
+  description: "Expert at integrating with external services, APIs, and MCP servers while maintaining simplicity. Also analyzes and manages dependencies for security, compatibility, and technical debt. MUST be used when connecting to external services, setting up MCP servers, handling API integrations, or analyzing project dependencies."
 
 model_role: general
 

--- a/agents/modular-builder.md
+++ b/agents/modular-builder.md
@@ -8,16 +8,6 @@ meta:
 
     **Authoritative on:** module implementation, bricks-and-studs pattern, self-contained modules, test writing, LSP-assisted code navigation, contract-based development, spec-to-code translation
 
-    <example>
-    user: 'Implement the CacheService from the spec in specs/cache-spec.md'
-    assistant: 'I\'ll use modular-builder to implement the CacheService.'
-    </example>
-
-    <example>
-    user: 'Add a caching layer to improve performance'
-    assistant: 'I\'ll first use zen-architect to analyze and design the caching approach, then modular-builder will implement it.'
-    </example>
-
 model_role: [coding, general]
 
 provider_preferences:

--- a/agents/post-task-cleanup.md
+++ b/agents/post-task-cleanup.md
@@ -1,7 +1,7 @@
 ---
 meta:
   name: post-task-cleanup
-  description: "Use this agent when a todo list or major task has been completed and you need to ensure codebase hygiene. MUST be invoked PROACTIVELY after task completion to review git status, identify all touched files, remove temporary artifacts, eliminate unnecessary complexity, and ensure adherence to project philosophy principles. <example>Context: Todo list for feature implementation completed. user: 'Todo list completed for new authentication feature' assistant: 'I'll use the post-task-cleanup agent to review what was changed and ensure the codebase follows our simplicity principles'</example> <example>Context: Bug fix completed with test files and debugging artifacts. user: 'Fixed the bug and all tests pass' assistant: 'Let me invoke the post-task-cleanup agent to clean up any debugging artifacts and temporary test files'</example>"
+  description: "Use this agent when a todo list or major task has been completed and you need to ensure codebase hygiene. MUST be invoked PROACTIVELY after task completion to review git status, identify all touched files, remove temporary artifacts, eliminate unnecessary complexity, and ensure adherence to project philosophy principles."
 
 model_role: fast
 

--- a/agents/security-guardian.md
+++ b/agents/security-guardian.md
@@ -8,19 +8,6 @@ meta:
 
     **Authoritative on:** OWASP Top 10, hardcoded secrets detection, input/output validation, cryptographic review, dependency vulnerability scanning, XSS, SQL injection, authentication failures, authorization flaws, CVE analysis
 
-    <example>
-    Context: User has just implemented a new API endpoint for user data updates.
-    user: 'I\'ve added a new endpoint for updating user profiles. Here\'s the code...'
-    assistant: 'I\'ll review this new endpoint for security vulnerabilities using the security-guardian agent.'
-    </example>
-
-    <example>
-    Context: Preparing for a production deployment.
-    user: 'We\'re ready to deploy version 2.0 to production'
-    assistant: 'Before deploying to production, let me run a security review with the security-guardian agent.'
-    </example>
-
-
 model_role: [security-audit, critique, general]
 
 provider_preferences:

--- a/agents/session-analyst.md
+++ b/agents/session-analyst.md
@@ -8,17 +8,6 @@ meta:
 
     **Authoritative on:** session repair, transcript surgery, rewind/rollback, orphaned tool_calls, ordering violations, events.jsonl analysis, session search, transcript.jsonl, provider rejection errors, session history
 
-    <example>
-    user: 'Session X won\'t resume' or 'Why did my session fail?'
-    assistant: 'I\'ll delegate to session-analyst — it has specialized tools for safely diagnosing transcript issues and reading events.jsonl without crashing the session.'
-    </example>
-
-    <example>
-    user: 'Find the session where we built the caching layer'
-    assistant: 'I\'ll use session-analyst to search your session history — it can query by project, date, keyword, or partial session ID.'
-    </example>
-
-
 model_role: fast
 
 provider_preferences:

--- a/agents/shell-exec.md
+++ b/agents/shell-exec.md
@@ -9,19 +9,7 @@ Use for:
 - Process management and system administration
 - Script execution with proper output capture
 
-Best for: build operations, test execution, package management, and system administration tasks.
-
-<example>
-Context: User needs to build or test a project
-user: 'Run the test suite for the Python project'
-assistant: 'I'll delegate to foundation:shell-exec to run pytest and capture the results.'
-</example>
-
-<example>
-Context: User needs to install or manage packages
-user: 'Install the dependencies from requirements.txt'
-assistant: 'I'll use foundation:shell-exec to run pip install -r requirements.txt.'
-</example>"
+Best for: build operations, test execution, package management, and system administration tasks."
 
 model_role: fast
 

--- a/agents/test-coverage.md
+++ b/agents/test-coverage.md
@@ -1,7 +1,7 @@
 ---
 meta:
   name: test-coverage
-  description: "Expert at analyzing test coverage, identifying gaps, and suggesting comprehensive test cases. MUST be used when writing new features, after bug fixes, or during test reviews. Examples: <example>user: 'Check if our synthesis pipeline has adequate test coverage' assistant: 'I'll use the test-coverage agent to analyze the test coverage and identify gaps in the synthesis pipeline.'</example> <example>user: 'What tests should I add for this new authentication module?' assistant: 'Let me use the test-coverage agent to analyze your module and suggest comprehensive test cases.'</example>"
+  description: "Expert at analyzing test coverage, identifying gaps, and suggesting comprehensive test cases. MUST be used when writing new features, after bug fixes, or during test reviews."
 
 model_role: [coding, general]
 

--- a/agents/web-research.md
+++ b/agents/web-research.md
@@ -1,19 +1,7 @@
 ---
 meta:
   name: web-research
-  description: "Web research agent for searching and fetching information from the internet. MUST be used for external documentation lookups and web searches. Use when you need to find external information, documentation, or resources. This agent handles: web searches, fetching URL content, and synthesizing information from multiple sources. Best for: looking up documentation, finding examples, researching libraries, and gathering external context.
-
-<example>
-Context: User needs external documentation
-user: 'How do I configure async timeouts in aiohttp?'
-assistant: 'I'll delegate to foundation:web-research to look up the aiohttp documentation for timeout configuration.'
-</example>
-
-<example>
-Context: User needs to research a library or package
-user: 'What are the best Python libraries for PDF generation?'
-assistant: 'I'll use foundation:web-research to research PDF libraries and compare their features.'
-</example>"
+  description: "Web research agent for searching and fetching information from the internet. MUST be used for external documentation lookups and web searches. Use when you need to find external information, documentation, or resources. This agent handles: web searches, fetching URL content, and synthesizing information from multiple sources. Best for: looking up documentation, finding examples, researching libraries, and gathering external context."
 
 model_role: fast
 

--- a/agents/zen-architect.md
+++ b/agents/zen-architect.md
@@ -1,7 +1,7 @@
 ---
 meta:
   name: zen-architect
-  description: "Use this agent PROACTIVELY for code planning, architecture design, and review tasks. It embodies ruthless simplicity and analysis-first development. This agent operates in three modes: ANALYZE mode for breaking down problems and designing solutions, ARCHITECT mode for system design and module specification, and REVIEW mode for code quality assessment. It creates specifications that the modular-builder agent then implements. Examples:\n\n<example>\nContext: User needs a new feature\nuser: 'Add a caching layer to improve API performance'\nassistant: 'I'll use the zen-architect agent to analyze requirements and design the caching architecture'\n</example>\n\n<example>\nContext: System design needed\nuser: 'We need to restructure our authentication system'\nassistant: 'Let me use the zen-architect agent to architect the new authentication structure'\n</example>"
+  description: "Use this agent PROACTIVELY for code planning, architecture design, and review tasks. It embodies ruthless simplicity and analysis-first development. This agent operates in three modes: ANALYZE mode for breaking down problems and designing solutions, ARCHITECT mode for system design and module specification, and REVIEW mode for code quality assessment. It creates specifications that the modular-builder agent then implements."
 
 model_role: [reasoning, general]
 


### PR DESCRIPTION
Follow-up to #340: brings foundation's own agents into compliance with the new no-examples description policy (`context/shared/description-authoring-principles.md` V3 — example blocks rejected entirely, not capped at 2).

- **16 agents**, each carried exactly 2 `<example>` blocks: bug-hunter, bundle-design-expert, ecosystem-expert, explorer, file-ops, foundation-expert, git-ops, integration-specialist, modular-builder, post-task-cleanup, security-guardian, session-analyst, shell-exec, test-coverage, web-research, zen-architect.
- **Every edit is a pure deletion** — each example was checked for load-bearing routing signal first; all were redundant with the surviving WHEN/WHAT prose, so zero prose was added. Diff: 16 files, +9/−131, description fields only (bodies, tools, model_role byte-identical).
- Scripted verification: no `<example>`/`<commentary>` in any description, all ≥100 chars, max token estimate now 190 (foundation-expert) — all 16 under the 300-token WARN tier.
- One judgment call flagged: git-ops's examples showed recommended `context_depth`/`context_scope` delegate parameters (HOW-to-invoke, not WHEN-to-route) — deleted per policy; that guidance belongs in body docs if wanted.

With this, `validate-agents` v1.4.0 passes foundation's own agent set again.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)