### PR TITLE
fix(bundle): instruction @mentions lead the system-prompt context block

### DIFF
--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -412,10 +412,33 @@ class PreparedBundle:
             deduplicator = ContentDeduplicator()
 
             # Build mention_to_path map for context block attribution
-            # This includes BOTH bundle context files AND @mentions from instruction
+            # This includes BOTH @mentions from instruction AND bundle context files
             mention_to_path: dict[str, Path] = {}
 
-            # 1. Bundle context files (from context: section)
+            # ORDER IS LOAD-BEARING. Both the deduplicator and mention_to_path are
+            # insertion-ordered dicts, and format_context_block emits in that order
+            # (get_unique_files iterates _content_by_hash). The instruction's own
+            # @mentions are the bundle author's primary voice, so they are resolved
+            # FIRST and therefore lead the context block; composed bundles' context:
+            # includes (peripheral awareness files) follow. Resolving them the other
+            # way round buried a root bundle's system.md behind every composed
+            # bundle's includes -- 73% into a 99 KB prompt in the reported case.
+
+            # 1. Resolve @mentions from main instruction (re-loads files each call)
+            mention_results = await load_mentions(
+                main_instruction,
+                resolver=resolver,
+                deduplicator=deduplicator,
+            )
+
+            # Add @mention results to mention_to_path for attribution.
+            # Done before the context: includes below so that a file referenced both
+            # ways leads its paths= label with the author's explicit @mention.
+            for mr in mention_results:
+                if mr.resolved_path:
+                    mention_to_path[mr.mention] = mr.resolved_path
+
+            # 2. Bundle context files (from context: section)
             # Add to deduplicator and mention_to_path for unified formatting
             for context_name, context_path in captured_bundle.context.items():
                 if context_path.exists():
@@ -425,19 +448,7 @@ class PreparedBundle:
                     # Add to mention_to_path for attribution (context_name → path)
                     mention_to_path[context_name] = context_path
 
-            # 2. Resolve @mentions from main instruction (re-loads files each call)
-            mention_results = await load_mentions(
-                main_instruction,
-                resolver=resolver,
-                deduplicator=deduplicator,
-            )
-
-            # Add @mention results to mention_to_path for attribution
-            for mr in mention_results:
-                if mr.resolved_path:
-                    mention_to_path[mr.mention] = mr.resolved_path
-
-            # 3. Format ALL context as XML blocks (bundle context + @mentions)
+            # 3. Format ALL context as XML blocks (@mentions + bundle context)
             # format_context_block uses deduplicator for unique content and
             # mention_to_path for attribution (showing name → resolved path)
             all_context = format_context_block(deduplicator, mention_to_path)

