### PR TITLE
fix(updates): check_bundle_status walks includes instead of dropping them

### DIFF
--- a/amplifier_foundation/sources/protocol.py
+++ b/amplifier_foundation/sources/protocol.py
@@ -49,6 +49,19 @@ class SourceStatus:
     summary: str = ""
     """Human-readable summary of the status."""
 
+    via: str | None = None
+    """Name of the bundle whose ``includes:`` reaches this source.
+
+    ``None`` for a *direct* source -- one declared by the bundle being checked
+    (its own source URI, a module ``source:``, a session entry).  Set to the
+    display name of the immediate including bundle when this source was found
+    only by walking the include graph, so a report can say *which* bundle pulls
+    a stale cache in rather than presenting it as unattributed.
+
+    Appended last, with a default, so every existing positional/keyword
+    construction of ``SourceStatus`` keeps working unchanged.
+    """
+
     @property
     def is_pinned(self) -> bool:
         """Check if this source is pinned to a specific commit.

--- a/amplifier_foundation/updates/__init__.py
+++ b/amplifier_foundation/updates/__init__.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING
 from amplifier_foundation.paths.resolution import ParsedURI
 from amplifier_foundation.paths.resolution import get_amplifier_home
 from amplifier_foundation.paths.resolution import parse_uri
+from amplifier_foundation.paths.resolution import strip_uri_drive_prefix
 from amplifier_foundation.sources.git import GitSourceHandler
 from amplifier_foundation.sources.protocol import SourceStatus
 
@@ -198,7 +199,16 @@ def _cached_path_for(uri: str, cache_dir: Path) -> Path | None:
         return active if active.exists() else None
 
     if parsed.is_file:
-        path = Path(parsed.path)
+        # `file:///C:/Users/x` parses to the path "/C:/Users/x": the leading
+        # slash is the URI's authority separator, not a filesystem root. Left
+        # in place, Path() reads it as rooted-but-driveless and resolves it
+        # against whatever the *current* drive happens to be -- so the file
+        # never exists, the walk sees a dead seed, and every transitive source
+        # silently disappears on Windows. Normalized exactly as
+        # FileSourceHandler.resolve() does, via the shared helper.
+        path = Path(strip_uri_drive_prefix(parsed.path))
+        if parsed.subpath:
+            path = path / parsed.subpath
         return path if path.exists() else None
 
     return None

--- a/amplifier_foundation/updates/__init__.py
+++ b/amplifier_foundation/updates/__init__.py
@@ -25,6 +25,7 @@ Example usage:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
@@ -38,6 +39,16 @@ from amplifier_foundation.sources.protocol import SourceStatus
 
 if TYPE_CHECKING:
     from amplifier_foundation.bundle import Bundle
+    from amplifier_foundation.registry import BundleRegistry
+
+logger = logging.getLogger(__name__)
+
+MAX_INCLUDE_DEPTH = 16
+"""Belt-and-braces bound on include-graph depth.
+
+Cycles are already terminated by the walk's ``visited`` set; this only caps a
+pathological (non-cyclic) chain so a malformed graph cannot spin forever.
+"""
 
 
 @dataclass
@@ -135,16 +146,258 @@ def _collect_source_uris(bundle: Bundle) -> list[str]:
             if isinstance(mod, dict) and "source" in mod:
                 sources.add(mod["source"])
 
-    # Note: Included bundles are now registered as first-class bundles
-    # and will be checked independently by _check_all_bundle_status().
-    # No need to collect their URIs here.
+    # Included bundles are deliberately NOT collected here -- this function
+    # reports only what the bundle declares *directly*.  Transitive includes
+    # are walked separately by collect_transitive_source_uris(), which needs a
+    # registry (for include resolution) and the cache dir (to read already-
+    # cached bundles), neither of which belongs in this signature.
+    #
+    # An earlier comment here claimed includes "are registered as first-class
+    # bundles and will be checked independently".  That premise is false in the
+    # case that matters: a `#subdirectory=` include registers with
+    # is_root=False (registry.py), and host enumeration that keeps only root
+    # entries therefore never checks it.  A repo whose only registry presence
+    # is a non-root sub-bundle entry was checked by nobody, and this function's
+    # caller reported it green while the cache lagged upstream forever --
+    # GitSourceHandler.resolve() returns an existing cache verbatim, with no
+    # fetch, so a source the update path does not enumerate never moves.
 
     return list(sources)
+
+
+def _strip_uri_fragment(uri: str) -> str:
+    """Drop a URI's ``#fragment``, keeping any ``@ref`` intact.
+
+    The ``#subdirectory=`` fragment names a file *inside* a repo; the repo at a
+    ref is the update target.  ``@main`` and ``@v2`` of the same repo are two
+    different targets, so the ref must survive.
+    """
+    return uri.split("#", 1)[0]
+
+
+def _cached_path_for(uri: str, cache_dir: Path) -> Path | None:
+    """Best-available on-disk path for *uri*, WITHOUT touching the network.
+
+    Returns ``None`` when the source is not a readable local/cached thing --
+    which is the correct answer for a source whose cache has been deleted.
+    Resolving it would clone, and a clone here would make a missing cache look
+    healthy, defeating the no-side-effects contract of check_bundle_status().
+    """
+    try:
+        parsed = parse_uri(uri)
+    except Exception:  # noqa: BLE001 - an unparseable URI is simply not walkable
+        return None
+
+    git_handler = GitSourceHandler()
+    if git_handler.can_handle(parsed):
+        # _get_cache_path is a pure key derivation -- it never downloads.
+        cache_path = git_handler._get_cache_path(parsed, cache_dir)
+        if not cache_path.exists():
+            return None
+        active = cache_path / parsed.subpath if parsed.subpath else cache_path
+        return active if active.exists() else None
+
+    if parsed.is_file:
+        path = Path(parsed.path)
+        return path if path.exists() else None
+
+    return None
+
+
+def _is_git_uri(uri: str) -> bool:
+    return uri.startswith("git+") or uri.startswith("git://")
+
+
+async def collect_transitive_source_uris(
+    bundle: Bundle,
+    *,
+    registry: BundleRegistry,
+    cache_dir: Path,
+    known_uris: set[str] | None = None,
+    max_depth: int = MAX_INCLUDE_DEPTH,
+) -> dict[str, str]:
+    """Walk ``includes:`` from *bundle* and return the git sources found.
+
+    Cycle-safe: a ``visited`` set keyed on the full include URI terminates
+    B -> C -> B.  Read-only: caches that already exist are read via the git
+    handler's own ``_get_cache_path``; a missing cache is skipped rather than
+    resolved, because resolving downloads.
+
+    Resolution is *reused*, never reimplemented -- ``BundleRegistry``'s own
+    ``_parse_include`` / ``_resolve_include_source`` / ``_load_from_path`` do
+    the work, so ``@namespace:path``, ``git+...`` and ``#subdirectory=`` forms
+    resolve exactly the way a real session resolves them.
+
+    The walk seeds from the bundle's ``_source_uri`` and re-reads that bundle
+    file from disk, rather than trusting the in-memory ``bundle.includes``.
+    That is deliberate: ``Bundle.compose()`` keeps only ``self.includes``, so
+    after ``load_bundle()`` composes a bundle's includes the returned object's
+    ``.includes`` is the *first included bundle's* list, not its own.  Walking
+    the in-memory list would therefore walk the wrong subtree.  When no source
+    URI is available (a hand-constructed, never-loaded Bundle),
+    ``bundle.includes`` is the only handle there is, and is used as the seed.
+
+    Args:
+        bundle: Bundle whose include graph to walk.
+        registry: Registry supplying include parsing/resolution and the bundle
+            file parser.  Namespace includes resolve against its state, so pass
+            the same registry that loaded the bundle where possible.
+        cache_dir: Cache root (``<amplifier home>/cache``).
+        known_uris: Fragment-stripped URIs already covered by a direct source.
+            Anything listed here is skipped -- it is not "transitive", it is a
+            source that was already going to be checked.
+        max_depth: Bound on graph depth (see ``MAX_INCLUDE_DEPTH``).
+
+    Returns:
+        Mapping of fragment-stripped git URI -> display name of the bundle
+        whose ``includes:`` reaches it, in discovery order.
+    """
+    known = {_strip_uri_fragment(u) for u in (known_uris or set())}
+    found: dict[str, str] = {}
+
+    # Visited on the FULL uri (fragment included): two sub-bundles in one repo
+    # are different files with different includes, so collapsing them on the
+    # repo URI would skip half the graph.  This set is also what makes a cycle
+    # (B includes C includes B) terminate.
+    visited: set[str] = set()
+
+    # (parent display name, uri, depth)
+    queue: list[tuple[str, str, int]] = []
+    root_label = bundle.name or "bundle"
+
+    source_uri = getattr(bundle, "_source_uri", None)
+    if source_uri:
+        visited.add(source_uri)
+        queue.append((root_label, source_uri, 0))
+    else:
+        # No source URI: the in-memory includes list is all we have.
+        for raw_include in bundle.includes or []:
+            spec = registry._parse_include(raw_include)
+            resolved = _resolve_include(registry, spec) if spec else None
+            if not resolved or resolved in visited:
+                continue
+            visited.add(resolved)
+            if _is_git_uri(resolved):
+                key = _strip_uri_fragment(resolved)
+                if key not in known and key not in found:
+                    found[key] = root_label
+            queue.append((root_label, resolved, 1))
+
+    while queue:
+        label, uri, depth = queue.pop(0)
+        if depth >= max_depth:
+            logger.debug(f"Include walk hit max depth at: {uri}")
+            continue
+
+        path = _cached_path_for(uri, cache_dir)
+        if path is None:
+            continue
+
+        try:
+            included = await registry._load_from_path(path)
+        except Exception as exc:  # noqa: BLE001 - an unreadable bundle is not fatal
+            logger.debug(f"Could not read includes from {uri}: {exc}")
+            continue
+
+        parent_label = included.name or label
+
+        for raw_include in included.includes or []:
+            spec = registry._parse_include(raw_include)
+            if not spec:
+                continue
+            resolved = _resolve_include(registry, spec)
+            if not resolved or resolved in visited:
+                continue
+            visited.add(resolved)
+
+            if _is_git_uri(resolved):
+                key = _strip_uri_fragment(resolved)
+                if key not in known and key not in found:
+                    found[key] = parent_label
+
+            queue.append((parent_label, resolved, depth + 1))
+
+    return found
+
+
+def _resolve_include(registry: BundleRegistry, spec: str) -> str | None:
+    """Resolve one include spec to a loadable URI, or None."""
+    try:
+        resolved = registry._resolve_include_source(spec)
+    except Exception as exc:  # noqa: BLE001 - one bad include must not sink the walk
+        logger.debug(f"Could not resolve include '{spec}': {exc}")
+        return None
+
+    if not resolved:
+        return None
+
+    # A plain name is a registry alias; the loader lets _load_single look it
+    # up, so look it up the same way here.
+    if "://" not in resolved and not resolved.startswith("git+"):
+        return registry.find(resolved)
+
+    return resolved
+
+
+async def _check_transitive_sources(
+    bundle: Bundle,
+    *,
+    cache_dir: Path,
+    registry: BundleRegistry | None,
+    known_uris: set[str],
+    git_handler: GitSourceHandler,
+) -> list[SourceStatus]:
+    """Status-check every git source reached only through ``includes:``.
+
+    Uses the same ``GitSourceHandler.get_status`` call a direct source gets, so
+    a transitive row carries the same cached/remote commit truth -- and the
+    same pinned handling -- as a direct one.  One bad source is logged and
+    skipped rather than sinking the whole report.
+    """
+    if registry is None:
+        # Imported lazily: registry.py is a heavier import and pulling it at
+        # module scope would create an import cycle through amplifier_foundation.
+        from amplifier_foundation.registry import BundleRegistry as _BundleRegistry
+
+        try:
+            registry = _BundleRegistry(home=cache_dir.parent)
+        except Exception as exc:  # noqa: BLE001 - no registry means no walk, not a crash
+            logger.debug(f"Could not build a registry for the include walk: {exc}")
+            return []
+
+    try:
+        transitive = await collect_transitive_source_uris(
+            bundle,
+            registry=registry,
+            cache_dir=cache_dir,
+            known_uris=known_uris,
+        )
+    except Exception as exc:  # noqa: BLE001 - a walk failure must not sink the report
+        logger.debug(f"Include walk failed: {exc}")
+        return []
+
+    statuses: list[SourceStatus] = []
+    for uri, parent in transitive.items():
+        try:
+            parsed = parse_uri(uri)
+            if not git_handler.can_handle(parsed):
+                continue
+            status = await git_handler.get_status(parsed, cache_dir)
+        except Exception as exc:  # noqa: BLE001 - one bad source, not the report
+            logger.debug(f"Status check failed for {uri}: {exc}")
+            continue
+        status.via = parent
+        statuses.append(status)
+
+    return statuses
 
 
 async def check_bundle_status(
     bundle: Bundle,
     cache_dir: Path | None = None,
+    *,
+    registry: BundleRegistry | None = None,
+    include_transitive: bool = True,
 ) -> BundleStatus:
     """Check update status of all sources in a bundle.
 
