### PR TITLE
fix(recipes): validate-agents must not recommend <example> blocks; validate-bundle must name itself (recipes-gpp)

### DIFF
--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -3,6 +3,18 @@
 # Validates agent definitions in a bundle repository for quality, tool access, and structural requirements
 #
 # CHANGELOG:
+# v1.5.1 - Prompt text caught up with the v1.4.0 example policy. The
+#          quick-approval and synthesize-report prompts still invited the
+#          model to offer "add <example> blocks" as optional polish, so a
+#          clean repo could be told to introduce the exact structural ERROR
+#          this recipe fails agents for. Both now forbid recommending
+#          <example>/<commentary> at any severity, and say why: an agent
+#          with none is in the REQUIRED shape, not missing a feature.
+#        - The report's quality table listed an "Examples" column rendered
+#          as OK/warn, which reads as "examples missing = warning" -- the
+#          pre-v1.4.0 polarity. Renamed to "No Examples" with OK/error and
+#          an explicit note on which way round it goes.
+#        - Prompt text only; no step, condition or logic change.
 # v1.5.0 - Portability: declare a schema_version 2 dependency manifest
 #          (contract recipe-dependency-manifest.v1). The four
 #          `agent: "foundation:zen-architect"` steps below previously
@@ -138,7 +150,7 @@ description: |
   
   This recipe helps maintain agent quality across the Amplifier ecosystem by codifying
   the audit criteria discovered in manual reviews.
-version: "1.5.0"
+version: "1.5.1"
 author: "Amplifier Foundation Team"
 tags: ["agents", "validation", "quality", "audit", "tools", "descriptions"]
 
@@ -967,6 +979,16 @@ steps:
       2. What's done well (patterns worth preserving)
       3. Any optional polish suggestions (NOT requirements - agents are already good)
 
+      **NEVER suggest adding `<example>` or `<commentary>` blocks.** Since
+      v1.4.0 they are rejected ENTIRELY, not merely capped
+      (description-authoring-principles.md V3/V6, enforced as a structural
+      ERROR by this same recipe). An agent whose description carries none is
+      in the REQUIRED shape -- it is not missing anything, and recommending
+      them here would tell an author to introduce the very error this recipe
+      would then fail them for. Absence of examples is never a polish item.
+      Where a trigger genuinely needs sharpening, state it as a decision rule
+      in the WHEN clause instead.
+
       Keep the response brief - this is the fast-track approval path.
       
       Format:
@@ -979,6 +1001,7 @@ steps:
       
       **Optional Polish (not required):**
       - [0-2 minor suggestions, or "None - agents are exemplary"]
+      - NEVER "add `<example>` blocks" or "add `<commentary>`" -- see above
     output: "approval_summary"
     timeout: 120
     on_error: "continue"
@@ -1243,9 +1266,16 @@ steps:
 
       ## Quality Classification Summary
 
-      | Agent | Quality | Triggers | Examples | Tools | Model Role | Description |
-      |-------|---------|----------|----------|-------|------------|-------------|
-      | name  | good/polish/needs_work/critical | ✅/⚠️ | ✅/⚠️ | ✅/⚠️ | ✅/⚠️/❌ | length |
+      | Agent | Quality | Triggers | No Examples | Tools | Model Role | Description |
+      |-------|---------|----------|-------------|-------|------------|-------------|
+      | name  | good/polish/needs_work/critical | ✅/⚠️ | ✅/❌ | ✅/⚠️ | ✅/⚠️/❌ | length |
+
+      In the "No Examples" column, ✅ means the description carries NO
+      `<example>`/`<commentary>` block (the required shape, from
+      has_examples == false) and ❌ means it carries one (a structural
+      ERROR). Do not invert this: a column that shows ⚠️ for an agent
+      WITHOUT examples reads as "examples missing", which is the pre-v1.4.0
+      policy.
 
       ## Model Role Coverage
 
@@ -1294,6 +1324,13 @@ steps:
 
       ### Suggestions (Consider) - LOW Priority
       Quality improvements for better LLM matching and discoverability.
