### PR TITLE
feat(validate-bundle-repo): module-dep-resolvability-check v3.11.0

### DIFF
--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -1,9 +1,63 @@
 # validate-bundle-repo.yaml
-# Repository-Wide Bundle Validator Recipe v3.10.0
+# Repository-Wide Bundle Validator Recipe v3.11.0
 # Validates an entire bundle repository against structural requirements, conventions,
 # and Amplifier bundle philosophy (context sink pattern, thin behaviors, tool placement)
 #
 # CHANGELOG:
+# v3.11.0 - NEW PHASE 0.6: module-dep-resolvability-check
+#        - Deterministic, no network, no LLM. `amplifier update` refreshes every
+#          bundle module with `uv pip install -e <cache-module-dir> --python
+#          <app venv> --quiet --no-sources`. --no-sources disables
+#          [tool.uv.sources] entirely; uv does not treat an already-installed
+#          editable as a resolution candidate. A module pyproject.toml that
+#          depends on a SIBLING distribution defined elsewhere in the same
+#          repo (root pyproject.toml or another modules/*/pyproject.toml) by
+#          BARE NAME -- or only via [tool.uv.sources] -- fails that refresh:
+#          "X was not found in the package registry".
+#        - REAL-WORLD EVIDENCE (two independent incidents, same defect class):
+#          (1) amplifier-engram: all 3 modules' pyproject.toml declared
+#          `dependencies = ["amplifier-engram"]` (bare name for the repo's own
+#          unpublished store library). `amplifier update` failed on a live
+#          user host with exactly the uv "not found in the package registry"
+#          error. Fixed by PEP 508 direct git references
+#          (`amplifier-engram @ git+https://github.com/bkrabach/amplifier-engram@main`).
+#          (2) amplifier-browser-bridge modules/tool-browser-bridge: same
+#          latent bare-name + [tool.uv.sources] pattern, found by survey while
+#          fixing (1); fix PR opened in parallel upstream. Same defect family
+#          as foundation PR #332 (BUNDLE_GUIDE.md's own module `source:`
+#          examples taught a relative path that only resolves under the
+#          AUTHORING context, not the actual RUNTIME resolution context) --
+#          all three are "a reference that is only valid in the context it
+#          was written in, not the context it is resolved in".
+#        - Builds a PEP 503-normalized set of every distribution name the repo
+#          itself defines (root pyproject.toml [project].name + every
+#          modules/*/pyproject.toml [project].name), then scans each module's
+#          [project].dependencies and [project.optional-dependencies] for a
+#          requirement naming one of those distributions without a PEP 508
+#          direct URL reference (`name @ <url>`).
+#        - Finding: module_dep_unresolvable_no_sources, severity ERROR (feeds
+#          critical_count, same tier as structure_lint/hygiene/mode_validation/
+#          agent_description ERRORs -- this is a real `amplifier update`
+#          breakage, not a style suggestion). Message names the exact failure
+#          mode and, when a [tool.uv.sources] entry exists for the dependency,
+#          states explicitly that --no-sources disables it (no protection).
+#          Fix names a PEP 508 direct git reference, with
+#          #subdirectory=modules/<name> when the dependency is itself a
+#          sibling module, plus the hatchling allow-direct-references = true
+#          note when the module's own build-backend is hatchling.
+#        - NEW context var published_distributions (v3.11.0): JSON list of
+#          repo-defined distribution names genuinely published to a real
+#          package registry -- same escape-hatch shape as root_bundle_repo.
+#          A bare-name reference to a published distribution DOES resolve
+#          under --no-sources, so its finding is downgraded ERROR -> INFO
+#          (module_dep_bare_name_but_published) instead of suppressed
+#          outright, so it stays visible without failing the build.
+#        - quality-classification incorporates module_dep_issues into
+#          critical_count exactly like the other ERROR-tier checks
+#        - synthesize-report includes Module Dependency Resolvability Check
+#          section + Executive Summary line
+#        - CRITICAL (repo lesson, v3.9.0): the new heredoc uses
+#          "${AMPLIFIER_PYTHON:-python3}", never bare python3
 # v3.10.0 - Example-policy tightening + NEW README install-convention checks
 #        - Phase 2.8 (agent description budget): <example> and <commentary>
 #          presence are now ERROR (was WARNING at >2 examples / any
@@ -258,6 +312,7 @@ description: |
   - **NEW in v3.6.0:** Mode description token budget validation (WARNING >500, ERROR >800 tokens)
   - **NEW in v3.6.0:** Mode advertising-rule enforcement (unadvertised modes must not be named in agent-readable files)
   - **NEW in v3.10.0:** README install-instructions convention (behavior-over-root recommendation, `--app` flag, `uv tool install`/`uv pip install` over bare `pip install`, git+https availability for shipped CLIs)
+  - **NEW in v3.11.0:** Module dependency resolvability (detects bare-name/uv.sources-only references from a module to a sibling in-repo distribution that break `amplifier update`'s per-module `--no-sources` refresh)
   - Deterministic quality classification with explicit PASS thresholds
   - Quick-approval path for clean repos (no unnecessary LLM analysis)
   - Repository composition analysis (do pieces fit together correctly?)
@@ -301,7 +356,7 @@ description: |
   - All measurements use TOKENS (len/4), never line counts
   
   For single bundle validation, use validate-bundle.yaml instead.
-version: "3.10.0"
+version: "3.11.0"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "repository", "packaging", "hygiene", "context-sink"]
 
@@ -316,6 +371,11 @@ context:
   root_bundle_repo: "false"  # Optional (v3.10.0): set "true" if this repo's own purpose is to
     # produce root bundles for users (uncommon) -- suppresses the
     # readme_recommends_root_bundle finding