--- a/docs/lanes/mikb-instruction-mentions-lead/DONE-NOTE.md
+++ b/docs/lanes/mikb-instruction-mentions-lead/DONE-NOTE.md
@@ -1,0 +1,276 @@
+# DONE-NOTE — `model_performance-mikb`
+
+Lane: `mikb-instruction-mentions-lead`
+Repo: `microsoft/amplifier-foundation`, branch `lane/mikb-instruction-mentions-lead`
+Draft PR: <https://github.com/microsoft/amplifier-foundation/pull/359>
+Base: `origin/main` @ `e681764`
+Date: 2026-09-06
+
+## OUTCOME: **A — RESOLVED.** All deliverables DONE. Nothing NOT-POSSIBLE. Cap did not bind.
+
+**Landing stage.** This lane's final state is the draft PR, marked ready. Procedure 4
+forbids merging; the manager re-runs the fail-befores and merges. The live installed
+CLI on this host still imports the unpatched `amplifier_foundation` — that is the
+landing stage, not an incomplete deliverable.
+
+---
+
+## Deliverables
+
+| # | Deliverable | State |
+|---|---|---|
+| 1 | GATE: verify `format_context_block` emits in INSERTION order **by reading it** | **DONE** |
+| 2 | Fail-before unit tests | **DONE** (3 fail-before + 1 no-regression guard — see the honesty note) |
+| 3 | Do NOT inline mention content into `main_instruction` | **DONE** |
+| 4 | `mentions:resolved` semantics unchanged; order change noted explicitly | **DONE** |
+| 5 | REAL-SESSION CHECK on this host (source override, no cache edits) | **DONE** |
+| 6 | ONE amplifier-tester DTU smoke, foundation branch pinned; DTU destroyed, ledger 0 open | **DONE** |
+| 7 | DRAFT PR, marked ready, with a verification comment | **DONE** |
+| 8 | DONE-NOTE.md at the lane artifact root | **DONE** (this file) |
+
+---
+
+## 1. THE GATE (done first, as instructed) — the approach is valid
+
+`format_context_block` does **not** sort. Read, not assumed:
+
+- `amplifier_foundation/mentions/loader.py:42` — `unique_files = deduplicator.get_unique_files()`,
+  then `for cf in unique_files:` at `:56`, joined `"\n\n"` at `:75`. No `sorted()`, no key.
+- `amplifier_foundation/mentions/deduplicator.py:63-70` — `get_unique_files()` is a list
+  comprehension over `self._content_by_hash.items()`, a plain `dict` (`:24`). Python dicts are
+  insertion-ordered (3.7+), and `add_file` (`:43-47`) inserts on first sight of a content hash.
+
+**Conclusion: emission order == deduplicator insertion order.** The swap is therefore
+sufficient, and no explicit ordering fix inside `format_context_block` was required.
+
+## 2. The change
+
+One reordering in `amplifier_foundation/bundle/_prepared.py::_create_system_prompt_factory`:
+resolve the instruction's `@mentions` into the `ContentDeduplicator` **before** adding
+`captured_bundle.context` includes. A comment marks the ordering as load-bearing so a future
+refactor does not silently undo it.
+
+Nothing else moved. `main_instruction` is untouched; no content is inlined; the
+`f"{main_instruction}\n\n---\n\n{all_context}"` shape is unchanged.
+
+## 3. Tests — stated honestly
+
+`tests/test_instruction_mentions_lead_context.py`, 4 tests. POSIX + Windows clean
+(`tmp_path` + `pathlib` only; no shell, no platform branch, therefore **no `skipif`** —
+the gate four PRs in this batch are stuck on does not apply here).
+
+Fail-before proof, produced by stashing **only** `_prepared.py` (the test file stayed):
+
+```
+=== ON MAIN CODE ===
+FF.F
+FAILED test_instruction_mention_is_the_first_context_block
+FAILED test_double_referenced_file_emitted_once_mention_leads
+FAILED test_mentions_resolved_payload_semantics_unchanged
+3 failed, 1 passed in 0.04s
+
+=== ON BRANCH ===
+4 passed in 0.23s
+```
+(raw: `evidence/fail-before-main.txt`)
+
+**3 fail-before, 1 no-regression guard.** The goal asked for three tests that all fail on
+main, one of them being "no instruction mentions → byte-identical output vs main". That one
+**cannot** fail on main: a test asserting output equals main's output passes on main by
+construction. Making it fail would mean pinning the bug rather than the invariant. So it is
+shipped as a guard and the byte comparison is carried out separately, below. Reported rather
+than fudged.
+
+`test_mentions_resolved_payload_semantics_unchanged` is the useful accident: on main it fails
+only on its **last** line (the ordering assertion). Every assertion above it — the resolution
+set, the `failed` list, `deduplicated_count` — **passed on main**. That is direct evidence that
+the event's *set* semantics are unchanged and only *order* moved.
+
+### Byte-identity, main vs branch (`evidence/byte-identity-main-vs-branch.txt`)
+
+Same script, fixed paths, run against both revisions:
+
+```
+### MAIN (e681764, context includes first)
+A_no_instruction_mentions:  sha256=d7f616c6a3088e55f2a21372213acd87438025eb51abf849cb94015846635c34 len=247
+B_with_instruction_mention: sha256=1b5d114da8f515287d011564fee150c3be2d8792271ab404616d8e8f753458c0 len=379 'You are Amplifier'@offset=333
+### BRANCH
+A_no_instruction_mentions:  sha256=d7f616c6a3088e55f2a21372213acd87438025eb51abf849cb94015846635c34 len=247
+B_with_instruction_mention: sha256=25bcb36828224b93624ecfe9719ee9cd4f32144a69c834b3ee3b68bc2db82fec len=379 'You are Amplifier'@offset=123
+```
+
+No-mention case: **identical sha256**. Mention case: **identical length** (379 both) — nothing
+added, nothing dropped, only reordered.
+
+### Full suite
+
+`uv run pytest tests/ -q` → **1787 passed, 1 skipped, 1 failed**.
+
+The single failure, `tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file`
+(`assert PosixPath('/tmp') == PosixPath('/tmp/tmpXXXX')`), is **pre-existing on `origin/main`
+on this host** — confirmed by re-running that one test with `_prepared.py` stashed, where it
+fails identically. It is a file-source-root assertion, untouched by this change.
+
+## 4. `mentions:resolved` — what changed and what did not
+
+Unchanged: the resolution **set**, the `failed` list, `deduplicated_count`, and the event name.
+Changed: the **order** of the `resolutions` list — instruction mentions now lead. Called out in
+the PR body rather than left for a consumer to discover.
+
+Doubly-referenced file (both a `context:` include and an instruction mention): still emitted
+**once**; its `paths=` label now **leads** with the author's explicit `@mention`, with the
+include's own attribution trailing. No attribution is dropped — "the mention wins" is
+implemented as "the mention leads", which is the minimal change consistent with
+*"the blocks stay blocks; only their order changes"*.
+
+## 5. REAL-SESSION CHECK on this host
+
+Method: **`PYTHONPATH` source override**, not a cache edit. `~/.amplifier/cache` was **never
+touched**. Verified first that the installed `amplifier_foundation` is **byte-identical to
+`origin/main`** except for the single file this lane changed (`diff -rq` → one differing file),
+so BEFORE (no `PYTHONPATH`) vs AFTER (`PYTHONPATH=<worktree>`) is an exact one-file A/B.
+
+`amplifier run "hi" --mode single`, cwd `/tmp/mikb-realsession`, Anthropic `claude-opus-5`.
+Extraction is jq slices/offsets/tallies only — the ~97k-char line was never loaded
+(`evidence/probe_session.sh`, raw output `evidence/real-session-before-after.txt`).
+
+### `anchors-amp-dev`
+
+| metric | BEFORE | AFTER |
+|---|---|---|
+| `raw.system` chars | 96,898 | **96,898** (identical) |
+| `<context_file>` blocks | 23 | **23** (identical) |
+| FIRST block `paths=` | `gitea:context/gitea-awareness.md` | **`@anchors-amp-dev:context/system.md`** |
+| offset of `"You are Amplifier"` | **72,491** | **225** |
+| offset of `configured for development OF` | 72,510 | 244 |
+| within first ~1,500 chars | no | **yes** |
+| `mentions:resolved` | 23 resolutions / 0 failed | 23 / 0 |
+| notify README present | no | no |
+
+### `anchors` (plain)
+
+| metric | BEFORE | AFTER |
+|---|---|---|
+| `raw.system` chars | 96,344 | **96,344** (identical) |
+| `<context_file>` blocks | 23 | **23** (identical) |
+| FIRST block `paths=` | `modes:context/modes-instructions.md` | **`@anchors:context/system.md`** |
+| offset of `"You are Amplifier"` | **72,467** | **201** |
+| `mentions:resolved` | 23 / 0 | 23 / 0 |
+
+The goal's quoted 72,012 (session `7132cbfd`) reproduces here as **72,491** — the small drift is
+bundle-content drift between that capture and today, not a different defect. Same block count,
+same shape, same 73–75% depth.
+
+### FINDING reported, not absorbed
+
+The goal's premise — *"run the plain `anchors` bundle once to confirm no regression when the
+root has an inline body and no mentions"* — **is false on this host.** `anchors`'s instruction
+is also `@anchors:context/system.md`, so `anchors` had the **same** defect and gets the **same**
+fix. There is no "inline body, no mentions" root bundle among the two named. The
+no-mention no-regression case is covered instead by the unit guard and the sha256 comparison
+above, which is the stronger evidence anyway.
+
+## 6. DTU smoke (one environment, cap respected)
+
+Delegated to `amplifier-tester:setup-digital-twin` with an explicit ledger (live=0, cap=1,
+remaining-after=0). Instance `mikb-foundation-order`. Full report:
+`evidence/dtu-smoke-results.md`; profile `evidence/dtu-profile-mikb-foundation-order.yaml`.
+
+The smoke went beyond the ask: it produced a **real before-arm inside the same DTU** by pinning
+the mirror to `e681764`, reinstalling, measuring, and restoring.
+
+| `anchors-amp-dev` (DTU) | BEFORE `e681764` | AFTER (branch) |
+|---|---|---|
+| `raw.system` chars | 43,564 | **43,564** (identical) |
+| `<context_file>` blocks | 9 | **9** (identical) |
+| instruction's mention position | **block 9 of 9 (LAST)** | **block 1 of 9 (FIRST)** |
+| offset of `"You are Amplifier"` | 19,232 | **214** |
+| `mentions:resolved` | 9 / 0 failed | 9 / 0 failed |
+
+| `anchors` (DTU) | BEFORE | AFTER |
+|---|---|---|
+| `raw.system` chars | 40,732 | **40,732** (identical) |
+| blocks | 8 | **8** |
+| mention position | **8 of 8 (LAST)** | **1 of 8 (FIRST)** |
+| offset of `"You are Amplifier"` | 16,930 | **190** |
+
+Both providers wired and exercised (`anthropic/claude-sonnet-5`, `openai/gpt-5.6-sol`), both
+bundles on each, all exit 0, no startup regressions, `ready: true`.
+
+**Deviations the sub-agent flagged, adjudicated here and accepted:**
+1. **Provider config is not a verbatim host mirror** — the host declares 15 providers, several
+   referencing `${ANTHROPIC_BASE_URL}` which is unset here and would render empty. A minimal
+   two-provider config was substituted. Accepted: the claim under test is *emission order*, not
+   provider fan-out.
+2. **App-bundle set is 2, not the host's 19** — so DTU block counts are 8/9 and sizes ~41–44k,
+   **not comparable to the host's 23 blocks / ~97k**. Accepted and stated: the DTU proves the
+   ordering and the absence of startup regressions; the host run carries the magnitudes.
+3. The shared `admin/amplifier-foundation` Gitea mirror was deliberately **not** touched (it
+   holds another lane's snapshot); a separate repo was used. Accepted.
+4. `amplifier update` alone did **not** downgrade the Python package — it refreshed the bundle
+   cache to `e681764` while site-packages stayed newer, a split state that would have produced a
+   **false before-arm**. Caught via `direct_url.json` and forced with
+   `uv tool install --reinstall --force`. Worth knowing for any future lane pinning a foundation
+   ref in a DTU.
+5. Three warm-up run costs were not captured verbatim; their ~$0.19 is an estimate. The other
+   seven costs are quoted from the CLI's own output.
+
+### Teardown — 0 open rows
+
+```
+ADDED:   type=dtu id=mikb-foundation-order status=open
+CLAIMED: id=mikb-foundation-order lane=mikb-instruction-mentions-lead
+TEARDOWN: lane=mikb-instruction-mentions-lead verified-gone=1 rows-flipped=1
+  already-absent=0 failed=0 live-skipped=0 unknown-skipped=0 unverifiable=0 protected-untouched=0
+```
+
+`lane_teardown.sh` was used with the **FULL** lane name. `infra_ledger.sh ... sweep` was **never**
+run. `PROTECTED — 0` (no foreign rows were in scope). Ledger rows matching `mikb`: `swept`, and
+**0 open rows owned by this lane**.
+
+Also cleaned up by this lane, beyond the ledger row:
+- Gitea repo `admin/amplifier-foundation-mikb` — deleted (`HTTP 204`); the 8 pre-existing repos,
+  including the shared `admin/amplifier-foundation`, are untouched.
+- Gitea instance `gitea-55cf7007` — **reused, not created**, therefore left running.
+- Credential scratch (`gitea-token.json`, `env.sh`) — removed from the lane directory.
+- Two pre-existing DTUs belonging to other sessions (`steward-desk-test`, `wayfinder-scout-eval`)
+  — **left alone**.
+
+## 7. SPEND
+
+**Cap: $3.00.** Goal arithmetic: `1 DTU smoke × ~$1.00 / 1.00 valid = $1.00`, plus `$2.00` slack.
+
+**Re-stated at the observed price, before the smoke and again after:**
+`1 smoke × $0.74 observed / 1.00 valid (first launch was valid, no retry) = $0.74` — under the
+$1.00 estimate. **The arithmetic closes; the cap did not bind and no deliverable was dropped.**
+
+| item | cost |
+|---|---|
+| host `amplifier run "hi"` × 4 (anchors-amp-dev before/after, anchors before/after) @ $0.27 | $1.08 |
+| DTU smoke, 10 sessions (7 observed $0.55 + 3 warm-ups estimated $0.19) | ~$0.74 |
+| unit tests, byte-identity probe, code, teardown | $0.00 |
+| **total** | **~$1.82** |
+
+Residue **~$1.18** of $3.00. Recorded per procedure 3, which classes the local
+`amplifier run "hi"` checks as normal local invocations rather than run-buying purchases; even
+counted against the cap in full, the total lands under it.
+
+## 8. Deviations / choices recorded (no human was waited on)
+
+1. **Test 2 ships as a no-regression guard, not a fail-before** — impossible as specified; see §3.
+2. **"The mention wins the `paths=` label" implemented as "the mention leads"** — the include's
+   attribution still trails, so no information is lost. Chosen because the goal also says only
+   the *order* may change.
+3. **Source override via `PYTHONPATH`**, not a scratch venv — cheaper, and verified to be an
+   exact one-file A/B against the installed package. `~/.amplifier/cache` untouched.
+4. **`anchors` was run twice (before and after), not once** — the goal said once, but the before
+   arm is what turned "no regression" into a measured claim, and it exposed the false premise in
+   §5. Cost of the extra run: $0.27.
+
+## 9. What remains open for the manager
+
+- **Merge.** The PR is ready-for-review, not merged. Re-run the fail-befores against
+  `_prepared.py` stashed; expect `3 failed, 1 passed`.
+- **The anchors DRY refactor is explicitly out of scope for this lane** and untouched. This lane
+  changed foundation only — one file, one reordering — so the two remain attributable.
+- The pre-existing `test_sources.py` failure on this host is unrelated and unfixed here.

--- a/docs/lanes/mikb-instruction-mentions-lead/evidence/byte-identity-main-vs-branch.txt
+++ b/docs/lanes/mikb-instruction-mentions-lead/evidence/byte-identity-main-vs-branch.txt
@@ -1,0 +1,6 @@
+### MAIN (e681764, context includes first)
+A_no_instruction_mentions: sha256=d7f616c6a3088e55f2a21372213acd87438025eb51abf849cb94015846635c34 len=247 'You are Amplifier'@offset=-1
+B_with_instruction_mention: sha256=1b5d114da8f515287d011564fee150c3be2d8792271ab404616d8e8f753458c0 len=379 'You are Amplifier'@offset=333
+### BRANCH (instruction mentions resolved first)
+A_no_instruction_mentions: sha256=d7f616c6a3088e55f2a21372213acd87438025eb51abf849cb94015846635c34 len=247 'You are Amplifier'@offset=-1
+B_with_instruction_mention: sha256=25bcb36828224b93624ecfe9719ee9cd4f32144a69c834b3ee3b68bc2db82fec len=379 'You are Amplifier'@offset=123

--- a/docs/lanes/mikb-instruction-mentions-lead/evidence/byte_identity_probe.py
+++ b/docs/lanes/mikb-instruction-mentions-lead/evidence/byte_identity_probe.py
@@ -1,0 +1,87 @@
+"""Byte-identity probe: main vs branch, factory output, fixed paths.
+
+Run the SAME script against both revisions of ``_prepared.py`` and compare the
+sha256 it prints.  Paths are fixed (not pytest tmp_path) so the output is
+byte-stable across runs; the only variable is the source revision.
+
+Case A: bundle with NO instruction @mentions  -> must be byte-identical.
+Case B: bundle WITH an instruction @mention   -> must change (that is the fix).
+
+Usage:
+    uv run python docs/lanes/mikb-instruction-mentions-lead/evidence/byte_identity_probe.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from amplifier_foundation.bundle import Bundle
+
+_prep = importlib.import_module("amplifier_foundation.bundle._prepared")
+PreparedBundle: Any = _prep.PreparedBundle
+BundleModuleResolver: Any = _prep.BundleModuleResolver
+
+ROOT = Path(tempfile.gettempdir()) / "mikb-byte-identity-probe"
+
+
+def _session() -> MagicMock:
+    hooks = AsyncMock()
+    hooks.list_handlers = MagicMock(return_value={})
+    hooks.register = MagicMock(return_value=MagicMock())
+    coordinator = MagicMock()
+    coordinator.hooks = hooks
+    s = MagicMock()
+    s.coordinator = coordinator
+    return s
+
+
+def _write(p: Path, text: str) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+async def main() -> None:
+    if ROOT.exists():
+        shutil.rmtree(ROOT)
+    sysmd = _write(ROOT / "context" / "system.md", "You are Amplifier. PRINCIPLES.")
+    a = _write(ROOT / "a.md", "AAA awareness body")
+    b = _write(ROOT / "b.md", "BBB awareness body")
+
+    cases = {
+        "A_no_instruction_mentions": Bundle(
+            name="ns",
+            base_path=ROOT,
+            instruction="Inline instruction, no mentions.",
+            context={"a:ctx.md": a, "b:ctx.md": b},
+        ),
+        "B_with_instruction_mention": Bundle(
+            name="ns",
+            base_path=ROOT,
+            instruction="@ns:context/system.md",
+            context={"a:ctx.md": a, "b:ctx.md": b},
+        ),
+    }
+
+    for label, bundle in cases.items():
+        prepared = PreparedBundle(
+            mount_plan={},
+            bundle=bundle,
+            resolver=BundleModuleResolver(module_paths={}),
+        )
+        out = await prepared._create_system_prompt_factory(bundle, _session())()
+        digest = hashlib.sha256(out.encode()).hexdigest()
+        marker = "You are Amplifier"
+        offset = out.find(marker)
+        print(f"{label}: sha256={digest} len={len(out)} '{marker}'@offset={offset}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/lanes/mikb-instruction-mentions-lead/evidence/dtu-extract.sh
+++ b/docs/lanes/mikb-instruction-mentions-lead/evidence/dtu-extract.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Safe extraction of system-prompt ordering metrics from an Amplifier session's events.jsonl.
+# NEVER prints the raw.system body -- only lengths, counts, offsets and short slices.
+# Usage: extract.sh <events.jsonl path> <label>
+set -uo pipefail
+EV="$1"; LABEL="${2:-session}"
+
+echo "### $LABEL"
+echo "events_file: $EV"
+echo "events_bytes: $(wc -c < "$EV")"
+
+# FIRST llm:request only -> raw system prompt (slice to disk, never to stdout)
+jq -r 'select(.event == "llm:request")
+       | (.data.raw.system[0].text // .data.raw.system // .data.raw.instructions // empty)' \
+   "$EV" > /tmp/_sys_all.txt
+
+if [ ! -s /tmp/_sys_all.txt ]; then
+  echo "RESULT: NO llm:request raw.system FOUND"
+  jq -r '.event' "$EV" | sort | uniq -c | head -25
+  exit 1
+fi
+
+python3 - "$LABEL" <<'PY'
+import re, sys
+s = open('/tmp/_sys_all.txt', encoding='utf-8', errors='replace').read().rstrip('\n')
+print(f"raw_system_total_chars: {len(s)}")
+print(f"first_120_chars: {s[:120]!r}")
+print(f"context_file_block_count: {s.count('<context_file paths=\"')}")
+m = re.search(r'<context_file paths="([^"]*)"', s)
+print(f"FIRST_context_file_paths: {m.group(1) if m else '<none>'}")
+i = s.find('You are Amplifier')
+print(f"offset_of_You_are_Amplifier: {i}")
+print(f"within_first_1500_chars: {i >= 0 and i < 1500}")
+if i >= 0:
+    print(f"context_around_offset: {s[max(0,i-70):i+70]!r}")
+paths = re.findall(r'<context_file paths="([^"]*)"', s)
+print("context_file_paths_in_emission_order:")
+for k, p in enumerate(paths, 1):
+    print(f"  {k}. {p[:170]}")
+print(f"notify_readme_present: {bool(re.search(r'notify[^\"]*README', s, re.I))}")
+PY
+
+echo "--- mentions:resolved ---"
+jq -c 'select(.event == "mentions:resolved")
+       | {resolutions: (.data.resolutions | length),
+          failed: (.data.failed | length),
+          failed_list: .data.failed}' "$EV"
+
+echo "--- error/failure events ---"
+jq -r 'select(.event | test("error|fail"; "i")) | .event' "$EV" | sort | uniq -c
+jq -r 'select(.status? and (.status | test("error|fail"; "i"))) | "\(.event) status=\(.status)"' "$EV" | head -10
+echo "(none above = no error events)"
+echo

--- a/docs/lanes/mikb-instruction-mentions-lead/evidence/dtu-profile-mikb-foundation-order.yaml
+++ b/docs/lanes/mikb-instruction-mentions-lead/evidence/dtu-profile-mikb-foundation-order.yaml
@@ -1,0 +1,111 @@
+# Validates local changes to: amplifier-foundation (branch lane/mikb-instruction-mentions-lead)
+#
+# Change under test: amplifier_foundation/bundle/_prepared.py::_create_system_prompt_factory
+# now resolves the bundle instruction's @mentions into the ContentDeduplicator BEFORE the
+# bundle's `context:` includes, so the instruction's mention blocks LEAD the <context_file>
+# section of the system prompt instead of trailing it.
+#
+# OUT-OF-BAND STATE REQUIRED (not self-contained -- documented per profiles.md):
+#   - A host-side Gitea instance holding a snapshot of the worktree under test at
+#     admin/amplifier-foundation-mikb (branch main).
+#   - Host env: ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENAI_BASE_URL.
+#
+# Launch invocation:
+#   amplifier-digital-twin launch \
+#     <repo>/.cache/dtu-smoke/mikb-foundation-order.yaml \
+#     --var GITEA_URL=http://10.119.176.1:10230 \
+#     --var GITEA_TOKEN=<token> \
+#     --name mikb-foundation-order
+#
+# NOTE: amplifier-foundation carries BOTH the Python package and the `anchors` /
+# `anchors-amp-dev` bundles (bundles/<name>/bundle.md), so the single url_rewrite below
+# redirects the package install AND the two bundles under test to the snapshot mirror.
+
+name: mikb-foundation-order
+description: >
+  Smoke-test the instruction-@mention ordering fix in amplifier-foundation:
+  the instruction's mention must be the FIRST <context_file> block.
+
+base:
+  image: ubuntu:24.04
+  config:
+    limits.cpu: "4"
+    limits.memory: "8GiB"
+
+url_rewrites:
+  auth:
+    username: admin
+    token_var: GITEA_TOKEN
+  default_match_mode: boundary
+  rules:
+    - match: github.com/microsoft/amplifier-foundation
+      target: ${GITEA_URL}/admin/amplifier-foundation-mikb
+
+passthrough:
+  allow_external: true
+  services:
+    - name: anthropic
+      key_env: ANTHROPIC_API_KEY
+    - name: openai
+      key_env: OPENAI_API_KEY
+    - name: openai-base-url
+      key_env: OPENAI_BASE_URL
+
+provision:
+  setup_cmds:
+    - apt-get update && apt-get install -y git curl jq
+    - curl -LsSf https://astral.sh/uv/install.sh | sh
+    - uv tool install git+https://github.com/microsoft/amplifier
+
+    # Provider config. DEVIATION from "mirror host config.providers verbatim":
+    # the host declares 15 providers, several referencing env vars that are UNSET on
+    # the host (e.g. ANTHROPIC_BASE_URL) which would render as empty YAML values here.
+    # This smoke needs two working providers, so a minimal two-provider config is used
+    # and the deviation is reported in the hand-back.
+    - |
+      mkdir -p /root/.amplifier
+      cat > /root/.amplifier/settings.yaml << EOF
+      config:
+        providers:
+          - id: sonnet
+            module: provider-anthropic
+            source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
+            config:
+              api_key: ${ANTHROPIC_API_KEY}
+              default_model: claude-sonnet-5
+              enable_prompt_caching: 'true'
+              priority: 1
+          - id: sol
+            module: provider-openai
+            source: git+https://github.com/microsoft/amplifier-module-provider-openai@main
+            config:
+              api_key: ${OPENAI_API_KEY}
+              base_url: ${OPENAI_BASE_URL}
+              default_model: gpt-5.6-sol
+              priority: 2
+      EOF
+
+    # Compose two app behaviors that contribute `context:` includes. Without these the
+    # ordering assertion is vacuous -- the defect under test is precisely that app-bundle
+    # context includes were emitted BEFORE the instruction's own mention.
+    - amplifier bundle add git+https://github.com/microsoft/amplifier-bundle-digital-twin-universe@main#subdirectory=behaviors/digital-twin-universe.yaml --app
+    - amplifier bundle add git+https://github.com/microsoft/amplifier-bundle-dot-graph@main#subdirectory=behaviors/dot-graph.yaml --app
+
+    - amplifier --version
+    - amplifier bundle list
+
+    # Warm-up: seed lazy provider/module installs for both bundles under test so the
+    # readiness poll and the measured runs do not race a cold install.
+    - 'amplifier run "Say exactly: warmup-ok" -B anchors --mode single'
+    - 'amplifier run "Say exactly: warmup-ok" -B anchors-amp-dev --mode single'
+
+update:
+  cmds:
+    - amplifier update --yes --force
+    - 'amplifier run "Say exactly: warmup-ok" -B anchors --mode single'
+
+readiness:
+  - name: amplifier-installed
+    command: amplifier --version
+  - name: anchors-bundle-resolves
+    command: amplifier bundle list

--- a/docs/lanes/mikb-instruction-mentions-lead/evidence/dtu-smoke-results.md
+++ b/docs/lanes/mikb-instruction-mentions-lead/evidence/dtu-smoke-results.md
@@ -1,0 +1,83 @@
+# DTU smoke — instruction @mentions lead the system-prompt context block
+
+Repo under test: `amplifier-foundation`, branch `lane/mikb-instruction-mentions-lead`
+DTU instance: `mikb-foundation-order` (launched 2026-09-06T15:16:01Z)
+Profile: `.cache/dtu-smoke/mikb-foundation-order.yaml` (git-ignored)
+
+## Provenance (the DTU really ran THIS code)
+
+`url_rewrites` redirected `github.com/microsoft/amplifier-foundation` to a Gitea
+snapshot of the worktree. `amplifier-foundation` carries BOTH the Python package
+and the `anchors` / `anchors-amp-dev` bundles, so one rewrite covered both.
+
+| state | installed foundation commit (`direct_url.json`) | `_prepared.py` step order |
+|---|---|---|
+| AFTER (branch)  | `1accb7581c9442b48ccbefd81f2e2ec8403b8d3f`, later `a3fb4e3f7920e8dd951d5b1d5bfd8d33e9da33ad` | `# 1. Resolve @mentions` (L427) → `# 2. Bundle context files` (L441) |
+| BEFORE (origin/main) | `e681764cb4313f83b456e1edd56d9df070e44f26` | `# 1. Bundle context files` (L418) → `# 2. Resolve @mentions` (L428) |
+
+Both snapshots have identical trees to the corresponding host commits; the AFTER
+sha changed on restore only because a fresh snapshot commit was made.
+
+## Result — fail-before / pass-after, measured in the SAME DTU
+
+### `anchors`
+
+| metric | BEFORE (`e681764`) | AFTER (branch) |
+|---|---|---|
+| `raw.system` total chars | **40,732** | **40,732** (identical) |
+| `<context_file>` block count | **8** | **8** (identical) |
+| FIRST block `paths=` | `modes:context/modes-instructions.md` | **`@anchors:context/system.md`** |
+| position of the instruction's mention | **block 8 of 8 (LAST)** | **block 1 of 8 (FIRST)** |
+| offset of `"You are Amplifier"` | **16,930** | **190** |
+| within first 1,500 chars | **False** | **True** |
+| `mentions:resolved` resolutions / failed | 8 / **0** | 8 / **0** |
+
+### `anchors-amp-dev`
+
+| metric | BEFORE (`e681764`) | AFTER (branch) |
+|---|---|---|
+| `raw.system` total chars | **43,564** | **43,564** (identical) |
+| `<context_file>` block count | **9** | **9** (identical) |
+| FIRST block `paths=` | `gitea:context/gitea-awareness.md` | **`@anchors-amp-dev:context/system.md`** |
+| position of the instruction's mention | **block 9 of 9 (LAST)** | **block 1 of 9 (FIRST)** |
+| offset of `"You are Amplifier"` | **19,232** | **214** |
+| within first 1,500 chars | **False** | **True** |
+| `mentions:resolved` resolutions / failed | 9 / **0** | 9 / **0** |
+
+Identical char counts and block counts on both arms: **content is unchanged,
+only emission order moved.** `failed=[]` on every run. `notify README` absent
+on every run.
+
+## Runs executed (all exit 0, no startup errors)
+
+| # | bundle | provider / model | cost |
+|---|---|---|---|
+| provision warm-up | anchors | anthropic claude-sonnet-5 | ~$0.06 (est.) |
+| provision warm-up | anchors-amp-dev | anthropic claude-sonnet-5 | ~$0.07 (est.) |
+| 1 | anchors | anthropic claude-sonnet-5 | $0.06 |
+| 2 | anchors-amp-dev | anthropic claude-sonnet-5 | $0.07 |
+| 3 | anchors | openai gpt-5.6-sol | $0.11 |
+| 4 | anchors-amp-dev | openai gpt-5.6-sol | $0.11 |
+| update warm-up | anchors | anthropic claude-sonnet-5 | ~$0.06 (est.) |
+| before-arm | anchors | anthropic claude-sonnet-5 | $0.06 |
+| before-arm | anchors-amp-dev | anthropic claude-sonnet-5 | $0.07 |
+| restore confirm | anchors-amp-dev | anthropic claude-sonnet-5 | $0.07 |
+
+**Total ≈ $0.74** (7 observed = $0.55, 3 warm-ups estimated at ~$0.19).
+
+Both providers were wired in the DTU (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+`OPENAI_BASE_URL` all forwarded via `passthrough`), and both were exercised on
+both bundles.
+
+## Final state
+
+DTU left RUNNING and pinned to the branch (AFTER) state; readiness `ready: true`.
+Teardown is owned by the calling lane.
+
+```
+amplifier-digital-twin destroy mikb-foundation-order
+```
+
+Also created on the host: Gitea repo `admin/amplifier-foundation-mikb` on the
+pre-existing instance `gitea-55cf7007` (port 10230). The shared
+`admin/amplifier-foundation` mirror was deliberately NOT touched.

--- a/docs/lanes/mikb-instruction-mentions-lead/evidence/fail-before-main.txt
+++ b/docs/lanes/mikb-instruction-mentions-lead/evidence/fail-before-main.txt
@@ -1,0 +1,22 @@
+FF.F                                                                     [100%]
+=================================== FAILURES ===================================
+E   AssertionError: assert '# Gitea Environments' == 'You are Ampl...ystem itself.'
+      
+      - You are Amplifier, configured for development OF the ecosystem itself.
+      + # Gitea Environments
+/home/bkrabach/dev/hw-model-performance/lanes/mikb-instruction-mentions-lead/amplifier-foundation/tests/test_instruction_mentions_lead_context.py:140: AssertionError: assert '# Gitea Environments' == 'You are Ampl...ystem itself.'
+E   AssertionError: assert False
+     +  where False = <built-in method startswith of str object at 0xf12cabd33ab0>('@ns:context/system.md')
+     +    where <built-in method startswith of str object at 0xf12cabd33ab0> = 'ns:context/system.md → /tmp/pytest-of-bkrabach/pytest-5621/test_double_referenced_file_em0/context/system.md'.startswith
+     +      where 'ns:context/system.md → /tmp/pytest-of-bkrabach/pytest-5621/test_double_referenced_file_em0/context/system.md' = Block(paths='ns:context/system.md → /tmp/pytest-of-bkrabach/pytest-5621/test_double_referenced_file_em0/context/system... /tmp/pytest-of-bkrabach/pytest-5621/test_double_referenced_file_em0/context/system.md', body='SHARED PRINCIPLES BODY').first_attribution
+/home/bkrabach/dev/hw-model-performance/lanes/mikb-instruction-mentions-lead/amplifier-foundation/tests/test_instruction_mentions_lead_context.py:188: AssertionError: assert False
+E   AssertionError: assert 'aware:ctx.md' == '@ns:context/system.md'
+      
+      - @ns:context/system.md
+      + aware:ctx.md
+/home/bkrabach/dev/hw-model-performance/lanes/mikb-instruction-mentions-lead/amplifier-foundation/tests/test_instruction_mentions_lead_context.py:275: AssertionError: assert 'aware:ctx.md' == '@ns:context/system.md'
+=========================== short test summary info ============================
+FAILED tests/test_instruction_mentions_lead_context.py::test_instruction_mention_is_the_first_context_block
+FAILED tests/test_instruction_mentions_lead_context.py::test_double_referenced_file_emitted_once_mention_leads
+FAILED tests/test_instruction_mentions_lead_context.py::test_mentions_resolved_payload_semantics_unchanged
+3 failed, 1 passed in 0.04s

--- a/docs/lanes/mikb-instruction-mentions-lead/evidence/probe_session.sh
+++ b/docs/lanes/mikb-instruction-mentions-lead/evidence/probe_session.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Safe extraction from a real session's raw.system.  Never loads the whole
+# ~99k-char line into a reader's context: jq slices, offsets and tallies only.
+#
+# Usage: probe_session.sh <session-dir> <label>
+set -euo pipefail
+
+SESSION_DIR="$1"
+LABEL="${2:-session}"
+EV="$SESSION_DIR/events.jsonl"
+
+echo "=== $LABEL ==="
+echo "session_dir: $SESSION_DIR"
+
+# raw.system for Anthropic is .data.raw.system[0].text; OpenAI Responses uses
+# .data.raw.instructions.  Take the FIRST llm:request only.
+jq -r --arg label "$LABEL" '
+  select(.event=="llm:request")
+  | (.data.raw.system[0].text // .data.raw.instructions // "")
+  | . as $s
+  | [
+      "raw.system_chars=\($s|length)",
+      "head_120=\($s[0:120]|gsub("\n";"\\n"))",
+      "context_file_blocks=\($s | [splits("<context_file paths=\"")] | length - 1)",
+      "first_block_paths=\(($s | capture("<context_file paths=\"(?<p>[^\"]*)\"")).p)",
+      "offset_of_You_are_Amplifier=\($s | (index("You are Amplifier") // -1))",
+      "offset_of_dev_marker=\($s | (index("configured for development OF") // -1))",
+      "notify_readme_present=\($s | test("# Notify Bundle"))"
+    ]
+  | .[]
+' "$EV" | head -20
+
+# mentions:resolved tallies -- counts only, no payload bodies.
+jq -r '
+  select(.event=="mentions:resolved")
+  | "mentions_resolved: resolutions=\(.data.resolutions|length) failed=\(.data.failed|length) dedup=\(.data.deduplicated_count)"
+' "$EV" | head -5
+
+jq -r '
+  select(.event=="mentions:resolved")
+  | .data.resolutions[0].mention // "none"
+  | "first_resolution_mention: \(.)"
+' "$EV" | head -1
+echo

--- a/docs/lanes/mikb-instruction-mentions-lead/evidence/real-session-before-after.txt
+++ b/docs/lanes/mikb-instruction-mentions-lead/evidence/real-session-before-after.txt
@@ -1,0 +1,48 @@
+=== BEFORE anchors-amp-dev (installed foundation == origin/main e681764) ===
+session_dir: /home/bkrabach/.amplifier/projects/-tmp-mikb-realsession/sessions/b90ff95e-3182-4c23-97ab-b418d1c50291
+raw.system_chars=96898
+head_120=@anchors-amp-dev:context/system.md\n\n---\n\n<context_file paths="gitea:context/gitea-awareness.md → /home/bkrabach/.amplifi
+context_file_blocks=23
+first_block_paths=gitea:context/gitea-awareness.md → /home/bkrabach/.amplifier/cache/amplifier-bundle-gitea-c559d851424c1857/context/gitea-awareness.md
+offset_of_You_are_Amplifier=72491
+offset_of_dev_marker=72510
+notify_readme_present=false
+mentions_resolved: resolutions=23 failed=0 dedup=0
+first_resolution_mention: gitea:context/gitea-awareness.md
+
+=== AFTER anchors-amp-dev (PYTHONPATH override == branch ed2ba00) ===
+session_dir: /home/bkrabach/.amplifier/projects/-tmp-mikb-realsession/sessions/9233a121-c46c-406e-b717-d7c4d9f61477
+raw.system_chars=96898
+head_120=@anchors-amp-dev:context/system.md\n\n---\n\n<context_file paths="@anchors-amp-dev:context/system.md → /home/bkrabach/.ampli
+context_file_blocks=23
+first_block_paths=@anchors-amp-dev:context/system.md → /home/bkrabach/.amplifier/cache/amplifier-foundation-c909465861f9d6ce/bundles/anchors-amp-dev/context/system.md
+offset_of_You_are_Amplifier=225
+offset_of_dev_marker=244
+notify_readme_present=false
+mentions_resolved: resolutions=23 failed=0 dedup=0
+first_resolution_mention: @anchors-amp-dev:context/system.md
+
+=== BEFORE anchors (installed foundation) ===
+session_dir: /home/bkrabach/.amplifier/projects/-tmp-mikb-realsession/sessions/d0da3cdf-ef6b-4421-a401-7268c067e186
+raw.system_chars=96344
+head_120=@anchors:context/system.md\n\n---\n\n<context_file paths="modes:context/modes-instructions.md → /home/bkrabach/.amplifier/ca
+context_file_blocks=23
+first_block_paths=modes:context/modes-instructions.md → /home/bkrabach/.amplifier/cache/amplifier-bundle-modes-85a0e90c360a77e3/context/modes-instructions.md
+offset_of_You_are_Amplifier=72467
+offset_of_dev_marker=-1
+notify_readme_present=false
+mentions_resolved: resolutions=23 failed=0 dedup=0
+first_resolution_mention: modes:context/modes-instructions.md
+
+=== AFTER anchors (PYTHONPATH override) ===
+session_dir: /home/bkrabach/.amplifier/projects/-tmp-mikb-realsession/sessions/cbc965c3-20ba-4fcc-a815-01bf850fa8fe
+raw.system_chars=96344
+head_120=@anchors:context/system.md\n\n---\n\n<context_file paths="@anchors:context/system.md → /home/bkrabach/.amplifier/cache/ampli
+context_file_blocks=23
+first_block_paths=@anchors:context/system.md → /home/bkrabach/.amplifier/cache/amplifier-foundation-c909465861f9d6ce/bundles/anchors/context/system.md
+offset_of_You_are_Amplifier=201
+offset_of_dev_marker=-1
+notify_readme_present=false
+mentions_resolved: resolutions=23 failed=0 dedup=0
+first_resolution_mention: @anchors:context/system.md
+

--- a/tests/test_instruction_mentions_lead_context.py
+++ b/tests/test_instruction_mentions_lead_context.py
@@ -1,0 +1,275 @@
+"""The instruction's own @mentions must LEAD the system-prompt context block.
+
+Defect this pins (measured, session 7132cbfd, bundle anchors-amp-dev):
+``raw.system`` was one 98,896-char block whose first line was the literal
+``@anchors-amp-dev:context/system.md``, followed by ``---`` and 23
+``<context_file>`` blocks.  Blocks 1-22 were composed bundles' ``context:``
+includes (peripheral awareness files).  Block 23 -- the LAST -- was the root
+bundle's own ``context/system.md``, the file that says "You are Amplifier".
+Byte offset 72,012 of 98,896: 73% into the prompt.
+
+Cause: ``_create_system_prompt_factory`` added ``bundle.context`` includes to
+the ``ContentDeduplicator`` BEFORE resolving the instruction's @mentions, and
+``format_context_block`` emits in deduplicator insertion order
+(``get_unique_files`` iterates ``_content_by_hash``, a plain insertion-ordered
+dict -- verified by reading it; nothing sorts).
+
+Fix: resolve instruction @mentions first, so the author's primary voice leads.
+
+Test inventory, stated honestly:
+
+* ``test_instruction_mention_is_the_first_context_block``     FAIL-BEFORE
+* ``test_double_referenced_file_emitted_once_mention_leads``  FAIL-BEFORE
+* ``test_no_instruction_mentions_output_is_byte_identical``   NO-REGRESSION GUARD
+  -- this one passes on main *by construction*.  It asserts that bundles
+  without instruction mentions are untouched by the reorder; a guard that
+  failed on main would be pinning the bug, not the invariant.  The
+  main-vs-branch byte comparison itself is in the PR body.
+* ``test_mentions_resolved_payload_semantics_unchanged``      NO-REGRESSION GUARD
+
+No shell, no platform-specific paths: runs identically on POSIX and Windows.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+from typing import Any, NamedTuple
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amplifier_foundation.bundle import Bundle
+
+_prep = importlib.import_module("amplifier_foundation.bundle._prepared")
+PreparedBundle: Any = _prep.PreparedBundle
+BundleModuleResolver: Any = _prep.BundleModuleResolver
+MENTIONS_RESOLVED: str = _prep._MENTIONS_RESOLVED_EVENT
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+class Block(NamedTuple):
+    """One parsed ``<context_file>`` block."""
+
+    paths: str
+    body: str
+
+    @property
+    def first_attribution(self) -> str:
+        """The leading entry of the ``paths=`` attribute."""
+        return self.paths.split(", ")[0]
+
+
+_BLOCK_RE = re.compile(
+    r'<context_file paths="(?P<paths>[^"]*)">\n(?P<body>.*?)\n</context_file>',
+    re.DOTALL,
+)
+
+
+def _blocks(system_prompt: str) -> list[Block]:
+    """Parse ``<context_file>`` blocks out of a system prompt, in emitted order."""
+    return [
+        Block(paths=m.group("paths"), body=m.group("body"))
+        for m in _BLOCK_RE.finditer(system_prompt)
+    ]
+
+
+def _make_prepared(bundle: Bundle) -> Any:
+    return PreparedBundle(
+        mount_plan={},
+        bundle=bundle,
+        resolver=BundleModuleResolver(module_paths={}),
+    )
+
+
+def _make_mock_session() -> MagicMock:
+    mock_hooks = AsyncMock()
+    mock_hooks.list_handlers = MagicMock(return_value={})
+    mock_hooks.register = MagicMock(return_value=MagicMock())
+    coordinator = MagicMock()
+    coordinator.hooks = mock_hooks
+    session = MagicMock()
+    session.coordinator = coordinator
+    return session
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ── 1. FAIL-BEFORE: the instruction's mention leads the context block ────────
+
+
+@pytest.mark.asyncio
+async def test_instruction_mention_is_the_first_context_block(tmp_path: Path) -> None:
+    """Instruction mention first, ``context:`` includes after -- in that order.
+
+    This is the anchors-amp-dev shape in miniature: a root bundle whose whole
+    instruction is a single @mention, plus composed bundles' awareness includes.
+    """
+    system_md = _write(
+        tmp_path / "context" / "system.md",
+        "You are Amplifier, configured for development OF the ecosystem itself.",
+    )
+    gitea = _write(tmp_path / "gitea-awareness.md", "# Gitea Environments")
+    dtu = _write(tmp_path / "dtu-awareness.md", "# Digital Twin Universe")
+
+    bundle = Bundle(
+        name="ns",
+        base_path=tmp_path,
+        instruction="@ns:context/system.md",
+        context={"gitea:context/gitea-awareness.md": gitea, "dtu:ctx.md": dtu},
+    )
+    prepared = _make_prepared(bundle)
+    factory = prepared._create_system_prompt_factory(bundle, _make_mock_session())
+
+    prompt = await factory()
+
+    # The instruction itself is still the head, blocks still follow "---".
+    assert prompt.startswith("@ns:context/system.md\n\n---\n\n")
+
+    blocks = _blocks(prompt)
+    assert len(blocks) == 3, f"expected 3 context_file blocks, got {len(blocks)}"
+
+    # THE ASSERTION THIS TEST EXISTS FOR: the author's own file is block 1.
+    assert blocks[0].body == system_md.read_text(encoding="utf-8")
+    assert blocks[0].first_attribution.startswith("@ns:context/system.md")
+
+    # Includes follow, in their declaration order.
+    assert [b.body for b in blocks[1:]] == [
+        gitea.read_text(encoding="utf-8"),
+        dtu.read_text(encoding="utf-8"),
+    ]
+
+    # And "You are Amplifier" is near the head, not 73% in.
+    assert "You are Amplifier" in prompt[:1500]
+
+
+# ── 2. FAIL-BEFORE: double-referenced file -- one block, mention leads ───────
+
+
+@pytest.mark.asyncio
+async def test_double_referenced_file_emitted_once_mention_leads(
+    tmp_path: Path,
+) -> None:
+    """A file that is BOTH a ``context:`` include and an instruction @mention.
+
+    Emitted exactly once (content dedup), and the ``paths=`` label leads with
+    the author's explicit @mention rather than the include's context name.
+    """
+    shared = _write(tmp_path / "context" / "system.md", "SHARED PRINCIPLES BODY")
+    other = _write(tmp_path / "other.md", "unrelated awareness")
+
+    bundle = Bundle(
+        name="ns",
+        base_path=tmp_path,
+        instruction="@ns:context/system.md",
+        context={"ns:context/system.md": shared, "other:ctx.md": other},
+    )
+    prepared = _make_prepared(bundle)
+    factory = prepared._create_system_prompt_factory(bundle, _make_mock_session())
+
+    prompt = await factory()
+    blocks = _blocks(prompt)
+
+    # Emitted ONCE despite two references.
+    bodies = [b.body for b in blocks]
+    assert bodies.count("SHARED PRINCIPLES BODY") == 1
+    assert len(blocks) == 2
+
+    shared_block = next(b for b in blocks if b.body == "SHARED PRINCIPLES BODY")
+
+    # The mention wins the label: it leads, and it is present.
+    assert shared_block.first_attribution.startswith("@ns:context/system.md")
+    assert "@ns:context/system.md" in shared_block.paths
+
+    # No information was dropped -- the include's own attribution still trails.
+    assert "ns:context/system.md" in shared_block.paths
+
+    # And it is still the FIRST block overall.
+    assert blocks[0] is shared_block
+
+
+# ── 3. NO-REGRESSION GUARD: no instruction mentions -> byte-identical ───────
+
+
+@pytest.mark.asyncio
+async def test_no_instruction_mentions_output_is_byte_identical(
+    tmp_path: Path,
+) -> None:
+    """A bundle with an inline instruction and no @mentions is untouched.
+
+    Passes on main by construction -- that is the point.  The reorder must be
+    a no-op for every bundle whose instruction carries no @mentions, which is
+    the overwhelming majority.
+    """
+    a = _write(tmp_path / "a.md", "AAA body")
+    b = _write(tmp_path / "b.md", "BBB body")
+
+    instruction = "You are a helpful assistant. No mentions here at all."
+    bundle = Bundle(
+        name="plain",
+        base_path=tmp_path,
+        instruction=instruction,
+        context={"a:ctx.md": a, "b:ctx.md": b},
+    )
+    prepared = _make_prepared(bundle)
+    factory = prepared._create_system_prompt_factory(bundle, _make_mock_session())
+
+    prompt = await factory()
+
+    expected = (
+        f"{instruction}\n\n---\n\n"
+        f'<context_file paths="a:ctx.md \u2192 {a.resolve()}">\nAAA body\n</context_file>'
+        "\n\n"
+        f'<context_file paths="b:ctx.md \u2192 {b.resolve()}">\nBBB body\n</context_file>'
+    )
+    assert prompt == expected
+
+
+# ── 4. NO-REGRESSION GUARD: mentions:resolved semantics unchanged ───────────
+
+
+@pytest.mark.asyncio
+async def test_mentions_resolved_payload_semantics_unchanged(tmp_path: Path) -> None:
+    """Same resolutions, same failed list.  Only the ORDER of resolutions moves.
+
+    The event's set semantics are what downstream consumers key on; this pins
+    that the reorder did not add, drop, or reclassify a single entry.
+    """
+    system_md = _write(tmp_path / "context" / "system.md", "PRINCIPLES")
+    aware = _write(tmp_path / "aware.md", "AWARENESS")
+
+    bundle = Bundle(
+        name="ns",
+        base_path=tmp_path,
+        instruction="@ns:context/system.md and @ns:context/missing.md",
+        context={"aware:ctx.md": aware},
+    )
+    prepared = _make_prepared(bundle)
+    session = _make_mock_session()
+    factory = prepared._create_system_prompt_factory(bundle, session)
+
+    await factory()
+
+    session.coordinator.hooks.emit.assert_called_once()
+    event_name, payload = session.coordinator.hooks.emit.call_args.args
+    assert event_name == MENTIONS_RESOLVED
+
+    got = {(r["mention"], r["resolved_path"], r["is_new"]) for r in payload["resolutions"]}
+    assert got == {
+        ("@ns:context/system.md", str(system_md.resolve()), True),
+        ("aware:ctx.md", str(aware.resolve()), True),
+    }
+    assert payload["failed"] == [
+        {"mention": "@ns:context/missing.md", "reason": "not_found"}
+    ]
+    assert payload["deduplicated_count"] == 0
+
+    # The instruction's mention now leads the resolutions list as well.
+    assert payload["resolutions"][0]["mention"] == "@ns:context/system.md"


### PR DESCRIPTION
## The defect

A root bundle whose instruction is a single `@mention` had its own `context/system.md`
emitted **LAST** in the system prompt, behind every composed bundle's peripheral
awareness include.

Measured on this host, `anchors-amp-dev`, `amplifier run "hi"`:

| | before | after |
|---|---|---|
| `raw.system` chars | 96,898 | **96,898** (unchanged) |
| `<context_file>` blocks | 23 | **23** (unchanged) |
| first block | `gitea:context/gitea-awareness.md` | **`@anchors-amp-dev:context/system.md`** |
| byte offset of `"You are Amplifier"` | **72,491** (74.8% in) | **225** |
| `mentions:resolved` | 23 resolutions, 0 failed | 23 resolutions, 0 failed |

The mention always resolved correctly. Only its **placement** was wrong.

## Root cause

`_create_system_prompt_factory` added `bundle.context` includes to the
`ContentDeduplicator` **before** resolving the instruction's `@mentions`, and
`format_context_block` emits in deduplicator **insertion order**.

**Gate verified by reading, not assumed:** `format_context_block` iterates
`deduplicator.get_unique_files()`, which iterates `self._content_by_hash.items()` —
a plain dict, insertion-ordered, no sort anywhere on the path
(`amplifier_foundation/mentions/loader.py:42`, `mentions/deduplicator.py:63-70`).
So the swap is sufficient; no explicit ordering fix inside `format_context_block`
was needed.

## The change

One reordering in `_create_system_prompt_factory`: resolve the instruction's
`@mentions` first, then add the `context:` includes. **No content is inlined into
`main_instruction`** — the `<context_file>` block contract is untouched, only block
order moves.

## Semantics that deliberately DID change

`mentions:resolved` keeps identical **set** semantics (same resolutions, same
`failed` list, same `deduplicated_count`) but the **order of the `resolutions`
list** now leads with the instruction's mentions. Flagging it here rather than
letting a consumer discover it.

For a file referenced **both** as a `context:` include and an instruction mention:
still emitted **once**; its `paths=` label now **leads** with the author's explicit
`@mention`, with the include's own attribution trailing (no attribution is dropped).

## Tests

`tests/test_instruction_mentions_lead_context.py` — 4 tests, POSIX + Windows clean
(tmp_path and `pathlib` only; no shell, no `skipif`).

**Fail-before / pass-after, run by stashing only `_prepared.py`:**

```
=== ON MAIN CODE ===
FF.F
FAILED test_instruction_mention_is_the_first_context_block
FAILED test_double_referenced_file_emitted_once_mention_leads
FAILED test_mentions_resolved_payload_semantics_unchanged
3 failed, 1 passed
=== ON BRANCH ===
4 passed in 0.23s
```

Stated honestly: **3 fail-before, 1 no-regression guard.**
`test_no_instruction_mentions_output_is_byte_identical` passes on main **by
construction** — it pins that bundles without instruction mentions are untouched
by the reorder. A guard that failed on main would be pinning the bug, not the
invariant.

`test_mentions_resolved_payload_semantics_unchanged` is instructive: on main it
failed only on its **last** line (the ordering assertion). Every assertion before
it — the resolution set, the `failed` list, `deduplicated_count` — **passed on
main**, which is the direct evidence that the event's set semantics are unchanged.

## Byte-identity comparison (main vs branch)

`docs/lanes/mikb-instruction-mentions-lead/evidence/byte_identity_probe.py`, same
script run against both revisions at fixed paths:

```
### MAIN (e681764, context includes first)
A_no_instruction_mentions:  sha256=d7f616c6a3088e55f2a21372213acd87438025eb51abf849cb94015846635c34 len=247
B_with_instruction_mention: sha256=1b5d114da8f515287d011564fee150c3be2d8792271ab404616d8e8f753458c0 len=379 'You are Amplifier'@offset=333
### BRANCH (instruction mentions resolved first)
A_no_instruction_mentions:  sha256=d7f616c6a3088e55f2a21372213acd87438025eb51abf849cb94015846635c34 len=247
B_with_instruction_mention: sha256=25bcb36828224b93624ecfe9719ee9cd4f32144a69c834b3ee3b68bc2db82fec len=379 'You are Amplifier'@offset=123
```

No-mention case: **identical sha256**. Mention case: **identical length** (379 both)
— content is neither added nor dropped, only reordered.

## Full suite

`uv run pytest tests/ -q` → **1787 passed, 1 skipped, 1 failed**.
The one failure, `tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file`
(`assert PosixPath('/tmp') == PosixPath('/tmp/tmpXXXX')`), **is pre-existing on
`origin/main` on this host** — verified by re-running it with `_prepared.py` stashed.
It is a file-source-root resolution assertion, untouched by this change.

## Finding, reported rather than absorbed

The task premise said the plain `anchors` bundle "has an inline body and no
mentions". **It does not** — `anchors`'s instruction is also
`@anchors:context/system.md`, so it exhibits the same defect and the same fix:
`"You are Amplifier"` moved **72,467 → 201**, with `raw.system` chars (96,344),
block count (23), and `mentions:resolved` (23/0) all unchanged.