+
+      **NEVER suggest adding `<example>` or `<commentary>` blocks**, at any
+      severity. Since v1.4.0 they are rejected entirely
+      (description-authoring-principles.md V3/V6) and are reported above as
+      structural ERRORS -- so recommending them here would contradict this
+      report's own Errors section. An agent with no examples is in the
+      required shape, not missing a feature.
       
       For each suggestion:
       ```
@@ -1308,7 +1345,7 @@ steps:
 
       ## Metadata
       - **Validated**: [timestamp]
-      - **Recipe**: validate-agents v1.5.0
+      - **Recipe**: validate-agents v1.5.1
       - **Quality Thresholds**: see
         `foundation:context/shared/description-authoring-principles.md`
         (canonical -- not restated here). Gates: no structural errors

--- a/recipes/validate-bundle.yaml
+++ b/recipes/validate-bundle.yaml
@@ -6,6 +6,18 @@
 # CHANGELOG
 # =============================================================================
 #
+# v2.1.2:
+#   - The synthesize-report prompt opened with a bare "Synthesize all bundle
+#     validation results", never naming its own recipe, and the report header
+#     it asked for ("Bundle Validation Report") named no recipe either -- so
+#     the model filled the gap and produced headers calling this recipe
+#     `validate-recipes`. The prompt now states which recipe it belongs to and
+#     forbids naming another as the producer, and the header is
+#     `validate-bundle Report`.
+#   - The Metadata block hardcoded "Recipe: validate-bundle v2.1.0" and was
+#     never bumped with the file; corrected and now matches `version:`.
+#   - Prompt text only; no step, condition or logic change.
+#
 # v2.1.1:
 #   - Honor the injected AMPLIFIER_PYTHON interpreter in both python heredocs
 #     (was bare `python3`). Companion to validate-single-bundle v2.3.1.
@@ -73,7 +85,7 @@ description: |
   For example, if a behavior is only included by `bundles/amplifier-dev.yaml`
   and NOT by the root `bundle.md`, its context files will only be counted
   when validating `amplifier-dev`.
-version: "2.1.1"
+version: "2.1.2"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "context-health", "dependency-tracing"]
 
@@ -252,6 +264,15 @@ steps:
     prompt: |
       Synthesize all bundle validation results into a comprehensive report.
 
+      You are the final step of the **validate-bundle** recipe. Every place
+      the report names the recipe that produced it -- the header, the
+      Metadata block, any self-reference in prose -- it MUST say
+      `validate-bundle`. Do not name any other recipe (`validate-recipes`,
+      `validate-agents`, `validate-single-bundle`) as the producer: those are
+      different recipes with different scopes, and mislabelling sends a
+      reader to the wrong one. `validate-single-bundle` is the sub-recipe
+      this one invokes per bundle, never the author of this report.
+
       **Repository:** {{bundle_path}}
       
       **Discovery Results:**
@@ -272,7 +293,7 @@ steps:
 
       **Generate a comprehensive report:**
 
-      ## Bundle Validation Report
+      ## validate-bundle Report
 
       ### Executive Summary
       - **Repository:** (path)
@@ -312,7 +333,7 @@ steps:
 
       ### Metadata
       - Validated: (current date/time)
-      - Recipe: validate-bundle v2.1.0
+      - Recipe: validate-bundle v2.1.2
       - Foundation available: (from env_check)
       - Dependency tracing: enabled
     output: "final_report"


### PR DESCRIPTION
## recipes-gpp (2) and (3) — two prompt-text defects from the smoke sweep

Prompt text only. No step, condition, agent, dependency or logic change in either recipe.

---

### (2) `validate-agents.yaml` — recommends the error it fails you for

**Defect.** v1.4.0 tightened the example policy from *"at most 2 examples, no
`<commentary>`"* to *"`<example>`/`<commentary>` rejected **entirely**"*, and the recipe
enforces it as a structural **ERROR**:

```
recipes/validate-agents.yaml:639
"message": f"Description has {len(example_blocks)} <example> block(s) -- example
            blocks are rejected entirely, not merely capped"