+  published_distributions: ""  # Optional (v3.11.0): JSON list of repo-defined distribution
+    # names genuinely published to a real package registry (PyPI/etc). Bare-name
+    # sibling references to these DO resolve under `amplifier update`'s
+    # --no-sources refresh, so findings for them are downgraded ERROR -> INFO.
+    # Default "" (empty list): assume nothing is published.
 
 steps:
   # ============================================================================
@@ -613,6 +673,274 @@ steps:
       print(json.dumps(result))
       EOF
     output: "packaging_check"
+    parse_json: true
+    timeout: 30
+    on_error: "continue"
+    depends_on: ["environment-check"]
+
+  # ============================================================================
+  # PHASE 0.6: Module Dependency Resolvability Check (v3.11.0)
+  #
+  # Deterministic, no network, no LLM. `amplifier update` refreshes every
+  # bundle module with:
+  #   uv pip install -e <cache-module-dir> --python <app venv> --quiet --no-sources
+  # `--no-sources` disables [tool.uv.sources] entirely. If a module's
+  # pyproject.toml depends on a SIBLING distribution defined elsewhere in
+  # THIS repo (root pyproject.toml or another modules/*/pyproject.toml) by
+  # BARE NAME -- or only via a [tool.uv.sources] path/git source -- that
+  # refresh fails: "X was not found in the package registry" (uv does not
+  # treat an already-installed editable as a resolution candidate). Real
+  # incidents: amplifier-engram (all 3 modules failed the updater's refresh
+  # on a user host; fixed by PEP 508 direct references) and
+  # amplifier-browser-bridge modules/tool-browser-bridge (same latent
+  # pattern). See also foundation PR #332 (bundle-guide module-source
+  # docs taught the same broken relative-path pattern) -- all three are the
+  # same defect family: a reference that only resolves under the AUTHORING
+  # context, not the actual RUNTIME resolution context.
+  #
+  # Builds a PEP 503-normalized set of every distribution name THIS repo
+  # defines (root pyproject.toml [project].name + every
+  # modules/*/pyproject.toml [project].name), then scans each module's
+  # [project].dependencies and [project.optional-dependencies] for a
+  # requirement naming one of those distributions without a PEP 508 direct
+  # URL reference (`name @ <url>`). Escape hatch: context var
+  # published_distributions lists names genuinely published to a real
+  # registry -- their bare-name references DO resolve under --no-sources,
+  # so findings for them are downgraded ERROR -> INFO.
+  # ============================================================================
+
+  - id: "module-dep-resolvability-check"
+    type: "bash"
+    command: |
+      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
+      import json
+      import re
+      import sys
+      from pathlib import Path
+
+      repo_path = "{{repo_path}}"
+      published_raw = """{{published_distributions}}"""
+
+      result = {
+          "phase": "module_dep_resolvability_check",
+          "skipped": False,
+          "modules_checked": 0,
+          "repo_defined_distributions": [],
+          "published_distributions": [],
+          "errors": [],
+          "warnings": [],
+          "info": []
+      }
+
+      path = Path(repo_path).resolve()
+
+      try:
+          import tomllib
+      except ImportError:
+          try:
+              import tomli as tomllib
+          except ImportError:
+              result["skipped"] = True
+              result["passed"] = True
+              result["info"].append({
+                  "type": "missing_toml_parser",
+                  "message": "Cannot parse pyproject.toml files - tomllib/tomli not available",
+                  "severity": "INFO"
+              })
+              print(json.dumps(result))
+              sys.exit(0)
+
+      def normalize(name):
+          """PEP 503 normalization: lowercase, collapse [-_.] runs to a single '-'."""
+          return re.sub(r"[-_.]+", "-", name).lower()
+
+      def parse_req_name(req):
+          """Extract the distribution name from a PEP 508 requirement string."""
+          req = req.strip()
+          if not req or req.startswith("#"):
+              return None
+          match = re.match(r"^([A-Za-z0-9][A-Za-z0-9._-]*)", req)
+          if not match:
+              return None
+          return match.group(1)
+
+      def has_direct_reference(req):
+          """True if this requirement uses a PEP 508 direct URL ref (name @ url).
+
+          --no-sources only disables [tool.uv.sources]; a direct reference
+          embedded in the requirement string itself survives it.
+          """
+          without_marker = req.split(";", 1)[0]
+          return "@" in without_marker
+
+      def load_pyproject(pyproject_path):
+          try:
+              with open(pyproject_path, "rb") as f:
+                  return tomllib.load(f), None
+          except Exception as exc:
+              return None, str(exc)
+
+      # Escape hatch: names genuinely published to a real registry (PyPI/etc).
+      # Bare-name references to these DO resolve under --no-sources.
+      published_distributions = set()
+      if published_raw.strip():
+          try:
+              published_list = json.loads(published_raw)
+              if isinstance(published_list, list):
+                  published_distributions = {normalize(str(n)) for n in published_list}
+          except (json.JSONDecodeError, ValueError):
+              pass
+      result["published_distributions"] = sorted(published_distributions)
+
+      # --- Step 1: the set of distributions THIS repo defines ---
+      # normalized_name -> {"display": str, "kind": "root"|"module", "module_dir": str|None}
+      repo_defined = {}
+
+      root_pyproject = path / "pyproject.toml"
+      if root_pyproject.exists():
+          config, err = load_pyproject(root_pyproject)
+          if config is not None:
+              name = config.get("project", {}).get("name")
+              if name:
+                  repo_defined[normalize(name)] = {"display": name, "kind": "root", "module_dir": None}
+
+      modules_dir = path / "modules"
+      module_pyprojects = sorted(modules_dir.glob("*/pyproject.toml")) if modules_dir.is_dir() else []
+      for mp in module_pyprojects:
+          config, err = load_pyproject(mp)
+          if config is None:
+              continue
+          name = config.get("project", {}).get("name")
+          if name:
+              repo_defined[normalize(name)] = {"display": name, "kind": "module", "module_dir": mp.parent.name}
+
+      result["repo_defined_distributions"] = sorted(v["display"] for v in repo_defined.values())
+
+      if not module_pyprojects:
+          result["skipped"] = True
+          result["passed"] = True
+          result["info"].append({
+              "type": "no_modules_dir",
+              "message": "No modules/*/pyproject.toml files found - nothing to check.",
+              "severity": "INFO"
+          })
+          print(json.dumps(result))
+          sys.exit(0)
+
+      # --- Step 2: check each module's own declared dependencies ---
+      for mp in module_pyprojects:
+          module_name = mp.parent.name
+          config, err = load_pyproject(mp)
+          if config is None:
+              result["warnings"].append({
+                  "type": "module_pyproject_parse_error",
+                  "module": module_name,
+                  "message": f"Failed to parse {mp.relative_to(path)}: {err}",
+                  "severity": "WARNING"
+              })
+              continue
+
+          result["modules_checked"] += 1
+          project = config.get("project", {})
+          uv_sources = config.get("tool", {}).get("uv", {}).get("sources", {}) or {}
+          backend = config.get("build-system", {}).get("build-backend", "") or ""
+          is_hatchling = "hatchling" in backend
+
+          dep_lists = {"dependencies": project.get("dependencies", []) or []}
+          for extra_name, extra_deps in (project.get("optional-dependencies", {}) or {}).items():
+              dep_lists[f"optional-dependencies.{extra_name}"] = extra_deps or []
+
+          for dep_field, deps in dep_lists.items():
+              for req in deps:
+                  if not isinstance(req, str):
+                      continue
+                  dep_name = parse_req_name(req)
+                  if not dep_name:
+                      continue
+                  dep_norm = normalize(dep_name)
+
+                  if dep_norm not in repo_defined:
+                      continue  # not a sibling distribution from this repo
+
+                  if has_direct_reference(req):
+                      continue  # PEP 508 direct reference survives --no-sources
+
+                  uv_source_entry = None
+                  for src_name, src_value in uv_sources.items():
+                      if normalize(src_name) == dep_norm:
+                          uv_source_entry = src_value
+                          break
+
+                  sibling = repo_defined[dep_norm]
+                  base_message = (
+                      f"modules/{module_name}/pyproject.toml declares a {dep_field} on "
+                      f"'{dep_name}' by bare name, but '{sibling['display']}' is a sibling "
+                      "distribution defined in THIS repo (not on any package registry). "
+                      "`amplifier update` refreshes each module with "
+                      "`uv pip install -e <module-dir> --python <app venv> --quiet "
+                      "--no-sources`, which resolves bare names against the package "
+                      f"registry ONLY -- it will fail with \"{dep_name} was not found in "
+                      "the package registry\"."
+                  )
+                  if uv_source_entry is not None:
+                      base_message += (
+                          f" A [tool.uv.sources] entry exists for '{dep_name}' "
+                          f"({json.dumps(uv_source_entry)}), but --no-sources disables "
+                          "[tool.uv.sources] entirely during this refresh, so it provides "
+                          "no protection."
+                      )
+
+                  subdirectory_hint = (
+                      f"#subdirectory=modules/{sibling['module_dir']}" if sibling["kind"] == "module" else ""
+                  )
+                  fix = (
+                      f"Reference '{dep_name}' with a PEP 508 direct git reference instead "
+                      f"of a bare name, e.g. `{dep_name} @ "
+                      f"git+https://github.com/<org>/<repo>@main{subdirectory_hint}`."
+                  )
+                  if is_hatchling:
+                      fix += (
+                          " This module's build backend is hatchling: also set "
+                          "`allow-direct-references = true` under [tool.hatch.metadata] "
+                          "in its pyproject.toml, or the build will refuse the reference."
+                      )
+
+                  if dep_norm in published_distributions:
+                      result["info"].append({
+                          "type": "module_dep_bare_name_but_published",
+                          "module": module_name,
+                          "dependency": dep_name,
+                          "field": dep_field,
+                          "message": (
+                              base_message
+                              + f" '{dep_name}' is listed in the published_distributions "
+                              "context var, so this bare-name reference is expected to "
+                              "resolve fine against the real registry."
+                          ),
+                          "severity": "INFO"
+                      })
+                  else:
+                      result["errors"].append({
+                          "type": "module_dep_unresolvable_no_sources",
+                          "module": module_name,
+                          "dependency": dep_name,
+                          "field": dep_field,
+                          "message": base_message,
+                          "severity": "ERROR",
+                          "fix": fix
+                      })
+
+      result["passed"] = len(result["errors"]) == 0
+      result["summary"] = {
+          "modules_checked": result["modules_checked"],
+          "repo_defined_distributions": len(result["repo_defined_distributions"]),
+          "errors": len(result["errors"]),
+          "warnings": len(result["warnings"]),
+          "info": len(result["info"])
+      }
+      print(json.dumps(result))
+      EOF
+    output: "module_dep_resolvability_check"
     parse_json: true
     timeout: 30
     on_error: "continue"
