### PR TITLE
fix(recipes): validate-bundle/validate-single-bundle honor AMPLIFIER_PYTHON (v2.1.1 / v2.3.1)

### DIFF
--- a/recipes/validate-bundle.yaml
+++ b/recipes/validate-bundle.yaml
@@ -6,6 +6,10 @@
 # CHANGELOG
 # =============================================================================
 #
+# v2.1.1:
+#   - Honor the injected AMPLIFIER_PYTHON interpreter in both python heredocs
+#     (was bare `python3`). Companion to validate-single-bundle v2.3.1.
+#
 # v2.1.0:
 #   - Portability: declare a schema_version 2 dependency manifest (contract
 #     recipe-dependency-manifest.v1). The `agent: "foundation:zen-architect"`
@@ -69,7 +73,7 @@ description: |
   For example, if a behavior is only included by `bundles/amplifier-dev.yaml`
   and NOT by the root `bundle.md`, its context files will only be counted
   when validating `amplifier-dev`.
-version: "2.1.0"
+version: "2.1.1"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "context-health", "dependency-tracing"]
 
@@ -84,7 +88,7 @@ steps:
   - id: "environment-check"
     type: "bash"
     command: |
-      python3 << 'EOF'
+      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
       import json
       import sys
 
@@ -139,7 +143,7 @@ steps:
   - id: "discover-bundles"
     type: "bash"
     command: |
-      python3 << 'EOF'
+      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
       import json
       from pathlib import Path
 

--- a/recipes/validate-single-bundle.yaml
+++ b/recipes/validate-single-bundle.yaml
@@ -9,6 +9,12 @@
 # CHANGELOG
 # =============================================================================
 #
+# v2.3.1:
+#   - Honor the injected AMPLIFIER_PYTHON interpreter in all 4 python heredocs
+#     (was bare `python3`, which lacks amplifier_foundation and made the
+#     body-instruction check skip with "amplifier_foundation not importable").
+#     Same fix validate-agents.yaml received in v1.3.1.
+#
 # v2.3.0:
 #   - Portability: declare a schema_version 2 dependency manifest (contract
 #     recipe-dependency-manifest.v1). The `agent: "foundation:zen-architect"`
@@ -85,7 +91,7 @@ description: |
   
   For example, if a behavior is not in this bundle's includes chain,
   its context files won't be counted.
-version: "2.3.0"
+version: "2.3.1"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "single", "dependency-tracing", "yaml-lint"]
 
@@ -114,7 +120,7 @@ steps:
   - id: "yaml-structure-lint"
     type: "bash"
     command: |
-      python3 << 'EOF'
+      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
       import json
       import sys
       from pathlib import Path
@@ -284,7 +290,7 @@ steps:
   - id: "trace-dependencies"
     type: "bash"
     command: |
-      python3 << 'EOF'
+      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
       import json
       import re
       import yaml
@@ -517,7 +523,7 @@ steps:
   - id: "body-instruction-check"
     type: "bash"
     command: |
-      python3 << 'EOF'
+      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
       import json
       import sys
       from pathlib import Path
@@ -582,7 +588,7 @@ steps:
   - id: "context-analysis"
     type: "bash"
     command: |
-      python3 << 'EOF'
+      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
       import json
       import re
       from pathlib import Path

--- a/tests/test_yaml_structure_lint.py
+++ b/tests/test_yaml_structure_lint.py
@@ -361,8 +361,8 @@ class TestSingleBundleRecipeStructure:
     def test_version_is_current(self, single_bundle_recipe):
         """Version must match the recipe's current release."""
         data, _ = single_bundle_recipe
-        assert data["version"] == "2.3.0", (
-            f"Expected version '2.3.0', got '{data['version']}'"
+        assert data["version"] == "2.3.1", (
+            f"Expected version '2.3.1', got '{data['version']}'"
         )
 
     def test_yaml_structure_lint_step_exists(self, single_bundle_steps):


### PR DESCRIPTION
Both recipes used bare python3 in their heredocs, which lacks
amplifier_foundation, so validate-single-bundle's body-instruction check
always skipped with 'amplifier_foundation not importable'. Same fix
validate-agents.yaml received in v1.3.1. Live-verified: the check now runs
and correctly flagged PROSE_BELOW_FRONTMATTER on amplifier-bundle-recipes'
bundle.md.