```

The prompts never caught up.

- `quick-approval` (`recipes/validate-agents.yaml:965-981`) asked for *"Any optional
  polish suggestions"* → *"`[0-2 minor suggestions, or "None - agents are exemplary"]`"*
  with no constraint at all.
- `synthesize-report`'s **Suggestions (Consider)** section (`:1296`) likewise.

So the fast-track path for a **clean** repo could tell an author to add `<example>`
blocks — the exact structural error the same recipe fails agents for, listed as an
ERROR further up the same report.

**Change.** Both prompts now forbid recommending `<example>`/`<commentary>` at any
severity, and give the reason rather than just the rule: an agent whose description
carries none is in the **required** shape, not missing a feature. Where a trigger
genuinely needs sharpening, the prompts point at the WHEN-clause decision rule instead
(V6).

**Also fixed, same defect class, same prompt.** The report's quality table
(`:1245-1247`) carried an `Examples` column rendered `✅/⚠️` and fed from
`has_examples`. Since `has_examples == true` is now an ERROR, a `⚠️` against an agent
*without* examples reads as "examples missing" — the pre-v1.4.0 polarity, stated in the
same report that calls their presence an error. Renamed to `No Examples`, rendered
`✅/❌`, with an explicit note on which way round it goes.

`1.5.0` → **`1.5.1`**, changelog entry added, and the report's
`- **Recipe**: validate-agents v1.5.0` metadata line bumped with it.

---

### (3) `validate-bundle.yaml` — the report called itself `validate-recipes`

**Defect.** `synthesize-report` (`recipes/validate-bundle.yaml:249-320`) opened with a
bare *"Synthesize all bundle validation results into a comprehensive report"* and asked
for a generic `## Bundle Validation Report` header. Neither names the recipe, so the
model filled the gap — and named `validate-recipes`, a **different recipe in a different
repo** (`amplifier-bundle-recipes`). A reader following that label lands on the wrong
tool.

**Change.** The prompt now states which recipe it belongs to, forbids naming another as
the producer (calling out `validate-recipes`, `validate-agents` and
`validate-single-bundle` explicitly, and noting the last is the *sub-recipe this one
invokes*, never the author of the report), and the header is `## validate-bundle Report`.

Its Metadata block also hardcoded `- Recipe: validate-bundle v2.1.0` while `version:`
said `2.1.1` — never bumped with the file. Corrected, and now matches.

`2.1.1` → **`2.1.2`**, changelog entry added.

---

### Verification

Both recipes re-validated live through the `recipes` tool after the edit:

```
recipes/validate-agents.yaml  -> {'status': 'valid', 'recipe': 'validate-agents',
                                  'execution_mode': 'runner-isolated',
                                  'schema_version': 2, 'warnings': []}
recipes/validate-bundle.yaml  -> {'status': 'valid', 'recipe': 'validate-bundle',
                                  'execution_mode': 'runner-isolated',
                                  'schema_version': 2, 'warnings': []}
```

Foundation test suite at this branch: **1782 passed, 1 skipped, 2 failed** — and both
failures are **pre-existing on pristine `origin/main`**, verified by stashing these two
files and re-running:

| Test | On this branch | On pristine origin/main |
|---|---|---|
| `test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes` | FAIL | FAIL |
| `test_sources.py::TestFileSourceHandler::test_resolve_existing_file` | FAIL | FAIL |

Neither reads a recipe YAML. The recipe-adjacent suites are all green:
`test_validate_agents_model_role.py`, `test_validate_bundle_repo_integration.py`,
`test_behavior_reference_hygiene.py`, `test_yaml_structure_lint.py`,
`test_module_dep_resolvability_check.py` — 190 passed.

Item (1) of recipes-gpp is the `bundle.md` PROSE_BELOW_FRONTMATTER fix and lives in the
other repo: microsoft/amplifier-bundle-recipes#101.