@@ -3559,6 +3887,13 @@ steps:
       except (json.JSONDecodeError, ValueError):
           readme_convention = {"passed": True, "skipped": True, "errors": [], "warnings": [], "info": []}
 
+      # v3.11.0: Parse module dependency resolvability check results
+      module_dep_raw = '''{{module_dep_resolvability_check}}'''
+      try:
+          module_dep_resolvability = json.loads(module_dep_raw)
+      except (json.JSONDecodeError, ValueError):
+          module_dep_resolvability = {"passed": True, "skipped": True, "errors": [], "warnings": [], "info": []}
+
       # Handle case where individual validation was skipped
       if individual.get("skipped", False):
           # v3.2.0: Check if this is an environment limitation (not a bundle problem)
@@ -3675,6 +4010,7 @@ steps:
               "body_instruction_issues": [],  # v3.7.0
               "agent_description_issues": [],  # Phase 2.8
               "readme_convention_issues": [],  # v3.10.0
+              "module_dep_issues": [],  # v3.11.0
               # v3.2.0: Environment status tracking
               "environment_status": {
                   "validation_mode": env_check.get("validation_mode", "unknown"),
@@ -3928,6 +4264,31 @@ steps:
                       "severity": "INFO"
                   })
 
+          # v3.11.0: Module dependency resolvability findings. ERROR severity --
+          # these ARE blocking (feed critical_count below), same tier as
+          # structure_lint/hygiene/mode_validation/agent_description ERRORs,
+          # because the failure mode is a real `amplifier update` breakage, not
+          # a style suggestion. INFO findings (published_distributions escape
+          # hatch) are informational only.
+          if not module_dep_resolvability.get("skipped", False):
+              for error in module_dep_resolvability.get("errors", []):
+                  results["module_dep_issues"].append({
+                      "type": error.get("type"),
+                      "module": error.get("module"),
+                      "dependency": error.get("dependency"),
+                      "message": error.get("message"),
+                      "severity": "ERROR",
+                      "fix": error.get("fix", "")
+                  })
+              for info in module_dep_resolvability.get("info", []):
+                  results["module_dep_issues"].append({
+                      "type": info.get("type"),
+                      "module": info.get("module"),
+                      "dependency": info.get("dependency"),
+                      "message": info.get("message"),
+                      "severity": "INFO"
+                  })
+
           # Determine overall quality level
           # Priority: critical > needs_work > polish > good
           