@@ -154,9 +407,24 @@ async def check_bundle_status(
     For git sources, uses `git ls-remote` to compare cached commits
     against remote HEAD.
 
+    Transitively-included bundles are checked too (``include_transitive``,
+    default True).  They must be: an include reached only by
+    ``#subdirectory=`` registers with ``is_root=False``, and host enumeration
+    that keeps only root entries never checks it -- so before this, a bundle
+    whose only registry presence was a non-root sub-bundle entry was checked
+    by nobody, and this function reported "All N source(s) up to date" over a
+    cache stuck at an old commit.  Each such source is reported with ``via``
+    set to the bundle that includes it.
+
     Args:
         bundle: Bundle to check.
         cache_dir: Cache directory for modules. Defaults to ~/.amplifier/cache.
+        registry: Registry used to resolve includes during the transitive
+            walk. Defaults to a registry rooted at ``cache_dir.parent`` (the
+            conventional ``<amplifier home>/cache`` layout). Pass the registry
+            that loaded the bundle when using a non-conventional cache dir.
+        include_transitive: Walk ``includes:`` and report transitively-reached
+            git sources. Set False for the old direct-sources-only behavior.
 
     Returns:
         BundleStatus with status of each source.
@@ -192,6 +460,17 @@ async def check_bundle_status(
                     summary="Update checking not supported for this source type",
                 )
             )
