### PR TITLE
fix(tool-delegate): thread model_role/provider_preferences through the resume path

### DIFF
--- a/docs/lanes/98a-foundation-resume-role/DONE-NOTE.md
+++ b/docs/lanes/98a-foundation-resume-role/DONE-NOTE.md
@@ -1,0 +1,183 @@
+# DONE-NOTE — 98a: tool-delegate resume path drops model_role/provider_preferences
+
+Item: `model_performance-98a` (project `model_performance`)
+Branch: `lane/98a-foundation-resume-role`
+Parent commit measured against: `0d7b3f6e66953bcdafd4372c16f6694aab942292`
+
+## Result
+
+DONE. The amplifier-foundation half of the "resume wipes the model role"
+defect is fixed, with a test that fails on the parent commit and passes on
+the fix. Full suite green. Draft PR opened. Nothing merged from this lane.
+
+## The two sites, quoted
+
+Both at `modules/tool-delegate/amplifier_module_tool_delegate/__init__.py`,
+line numbers as of the parent commit `0d7b3f6`.
+
+### Site 1 — the call site, `execute()` :1533-1539
+
+```python
+            return await self._resume_existing_session(
+                session_id,
+                instruction,
+                hooks,
+                tool_call_id=tool_call_id,
+                parallel_group_id=parallel_group_id,
+            )
+```
+
+**Why it drops the role.** By the time control reaches this branch,
+`execute()` has *already* resolved the caller's `model_role` into
+`provider_preferences` (the resolver block at :1396-1490) — both values are
+live local variables. The spawn branch 60 lines below passes both to
+`_spawn_new_session(... provider_preferences=..., raw_model_role=...)`. This
+branch passes neither. The resolution work is done and then thrown away.
+
+### Site 2 — the resume path, `_resume_existing_session()`
+
+Signature, :2113-2121 — no parameter exists to receive them even if the
+call site had sent them:
+
+```python
+    async def _resume_existing_session(
+        self,
+        session_id: str,
+        instruction: str,
+        hooks,
+        *,
+        tool_call_id: str = "",
+        parallel_group_id: str | None = None,
+    ) -> ToolResult:
+```
+
+The wire call to the app layer, :2199-2202:
+
+```python
+            # Resume agent session (with optional session-level timeout)
+            resume_coro = resume_fn(
+                sub_session_id=full_session_id,
+                instruction=effective_instruction,
+            )
+```
+
+**Why it drops the role.** `session.resume` is the app-layer capability —
+this call *is* the request tool-delegate makes of the app layer, and its
+kwargs are what the app layer turns into the resumed session's provider
+config. Two kwargs and no more. The app-layer half already accepts
+`provider_preferences` and `model_role`
+(amplifier-app-cli `session_spawner.py:911-926` → `resume_sub_session`
+:1246-1251, shipped in #292 / `31ad917`); this repo simply never sent them,
+so the app layer's promotion had nothing to promote and the resumed leg fell
+back to settings priority. Silent: no error, no telemetry difference —
+`delegate:agent_spawned` carried `model_role`, `delegate:agent_resumed`
+carried no routing field at all, so there was nothing to compare it against.
+
+The two sites are one bug: the call site has the values and does not pass
+them; the resume path could not accept them if it did.
+
+## What changed
+
+1. **Call site** now threads `provider_preferences` + `raw_model_role`.
+2. **`_resume_existing_session`** accepts both; sends them to `resume_fn`.
+3. **`_session_routing` cache** — records the routing each spawn resolved
+   to, keyed by sub_session_id, mirroring the existing `_session_agents`
+   cache. This is what makes the acceptance criterion hold for the shape
+   every real caller uses: routing is pinned once on the *spawn* call, and
+   resumes are then issued as `(session_id, instruction)` with no routing
+   argument at all. Caller-explicit routing on the resume call still wins.
+4. **`_supported_resume_routing_kwargs()`** — introspects the app-layer
+   capability and sends only what it declares. An older app layer taking
+   `(sub_session_id, instruction)` keeps working instead of dying on an
+   unexpected kwarg; what it *cannot* do is drop the routing quietly — the
+   withheld kwargs are named in a `logger.warning`.
+5. **`delegate:agent_resumed`** now carries `model_role` /
+   `provider_preferences`, same shape as `delegate:agent_spawned`, so the
+   two legs of a delegation are comparable in telemetry. Additive.
+6. README: documents the resume capability's optional kwargs and the
+   precedence rule.
+
+## Measured
+
+**Fail-before / pass-after.** Same test file both times; the fix was stashed
+for the "before" run, so only the module changed.
+
+Before (parent `0d7b3f6`, fix stashed) — `docs/lanes/98a-foundation-resume-role/fail-before.txt`:
+
+```
+8 failed, 2 passed
+```
+
+The 2 that passed before are the backward-compatibility tests
+(`test_legacy_two_argument_resume_capability_still_works`,
+`test_plain_resume_sends_no_routing_kwargs`) — they *should* pass before, and
+they pin the behaviour the fix must not break.
+
+After: `10 passed`.
+
+**Full suite:** `1873 passed, 1 skipped, 1 warning in 19.45s` (the warning is
+pre-existing, in `tests/test_subprocess_runner.py`).
+
+## Honest scope of "the wire"
+
+The acceptance criterion says "the resumed session's first LLM request
+carries the same model_role/provider_preferences". This repo does not build
+LLM requests — it defines the capability contract and the app layer
+implements it. So the strongest assertion available *here* is at the
+`session.resume` seam, which is where the values were being lost.
+
+`TestResumedRequestConfig` closes as much of the remaining gap as this repo
+can: it drives foundation's own `apply_provider_preferences` — the same
+function the app layer calls to build a child's provider config — with
+whatever actually crossed the seam, and asserts the resumed leg's effective
+provider/model (`provider-anthropic` / `claude-opus-4`) equals the spawn
+leg's. That is the config the first request would be issued against. The
+end-to-end wire capture that proves it against a live provider is rc0's, and
+is what motivated this item; it is not re-run here (no spend authority).
+
+## Spend
+
+**$0.00.** No API calls, no DTU, no infrastructure created, nothing to tear
+down. The spend cap for this item was $0 and it was not approached: every
+assertion is a local unit test against mocked capabilities. Nothing in the
+remaining budget would have bought a stronger result at this layer — an
+end-to-end wire re-capture would need a live provider and belongs with the
+integration lane, not here.
+
+## Deviations
+
+1. **Added the `_session_routing` spawn-time cache.** Strictly more than
+   "thread the two arguments through". Without it the fix only covers a
+   caller who restates the role on *every* resume call, which is not how the
+   tool is used — and the acceptance criterion is phrased about a session
+   *spawned* with a role, not a resume call carrying one. Same lifetime and
+   same cold-cache caveat as the existing `_session_agents` cache; on a cold
+   cache the app layer's own recovery (agent overlay → persisted mount plan)
+   takes over, so a cold cache is a fallback, not a regression.
+
+2. **Added the capability-signature guard.** Unconditionally sending two new
+   kwargs to an app-layer-provided callable would have turned a silent
+   downgrade into a hard `TypeError` for any app layer that has not taken
+   app-cli #292. Guarded + warned instead. A callable that cannot be
+   introspected is treated as accepting nothing (preserve the working call
+   shape) and is also warned about — chosen deliberately over guessing and
+   crashing a resume.
+
+3. **Added routing fields to `delegate:agent_resumed`.** Not asked for. The
+   reason the drop survived this long is that it was invisible in telemetry;
+   leaving that gap open would leave the next regression equally invisible.
+   Additive — absence in an old capture means UNKNOWN, never "no routing".
+
+4. **CI runs `pytest tests/` only**, which does not include
+   `modules/tool-delegate/tests`. The local `testpaths` does include it and
+   that is what was run for the green result above. Not changed here — out
+   of scope for a bug fix, and worth its own item.
+
+## Open
+
+- The app-cli half (#292) is merged; the foundation half is this draft PR.
+  Neither alone closes the defect — a deployment needs both.
+- `routing-matrix` #53 (`dca54b5`) remains defense-in-depth only; it does not
+  substitute for either fix.
+- CI's `pytest tests/` excludes the tool-delegate module tests, so this
+  test would not run in CI as configured. Flagged, not fixed.

--- a/docs/lanes/98a-foundation-resume-role/fail-before.txt
+++ b/docs/lanes/98a-foundation-resume-role/fail-before.txt
@@ -1,0 +1,13 @@
+--- FAIL-BEFORE (parent 0d7b3f6, fix stashed) ---
+
+modules/tool-delegate/tests/test_delegate_resume_routing.py:428: KeyError
+=========================== short test summary info ============================
+FAILED modules/tool-delegate/tests/test_delegate_resume_routing.py::TestResumeThreadsExplicitRouting::test_resume_sends_model_role_to_resume_capability
+FAILED modules/tool-delegate/tests/test_delegate_resume_routing.py::TestResumeThreadsExplicitRouting::test_resume_sends_resolved_preferences_to_resume_capability
+FAILED modules/tool-delegate/tests/test_delegate_resume_routing.py::TestResumeThreadsExplicitRouting::test_resume_sends_explicit_provider_preferences
+FAILED modules/tool-delegate/tests/test_delegate_resume_routing.py::TestResumeInheritsSpawnRouting::test_resume_reuses_spawn_time_routing_when_caller_omits_it
+FAILED modules/tool-delegate/tests/test_delegate_resume_routing.py::TestResumeInheritsSpawnRouting::test_explicit_resume_role_overrides_the_spawn_time_role
+FAILED modules/tool-delegate/tests/test_delegate_resume_routing.py::TestResumedRequestConfig::test_resumed_leg_resolves_to_the_same_provider_and_model_as_spawn
+FAILED modules/tool-delegate/tests/test_delegate_resume_routing.py::TestResumeCapabilityCompatibility::test_legacy_capability_drop_is_logged_not_silent
+FAILED modules/tool-delegate/tests/test_delegate_resume_routing.py::TestResumedEventRouting::test_agent_resumed_event_carries_role_and_preferences
+8 failed, 2 passed in 0.08s

--- a/modules/tool-delegate/README.md
+++ b/modules/tool-delegate/README.md
@@ -30,6 +30,31 @@ Resume sessions using the full `session_id` returned by previous delegate calls:
 session_id: "abc123-def456-..._foundation:explorer"
 ```
 
+#### Routing survives the resume
+
+A delegation pinned to a model stays pinned on every leg. The resume path
+sends the app layer's `session.resume` capability two optional kwargs
+alongside `sub_session_id` / `instruction`:
+
+| kwarg | value |
+|---|---|
+| `provider_preferences` | the preferences this call resolved to |
+| `model_role` | the raw role string the caller asked for |
+
+Precedence: what the caller states on the resume call wins; otherwise the
+routing recorded when this tool spawned that sub-session is reused. So
+`delegate(agent=X, model_role="reasoning")` followed by
+`delegate(session_id=..., instruction=...)` resumes under `reasoning`,
+instead of silently falling back to settings priority (the measured
+"resume wipes the role" defect).
+
+Both kwargs are **optional on the capability**. An app layer whose resume
+capability still takes only `(sub_session_id, instruction)` keeps working
+unchanged — the kwargs are withheld and a warning naming them is logged, so
+the downgrade is never silent. `delegate:agent_resumed` also carries
+`model_role` / `provider_preferences` now, matching `delegate:agent_spawned`
+so the two legs can be compared in telemetry.
+
 ### Layered bounding: call budget (Layer 1) + wall-clock backstop (Layer 3)
 
 Delegated sessions are bounded two ways, and they are meant to be read as a

--- a/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
+++ b/modules/tool-delegate/amplifier_module_tool_delegate/__init__.py
@@ -50,6 +50,7 @@ Tool Parameters:
 __amplifier_module_type__ = "tool"
 
 import asyncio
+import inspect
 import json
 import logging
 import math
@@ -183,6 +184,45 @@ def _return_contract_event_fields(contract: dict[str, Any]) -> dict[str, Any]:
         "not_covered_count": len(contract.get("not_covered") or []),
         "artifacts_count": len(contract.get("artifacts") or []),
     }
+
+
+#: Routing kwargs the resume path threads to the app layer's
+#: ``session.resume`` capability. Both are OPTIONAL on that capability --
+#: see :func:`_supported_resume_routing_kwargs`.
+_RESUME_ROUTING_KWARGS = ("provider_preferences", "model_role")
+
+
+def _supported_resume_routing_kwargs(resume_fn: Any) -> set[str]:
+    """Which of ``_RESUME_ROUTING_KWARGS`` ``resume_fn`` can actually accept.
+
+    ``session.resume`` is an app-layer capability, so its signature is not
+    ours to guarantee. The original contract was
+    ``(sub_session_id, instruction)``; routing kwargs were added later
+    (amplifier-app-cli #292). Sending a kwarg an older app layer does not
+    declare would raise ``TypeError`` and break resume outright, so this
+    reports exactly what the callee declares and the caller sends only that
+    -- and logs a warning naming anything it had to hold back, because a
+    silent drop is the very defect this threading exists to fix.
+
+    A callable that cannot be introspected (some C-implemented or exotically
+    wrapped callables) is treated as accepting NOTHING: preserving today's
+    working call shape beats crashing a resume on a guess. That case is
+    warned about at the call site too, so it is never silent either.
+    """
+    try:
+        params = inspect.signature(resume_fn).parameters
+    except (TypeError, ValueError):
+        logger.warning(
+            "Could not introspect the session.resume capability's signature; "
+            "resuming without threading routing kwargs (%s)",
+            ", ".join(_RESUME_ROUTING_KWARGS),
+        )
+        return set()
+
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return set(_RESUME_ROUTING_KWARGS)
+
+    return {name for name in _RESUME_ROUTING_KWARGS if name in params}
 
 
 def _matrix_provenance(resolver: Any) -> dict[str, Any] | None:
@@ -485,6 +525,25 @@ class DelegateTool:
         # "{parent_span}-{child_span}_{sanitized_agent_name}" shape for every
         # sub-session id this tool creates.
         self._session_agents: dict[str, str] = {}
+
+        # Maps sub_session_id -> the routing this tool resolved at spawn time:
+        # {"model_role": str | None, "provider_preferences": list | None}.
+        #
+        # Why this exists: a caller pins routing ONCE, on the spawn call
+        # (delegate(agent=..., model_role="reasoning")), and then resumes
+        # with (session_id, instruction) -- the shape every existing caller
+        # uses. Without this record the resume leg has nothing to thread and
+        # the child silently falls back to settings priority, which is the
+        # measured "resume wipes the role" defect. An explicit model_role /
+        # provider_preferences on the resume call still wins over it.
+        #
+        # Same scope and same cold-cache caveat as _session_agents above:
+        # per-DelegateTool-instance, so it does not survive a process
+        # restart or a resume issued from a different parent session. That
+        # case is not a silent drop either -- the app layer recovers the
+        # preferences from the persisted session (agent overlay, then mount
+        # plan); see amplifier-app-cli's resume_sub_session.
+        self._session_routing: dict[str, dict[str, Any]] = {}
 
     def _build_feature_registry(self) -> list[dict[str, Any]]:
         """Build registry of features with their descriptions.
@@ -1530,12 +1589,21 @@ Agent usage notes:
                     success=False,
                     error={"message": "Session resumption is disabled"},
                 )
+            # provider_preferences / raw_model_role are threaded here for the
+            # same reason the spawn branch below threads them: a caller that
+            # pins a model for a delegation must get that model on EVERY leg
+            # of it, not just the first. Both are already fully resolved
+            # above (the model_role -> preferences resolution runs before
+            # this branch), so the resume path receives exactly what the
+            # spawn path would have.
             return await self._resume_existing_session(
                 session_id,
                 instruction,
                 hooks,
                 tool_call_id=tool_call_id,
                 parallel_group_id=parallel_group_id,
+                provider_preferences=provider_preferences,
+                raw_model_role=raw_model_role,
             )
 
         # SPAWN MODE: Create new agent session (requires agent)
@@ -1708,6 +1776,18 @@ Agent usage notes:
         # here, instead of re-deriving a lossy, sanitized approximation from
         # the session_id suffix. See _resolve_agent_for_session().
         self._session_agents[sub_session_id] = agent_name
+
+        # Record the routing this delegation resolved to, for the same
+        # reason: a later resume of THIS sub-session must be able to route
+        # the way the caller asked here, even when the resume call itself
+        # says nothing about routing. See _session_routing's declaration and
+        # _resolve_routing_for_session().
+        self._session_routing[sub_session_id] = {
+            "model_role": raw_model_role or None,
+            "provider_preferences": (
+                list(provider_preferences) if provider_preferences else None
+            ),
+        }
 
         # Resolve agents from coordinator config if not provided directly
         if agents is None:
@@ -2110,6 +2190,25 @@ Agent usage notes:
 
         return "unknown"
 
+    def _resolve_routing_for_session(
+        self, session_id: str
+    ) -> tuple[str | None, list | None]:
+        """Recover the routing recorded when ``session_id`` was spawned.
+
+        Source priority mirrors :meth:`_resolve_agent_for_session`: this
+        tool's own spawn-time record, else nothing. Unlike agent identity
+        there is no lossy fallback to parse out of the session_id -- routing
+        is not encoded there -- so a cold cache returns ``(None, None)`` and
+        the app layer's own recovery (agent overlay, then persisted mount
+        plan) takes over.
+
+        Returns:
+            ``(model_role, provider_preferences)``, either of which may be
+            ``None``.
+        """
+        recorded = self._session_routing.get(session_id) or {}
+        return recorded.get("model_role"), recorded.get("provider_preferences")
+
     async def _resume_existing_session(
         self,
         session_id: str,
@@ -2118,6 +2217,8 @@ Agent usage notes:
         *,
         tool_call_id: str = "",
         parallel_group_id: str | None = None,
+        provider_preferences: list | None = None,
+        raw_model_role: str = "",
     ) -> ToolResult:
         """Resume existing agent session.
 
@@ -2127,6 +2228,11 @@ Agent usage notes:
             hooks: Hook coordinator for event emission
             tool_call_id: Orchestrator tool call ID (enriches event payloads)
             parallel_group_id: Parallel group ID (enriches event payloads)
+            provider_preferences: Preferences resolved by execute() for THIS
+                resume call, if the caller pinned any. ``None`` falls back to
+                whatever was recorded when the sub-session was spawned.
+            raw_model_role: The raw model role string supplied on THIS resume
+                call, if any. Same fallback as ``provider_preferences``.
 
         Returns:
             ToolResult with success status and output or error
@@ -2149,6 +2255,19 @@ Agent usage notes:
         # first).
         agent_name = self._resolve_agent_for_session(session_id)
 
+        # Resolve the routing this leg should run under. Precedence:
+        #   1. what the caller stated on THIS resume call (already resolved
+        #      by execute(): model_role -> provider_preferences), then
+        #   2. what this tool recorded when it spawned the sub-session.
+        # Only when the caller stated NEITHER do we fall back, so an
+        # explicit resume-time pin is never quietly overruled by history.
+        effective_model_role: str | None = raw_model_role or None
+        effective_preferences: list | None = provider_preferences
+        if effective_model_role is None and effective_preferences is None:
+            effective_model_role, effective_preferences = (
+                self._resolve_routing_for_session(session_id)
+            )
+
         try:
             # Use session_id as-is (no short ID resolution - LLMs can handle full IDs)
             full_session_id = session_id
@@ -2166,6 +2285,19 @@ Agent usage notes:
                         "parent_session_id": parent_session_id,
                         "tool_call_id": tool_call_id,
                         "parallel_group_id": parallel_group_id,
+                        # Same two fields, same shape, as delegate:agent_spawned.
+                        # Additive: a consumer that does not read them is
+                        # unaffected, and absence in an OLD capture means
+                        # UNKNOWN (predates this field), never "no routing".
+                        # Their whole point is that the drop this fix closes
+                        # was invisible in telemetry -- spawned carried a role,
+                        # resumed carried nothing to compare it against.
+                        "model_role": effective_model_role,
+                        "provider_preferences": (
+                            [p.to_dict() for p in effective_preferences]
+                            if effective_preferences
+                            else None
+                        ),
                     },
                 )
 
@@ -2196,10 +2328,45 @@ Agent usage notes:
                         f"{instruction}\n\n{RETURN_CONTRACT_INSTRUCTION}"
                     )
 
+            # Thread the caller's routing across the app-layer seam.
+            #
+            # This is the fix for the measured "resume wipes the model role"
+            # defect: this call used to be (sub_session_id, instruction)
+            # only, so provider_preferences and model_role never reached the
+            # app layer and the resumed leg fell back to settings priority
+            # -- a silent downgrade, invisible until it was caught on the
+            # wire. The kwargs are OPTIONAL on the capability (see
+            # _supported_resume_routing_kwargs), so an app layer that
+            # predates them keeps working unchanged; what it cannot do is
+            # drop them quietly.
+            resume_routing: dict[str, Any] = {}
+            if effective_preferences is not None:
+                resume_routing["provider_preferences"] = effective_preferences
+            if effective_model_role is not None:
+                resume_routing["model_role"] = effective_model_role
+
+            if resume_routing:
+                supported = _supported_resume_routing_kwargs(resume_fn)
+                unsupported = sorted(set(resume_routing) - supported)
+                if unsupported:
+                    logger.warning(
+                        "session.resume capability does not accept %s -- resuming "
+                        "session %s WITHOUT the caller's routing, which may resolve "
+                        "to a different provider/model than the spawn leg. Update "
+                        "the app layer's resume capability to accept %s.",
+                        ", ".join(unsupported),
+                        full_session_id,
+                        ", ".join(_RESUME_ROUTING_KWARGS),
+                    )
+                resume_routing = {
+                    k: v for k, v in resume_routing.items() if k in supported
+                }
+
             # Resume agent session (with optional session-level timeout)
             resume_coro = resume_fn(
                 sub_session_id=full_session_id,
                 instruction=effective_instruction,
+                **resume_routing,
             )
             result = await self._await_child_with_deadline(resume_coro)
 

--- a/modules/tool-delegate/tests/test_delegate_resume_routing.py
+++ b/modules/tool-delegate/tests/test_delegate_resume_routing.py
@@ -1,0 +1,442 @@
+"""Resume must carry the caller's routing, not silently drop it.
+
+Measured defect (rc0, on the wire): a delegate spawned with an explicit
+``model_role`` loses that role the moment it is resumed. Two independent
+sites had to be fixed; this file covers the amplifier-foundation one.
+
+The tool-delegate resume path called the app layer's ``session.resume``
+capability with ``(sub_session_id, instruction)`` ONLY -- neither
+``provider_preferences`` nor ``model_role`` crossed the seam, so the app
+layer never had the values it needed to promote the caller's provider on
+the resumed leg. The app-layer half (amplifier-app-cli #292) already
+accepts both kwargs; this repo simply never sent them.
+
+"Wire" at this repo's boundary is the ``session.resume`` capability call:
+that call IS the request tool-delegate makes of the app layer, and its
+kwargs are what the app layer turns into the resumed session's provider
+config. ``TestResumedRequestConfig`` closes the remaining gap by driving
+foundation's own ``apply_provider_preferences`` with what crossed the
+seam, asserting the resumed leg's effective provider/model -- the thing
+the first LLM request is actually built from -- matches the spawn leg's.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from amplifier_module_tool_delegate import DelegateTool
+
+from amplifier_foundation.spawn_utils import (
+    ProviderPreference,
+    apply_provider_preferences,
+)
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _resume_result(session_id: str = "child-001") -> dict:
+    return {
+        "output": "resumed",
+        "session_id": session_id,
+        "status": "success",
+        "turn_count": 2,
+        "metadata": {},
+    }
+
+
+def _spawn_result(**kwargs) -> dict:
+    return {
+        "output": "spawned",
+        "session_id": kwargs.get("sub_session_id", "child-001"),
+        "status": "success",
+        "turn_count": 1,
+        "metadata": {},
+    }
+
+
+def _make_delegate_tool(
+    *,
+    spawn_fn=None,
+    resume_fn=None,
+    agents: dict | None = None,
+    model_role_resolver=None,
+    settings: dict | None = None,
+) -> DelegateTool:
+    """DelegateTool over a mocked coordinator exposing spawn + resume."""
+    coordinator = MagicMock()
+    coordinator.session_id = "parent-session-123"
+    coordinator.config = {"agents": agents or {}}
+    coordinator.session_state = {}
+
+    capabilities: dict = {
+        "session.spawn": spawn_fn
+        or AsyncMock(side_effect=lambda **kw: _spawn_result(**kw)),
+        "session.resume": resume_fn or AsyncMock(return_value=_resume_result()),
+        "agents.list": lambda: agents or {},
+        "agents.get": lambda name: (agents or {}).get(name),
+        "self_delegation_depth": 0,
+        "model_role_resolver": model_role_resolver,
+    }
+
+    coordinator.get_capability = lambda name: capabilities.get(name)
+    coordinator.get = MagicMock(return_value=None)  # hooks = None
+
+    parent_session = MagicMock()
+    parent_session.session_id = "parent-session-123"
+    parent_session.config = {"session": {"orchestrator": {}}}
+    coordinator.session = parent_session
+
+    config: dict = {
+        "features": {},
+        "settings": {"exclude_tools": [], **(settings or {})},
+    }
+    return DelegateTool(coordinator, config)
+
+
+def _make_resolver(*, return_value: list | None = None, name: str = "test-matrix"):
+    resolver = MagicMock()
+    resolver.name = name
+    resolver.resolve = AsyncMock(
+        return_value=return_value if return_value is not None else []
+    )
+    return resolver
+
+
+_REASONING = ProviderPreference(provider="anthropic", model="claude-opus-4")
+_FAST = ProviderPreference(provider="anthropic", model="claude-haiku-4")
+
+
+# =============================================================================
+# The caller states a role ON the resume call
+# =============================================================================
+
+
+class TestResumeThreadsExplicitRouting:
+    @pytest.mark.asyncio
+    async def test_resume_sends_model_role_to_resume_capability(self):
+        """An explicit model_role on a resume call must reach session.resume."""
+        resume_fn = AsyncMock(return_value=_resume_result())
+        tool = _make_delegate_tool(
+            resume_fn=resume_fn,
+            model_role_resolver=_make_resolver(return_value=[_REASONING]),
+        )
+
+        await tool.execute(
+            {
+                "session_id": "child-001",
+                "instruction": "Continue",
+                "model_role": "reasoning",
+            }
+        )
+
+        _, kwargs = resume_fn.call_args
+        assert kwargs.get("model_role") == "reasoning", (
+            "resume path dropped the caller's model_role before it reached the app layer"
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_sends_resolved_preferences_to_resume_capability(self):
+        """The preferences the role resolved to must reach session.resume too."""
+        resume_fn = AsyncMock(return_value=_resume_result())
+        tool = _make_delegate_tool(
+            resume_fn=resume_fn,
+            model_role_resolver=_make_resolver(return_value=[_REASONING]),
+        )
+
+        await tool.execute(
+            {
+                "session_id": "child-001",
+                "instruction": "Continue",
+                "model_role": "reasoning",
+            }
+        )
+
+        _, kwargs = resume_fn.call_args
+        assert kwargs.get("provider_preferences") == [_REASONING]
+
+    @pytest.mark.asyncio
+    async def test_resume_sends_explicit_provider_preferences(self):
+        """An explicit provider_preferences pin on resume must reach the app layer."""
+        resume_fn = AsyncMock(return_value=_resume_result())
+        tool = _make_delegate_tool(resume_fn=resume_fn)
+
+        await tool.execute(
+            {
+                "session_id": "child-001",
+                "instruction": "Continue",
+                "provider_preferences": [{"provider": "openai", "model": "gpt-5"}],
+            }
+        )
+
+        _, kwargs = resume_fn.call_args
+        assert kwargs.get("provider_preferences") == [
+            ProviderPreference(provider="openai", model="gpt-5")
+        ]
+
+
+# =============================================================================
+# The caller stated the role at SPAWN and says nothing on resume
+# =============================================================================
+
+
+class TestResumeInheritsSpawnRouting:
+    @pytest.mark.asyncio
+    async def test_resume_reuses_spawn_time_routing_when_caller_omits_it(self):
+        """Acceptance criterion: a session spawned with a role keeps that role on resume.
+
+        The caller resumes with (session_id, instruction) only -- the shape
+        every existing caller uses -- so the routing must come from what
+        THIS tool recorded at spawn time.
+        """
+        spawn_fn = AsyncMock(side_effect=lambda **kw: _spawn_result(**kw))
+        resume_fn = AsyncMock(return_value=_resume_result())
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            resume_fn=resume_fn,
+            agents={"explorer": {"description": "d"}},
+            model_role_resolver=_make_resolver(return_value=[_REASONING]),
+        )
+
+        spawned = await tool.execute(
+            {
+                "agent": "explorer",
+                "instruction": "Investigate",
+                "context_depth": "none",
+                "model_role": "reasoning",
+            }
+        )
+        session_id = spawned.output["session_id"]
+
+        await tool.execute({"session_id": session_id, "instruction": "Keep going"})
+
+        _, spawn_kwargs = spawn_fn.call_args
+        _, resume_kwargs = resume_fn.call_args
+        assert (
+            resume_kwargs.get("provider_preferences")
+            == spawn_kwargs["provider_preferences"]
+        )
+        assert resume_kwargs.get("model_role") == "reasoning"
+
+    @pytest.mark.asyncio
+    async def test_explicit_resume_role_overrides_the_spawn_time_role(self):
+        """A role stated on the resume call wins over the one recorded at spawn."""
+        spawn_fn = AsyncMock(side_effect=lambda **kw: _spawn_result(**kw))
+        resume_fn = AsyncMock(return_value=_resume_result())
+        resolver = _make_resolver(return_value=[_REASONING])
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_fn,
+            resume_fn=resume_fn,
+            agents={"explorer": {"description": "d"}},
+            model_role_resolver=resolver,
+        )
+
+        spawned = await tool.execute(
+            {
+                "agent": "explorer",
+                "instruction": "Investigate",
+                "context_depth": "none",
+                "model_role": "reasoning",
+            }
+        )
+        session_id = spawned.output["session_id"]
+
+        resolver.resolve = AsyncMock(return_value=[_FAST])
+        await tool.execute(
+            {
+                "session_id": session_id,
+                "instruction": "Just summarise",
+                "model_role": "fast",
+            }
+        )
+
+        _, resume_kwargs = resume_fn.call_args
+        assert resume_kwargs.get("model_role") == "fast"
+        assert resume_kwargs.get("provider_preferences") == [_FAST]
+
+
+# =============================================================================
+# What the resumed leg's request is actually built from
+# =============================================================================
+
+
+class TestResumedRequestConfig:
+    @pytest.mark.asyncio
+    async def test_resumed_leg_resolves_to_the_same_provider_and_model_as_spawn(self):
+        """Drive the real promotion with what crossed the seam.
+
+        ``apply_provider_preferences`` is the same foundation function the
+        app layer calls to build a child session's provider config, so the
+        promoted provider/model here is what the resumed session's first
+        LLM request would be issued against.
+        """
+        mount_plan = {
+            "providers": [
+                {
+                    "module": "provider-openai",
+                    "config": {"default_model": "gpt-5-mini", "priority": 0},
+                },
+                {
+                    "module": "provider-anthropic",
+                    "config": {"default_model": "claude-haiku-4", "priority": 1},
+                },
+            ]
+        }
+        effective: dict[str, dict] = {}
+
+        def _record(leg: str, preferences):
+            # Lower priority number wins (see _apply_single_override).
+            plan = apply_provider_preferences(mount_plan, list(preferences or []))
+            top = min(plan["providers"], key=lambda p: p["config"].get("priority", 99))
+            effective[leg] = {
+                "module": top["module"],
+                "model": top["config"]["default_model"],
+            }
+
+        async def spawn_capability(**kw):
+            _record("spawn", kw.get("provider_preferences"))
+            return _spawn_result(**kw)
+
+        async def resume_capability(
+            sub_session_id: str,
+            instruction: str,
+            provider_preferences: list | None = None,
+            model_role: str | list[str] | None = None,
+        ):
+            _record("resume", provider_preferences)
+            return _resume_result(sub_session_id)
+
+        tool = _make_delegate_tool(
+            spawn_fn=spawn_capability,
+            resume_fn=resume_capability,
+            agents={"explorer": {"description": "d"}},
+            model_role_resolver=_make_resolver(return_value=[_REASONING]),
+        )
+
+        spawned = await tool.execute(
+            {
+                "agent": "explorer",
+                "instruction": "Investigate",
+                "context_depth": "none",
+                "model_role": "reasoning",
+            }
+        )
+        await tool.execute(
+            {"session_id": spawned.output["session_id"], "instruction": "Keep going"}
+        )
+
+        assert effective["spawn"] == {
+            "module": "provider-anthropic",
+            "model": "claude-opus-4",
+        }
+        assert effective["resume"] == effective["spawn"], (
+            "the resumed leg would issue its first request against a different "
+            f"provider/model than the spawn leg: {effective}"
+        )
+
+
+# =============================================================================
+# Backward compatibility: don't crash, don't drop silently
+# =============================================================================
+
+
+class TestResumeCapabilityCompatibility:
+    @pytest.mark.asyncio
+    async def test_legacy_two_argument_resume_capability_still_works(self):
+        """An app layer that predates the routing kwargs must not start crashing."""
+        seen: dict = {}
+
+        async def legacy_resume(sub_session_id: str, instruction: str):
+            seen["sub_session_id"] = sub_session_id
+            seen["instruction"] = instruction
+            return _resume_result(sub_session_id)
+
+        tool = _make_delegate_tool(
+            resume_fn=legacy_resume,
+            model_role_resolver=_make_resolver(return_value=[_REASONING]),
+        )
+
+        result = await tool.execute(
+            {
+                "session_id": "child-001",
+                "instruction": "Continue",
+                "model_role": "reasoning",
+            }
+        )
+
+        assert result.success is True
+        assert seen["sub_session_id"] == "child-001"
+
+    @pytest.mark.asyncio
+    async def test_legacy_capability_drop_is_logged_not_silent(self, caplog):
+        """Dropping the caller's routing must be loud -- silence is the original bug."""
+
+        async def legacy_resume(sub_session_id: str, instruction: str):
+            return _resume_result(sub_session_id)
+
+        tool = _make_delegate_tool(
+            resume_fn=legacy_resume,
+            model_role_resolver=_make_resolver(return_value=[_REASONING]),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="amplifier_module_tool_delegate"):
+            await tool.execute(
+                {
+                    "session_id": "child-001",
+                    "instruction": "Continue",
+                    "model_role": "reasoning",
+                }
+            )
+
+        assert any("model_role" in rec.getMessage() for rec in caplog.records), (
+            "expected a warning naming the routing that could not be threaded"
+        )
+
+    @pytest.mark.asyncio
+    async def test_plain_resume_sends_no_routing_kwargs(self):
+        """With nothing to thread, the call stays exactly as it was before this fix."""
+        resume_fn = AsyncMock(return_value=_resume_result())
+        tool = _make_delegate_tool(resume_fn=resume_fn)
+
+        await tool.execute({"session_id": "child-001", "instruction": "Continue"})
+
+        _, kwargs = resume_fn.call_args
+        assert set(kwargs) == {"sub_session_id", "instruction"}
+
+
+# =============================================================================
+# Telemetry: the resumed event must show what the resumed leg was routed to
+# =============================================================================
+
+
+class TestResumedEventRouting:
+    @pytest.mark.asyncio
+    async def test_agent_resumed_event_carries_role_and_preferences(self):
+        emitted: dict = {}
+
+        hooks = MagicMock()
+
+        async def _emit(event, payload):
+            emitted[event] = payload
+
+        hooks.emit = _emit
+
+        tool = _make_delegate_tool(
+            model_role_resolver=_make_resolver(return_value=[_REASONING]),
+        )
+        tool.coordinator.get = MagicMock(return_value=hooks)
+
+        await tool.execute(
+            {
+                "session_id": "child-001",
+                "instruction": "Continue",
+                "model_role": "reasoning",
+            }
+        )
+
+        payload = emitted["delegate:agent_resumed"]
+        assert payload["model_role"] == "reasoning"
+        assert payload["provider_preferences"] == [_REASONING.to_dict()]


### PR DESCRIPTION
## The defect

A delegation pinned to a model **lost that pin the moment it was resumed**.
Confirmed on the wire (rc0). Two independent sites had to be fixed; the
app-cli half shipped in microsoft/amplifier-app-cli#292 (`31ad917`). This PR
is the amplifier-foundation half, which was the one still open.

## The two sites (at parent `0d7b3f6`)

Both in `modules/tool-delegate/amplifier_module_tool_delegate/__init__.py`.

**Call site, `execute()` :1533-1539** — `execute()` has *already* resolved
the caller's `model_role` into `provider_preferences` (resolver block at
:1396-1490); both are live locals. The spawn branch 60 lines below passes
both to `_spawn_new_session`. This branch passes neither:

```python
            return await self._resume_existing_session(
                session_id,
                instruction,
                hooks,
                tool_call_id=tool_call_id,
                parallel_group_id=parallel_group_id,
            )
```

**Resume path, `_resume_existing_session()` :2113-2121** — no parameter
exists to receive them even if the call site had sent them. And the wire
call to the app layer, :2199-2202:

```python
            resume_coro = resume_fn(
                sub_session_id=full_session_id,
                instruction=effective_instruction,
            )
```

`session.resume` is the app-layer capability — this call **is** the request
tool-delegate makes of the app layer, and its kwargs are what the app layer
turns into the resumed session's provider config. The app layer already
accepts `provider_preferences` and `model_role` (app-cli `session_spawner.py`
:911-926 → `resume_sub_session` :1246-1251, #292). This repo simply never
sent them, so the promotion had nothing to promote and the resumed leg fell
back to settings priority.

It failed **silently**: `delegate:agent_spawned` carried `model_role`,
`delegate:agent_resumed` carried no routing field at all — nothing to compare
it against.

## The fix

1. Call site threads `provider_preferences` + `raw_model_role`.
2. `_resume_existing_session` accepts both and sends them to `resume_fn`.
3. **`_session_routing`** records the routing each spawn resolved to, keyed
   by sub_session_id (mirrors the existing `_session_agents` cache). This is
   what makes the acceptance criterion hold for the shape real callers use:
   routing is pinned once on the *spawn* call, and resumes are then issued as
   `(session_id, instruction)` with no routing argument. Caller-explicit
   routing on the resume call still wins.
4. **`_supported_resume_routing_kwargs()`** introspects the app-layer
   capability and sends only what it declares. An app layer still taking
   `(sub_session_id, instruction)` keeps working instead of dying on an
   unexpected kwarg — but cannot drop the routing quietly: withheld kwargs
   are named in a `logger.warning`.
5. `delegate:agent_resumed` now carries `model_role` /
   `provider_preferences`, matching `delegate:agent_spawned`. Additive;
   absence in an old capture means UNKNOWN, never "no routing".
6. README documents the capability's optional kwargs and the precedence rule.

## Evidence

**Fail-before / pass-after** — same test file both runs; the module fix was
stashed for the "before" run, so only the module differed.

Before (parent `0d7b3f6`, fix stashed):

```
FAILED test_delegate_resume_routing.py::TestResumeThreadsExplicitRouting::test_resume_sends_model_role_to_resume_capability
FAILED test_delegate_resume_routing.py::TestResumeThreadsExplicitRouting::test_resume_sends_resolved_preferences_to_resume_capability
FAILED test_delegate_resume_routing.py::TestResumeThreadsExplicitRouting::test_resume_sends_explicit_provider_preferences
FAILED test_delegate_resume_routing.py::TestResumeInheritsSpawnRouting::test_resume_reuses_spawn_time_routing_when_caller_omits_it
FAILED test_delegate_resume_routing.py::TestResumeInheritsSpawnRouting::test_explicit_resume_role_overrides_the_spawn_time_role
FAILED test_delegate_resume_routing.py::TestResumedRequestConfig::test_resumed_leg_resolves_to_the_same_provider_and_model_as_spawn
FAILED test_delegate_resume_routing.py::TestResumeCapabilityCompatibility::test_legacy_capability_drop_is_logged_not_silent
FAILED test_delegate_resume_routing.py::TestResumedEventRouting::test_agent_resumed_event_carries_role_and_preferences
8 failed, 2 passed in 0.08s
```

The 2 that pass before are the backward-compatibility tests — they *should*
pass before; they pin what the fix must not break.

After: `10 passed`.

**Full suite** (`uv run pytest -q`, local `testpaths` = `tests` +
`modules/tool-delegate/tests`):

```
1873 passed, 1 skipped, 1 warning in 19.45s
```

The one warning is pre-existing (`tests/test_subprocess_runner.py`).

## Honest scope of "the wire"

This repo does not build LLM requests — it defines the capability contract;
the app layer implements it. The strongest assertion available *here* is at
the `session.resume` seam, which is exactly where the values were lost.

`TestResumedRequestConfig` closes as much of the rest as this repo can: it
drives foundation's own `apply_provider_preferences` — the same function the
app layer calls to build a child's provider config — with what actually
crossed the seam, and asserts the resumed leg's effective provider/model
(`provider-anthropic` / `claude-opus-4`) equals the spawn leg's. That is the
config the first request would be issued against.

## Spend

**$0.00** — no API calls, no DTU, no infrastructure created. Cap for this
item was $0.

## Deviations from a literal "thread two arguments"

- **`_session_routing` cache added.** Without it the fix only helps a caller
  who restates the role on every resume, which is not how the tool is used,
  and the acceptance criterion is about a session *spawned* with a role.
  Same lifetime/cold-cache caveat as `_session_agents`; on a cold cache the
  app layer's own recovery (agent overlay → persisted mount plan) takes over.
- **Signature guard added.** Sending two new kwargs unconditionally to an
  app-supplied callable would convert a silent downgrade into a hard
  `TypeError` for any app layer without #292.
- **Routing fields on `delegate:agent_resumed`.** Not requested. The drop
  survived this long because it was invisible in telemetry.
- **Note:** CI runs `pytest tests/` only, which excludes
  `modules/tool-delegate/tests` — so this test would not run in CI as
  configured. Flagged, not changed here; worth its own item.

---

## Lane DONE-NOTE (verbatim)

Committed in this PR at `docs/lanes/98a-foundation-resume-role/DONE-NOTE.md` (commit `a8b5e73`, present on the remote branch head). Inlined here so the measurements, spend, and deviations are readable in the PR body itself, not only by opening the file.

<details>
<summary>docs/lanes/98a-foundation-resume-role/DONE-NOTE.md</summary>

# DONE-NOTE — 98a: tool-delegate resume path drops model_role/provider_preferences

Item: `model_performance-98a` (project `model_performance`)
Branch: `lane/98a-foundation-resume-role`
Parent commit measured against: `0d7b3f6e66953bcdafd4372c16f6694aab942292`

## Result

DONE. The amplifier-foundation half of the "resume wipes the model role"
defect is fixed, with a test that fails on the parent commit and passes on
the fix. Full suite green. Draft PR opened. Nothing merged from this lane.

## The two sites, quoted

Both at `modules/tool-delegate/amplifier_module_tool_delegate/__init__.py`,
line numbers as of the parent commit `0d7b3f6`.

### Site 1 — the call site, `execute()` :1533-1539

```python
            return await self._resume_existing_session(
                session_id,
                instruction,
                hooks,
                tool_call_id=tool_call_id,
                parallel_group_id=parallel_group_id,
            )
```

**Why it drops the role.** By the time control reaches this branch,
`execute()` has *already* resolved the caller's `model_role` into
`provider_preferences` (the resolver block at :1396-1490) — both values are
live local variables. The spawn branch 60 lines below passes both to
`_spawn_new_session(... provider_preferences=..., raw_model_role=...)`. This
branch passes neither. The resolution work is done and then thrown away.

### Site 2 — the resume path, `_resume_existing_session()`

Signature, :2113-2121 — no parameter exists to receive them even if the
call site had sent them:

```python
    async def _resume_existing_session(
        self,
        session_id: str,
        instruction: str,
        hooks,
        *,
        tool_call_id: str = "",
        parallel_group_id: str | None = None,
    ) -> ToolResult:
```

The wire call to the app layer, :2199-2202:

```python
            # Resume agent session (with optional session-level timeout)
            resume_coro = resume_fn(
                sub_session_id=full_session_id,
                instruction=effective_instruction,
            )
```

**Why it drops the role.** `session.resume` is the app-layer capability —
this call *is* the request tool-delegate makes of the app layer, and its
kwargs are what the app layer turns into the resumed session's provider
config. Two kwargs and no more. The app-layer half already accepts
`provider_preferences` and `model_role`
(amplifier-app-cli `session_spawner.py:911-926` → `resume_sub_session`
:1246-1251, shipped in #292 / `31ad917`); this repo simply never sent them,
so the app layer's promotion had nothing to promote and the resumed leg fell
back to settings priority. Silent: no error, no telemetry difference —
`delegate:agent_spawned` carried `model_role`, `delegate:agent_resumed`
carried no routing field at all, so there was nothing to compare it against.

The two sites are one bug: the call site has the values and does not pass
them; the resume path could not accept them if it did.

## What changed

1. **Call site** now threads `provider_preferences` + `raw_model_role`.
2. **`_resume_existing_session`** accepts both; sends them to `resume_fn`.
3. **`_session_routing` cache** — records the routing each spawn resolved
   to, keyed by sub_session_id, mirroring the existing `_session_agents`
   cache. This is what makes the acceptance criterion hold for the shape
   every real caller uses: routing is pinned once on the *spawn* call, and
   resumes are then issued as `(session_id, instruction)` with no routing
   argument at all. Caller-explicit routing on the resume call still wins.
4. **`_supported_resume_routing_kwargs()`** — introspects the app-layer
   capability and sends only what it declares. An older app layer taking
   `(sub_session_id, instruction)` keeps working instead of dying on an
   unexpected kwarg; what it *cannot* do is drop the routing quietly — the
   withheld kwargs are named in a `logger.warning`.
5. **`delegate:agent_resumed`** now carries `model_role` /
   `provider_preferences`, same shape as `delegate:agent_spawned`, so the
   two legs of a delegation are comparable in telemetry. Additive.
6. README: documents the resume capability's optional kwargs and the
   precedence rule.

## Measured

**Fail-before / pass-after.** Same test file both times; the fix was stashed
for the "before" run, so only the module changed.

Before (parent `0d7b3f6`, fix stashed) — `docs/lanes/98a-foundation-resume-role/fail-before.txt`:

```
8 failed, 2 passed
```

The 2 that passed before are the backward-compatibility tests
(`test_legacy_two_argument_resume_capability_still_works`,
`test_plain_resume_sends_no_routing_kwargs`) — they *should* pass before, and
they pin the behaviour the fix must not break.

After: `10 passed`.

**Full suite:** `1873 passed, 1 skipped, 1 warning in 19.45s` (the warning is
pre-existing, in `tests/test_subprocess_runner.py`).

## Honest scope of "the wire"

The acceptance criterion says "the resumed session's first LLM request
carries the same model_role/provider_preferences". This repo does not build
LLM requests — it defines the capability contract and the app layer
implements it. So the strongest assertion available *here* is at the
`session.resume` seam, which is where the values were being lost.

`TestResumedRequestConfig` closes as much of the remaining gap as this repo
can: it drives foundation's own `apply_provider_preferences` — the same
function the app layer calls to build a child's provider config — with
whatever actually crossed the seam, and asserts the resumed leg's effective
provider/model (`provider-anthropic` / `claude-opus-4`) equals the spawn
leg's. That is the config the first request would be issued against. The
end-to-end wire capture that proves it against a live provider is rc0's, and
is what motivated this item; it is not re-run here (no spend authority).

## Spend

**$0.00.** No API calls, no DTU, no infrastructure created, nothing to tear
down. The spend cap for this item was $0 and it was not approached: every
assertion is a local unit test against mocked capabilities. Nothing in the
remaining budget would have bought a stronger result at this layer — an
end-to-end wire re-capture would need a live provider and belongs with the
integration lane, not here.

## Deviations

1. **Added the `_session_routing` spawn-time cache.** Strictly more than
   "thread the two arguments through". Without it the fix only covers a
   caller who restates the role on *every* resume call, which is not how the
   tool is used — and the acceptance criterion is phrased about a session
   *spawned* with a role, not a resume call carrying one. Same lifetime and
   same cold-cache caveat as the existing `_session_agents` cache; on a cold
   cache the app layer's own recovery (agent overlay → persisted mount plan)
   takes over, so a cold cache is a fallback, not a regression.

2. **Added the capability-signature guard.** Unconditionally sending two new
   kwargs to an app-layer-provided callable would have turned a silent
   downgrade into a hard `TypeError` for any app layer that has not taken
   app-cli #292. Guarded + warned instead. A callable that cannot be
   introspected is treated as accepting nothing (preserve the working call
   shape) and is also warned about — chosen deliberately over guessing and
   crashing a resume.

3. **Added routing fields to `delegate:agent_resumed`.** Not asked for. The
   reason the drop survived this long is that it was invisible in telemetry;
   leaving that gap open would leave the next regression equally invisible.
   Additive — absence in an old capture means UNKNOWN, never "no routing".

4. **CI runs `pytest tests/` only**, which does not include
   `modules/tool-delegate/tests`. The local `testpaths` does include it and
   that is what was run for the green result above. Not changed here — out
   of scope for a bug fix, and worth its own item.

## Open

- The app-cli half (#292) is merged; the foundation half is this draft PR.
  Neither alone closes the defect — a deployment needs both.
- `routing-matrix` #53 (`dca54b5`) remains defense-in-depth only; it does not
  substitute for either fix.
- CI's `pytest tests/` excludes the tool-delegate module tests, so this
  test would not run in CI as configured. Flagged, not fixed.

</details>