@@ -3939,6 +4300,7 @@ steps:
           critical_count += len([i for i in results["experiment_issues"] if i.get("severity") == "ERROR"])
           critical_count += len([i for i in results["mode_validation_issues"] if i.get("severity") == "ERROR"])  # v3.6.0
           critical_count += len([i for i in results["agent_description_issues"] if i.get("severity") == "ERROR"])  # Phase 2.8
+          critical_count += len([i for i in results["module_dep_issues"] if i.get("severity") == "ERROR"])  # v3.11.0
 
           # Recipe validation impact
           recipe_quality = recipe_validation.get("quality_level", "good")
@@ -4007,7 +4369,8 @@ steps:
               "body_instruction_warnings": len(results["body_instruction_issues"]),  # v3.7.0
               "agent_description_errors": len([i for i in results["agent_description_issues"] if i.get("severity") == "ERROR"]),  # Phase 2.8
               "agent_description_warnings": len([i for i in results["agent_description_issues"] if i.get("severity") == "WARNING"]),  # Phase 2.8
-              "readme_convention_needs_work": len([i for i in results["readme_convention_issues"] if i.get("severity") == "needs_work"])  # v3.10.0
+              "readme_convention_needs_work": len([i for i in results["readme_convention_issues"] if i.get("severity") == "needs_work"]),  # v3.10.0
+              "module_dep_errors": len([i for i in results["module_dep_issues"] if i.get("severity") == "ERROR"])  # v3.11.0
           }
 
           # v3.3.0: Recipe validation summary
@@ -4034,7 +4397,7 @@ steps:
     parse_json: true
     timeout: 60
     on_error: "fail"
-    depends_on: ["validate-all-bundles", "behavior-hygiene-validation", "behavior-reference-hygiene", "standalone-completeness-validation", "experiments-validation", "context-sink-compliance", "tool-placement-analysis", "validate-recipes", "set-default-recipe-validation", "yaml-structure-lint", "mode-validation", "body-instruction-check", "agent-description-validation", "readme-install-convention-check"]
+    depends_on: ["validate-all-bundles", "behavior-hygiene-validation", "behavior-reference-hygiene", "standalone-completeness-validation", "experiments-validation", "context-sink-compliance", "tool-placement-analysis", "validate-recipes", "set-default-recipe-validation", "yaml-structure-lint", "mode-validation", "body-instruction-check", "agent-description-validation", "readme-install-convention-check", "module-dep-resolvability-check"]
 
   # ============================================================================
   # PHASE 2.75: Initialize Optional Outputs
@@ -4701,6 +5064,11 @@ steps:
       {{readme_install_convention_results}}
       ```
 
+      **Module Dependency Resolvability Check (v3.11.0):**
+      ```json
+      {{module_dep_resolvability_check}}
+      ```
+
       **Bundle Doc Freshness (Phase 6 v3):**
       ```json
       {{bundle_doc_freshness}}
@@ -4734,6 +5102,7 @@ steps:
       - **Quality Breakdown**: X good, Y polish, Z needs_work, W critical
       - **Packaging**: PASS/FAIL/SKIPPED
       - **Hygiene**: PASS/FAIL (v3.0.0 checks)
+      - **Module Dependency Resolvability**: PASS/FAIL (v3.11.0 -- 0 module_dep_unresolvable_no_sources errors = PASS)
       - **Issues**: X errors, Y warnings, Z suggestions
 
       ## Environment Status (v3.2.0)
@@ -4868,6 +5237,33 @@ steps:
       - INFO findings (no_readme, no_bundle_add_commands, docs_pip_install) are informational only -- do not treat as defects
       - If no warnings: "README install-instructions convention: no findings"
       - Severity is "needs_work" for all warnings here -- these feed needs_work_count, not critical_count