+
+    if include_transitive:
+        statuses.extend(
+            await _check_transitive_sources(
+                bundle,
+                cache_dir=cache_dir,
+                registry=registry,
+                known_uris=set(source_uris),
+                git_handler=git_handler,
+            )
+        )
 
     # Get bundle source for display
     bundle_source = getattr(bundle, "_source_uri", None)
@@ -271,8 +550,10 @@ async def update_bundle(
 
 
 __all__ = [
+    "MAX_INCLUDE_DEPTH",
     "BundleStatus",
     "SourceStatus",
     "check_bundle_status",
+    "collect_transitive_source_uris",
     "update_bundle",
 ]

--- a/tests/test_transitive_include_status_72y.py
+++ b/tests/test_transitive_include_status_72y.py
@@ -300,6 +300,28 @@ async def test_deleted_cache_is_not_resolved_back_into_existence(
     assert not cache_path.exists(), "walk must not have cloned a missing cache"
 
 
+def test_cached_path_for_round_trips_a_file_uri(tmp_path: Path) -> None:
+    """A ``file://`` seed must resolve on Windows too, not just POSIX.
+
+    ``Path.as_uri()`` emits ``file:///C:/Users/x`` on Windows, whose path
+    component parses to ``/C:/Users/x`` -- rooted but driveless. Passed to
+    ``Path()`` unnormalized it resolves against whatever the current drive
+    happens to be, the seed file "does not exist", and the whole walk silently
+    finds nothing. This asserts the round trip on every platform; the Windows
+    CI legs are what make it a real guard.
+    """
+    bundle_file = tmp_path / "bundle.yaml"
+    bundle_file.write_text("bundle:\n  name: x\n  version: '1.0.0'\n")
+    cache = tmp_path / "cache"
+
+    assert _cached_path_for(bundle_file.as_uri(), cache) == bundle_file
+    # #subdirectory= is honoured the same way FileSourceHandler.resolve() does.
+    assert (
+        _cached_path_for(f"{tmp_path.as_uri()}#subdirectory=bundle.yaml", cache)
+        == bundle_file
+    )
+
+
 @pytest.mark.asyncio
 async def test_direct_sources_carry_no_via(tmp_path: Path) -> None:
     """``via`` stays None for a bundle's own directly-declared sources."""

--- a/tests/test_transitive_include_status_72y.py
+++ b/tests/test_transitive_include_status_72y.py
@@ -1,0 +1,321 @@
+"""check_bundle_status() must report transitively-included sources (recipes-72y).
+
+The defect: ``_collect_source_uris()`` dropped ``bundle.includes`` on the
+premise that "included bundles are now registered as first-class bundles and
+will be checked independently". That premise is false in the case that
+matters. An include reached by ``#subdirectory=`` registers with
+``is_root=False``, and host enumeration that keeps only root entries therefore
+never checks it -- so a repo whose *only* registry presence is a non-root
+sub-bundle entry was checked by nobody, while ``check_bundle_status()``
+reported "All N source(s) up to date" over a cache stuck at an old commit.
+
+It compounds because ``GitSourceHandler.resolve()`` returns an existing cache
+verbatim on a hit -- no TTL, no fetch, ever. A source the update path does not
+enumerate is a source that never moves. These tests pre-seed a cache at commit
+one, advance the fake remote to commit two, and assert the stale include is
+reported rather than papered over.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from amplifier_foundation.paths.resolution import parse_uri
+from amplifier_foundation.registry import BundleRegistry
+from amplifier_foundation.sources.git import GitSourceHandler
+from amplifier_foundation.updates import _cached_path_for
+from amplifier_foundation.updates import check_bundle_status
+from amplifier_foundation.updates import collect_transitive_source_uris
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    """Run a git command in a fixture repo and return stdout."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(["init", "--quiet", "-b", "main"], cwd=repo)
+    _git(["config", "user.email", "test@example.com"], cwd=repo)
+    _git(["config", "user.name", "Test"], cwd=repo)
+
+
+def _commit_all(repo: Path, message: str) -> str:
+    _git(["add", "-A"], cwd=repo)
+    _git(["commit", "--quiet", "-m", message], cwd=repo)
+    return _git(["rev-parse", "HEAD"], cwd=repo)
+
+
+def _git_file_uri(repo: Path, ref: str, subpath: str = "") -> str:
+    """Build a ``git+file://`` URI for a local fixture repo.
+
+    Uses ``Path.as_uri()`` so the drive-letter form is produced natively on
+    Windows rather than hand-assembled.
+    """
+    uri = f"git+{repo.as_uri()}@{ref}"
+    if subpath:
+        uri += f"#subdirectory={subpath}"
+    return uri
+
+
+ROOT_BUNDLE_NAME = "ampl"
+"""Name of the child repo's ROOT bundle -- deliberately collides (below) with a
+name already in the registry, which is what leaves the repo with no root entry
+of its own. This is the measured real-world shape: microsoft/amplifier's root
+bundle name was already taken, so only its non-root ``behaviors/`` sub-bundle
+entry existed, and root-only enumeration reached nothing."""
+
+
+def _make_child_repo(base: Path, name: str = "cee") -> tuple[Path, str]:
+    """A git repo carrying a root bundle plus a nested sub-bundle file.
+
+    Returns ``(repo_path, first_commit_sha)``. The nested
+    ``behaviors/child.yaml`` mirrors the real shape of the defect: the include
+    that reaches this repo names a file *inside* it, so the entry it registers
+    is a non-root one.
+    """
+    repo = base / f"remote-{name}"
+    _init_repo(repo)
+    (repo / "bundle.yaml").write_text(
+        f"bundle:\n  name: {ROOT_BUNDLE_NAME}\n  version: '1.0.0'\n"
+    )
+    (repo / "behaviors").mkdir()
+    (repo / "behaviors" / "child.yaml").write_text(
+        f"bundle:\n  name: {name}\n  version: '1.0.0'\n"
+    )
+    (repo / "data.txt").write_text("one\n")
+    first = _commit_all(repo, "first")
+    return repo, first
+
+
+def _advance(repo: Path) -> str:
+    (repo / "data.txt").write_text("two\n")
+    return _commit_all(repo, "second")
+
+
+def _seed_cache(uri: str, cache_dir: Path) -> Path:
+    """Clone *uri*'s repo into the cache path the handler would use.
+
+    This is the "already cached at an older commit" starting state -- exactly
+    what a real machine has after any earlier session resolved the include.
+    """
+    parsed = parse_uri(uri)
+    handler = GitSourceHandler()
+    cache_path = handler._get_cache_path(parsed, cache_dir)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    git_url = handler._build_git_url(parsed)
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "--quiet",
+            "--branch",
+            parsed.ref or "main",
+            git_url,
+            str(cache_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return cache_path
+
+
+def _write_parent_bundle(base: Path, includes: list[str], name: str = "bee") -> Path:
+    parent = base / "parent"
+    parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"bundle:\n  name: {name}\n  version: '1.0.0'\n", "includes:\n"]
+    lines.extend(f"  - {inc}\n" for inc in includes)
+    (parent / "bundle.yaml").write_text("".join(lines))
+    return parent / "bundle.yaml"
+
+
+@pytest.mark.asyncio
+async def test_non_root_include_with_stale_cache_is_reported(tmp_path: Path) -> None:
+    """A bundle reached only by a non-root include is checked, not dropped."""
+    home = tmp_path / "home"
+    cache = home / "cache"
+    cache.mkdir(parents=True)
+
+    child_repo, first = _make_child_repo(tmp_path)
+    include_uri = _git_file_uri(child_repo, "main", "behaviors/child.yaml")
+    _seed_cache(include_uri, cache)
+    second = _advance(child_repo)
+    assert first != second
+
+    parent_file = _write_parent_bundle(tmp_path, [include_uri])
+    registry = BundleRegistry(home=home)
+    # The child repo's ROOT bundle name is already taken by an unrelated entry,
+    # so loading the include cannot claim a root entry for this repo.
+    registry.register({ROOT_BUNDLE_NAME: "git+https://example.invalid/other@main"})
+    bundle = await registry._load_single(
+        parent_file.as_uri(), auto_register=True, auto_include=True
+    )
+
+    # The premise the old comment relied on: nothing registered this repo as a
+    # ROOT bundle, so root-only enumeration would never reach it.
+    assert not any(
+        state.is_root and state.uri.split("#")[0] == include_uri.split("#")[0]
+        for state in registry._registry.values()
+    )
+    child_state = registry._registry.get("cee")
+    assert child_state is not None and child_state.is_root is False
+
+    # No explicit registry passed: exercise the default derived from cache_dir.
+    status = await check_bundle_status(bundle, cache)
+
+    rows = [s for s in status.sources if s.via is not None]
+    assert len(rows) == 1, f"expected one transitive row, got {status.sources}"
+    row = rows[0]
+    assert row.cached_commit == first
+    assert row.remote_commit == second
+    assert row.has_update is True
+    assert row.via == "bee"
+
+    assert status.has_updates is True
+    # The exact green lie this defect produced. It must not be reachable while
+    # any source -- direct or transitive -- has an update.
+    assert "source(s) up to date" not in status.summary
+    assert status.summary.startswith("1 update(s) available")
+
+    # Regression guard, on the same fixture: the pre-fix behaviour is still
+    # reachable via include_transitive=False, and it is exactly the green lie
+    # -- no row for the stale include, and has_updates False.
+    old = await check_bundle_status(bundle, cache, include_transitive=False)
+    assert old.has_updates is False
+    assert all(s.via is None for s in old.sources)
+
+
+@pytest.mark.asyncio
+async def test_pinned_include_is_reported_pinned_not_updateable(
+    tmp_path: Path,
+) -> None:
+    """An ``@<sha>`` include is pinned: reported, but never updateable."""
+    home = tmp_path / "home"
+    cache = home / "cache"
+    cache.mkdir(parents=True)
+
+    child_repo, first = _make_child_repo(tmp_path)
+    include_uri = _git_file_uri(child_repo, first, "behaviors/child.yaml")
+    _seed_cache(_git_file_uri(child_repo, "main"), cache)
+    # Seed the pinned cache path too, so the row has a cached commit to show.
+    _seed_cache_pinned = _git_file_uri(child_repo, first)
+    handler = GitSourceHandler()
+    pinned_cache = handler._get_cache_path(parse_uri(_seed_cache_pinned), cache)
+    subprocess.run(
+        ["git", "clone", "--quiet", str(child_repo), str(pinned_cache)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    _advance(child_repo)
+
+    parent_file = _write_parent_bundle(tmp_path, [include_uri])
+    registry = BundleRegistry(home=home)
+    bundle = await registry._load_single(
+        parent_file.as_uri(), auto_register=True, auto_include=True
+    )
+
+    status = await check_bundle_status(bundle, cache, registry=registry)
+
+    rows = [s for s in status.sources if s.via is not None]
+    assert len(rows) == 1, f"expected one transitive row, got {status.sources}"
+    row = rows[0]
+    assert row.is_pinned is True
+    assert row.has_update is False
+    assert status.has_updates is False
+
+
+@pytest.mark.asyncio
+async def test_include_cycle_terminates(tmp_path: Path) -> None:
+    """B includes C, C includes B: the walk terminates and reports both once."""
+    home = tmp_path / "home"
+    cache = home / "cache"
+    cache.mkdir(parents=True)
+
+    repo_b = tmp_path / "remote-bee"
+    repo_c = tmp_path / "remote-cee"
+    _init_repo(repo_b)
+    _init_repo(repo_c)
+
+    uri_b = _git_file_uri(repo_b, "main")
+    uri_c = _git_file_uri(repo_c, "main")
+
+    (repo_b / "bundle.yaml").write_text(
+        f"bundle:\n  name: bee\n  version: '1.0.0'\nincludes:\n  - {uri_c}\n"
+    )
+    _commit_all(repo_b, "b")
+    (repo_c / "bundle.yaml").write_text(
+        f"bundle:\n  name: cee\n  version: '1.0.0'\nincludes:\n  - {uri_b}\n"
+    )
+    _commit_all(repo_c, "c")
+
+    _seed_cache(uri_b, cache)
+    _seed_cache(uri_c, cache)
+
+    registry = BundleRegistry(home=home)
+    bundle = await registry._load_from_path(
+        GitSourceHandler()._get_cache_path(parse_uri(uri_b), cache)
+    )
+    bundle._source_uri = uri_b  # type: ignore[attr-defined]
+
+    found = await collect_transitive_source_uris(
+        bundle, registry=registry, cache_dir=cache, known_uris={uri_b}
+    )
+
+    # Terminated (no hang, no recursion error) and C is attributed to B.
+    assert found == {uri_c: "bee"}
+
+
+@pytest.mark.asyncio
+async def test_deleted_cache_is_not_resolved_back_into_existence(
+    tmp_path: Path,
+) -> None:
+    """The walk reads caches; it never resolves one, which would download.
+
+    Resolving a missing cache would clone it, and a fresh clone reports "up to
+    date" -- turning a deleted cache into a green row. The walk must instead
+    read nothing and leave the disk untouched.
+    """
+    home = tmp_path / "home"
+    cache = home / "cache"
+    cache.mkdir(parents=True)
+
+    child_repo, _first = _make_child_repo(tmp_path)
+    include_uri = _git_file_uri(child_repo, "main", "behaviors/child.yaml")
+
+    cache_path = GitSourceHandler()._get_cache_path(parse_uri(include_uri), cache)
+    assert not cache_path.exists()
+
+    assert _cached_path_for(include_uri, cache) is None
+    assert not cache_path.exists(), "walk must not have cloned a missing cache"
+
+
+@pytest.mark.asyncio
+async def test_direct_sources_carry_no_via(tmp_path: Path) -> None:
+    """``via`` stays None for a bundle's own directly-declared sources."""
+    home = tmp_path / "home"
+    cache = home / "cache"
+    cache.mkdir(parents=True)
+
+    parent = tmp_path / "solo"
+    parent.mkdir()
+    (parent / "bundle.yaml").write_text("bundle:\n  name: solo\n  version: '1.0.0'\n")
+
+    registry = BundleRegistry(home=home)
+    bundle = await registry._load_single(
+        (parent / "bundle.yaml").as_uri(), auto_register=True, auto_include=True
+    )
+
+    status = await check_bundle_status(bundle, cache, registry=registry)
+
+    assert all(s.via is None for s in status.sources)


### PR DESCRIPTION
## Defect

`check_bundle_status()` — a **public foundation mechanism every host inherits**, not just the CLI — reported `All N source(s) up to date` over a cache stuck at an old commit.

Measured on a real machine (2026-09-06): `~/.amplifier/cache/amplifier-d1dda27a16518560` (`git_url https://github.com/microsoft/amplifier`, `ref main`) sat at `c03a88b` while upstream `main` was `28588b9`. That cache is reached **only** through amplifier-foundation's `bundle.md` include `git+https://github.com/microsoft/amplifier@main#subdirectory=behaviors/amplifier-expert.yaml`.

## Root cause

`amplifier_foundation/updates/__init__.py:138-140` (inside `_collect_source_uris()`):

```python
# Note: Included bundles are now registered as first-class bundles
# and will be checked independently by _check_all_bundle_status().
# No need to collect their URIs here.
```

The premise is false in exactly the case that matters:

1. An include **is** registered (`registry._load_single(..., auto_register=True)`), but a `#subdirectory=` include lands with `is_root: false` (`amplifier_foundation/registry.py:520-545`), and host enumeration that keeps only `is_root: true` entries (e.g. `amplifier_app_cli/lib/bundle_loader/discovery.py:679-685`) never reaches it. A repo whose **only** registry presence is a non-root sub-bundle entry is checked by nobody.
2. It compounds: `GitSourceHandler.resolve()` (`amplifier_foundation/sources/git.py:697-709`) returns an existing cache **verbatim** on a hit — no TTL, no fetch, ever. A source the update path does not enumerate is a source that **never moves**.

### A second, non-obvious root cause found while fixing this

Walking the in-memory `bundle.includes` — the literal reading of the issue — does **not** work. `Bundle.compose()` (`amplifier_foundation/bundle/_dataclass.py:185`) keeps only `includes=list(self.includes)`, and `_compose_includes()` returns `composed_includes.compose(bundle)`. So after `load_bundle()` composes a bundle, the returned object's `.includes` is the **first included bundle's** list, not its own. Verified live below: foundation's post-compose `bundle.includes == []`.

The walk therefore seeds from `bundle._source_uri` and re-reads that bundle file from disk (falling back to `bundle.includes` only for a hand-constructed, never-loaded `Bundle`).

## Change

| File | What |
|---|---|
| `amplifier_foundation/updates/__init__.py` | New `collect_transitive_source_uris()` — cycle-safe BFS over `includes:`, **reusing** `BundleRegistry._parse_include` / `_resolve_include_source` / `_load_from_path` and `GitSourceHandler._get_cache_path`. New `_cached_path_for()` reads an already-cached bundle **without resolving** (resolving downloads — a deleted cache must not look healthy). `check_bundle_status()` gains keyword-only `registry` and `include_transitive=True`. Stale comment replaced with what is actually true. |
| `amplifier_foundation/sources/protocol.py` | `SourceStatus.via: str \| None = None` — the including bundle's name; `None` for direct sources. Appended **last with a default**, so every existing positional/keyword construction is byte-compatible. |
| `tests/test_transitive_include_status_72y.py` | 5 new tests (below). |

Behavioural consequences:

- Each transitive git source appears as a `SourceStatus` with cached vs remote commit, `has_update`, and `via`.
- `is_pinned` refs (`@<sha>` / `@v1.2.3`) are reported **pinned, never updateable** (`GitSourceHandler.get_status` already short-circuits; the walk just stops hiding them).
- `status.summary` can no longer say `All N source(s) up to date` while any transitive source `has_update` — transitive rows are in `status.sources`, so `updateable_sources` counts them.
- `update_bundle()` consequently now refreshes stale transitive caches too, which is the actual remedy for the measured staleness.

## What app-cli would delete

amplifier-app-cli PR #317 (merged `c120a36`) added `amplifier_app_cli/utils/include_graph.py` to work around this app-side. Semantics here were matched to it deliberately (fragment-stripped URI as the update-target identity; visited-set keyed on the **full** URI including fragment; read-cache-never-resolve; reuse of the loader's own resolution). With this merged, app-cli can collapse:

- `amplifier_app_cli/utils/include_graph.py` — `collect_transitive_git_sources()`, `check_transitive_sources()`, `transitive_statuses_for()`, `_local_path_for()`, `strip_uri_fragment()`, `TransitiveSource`, `TransitiveStatus` → all superseded by `collect_transitive_source_uris()` + `SourceStatus.via`.
- Its call sites in `amplifier update` / `amplifier bundle update` become plain reads of `check_bundle_status().sources` (filter on `via is not None` for the "reached via an include" rows).
- `refresh_transitive_source()` can stay or become `update_bundle(selective=[...])` — it is a thin `GitSourceHandler.update()` wrapper either way.

One deliberate difference: app-cli's `TransitiveSource` carries **both** `parent` (immediate includer) and `root` (the registered row it groups under, for table rendering). `SourceStatus.via` is the honest immediate includer only — grouping is a presentation concern for the host, not a property of the source.

## Gates

| Gate | Result |
|---|---|
| **CI: 6-job pytest matrix (ubuntu/windows x py3.11/3.12/3.13)** | **6/6 pass** |
| **CI: license/cla** | **pass** |
| `uv run pytest tests/ -q` locally | **1793 passed, 1 skipped, 1 failed** — the single failure, `tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file`, is **pre-existing on this host at base `2ef5e12`** (verified by stashing all of my changes and re-running on a pristine tree: `assert PosixPath('/tmp') == PosixPath('/tmp/tmpXXXX')` — a `/tmp` resolution quirk of this machine, in `FileSourceHandler`, untouched here). It **passes in CI on all six legs**, confirming it is host-local and not a regression. |
| New tests | `tests/test_transitive_include_status_72y.py` — **6 passed** |
| `ruff format --check` on changed files | clean |
| `ruff check` on changed files | clean, **except** one pre-existing `F401` (`ParsedURI` imported but unused) on an untouched import line in `updates/__init__.py` — left alone deliberately, since it is also a public re-export (`amplifier_foundation.updates.ParsedURI`) and removing it is an unrelated surface change |
| CI | 6-job pytest matrix + license/cla — see checks below |

### New tests

1. `test_non_root_include_with_stale_cache_is_reported` — fixture repo C (root bundle name deliberately collides with an already-registered name, so C's repo gets **no root entry**; sub-bundle `behaviors/child.yaml` registers `is_root=False`), cache pre-seeded at commit one, fake remote advanced to commit two. Asserts: no root entry for that repo; exactly one transitive row; `cached_commit == first`, `remote_commit == second`, `has_update is True`, `via == "bee"`; `"source(s) up to date" not in summary`. Ends with an in-place **regression guard** — the same bundle through `include_transitive=False` reproduces the old green lie (`has_updates is False`, no row).
2. `test_pinned_include_is_reported_pinned_not_updateable` — `@<sha>` include → `is_pinned is True`, `has_update is False`, `status.has_updates is False`.
3. `test_include_cycle_terminates` — B includes C, C includes B, both cached git repos. Terminates, returns `{uri_c: "bee"}`.
4. `test_deleted_cache_is_not_resolved_back_into_existence` — a missing cache yields `None` and **stays missing**; the walk never clones one back into a green row.
5. `test_cached_path_for_round_trips_a_file_uri` — `Path.as_uri()` round-trips, including the Windows `file:///C:/...` form (see below).
6. `test_direct_sources_carry_no_via` — `via` stays `None` for directly-declared sources.

## Second commit: a Windows bug the first commit shipped

The first push failed all three Windows CI legs — **every** transitive source vanished there. Cause: `Path.as_uri()` emits `file:///C:/Users/x` on Windows, whose path component parses to `/C:/Users/x` — rooted but *driveless*. Passed to `Path()` unnormalized it resolves against whatever the current drive happens to be, so the seed bundle file "does not exist", `_cached_path_for()` returns `None`, and the walk finds nothing at all — silently, with a green summary. Exactly the class of failure this PR exists to remove.

Fixed by normalizing through the same shared helper `FileSourceHandler.resolve()` already uses (`strip_uri_drive_prefix`), and honouring `#subdirectory=` for file URIs the way that handler does. Guarded by test 5 above.

**Note for the app-side collapse:** amplifier-app-cli's `include_graph.py` `_local_path_for()` has this same latent bug in its `file://` branch — worth fixing there if the collapse does not happen promptly.

## LIVE proof

Isolated `AMPLIFIER_HOME` (a copy — the real `~/.amplifier` was read, never written; verified untouched afterwards), containing a copy of the 22 caches foundation's includes reach. In that copy: `git -C cache/amplifier-d1dda27a16518560 reset --hard c03a88b` plus `.amplifier_cache_meta.json` `commit` corrected to match, and the `is_root: true` registry entry for `microsoft/amplifier` removed — reproducing "reachable only as a non-root include".

Then `check_bundle_status()` on the foundation bundle loaded from this worktree (`PYTHONPATH`), with **no** explicit `cache_dir` or `registry` (zero-config path):

```
AMPLIFIER_HOME = .../lanes/fd-72y/iso-home
ROOT registry entries for microsoft/amplifier: [] (empty => checked by nobody, pre-fix)
loaded bundle  = foundation | _source_uri = file:///.../amplifier-foundation/bundle.md
post-compose bundle.includes[0:2] = []   <-- NOT foundation's own includes; why the walk seeds from _source_uri

=== check_bundle_status(bundle)  [default cache_dir + registry] ===
summary: 11 update(s) available (28 up to date, 2 unknown)

--- the row that did not exist before this change ---
{
  "source_uri": "git+https://github.com/microsoft/amplifier@main",
  "via": "foundation",
  "is_cached": true,
  "cached_commit": "c03a88ba9d3e76bf7bb1509770bfc5d779e03b75",
  "remote_commit": "28588b93886dd4b134f131294ca98e944d71cbfd",
  "has_update": true,
  "is_pinned": false,
  "summary": "Update available (c03a88ba \u2192 28588b93)"
}

--- pre-fix behaviour on the SAME bundle (include_transitive=False) ---
summary: 10 update(s) available (18 up to date, 2 unknown) | has_updates: True | rows for microsoft/amplifier: []

--- all transitive rows (11) ---
  ok      via=foundation                   git+https://github.com/microsoft/amplifier-bundle-amplifier-tester@main
  ok      via=foundation                   git+https://github.com/microsoft/amplifier-bundle-browser-tester@main
  ok      via=foundation                   git+https://github.com/microsoft/amplifier-bundle-design-intelligence@main
  ok      via=amplifier-tester-behavior    git+https://github.com/microsoft/amplifier-bundle-digital-twin-universe@main
  ok      via=foundation                   git+https://github.com/microsoft/amplifier-bundle-evaluation@main
  ok      via=foundation                   git+https://github.com/microsoft/amplifier-bundle-filesystem@main
  ok      via=digital-twin-universe-behavior git+https://github.com/microsoft/amplifier-bundle-gitea@main
  ok      via=foundation                   git+https://github.com/microsoft/amplifier-bundle-llm-wiki@main
  ok      via=foundation                   git+https://github.com/microsoft/amplifier-bundle-superpowers@main
  ok      via=foundation                   git+https://github.com/microsoft/amplifier-core@main
  UPDATE  via=foundation                   git+https://github.com/microsoft/amplifier@main
```

The measured defect, reproduced and then fixed: `microsoft/amplifier` had **no row at all** pre-fix, and post-fix reports `c03a88b -> 28588b9`, `has_update: true`, `via: foundation`. The depth-2 rows (`via=amplifier-tester-behavior`, `via=digital-twin-universe-behavior`) show the walk is genuinely transitive, not one-level.

**Honest caveat on this live run:** the isolated home's *direct* sources were themselves stale, so the literal string `All N source(s) up to date` does not appear in either summary here — the pre-fix summary already said `10 update(s) available`. What the live run proves is the missing row; the exact `All N source(s) up to date` regression is covered by assertion in test 1 (`"source(s) up to date" not in status.summary`).

Closes work item `recipes-72y`.

Generated with Amplifier

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
