### PR TITLE
chore: validate-agents version field 1.3.1 → 1.4.0 (header/field drift)

### DIFF
--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -109,7 +109,7 @@ description: |
   
   This recipe helps maintain agent quality across the Amplifier ecosystem by codifying
   the audit criteria discovered in manual reviews.
-version: "1.3.1"
+version: "1.4.0"
 author: "Amplifier Foundation Team"
 tags: ["agents", "validation", "quality", "audit", "tools", "descriptions"]
 


### PR DESCRIPTION
Follow-up to #340: the header comment was bumped to v1.4.0 but the authoritative YAML `version:` field stayed at 1.3.1, so recipe runs reported the old version while enforcing the new checks. One-line fix.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)