+
+      ### Module Dependency Resolvability Check (v3.11.0)
+      Use module_dep_resolvability_check to report:
+      - modules_checked: total number of modules/*/pyproject.toml files checked
+      - repo_defined_distributions: list of distribution names this repo itself defines (root + modules)
+      - For each ERROR of type module_dep_unresolvable_no_sources:
+        - [ERROR] the finding's message (names the module, the bare sibling dependency, and the
+          exact `amplifier update` failure mode: `uv pip install -e ... --no-sources` resolves
+          bare names against the package registry only, and an already-installed editable is
+          NOT a resolution candidate)
+        - The fix: the finding's own `fix` field (PEP 508 direct git reference, with
+          `#subdirectory=modules/<name>` when the dependency is a sibling module, plus the
+          hatchling `allow-direct-references = true` note when applicable)
+        - If the message mentions a [tool.uv.sources] entry, make clear that entry provides
+          NO protection here -- `--no-sources` is exactly what disables it
+      - For each INFO of type module_dep_bare_name_but_published: informational only -- the
+        dependency is listed in published_distributions, so uv can resolve it against the real
+        registry even under --no-sources; do not treat as a defect
+      - If module_dep_resolvability_check.skipped == true: "Module dependency resolvability
+        check: skipped (no modules/*/pyproject.toml files found)"
+      - If no errors: "Module dependency resolvability: all N modules' sibling-distribution
+        dependencies use resolvable references"
+      - This check is ERROR severity (feeds critical_count, not needs_work_count) -- unlike the
+        README convention check above, this is a real `amplifier update` breakage, not a style
+        suggestion. Real-world precedent: amplifier-engram (all 3 modules broke the updater's
+        refresh on a live host) and amplifier-browser-bridge modules/tool-browser-bridge (same
+        latent pattern, fix in a parallel PR)
 
       ### Standalone Completeness
       | Bundle | Orchestrator | Context | Provider | Status |

--- a/tests/test_module_dep_resolvability_check.py
+++ b/tests/test_module_dep_resolvability_check.py
@@ -1,0 +1,355 @@
+"""Tests for Module Dependency Resolvability Check (validate-bundle-repo.yaml v3.11.0).
+
+Real-world motivation: `amplifier update` refreshes every bundle module with
+`uv pip install -e <cache-module-dir> --python <app venv> --quiet --no-sources`.
+`--no-sources` disables [tool.uv.sources] entirely, and uv does not treat an
+already-installed editable as a resolution candidate. A module pyproject.toml
+that depends on a SIBLING in-repo distribution by bare name -- or only via
+[tool.uv.sources] -- fails that refresh with "X was not found in the package
+registry".
+
+Two real incidents drove this check: amplifier-engram (all 3 modules broke
+the updater's refresh on a live host; fixed by PEP 508 direct git
+references) and amplifier-browser-bridge modules/tool-browser-bridge (same
+latent bare-name + [tool.uv.sources] pattern).
+
+These tests both:
+1. Verify the recipe's structural wiring (step exists, correct dependencies,
+   quality-classification/synthesize-report integration, changelog/version).
+2. Execute the ACTUAL embedded check script (extracted verbatim from the
+   recipe YAML, never reimplemented) against on-disk pyproject.toml
+   fixtures, so a future edit to the recipe's script is exercised by these
+   tests instead of a separately-maintained copy that could silently drift.
+"""
+
+import json
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+RECIPE_PATH = Path(__file__).parent.parent / "recipes" / "validate-bundle-repo.yaml"
+
+
+@pytest.fixture(scope="module")
+def recipe_data():
+    """Load and parse the recipe YAML once for all tests."""
+    if not RECIPE_PATH.exists():
+        pytest.skip("Recipe file not found")
+    content = RECIPE_PATH.read_text(encoding="utf-8")
+    return yaml.safe_load(content), content
+
+
+@pytest.fixture(scope="module")
+def steps_by_id(recipe_data):
+    """Build a dict of steps keyed by id for easy lookup."""
+    data, _ = recipe_data
+    return {step["id"]: step for step in data.get("steps", []) if "id" in step}
+
+
+@pytest.fixture(scope="module")
+def check_script(steps_by_id):
+    """Extract the module-dep-resolvability-check step's embedded Python verbatim."""
+    step = steps_by_id.get("module-dep-resolvability-check")
+    if step is None:
+        pytest.skip("module-dep-resolvability-check step not found")
+    command = step["command"]
+    match = re.search(r"<< 'EOF'\n(.*)\nEOF\n?$", command, re.DOTALL)
+    assert match, "Could not extract heredoc body from module-dep-resolvability-check command"
+    return match.group(1)
+
+
+def run_check(check_script: str, repo_dir: Path, published_distributions: str = "") -> dict:
+    """Run the extracted check script against repo_dir, returning parsed JSON.
+
+    Substitutes the recipe's {{repo_path}} / {{published_distributions}}
+    template placeholders exactly as the recipe executor would, then runs
+    the real script as a subprocess (not imported/exec'd in-process, so a
+    stray sys.exit() in the script can't take down the test runner).
+    """
+    script = check_script.replace('"{{repo_path}}"', repr(str(repo_dir)))
+    script = script.replace('"""{{published_distributions}}"""', repr(published_distributions))
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, f"Check script failed (exit {proc.returncode}): {proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+# ── Structural wiring ────────────────────────────────────────────────────────
+
+
+class TestStepExistsAndWired:
+    def test_step_exists(self, steps_by_id):
+        assert "module-dep-resolvability-check" in steps_by_id
+
+    def test_step_is_bash(self, steps_by_id):
+        step = steps_by_id["module-dep-resolvability-check"]
+        assert step.get("type") == "bash"
+
+    def test_step_output_name(self, steps_by_id):
+        step = steps_by_id["module-dep-resolvability-check"]
+        assert step.get("output") == "module_dep_resolvability_check"
+
+    def test_step_parse_json(self, steps_by_id):
+        step = steps_by_id["module-dep-resolvability-check"]
+        assert step.get("parse_json") is True
+
+    def test_step_depends_on_environment_check(self, steps_by_id):
+        step = steps_by_id["module-dep-resolvability-check"]
+        assert "environment-check" in step.get("depends_on", [])
+
+    def test_step_on_error_continue(self, steps_by_id):
+        step = steps_by_id["module-dep-resolvability-check"]
+        assert step.get("on_error") == "continue"
+
+    def test_uses_amplifier_python_interpreter(self, steps_by_id):
+        """CRITICAL repo lesson (v3.9.0): a heredoc must never use bare python3."""
+        step = steps_by_id["module-dep-resolvability-check"]
+        assert step["command"].strip().startswith("\"${AMPLIFIER_PYTHON:-python3}\" << 'EOF'")
+
+
+class TestContextVariable:
+    def test_context_has_published_distributions(self, recipe_data):
+        data, _ = recipe_data
+        assert "published_distributions" in data.get("context", {})
+
+    def test_published_distributions_default_is_empty_string(self, recipe_data):
+        data, _ = recipe_data
+        assert data["context"].get("published_distributions") == ""
+
+
+class TestQualityClassificationWiring:
+    def test_depends_on_includes_new_step(self, steps_by_id):
+        step = steps_by_id["quality-classification"]
+        assert "module-dep-resolvability-check" in step.get("depends_on", [])
+
+    def test_quality_classification_parses_new_output(self, recipe_data):
+        _, content = recipe_data
+        assert "module_dep_resolvability_check" in content
+        assert "module_dep_issues" in content
+
+    def test_error_severity_feeds_critical_count(self, recipe_data):
+        _, content = recipe_data
+        assert 'critical_count += len([i for i in results["module_dep_issues"]' in content
+
+
+class TestSynthesizeReportWiring:
+    def test_includes_module_dependency_section(self, recipe_data):
+        _, content = recipe_data
+        assert "Module Dependency Resolvability" in content
+
+    def test_synthesize_report_references_output(self, steps_by_id):
+        step = steps_by_id["synthesize-report"]
+        assert "{{module_dep_resolvability_check}}" in step["prompt"]
+
+
+class TestVersionAndChangelog:
+    def test_version_is_3_11_0(self, recipe_data):
+        data, _ = recipe_data
+        assert data["version"] == "3.11.0"
+
+    def test_changelog_has_v3_11_0_entry(self, recipe_data):
+        _, content = recipe_data
+        assert "v3.11.0" in content
+
+    def test_changelog_mentions_engram_incident(self, recipe_data):
+        _, content = recipe_data
+        assert "amplifier-engram" in content
+
+    def test_changelog_mentions_browser_bridge_incident(self, recipe_data):
+        _, content = recipe_data
+        assert "amplifier-browser-bridge" in content
+
+
+# ── Check logic (executes the actual embedded script) ───────────────────────
+
+
+class TestCheckLogicBareSiblingReference:
+    def test_bare_dependency_on_root_package_is_error(self, tmp_path, check_script):
+        _write(tmp_path / "pyproject.toml", """
+            [project]
+            name = "acme-repo"
+        """)
+        _write(tmp_path / "modules" / "mod-a" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-a"
+            dependencies = ["acme-repo>=0.1.0"]
+
+            [build-system]
+            build-backend = "hatchling.build"
+        """)
+        result = run_check(check_script, tmp_path)
+        assert result["passed"] is False
+        assert result["modules_checked"] == 1
+        assert len(result["errors"]) == 1
+        error = result["errors"][0]
+        assert error["type"] == "module_dep_unresolvable_no_sources"
+        assert error["dependency"] == "acme-repo"
+        assert error["severity"] == "ERROR"
+        assert "not found in the package registry" in error["message"]
+        assert "allow-direct-references" in error["fix"]  # hatchling backend
+
+    def test_bare_dependency_on_sibling_module_includes_subdirectory_hint(self, tmp_path, check_script):
+        _write(tmp_path / "pyproject.toml", """
+            [project]
+            name = "acme-repo"
+        """)
+        _write(tmp_path / "modules" / "mod-a" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-a"
+        """)
+        _write(tmp_path / "modules" / "mod-b" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-b"
+            dependencies = ["acme-module-mod-a"]
+        """)
+        result = run_check(check_script, tmp_path)
+        errors = [e for e in result["errors"] if e["module"] == "mod-b"]
+        assert len(errors) == 1
+        assert "#subdirectory=modules/mod-a" in errors[0]["fix"]
+
+    def test_uv_sources_entry_provides_no_protection(self, tmp_path, check_script):
+        _write(tmp_path / "pyproject.toml", """
+            [project]
+            name = "acme-repo"
+        """)
+        _write(tmp_path / "modules" / "mod-a" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-a"
+        """)
+        _write(tmp_path / "modules" / "mod-b" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-b"
+            dependencies = ["acme-module-mod-a"]
+
+            [tool.uv.sources]
+            acme-module-mod-a = { path = "../mod-a", editable = true }
+        """)
+        result = run_check(check_script, tmp_path)
+        errors = [e for e in result["errors"] if e["module"] == "mod-b"]
+        assert len(errors) == 1
+        assert "--no-sources disables" in errors[0]["message"]
+        assert "no protection" in errors[0]["message"]
+
+    def test_direct_url_reference_does_not_fire(self, tmp_path, check_script):
+        _write(tmp_path / "pyproject.toml", """
+            [project]
+            name = "acme-repo"
+        """)
+        _write(tmp_path / "modules" / "mod-a" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-a"
+            dependencies = ["acme-repo @ git+https://example.com/acme-repo@main"]
+        """)
+        result = run_check(check_script, tmp_path)
+        assert result["passed"] is True
+        assert result["errors"] == []
+
+    def test_unrelated_external_dependency_does_not_fire(self, tmp_path, check_script):
+        _write(tmp_path / "pyproject.toml", """
+            [project]
+            name = "acme-repo"
+        """)
+        _write(tmp_path / "modules" / "mod-a" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-a"
+            dependencies = ["requests>=2.0", "amplifier-core>=1.0.0"]
+        """)
+        result = run_check(check_script, tmp_path)
+        assert result["passed"] is True
+        assert result["errors"] == []
+
+
+class TestPublishedDistributionsEscapeHatch:
+    def test_published_distribution_downgrades_to_info(self, tmp_path, check_script):
+        _write(tmp_path / "pyproject.toml", """
+            [project]
+            name = "acme-repo"
+        """)
+        _write(tmp_path / "modules" / "mod-a" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-a"
+            dependencies = ["acme-repo>=0.1.0"]
+        """)
+        result = run_check(check_script, tmp_path, published_distributions='["acme-repo"]')
+        assert result["errors"] == []
+        assert len(result["info"]) == 1
+        assert result["info"][0]["type"] == "module_dep_bare_name_but_published"
+        assert result["info"][0]["severity"] == "INFO"
+
+    def test_unpublished_sibling_still_fires_alongside_published_one(self, tmp_path, check_script):
+        _write(tmp_path / "pyproject.toml", """
+            [project]
+            name = "acme-repo"
+        """)
+        _write(tmp_path / "modules" / "mod-a" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-a"
+        """)
+        _write(tmp_path / "modules" / "mod-b" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-b"
+            dependencies = ["acme-repo>=0.1.0", "acme-module-mod-a"]
+        """)
+        result = run_check(check_script, tmp_path, published_distributions='["acme-repo"]')
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["dependency"] == "acme-module-mod-a"
+        assert len(result["info"]) == 1
+        assert result["info"][0]["dependency"] == "acme-repo"
+
+
+class TestSkipConditions:
+    def test_no_modules_dir_skips(self, tmp_path, check_script):
+        _write(tmp_path / "pyproject.toml", """
+            [project]
+            name = "acme-repo"
+        """)
+        result = run_check(check_script, tmp_path)
+        assert result["skipped"] is True
+        assert result["passed"] is True
+
+    def test_no_root_pyproject_still_checks_modules(self, tmp_path, check_script):
+        _write(tmp_path / "modules" / "mod-a" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-a"
+        """)
+        _write(tmp_path / "modules" / "mod-b" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-b"
+            dependencies = ["acme-module-mod-a"]
+        """)
+        result = run_check(check_script, tmp_path)
+        assert result["skipped"] is False
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["dependency"] == "acme-module-mod-a"
+
+
+class TestOptionalDependencies:
+    def test_bare_sibling_in_optional_dependencies_fires(self, tmp_path, check_script):
+        _write(tmp_path / "pyproject.toml", """
+            [project]
+            name = "acme-repo"
+        """)
+        _write(tmp_path / "modules" / "mod-a" / "pyproject.toml", """
+            [project]
+            name = "acme-module-mod-a"
+
+            [project.optional-dependencies]
+            extra = ["acme-repo>=0.1.0"]
+        """)
+        result = run_check(check_script, tmp_path)
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["field"] == "optional-dependencies.extra"


### PR DESCRIPTION
## Summary

Adds a new deterministic phase to `validate-bundle-repo.yaml` (v3.10.0 -> v3.11.0): **module-dep-resolvability-check**. It detects module `pyproject.toml` dependencies on a sibling in-repo distribution that break `amplifier update`'s per-module refresh.

## The gap this closes

`amplifier update` refreshes every bundle module with:

```
uv pip install -e <cache-module-dir> --python <app venv> --quiet --no-sources
```

`--no-sources` disables `[tool.uv.sources]` entirely, and uv resolves bare requirement names against the package registry only -- it does **not** treat an already-installed editable as a resolution candidate. A module that depends on a sibling distribution (root `pyproject.toml`, or another `modules/*/pyproject.toml`) by **bare name** -- or only via `[tool.uv.sources]` -- fails that refresh with `"X was not found in the package registry"`.

`validate-bundle-repo.yaml` v3.10.0 had **no check for this class**: `packaging-check` (Phase 0.5) only validates `force-include` paths in `pyproject.toml`, never inspects the `dependencies` list; `build-check` is a wheel-build dry run, not a module install, and not `--no-sources`. Confirmed by grep across the recipe: zero `--no-sources` mentions, zero module-dependency checks, before this PR.

## Real-world evidence (three incidents, one defect family)

1. **amplifier-engram** (private repo I maintain): all 3 modules declared `dependencies = ["amplifier-engram"]` -- a bare name for the repo's own unpublished store library. `amplifier update` failed on a live host with exactly this uv error:
   ```
   × No solution found when resolving dependencies:
   ╰─▶ Because amplifier-engram was not found in the package registry and
       amplifier-module-hooks-engram-inject==0.1.0 depends on amplifier-engram, ...
   ```
   Fixed by PEP 508 direct git references (`amplifier-engram @ git+https://github.com/bkrabach/amplifier-engram@main`).

2. **microsoft/amplifier-browser-bridge** `modules/tool-browser-bridge`: same latent bare-name + `[tool.uv.sources]` pattern, found by survey while fixing (1). Fix opened in parallel: microsoft/amplifier-browser-bridge#13.

3. **This repo, PR #332** (open): `BUNDLE_GUIDE.md`'s own module `source:` documentation taught a relative-path form (`source: ./modules/<m>`) that resolves fine when *authoring* a bundle but not at actual *runtime* resolution (behavior-relative, not repo-relative). Same defect family as (1) and (2): **a reference that is only valid in the context it was written in, not the context it is actually resolved in.**

This PR is the validator-side fix for the same family: catch it deterministically, in CI, before it reaches a user's `amplifier update`.

## What's new

- **Phase 0.6 `module-dep-resolvability-check`** (deterministic, no network, no LLM): builds a PEP 503-normalized set of every distribution name the repo itself defines (root `pyproject.toml` `[project].name` + every `modules/*/pyproject.toml` `[project].name`), then scans each module's `[project].dependencies` and `[project.optional-dependencies]` for a requirement naming one of those distributions **without** a PEP 508 direct URL reference (`name @ <url>`).
- **Finding `module_dep_unresolvable_no_sources`**, severity `ERROR` (feeds `critical_count`, same tier as `structure_lint`/`hygiene`/`mode_validation`/`agent_description` ERRORs -- this is a real `amplifier update` breakage, not a style suggestion). The message names the exact failure mode, and -- when a `[tool.uv.sources]` entry exists for the dependency -- states explicitly that `--no-sources` disables it (no protection). The fix names a PEP 508 direct git reference, with `#subdirectory=modules/<name>` when the dependency is itself a sibling module, plus the hatchling `allow-direct-references = true` note when the module's own build backend is hatchling.
- **New context var `published_distributions`** (JSON list, default `""`): same escape-hatch shape as the existing `root_bundle_repo` var. A repo-defined distribution genuinely published to a real registry has its bare-name findings downgraded `ERROR -> INFO` (`module_dep_bare_name_but_published`) instead of suppressed outright, so it stays visible without failing the build.
- **`quality-classification` and `synthesize-report`** wired the same way v3.10.0's `readme-install-convention-check` was wired: parse -> classify -> `critical_count` -> report section + Executive Summary line.
- Heredoc uses `"${AMPLIFIER_PYTHON:-python3}"`, per the v3.9.0 lesson (a bare `python3` silently skips foundation-gated phases when `amplifier_foundation` isn't on the system interpreter).

## Verification

**Synthetic bad fixture** (root `amplifier-testrepo` + `mod-a` bare-depends-on-root + `mod-b` bare-depends-on-sibling-module with a `[tool.uv.sources]` entry, run against the extracted script standalone):

```json
{
  "modules_checked": 2,
  "repo_defined_distributions": ["amplifier-module-mod-a", "amplifier-module-mod-b", "amplifier-testrepo"],
  "errors": [
    {"type": "module_dep_unresolvable_no_sources", "module": "mod-a", "dependency": "amplifier-testrepo", "severity": "ERROR", ...},
    {"type": "module_dep_unresolvable_no_sources", "module": "mod-b", "dependency": "amplifier-module-mod-a", "severity": "ERROR",
     "message": "...A [tool.uv.sources] entry exists for 'amplifier-module-mod-a' ({\"path\": \"../mod-a\", \"editable\": true}), but --no-sources disables [tool.uv.sources] entirely during this refresh, so it provides no protection.", ...}
  ],
  "passed": false
}
```

**Real amplifier-engram checkout** (all 3 modules already fixed with PEP 508 direct git references -- the actual incident this check exists to catch), same script, run against the real repo:

```json
{
  "modules_checked": 3,
  "repo_defined_distributions": ["amplifier-engram", "amplifier-module-hooks-engram-capture", "amplifier-module-hooks-engram-inject", "amplifier-module-tool-engram"],
  "errors": [], "warnings": [], "info": [],
  "passed": true
}
```
Zero findings on the as-fixed form -- confirms the check does not false-positive on correct PEP 508 direct references.

**New test file** `tests/test_module_dep_resolvability_check.py` (28 tests): structural wiring (step exists/type/output/depends_on/on_error, context var + default, `quality-classification` `depends_on` + parsing + `critical_count` wiring, `synthesize-report` section + prompt reference, version + changelog) plus **execution tests that extract the actual embedded script from the recipe YAML and run it as a subprocess** against on-disk `pyproject.toml` fixtures (bare root dep, bare sibling-module dep with subdirectory hint, `[tool.uv.sources]` no-protection message, direct-URL no-fire, unrelated-external no-fire, `published_distributions` escape hatch both alone and mixed with an unpublished sibling, no-modules-dir skip, no-root-pyproject-still-checks-modules, optional-dependencies). This exercises the shipped script directly rather than a separately-maintained logic copy that could drift.

```
$ uv run pytest tests/test_module_dep_resolvability_check.py -q
............................                                             [100%]
28 passed in 0.36s
```

**Full suite** (unchanged baseline):
```
$ uv run pytest tests/ -q
1675 passed, 1 skipped in 17.59s
```

**Pre-commit tripwire**:
```
$ python3 scripts/ci_checks/resolver_priority_tripwire.py --diff-only
resolver-priority-tripwire: 0 error(s), 0 warning(s), 0 baselined
```

## Related

- microsoft/amplifier-browser-bridge#13 -- sibling fix for the same defect class in that repo's own module dependency
- #332 -- same defect family (context-dependent reference), fixes the docs that taught the broken pattern this check now catches in code

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
