### PR TITLE
fix(recipes): validate-agents discovers only 23 of 32 agents -- widen discovery to repo-wide scope

### DIFF
--- a/docs/lanes/xe1u-validate-agents-discovery/DONE-NOTE.md
+++ b/docs/lanes/xe1u-validate-agents-discovery/DONE-NOTE.md
@@ -1,0 +1,322 @@
+# Lane xe1u -- `validate-agents` discovery widened (23 -> 32)
+
+**Item:** `model_performance-xe1u` (project `model_performance`)
+**Branch:** `lane/xe1u-validate-agents-discovery` off `origin/main` @ `5a9e07b`
+**Outcome:** **A. RESOLVED** -- every deliverable DONE. Nothing was cut by the cap.
+**Landing stage:** draft PR only. Per the goal's LANDING STAGE clause, a deliverable
+whose final state needs a merge is satisfied here as *demonstrated fail-before /
+pass-after and shipped for landing*; the merge is the manager's next stage.
+
+**Headline:** widening discovery flipped the verdict **PASS -> FAIL**, and the goal
+anticipated exactly this. The four newly-surfaced ERRORs are **not dirty agents** --
+they are four *context documents* that live in a directory named `agents/`. Reported,
+**left unfixed**, per the scope-out. The recipe was **not** weakened to restore PASS.
+
+---
+
+## Deliverables
+
+| # | Deliverable | State |
+|---|---|---|
+| 1 | Discovery widened to every `**/agents/*.md`, using 6phe's existing exclusion set (quoted) | **DONE** |
+| 2 | Before/after discovered counts, both measured by running the recipe | **DONE** -- 23 -> **32** |
+| 3 | Verdict stays PASS | **DONE as reported: it did NOT.** PASS -> FAIL, headline finding F1, left unfixed |
+| 4 | Report metadata names search locations AND discovered total | **DONE** |
+| 5 | Shared-helper question answered either way | **DONE** -- shared implementation **DECLINED with reason**; a cheap *parity guard* implemented instead |
+| 6 | Suite green, draft PR, not merged | **DONE** |
+| 7 | DONE-NOTE at the lane artifact root | **DONE** (this file) |
+
+---
+
+## 1. Discovery widened -- and where the exclusion set was read from
+
+`recipes/validate-agents.yaml`, step `agent-discovery`, previously walked a
+hand-maintained list of three places (`agents/`, `behaviors/*/agents/`,
+`bundles/*/agents/`). It now globs the repo and drops excluded parts:
+
+```python
+candidates = list(path.rglob("*/agents/*.md")) + list((path / "agents").glob("*.md"))
+```
+
+**The exclusion set was copied, not invented.** Quoting the source verbatim --
+`tests/test_anchors_bundles_dry.py:52-69` (added by lane 6phe):
+
+```python
+# The validator's own agent-discovery scope, copied deliberately rather than
+# approximated. `@foundation:recipes/validate-bundle-repo.yaml`'s
+# `agent-description-validation` step globs
+# `rglob("*/agents/*.md") + glob("agents/*.md")` and drops any path containing
+# one of these parts. Two validators disagreeing about which files exist is
+# exactly how the 11 `experiments/` violators survived #341 and ux32:
+# `validate-agents` discovers 23 agents and never walks `experiments/`, while
+# `validate-bundle-repo` discovers 45 and does. This guard follows the wider
+# one. `docs` is added on top of the validator's set: `docs/` holds frozen lane
+# records that quote violations verbatim as evidence and must never be rewritten.
+AGENT_SCAN_EXCLUDED_PARTS = {
+    "test-fixtures",
+    "tests",
+    "node_modules",
+    ".git",
+    ".venv",
+    "docs",
+}
+```
+
+That six-element set is now `EXCLUDED_PARTS` in the recipe, byte-for-byte, with the
+provenance in a comment above it. **No second list was created** -- and
+`TestDiscoveryScopeParity` (below) fails the build if one ever appears.
+
+## 2. Before / after -- both measured by running the recipe
+
+| | BEFORE | AFTER |
+|---|---|---|
+| Recipe version | v1.5.1 (unmodified) | v1.6.0 (this branch) |
+| `run_id` | `run-c26b396f2f1e` | `run-67388a546d75` |
+| `total_count` | **23** | **32** |
+| `search_locations` | 3 | 6 |
+| `quality_level` | `good` | `critical` |
+| **Verdict** | **PASS** | **FAIL** |
+
+Per-location counts, from the AFTER run's `location_counts`:
+
+| Location | Agents | |
+|---|---|---|
+| `agents/` | 16 | walked before |
+| `bundles/anchors/agents/` | 6 | walked before |
+| `bundles/anchors-amp-dev/agents/` | 1 | walked before |
+| `context/agents/` | 4 | **newly walked** |
+| `examples/agents/` | 1 | **newly walked** |
+| `experiments/build-up/agents/` | 4 | **newly walked** |
+
+**32 is measured, not assumed** -- and it is the *same 32 files*, by path, as
+6phe's `evidence/scope-parity.txt` ("validator scope ... 32 agents / guard (c)
+scope ... 32 agents / identical sets: True"). All three scopes now agree.
+
+Full run records: [`evidence/before-validate-agents-run.txt`](evidence/before-validate-agents-run.txt),
+[`evidence/after-validate-agents-run.txt`](evidence/after-validate-agents-run.txt),
+and [`evidence/after-deterministic-phases.json`](evidence/after-deterministic-phases.json)
+(the discovery/structural/classification output re-derived locally, no LLM step, so
+the numbers above are reproducible for $0).
+
+## 3. The verdict did NOT stay PASS -- and that is finding F1
+
+The goal's own words: *"If it does not stay PASS, that is the headline finding:
+report exactly which newly-walked agent fails and why, and leave it unfixed."*
+
+`structural summary: total 32, passed 28, errors 4, warnings 1`
+
+```
+4x ERROR  NO_FRONTMATTER
+    context/agents/delegation-instructions.md
+    context/agents/multi-agent-patterns.md
+    context/agents/session-repair-knowledge.md
+    context/agents/session-storage-knowledge.md
+
+1x WARNING NO_TOOLS_SECTION
+    examples/agents/file-responder.md
+```
+
+**Zero findings in `experiments/build-up/agents/` (4 files)** -- the tree that
+started this whole chain is clean, confirming 6phe fixed the content. That is the
+widened scan's good news, and it is only visible because the scan now reaches it.
+
+Details, and why nothing was fixed, in **Findings** below.
+
+## 4. Under-coverage is now visible in the output
+
+`discovery_results` gained three fields -- `location_counts`, `scan_patterns`,
+`excluded_parts` -- and `location` is now **derived** from each file's own parent
+directory instead of hardcoded, so a new `agents/` tree names itself in the report
+the first time it appears rather than the day someone remembers to add it.
+
+The `synthesize-report` prompt now *requires* a Coverage block in both the executive
+summary and the metadata: patterns scanned, parts excluded, total, and a row per
+location with its count. The `quick-approval` fast path (the one a PASSing repo
+actually reads) restates the same coverage line.
+
+The AFTER report emitted it:
+
+```
+- **Agents discovered**: 32 total across 6 locations -- agents/ 16,
+  bundles/anchors-amp-dev/agents/ 1, bundles/anchors/agents/ 6, context/agents/ 4, ...
+- excluded_parts: .git, .venv, docs, node_modules, test-fixtures, tests
+```
+
+The BEFORE report's *"Agents Found: 23 total across 3 search locations"* is the
+anti-pattern this replaces: complete-looking, and silent about nine files.
+
+## 5. The shared-helper question -- **DECLINED**, with the reason
+
+**A shared discovery implementation is NOT cheap, and I did not build one.**
+
+Two routes exist and both are worse than the divergence they would fix:
+
+1. **A recipe-engine `include` / step-library concept.** Recipe steps are
+   self-contained heredocs interpolated as strings; there is no import mechanism
+   between two `.yaml` recipes. Adding one restructures the step contract -- which
+   the goal names explicitly as the "say so and leave it" case.
+2. **A Python helper in `amplifier_foundation/`, imported by both.** This looks
+   cheap and is a trap. `validate-agents`' own `structural-validation` step already
+   documents why, in code:
+
+   > `amplifier_foundation` is not guaranteed to be importable in every
+   > environment this recipe runs in (it is run against third-party bundle
+   > repos). Degrade to a no-op rather than killing the whole run.
+
+   Discovery cannot degrade to a no-op -- a discovery that silently finds nothing is
+   the exact failure this lane exists to remove. Making the *scope* depend on an
+   import that is explicitly allowed to be missing would trade a visible
+   under-count for an invisible one.
+
+**Implemented instead (cheap, and it actually closes the hole):
+`TestDiscoveryScopeParity`** in `tests/test_anchors_bundles_dry.py` -- two guards
+that run on every CI job:
+
+- `test_exclusion_sets_agree_across_both_recipes_and_this_guard` -- parses the set
+  literals out of both recipes and compares them to `AGENT_SCAN_EXCLUDED_PARTS`. A
+  fourth list, or a drifting third, fails the build by name. The one permitted
+  delta (`docs`, present in the guard and `validate-agents`, absent from
+  `validate-bundle-repo`) is asserted **explicitly** rather than tolerated.
+- `test_validate_agents_discovers_exactly_the_guards_agent_files` -- **executes the
+  recipe's own discovery step** and compares its file set to `_agent_files()`. A test
+  that re-implemented the glob would keep passing while the recipe diverged, which is
+  precisely the failure mode being guarded.
+
+**Fail-before / pass-after** (both committed):
+
+```
+$ git stash push -- recipes/validate-agents.yaml   # guards vs the OLD recipe
+FAILED ...TestDiscoveryScopeParity::test_exclusion_sets_agree_across_both_recipes_and_this_guard
+FAILED ...TestDiscoveryScopeParity::test_validate_agents_discovers_exactly_the_guards_agent_files
+2 failed in 0.09s
+```
+
+The second failure named all nine missing files:
+
+```
+In recipe not guard: []; in guard not recipe:
+['context/agents/delegation-instructions.md', 'context/agents/multi-agent-patterns.md',
+ 'context/agents/session-repair-knowledge.md', 'context/agents/session-storage-knowledge.md',
+ 'examples/agents/file-responder.md', 'experiments/build-up/agents/coder.md',
+ 'experiments/build-up/agents/explorer.md', 'experiments/build-up/agents/planner.md',
+ 'experiments/build-up/agents/tester.md']
+```
+
+After: `8 passed in 0.13s` (was 6 tests; +2).
+[`evidence/parity-guards-FAIL-BEFORE.txt`](evidence/parity-guards-FAIL-BEFORE.txt),
+[`evidence/parity-guards-PASS-AFTER.txt`](evidence/parity-guards-PASS-AFTER.txt).
+
+## 6. Suite
+
+`2 failed, 2017 passed, 3 skipped` -- and the two failures are **exactly the two the
+goal names as pre-existing on this host**, neither touched by this branch:
+`tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file` and
+`tests/test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes`.
+[`evidence/full-suite.txt`](evidence/full-suite.txt).
+
+`git status` after all runs shows only the two source files plus this lane
+directory. **`validate-bundle-repo` was deliberately NOT run in this lane**, so
+6phe's F1 regen side effect (`bundle.dot` / `bundle.png` rewritten
+unconditionally) could not fire. Verified rather than assumed.
+
+---
+
+## Spend
+
+**Authority: $0 -- arithmetic `0 runs x 0 arms x $0 / 1.00 = $0.00`, slack $0.00.**
+
+**That arithmetic closes, and the authoring rule's failure mode cannot arise here**:
+this item buys *no measurement runs at all* -- there is no run-count/price pair to
+mis-size. It is a recipe edit, a guard test, and two recipe runs, which the goal
+carves out of the cap explicitly ("if a run costs API spend, RECORD it rather than
+treating it as free"). **Nothing was dropped for want of budget; branch B was never
+reached.**
+
+**API spend actually incurred, recorded rather than treated as free:**
+
+| Run | Recipe | LLM steps executed | Metered cost |
+|---|---|---|---|
+| `run-c26b396f2f1e` | `validate-agents` v1.5.1 (BEFORE) | 2 -- `quick-approval`, `synthesize-report`; `description-quality-check` and `tool-access-analysis` **skipped** (`requires_llm_analysis == false`) | not separately metered by the runner |
+| `run-67388a546d75` | `validate-agents` v1.6.0 (AFTER) | 3 -- `description-quality-check`, `tool-access-analysis`, `synthesize-report`; `quick-approval` **skipped** (same condition, now false the other way) | not separately metered by the runner |
+
+Five LLM steps across two runs. The runner reports no per-run cost figure, so the
+executed step count and the skips are recorded rather than a dollar amount invented.
+
+**Note for the manager, since it is a real cost signal:** widening discovery moved
+this repo off the quick-approval fast path. A FAILing run costs *more* LLM steps than
+a PASSing one (3 vs 2), because the two conditional deep-analysis phases now fire.
+That is a consequence of finding F1, and it reverses the moment F1 is resolved.
+
+No DTU, no container, no other infrastructure was created. Nothing in the infra
+ledger for this lane; nothing to tear down.
+
+---
+
+## Findings
+
+**F1 (headline) -- `context/agents/` is a path collision, not four broken agents.**
+The four `NO_FRONTMATTER` ERRORs are *context documents*, not agent definitions.
+Evidence, gathered rather than assumed:
+
+- `behaviors/agents.yaml:44-45` and `behaviors/tasks.yaml:18-19` list
+  `delegation-instructions.md` and `multi-agent-patterns.md` under `context:` --
+  never under `agents:`.
+- `agents/session-analyst.md:369-370` `@`-mentions the two session-knowledge files
+  as context.
+- `context/agents/` means *context about agents*, not *agents*. Nothing ever spawns
+  them, so `NO_FRONTMATTER`'s "agent won't load" describes an event that cannot
+  occur.
+
+The defect is in the **discovery predicate's semantics**: `**/agents/*.md` uses the
+*directory name* as the type signal, conflating definitions with context that
+happens to live beside them. `AGENT_SCAN_EXCLUDED_PARTS` does not exclude `context`,
+and correctly so -- excluding it would hide a real agent tree the day someone adds
+one.
+
+**Left unfixed, deliberately.** Adding frontmatter would be worse than the finding:
+it would make four context docs advertise themselves as spawnable agents. The
+architecturally correct fix is a type discriminator matching the loader's own
+contract -- *discover by path, classify by `meta:` presence; a `.md` under an
+`agents/` directory with no `meta:` is skipped as not-an-agent, not errored*. That
+neither weakens a check nor invents a second exclusion list. **It is a separate
+item**, and it is the one thing that would restore PASS honestly.
+
+**F2 -- `validate-bundle-repo`'s "32 agents, errors: []" is quietly wrong on the
+same 32 files.** The two recipes now agree on *scope* and still disagree on
+*content*: `validate-bundle-repo`'s `agent-description-validation` step reads only
+`meta.description` (`extract_description()` returns `""` when frontmatter is
+absent), so a file with **no frontmatter at all** scores 0 tokens, 0 `<example>`,
+0 `<commentary>` and passes clean. It therefore counted the four context docs as
+checked agents and reported `errors: []` (6phe, `run-864d8d1c009a`). Two
+consequences: its headline count of 32 is inflated by 4 -- **the true agent count in
+this repo is 28** -- and it cannot detect a genuinely broken or missing frontmatter
+in any agent. Reported, not fixed; it is content-check scope, not discovery scope.
+
+**F3 -- `examples/agents/file-responder.md` has no `tools:` section (WARNING).**
+Benign and arguably correct: the fixture exists to demonstrate spawn-capability
+*inheritance* from an agent `.md` (`examples/23_spawn_with_agents.py:200` maps the
+name to a literal file path). Declaring `tools: []` would erase the behaviour being
+demonstrated. Reported, not fixed.
+
+**F4 -- a FAILing repo costs more LLM steps than a PASSing one.** See the spend
+note above. Worth knowing before anyone widens discovery on a larger repo.
+
+---
+
+## Deviations from the goal
+
+1. **Deliverable 3 ("the verdict must stay PASS") was not met, by design.** The goal
+   predicted PASS on the premise "all agents are clean post-6phe". That premise
+   holds for every *agent* -- all 28 are clean, including all 4 in
+   `experiments/build-up/`. It does not hold for four *non-agents* the widened glob
+   now walks. The goal's own branch for this case was taken: report which files
+   fail and why, leave them unfixed, do not weaken anything. Recorded, not absorbed.
+2. **The shared-helper question was answered "no", and something cheaper was built
+   instead.** The goal accepts a stated "no, because X" as complete. I went slightly
+   further and added the parity guards, because they are cheap (two tests, no engine
+   change) and they are what actually prevents the divergence from recurring. If the
+   reviewer considers the extra test out of scope, it is severable in one commit --
+   the recipe change stands alone.
+3. **`validate-bundle-repo` was not re-run.** 6phe's `run-864d8d1c009a` already
+   records its side of the parity, this lane does not change that recipe, and
+   running it risks 6phe's F1 artifact-rewrite side effect for no new information.

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/after-deterministic-phases.json
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/after-deterministic-phases.json
@@ -1,0 +1,88 @@
+{
+  "discovery": {
+    "phase": "discovery",
+    "repo_path": "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation",
+    "total_count": 32,
+    "search_locations": [
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/agents",
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/bundles/anchors-amp-dev/agents",
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/bundles/anchors/agents",
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/context/agents",
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/examples/agents",
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/experiments/build-up/agents"
+    ],
+    "location_counts": {
+      "agents/": 16,
+      "bundles/anchors-amp-dev/agents/": 1,
+      "bundles/anchors/agents/": 6,
+      "context/agents/": 4,
+      "examples/agents/": 1,
+      "experiments/build-up/agents/": 4
+    },
+    "scan_patterns": [
+      "<repo>/**/agents/*.md",
+      "<repo>/agents/*.md"
+    ],
+    "excluded_parts": [
+      ".git",
+      ".venv",
+      "docs",
+      "node_modules",
+      "test-fixtures",
+      "tests"
+    ],
+    "errors": []
+  },
+  "structural_summary": {
+    "total": 32,
+    "passed": 28,
+    "errors": 4,
+    "warnings": 1
+  },
+  "structural_findings": [
+    {
+      "path": "context/agents/delegation-instructions.md",
+      "errors": [
+        "NO_FRONTMATTER"
+      ],
+      "warnings": []
+    },
+    {
+      "path": "context/agents/multi-agent-patterns.md",
+      "errors": [
+        "NO_FRONTMATTER"
+      ],
+      "warnings": []
+    },
+    {
+      "path": "context/agents/session-repair-knowledge.md",
+      "errors": [
+        "NO_FRONTMATTER"
+      ],
+      "warnings": []
+    },
+    {
+      "path": "context/agents/session-storage-knowledge.md",
+      "errors": [
+        "NO_FRONTMATTER"
+      ],
+      "warnings": []
+    },
+    {
+      "path": "examples/agents/file-responder.md",
+      "errors": [],
+      "warnings": [
+        "NO_TOOLS_SECTION"
+      ]
+    }
+  ],
+  "quality_level": "critical",
+  "requires_llm_analysis": true,
+  "class_summary": {
+    "total": 32,
+    "good": 27,
+    "polish": 0,
+    "needs_work": 1,
+    "critical": 4
+  }
+}

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/after-validate-agents-run.txt
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/after-validate-agents-run.txt
@@ -1,0 +1,53 @@
+AFTER  --  validate-agents v1.6.0 (widened discovery), same repo, same host, same day
+run_id:        run-67388a546d75
+session_id:    10ba26d6554c4252-20260906-123907_recipe
+repo_path:     /home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation
+status:        completed
+
+discovery_results.total_count:       32          (was 23)
+discovery_results.search_locations:  6           (was 3)
+discovery_results.scan_patterns:     ["<repo>/**/agents/*.md", "<repo>/agents/*.md"]
+discovery_results.excluded_parts:    [".git", ".venv", "docs", "node_modules", "test-fixtures", "tests"]
+discovery_results.location_counts:
+  agents/                          16   (walked before)
+  bundles/anchors/agents/           6   (walked before)
+  bundles/anchors-amp-dev/agents/   1   (walked before)
+  context/agents/                   4   NEWLY WALKED
+  examples/agents/                  1   NEWLY WALKED
+  experiments/build-up/agents/      4   NEWLY WALKED
+
+This set is IDENTICAL to the 32 files in 6phe's
+docs/lanes/6phe-experiments-example-sweep/evidence/scope-parity.txt
+("validator scope ... 32 agents / guard (c) scope ... 32 agents / identical sets: True").
+All three scopes now agree.
+
+structural summary:  total 32, passed 28, errors 4, warnings 1
+quality_level:       critical   (was "good")
+requires_llm_analysis: true     (was false)
+classification:      good 27, polish 0, needs_work 1, critical 4
+
+VERDICT (synthesize-report): FAIL   <-- CHANGED from PASS
+
+NEWLY-SURFACED FINDINGS -- REPORTED, NOT FIXED (goal scope-out):
+
+  4x ERROR  NO_FRONTMATTER
+      context/agents/delegation-instructions.md
+      context/agents/multi-agent-patterns.md
+      context/agents/session-repair-knowledge.md
+      context/agents/session-storage-knowledge.md
+
+  1x WARNING NO_TOOLS_SECTION
+      examples/agents/file-responder.md
+
+  0 findings in experiments/build-up/agents/ (4 files) -- confirms 6phe cleaned
+    the content to zero; the widened scan's good news.
+
+LLM steps EXECUTED (3):  description-quality-check, tool-access-analysis, synthesize-report
+LLM steps SKIPPED  (1):  quick-approval (condition requires_llm_analysis == false)
+  -- note the inversion vs the BEFORE run, which executed quick-approval and
+     skipped the other two.
+
+REPRODUCE THE DETERMINISTIC PART FOR $0:
+  the discovery / structural / classification steps are pure bash+python.
+  after-deterministic-phases.json in this directory is their exact output,
+  re-derived locally from the same recipe file with no LLM step involved.

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/before-validate-agents-run.txt
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/before-validate-agents-run.txt
@@ -1,0 +1,28 @@
+BEFORE  --  validate-agents v1.5.1 (unmodified, at lane branch point = origin/main 5a9e07b)
+run_id:        run-c26b396f2f1e
+session_id:    6fd60e5f3961435a-20260906-123542_recipe
+repo_path:     /home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation
+status:        completed
+
+discovery_results.total_count:        23
+discovery_results.search_locations:   3
+  agents/                          16 agents
+  bundles/anchors/agents/           6 agents
+  bundles/anchors-amp-dev/agents/   1 agent
+
+quality_classification.quality_level:        good
+quality_classification.requires_llm_analysis: false
+quality_classification.summary: {good: 23, polish: 0, needs_work: 0, critical: 0, total: 23}
+
+VERDICT (synthesize-report): PASS
+  "Agents Found: 23 total across 3 search locations"
+  "Quality Breakdown: 23 good, 0 polish, 0 needs_work, 0 critical"
+  "Issues: 0 errors, 0 warnings, 2 optional suggestions"
+
+LLM steps EXECUTED (2):  quick-approval, synthesize-report
+LLM steps SKIPPED  (2):  description-quality-check, tool-access-analysis
+                         (skipped by condition: requires_llm_analysis == false)
+
+THE BLIND SPOT THIS RUN DEMONSTRATES: the report says "23 found, 3 locations"
+and carries NO signal that other agent directories exist in the repo. Nine
+further files match the wider validator scope and were never walked.

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/full-suite.txt
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/full-suite.txt
@@ -1,0 +1,11 @@
+FULL SUITE -- lane branch (validate-agents v1.6.0 + parity guards)
+command: python -m pytest -q
+
+  Enable tracemalloc to get traceback where the object was allocated.
+  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+FAILED tests/test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes
+FAILED tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file
+2 failed, 2017 passed, 3 skipped, 1 warning in 20.38s

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/parity-guards-FAIL-BEFORE.txt
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/parity-guards-FAIL-BEFORE.txt
@@ -1,0 +1,54 @@
+FAIL-BEFORE -- new parity guards run against validate-agents v1.5.1 (unmodified recipe, guards applied)
+command: python -m pytest tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity -q
+
+FF                                                                       [100%]
+=================================== FAILURES ===================================
+_ TestDiscoveryScopeParity.test_exclusion_sets_agree_across_both_recipes_and_this_guard _
+
+self = <tests.test_anchors_bundles_dry.TestDiscoveryScopeParity object at 0xfe7b49302f00>
+
+    def test_exclusion_sets_agree_across_both_recipes_and_this_guard(self) -> None:
+        """A fourth exclusion list is how the first divergence started."""
+        agents_sets = _literal_set(
+            VALIDATE_AGENTS_RECIPE.read_text(encoding="utf-8"), "EXCLUDED_PARTS"
+        )
+>       assert len(agents_sets) == 1, (
+            "validate-agents.yaml must declare exactly one EXCLUDED_PARTS set, "
+            f"found {len(agents_sets)}"
+        )
+E       AssertionError: validate-agents.yaml must declare exactly one EXCLUDED_PARTS set, found 0
+E       assert 0 == 1
+E        +  where 0 = len([])
+
+tests/test_anchors_bundles_dry.py:344: AssertionError
+_ TestDiscoveryScopeParity.test_validate_agents_discovers_exactly_the_guards_agent_files _
+
+self = <tests.test_anchors_bundles_dry.TestDiscoveryScopeParity object at 0xfe7b49060aa0>
+
+    def test_validate_agents_discovers_exactly_the_guards_agent_files(self) -> None:
+        """Proven parity, by running the recipe's own step -- not asserted."""
+        from_recipe = _run_recipe_discovery_step()
+        from_guard = {path.relative_to(REPO_ROOT).as_posix() for path in _agent_files()}
+>       assert from_recipe == from_guard, (
+            "validate-agents' discovery and this guard's _agent_files must find "
+            "the same files. In recipe not guard: "
+            f"{sorted(from_recipe - from_guard)}; in guard not recipe: "
+            f"{sorted(from_guard - from_recipe)}"
+        )
+E       AssertionError: validate-agents' discovery and this guard's _agent_files must find the same files. In recipe not guard: []; in guard not recipe: ['context/agents/delegation-instructions.md', 'context/agents/multi-agent-patterns.md', 'context/agents/session-repair-knowledge.md', 'context/agents/session-storage-knowledge.md', 'examples/agents/file-responder.md', 'experiments/build-up/agents/coder.md', 'experiments/build-up/agents/explorer.md', 'experiments/build-up/agents/planner.md', 'experiments/build-up/agents/tester.md']
+E       assert {'agents/bug-...pert.md', ...} == {'agents/bug-...pert.md', ...}
+E         
+E         Extra items in the right set:
+E         'context/agents/multi-agent-patterns.md'
+E         'experiments/build-up/agents/coder.md'
+E         'experiments/build-up/agents/explorer.md'
+E         'context/agents/session-repair-knowledge.md'
+E         'experiments/build-up/agents/planner.md'...
+E         
+E         ...Full output truncated (5 lines hidden), use '-vv' to show
+
+tests/test_anchors_bundles_dry.py:377: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity::test_exclusion_sets_agree_across_both_recipes_and_this_guard
+FAILED tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity::test_validate_agents_discovers_exactly_the_guards_agent_files
+2 failed in 0.09s

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/parity-guards-PASS-AFTER.txt
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/parity-guards-PASS-AFTER.txt
@@ -1,0 +1,5 @@
+PASS-AFTER -- whole guard module against validate-agents v1.6.0 (widened discovery)
+command: python -m pytest tests/test_anchors_bundles_dry.py -q
+
+........                                                                 [100%]
+8 passed in 0.13s

--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -3,6 +3,38 @@
 # Validates agent definitions in a bundle repository for quality, tool access, and structural requirements
 #
 # CHANGELOG:
+# v1.6.0 - Agent discovery is now REPO-WIDE, matching the other two scopes
+#          in this repo instead of diverging from them. Phase 1 walked a
+#          hand-maintained list of three places (`agents/`,
+#          `behaviors/*/agents/`, `bundles/*/agents/`); it now globs
+#          `rglob("*/agents/*.md") + glob("agents/*.md")` and drops any path
+#          containing an excluded part -- the identical pair
+#          `validate-bundle-repo.yaml`'s `agent-description-validation` step
+#          uses, and the identical exclusion set
+#          `tests/test_anchors_bundles_dry.py`'s AGENT_SCAN_EXCLUDED_PARTS
+#          uses (its five plus `docs`).
+#        - WHY: the narrow walk was the ROOT CAUSE of a recurrence chain. On
+#          amplifier-foundation it discovered 23 agents while the other two
+#          scopes saw 32, so 11 `<example>` violators under
+#          `experiments/**/agents/` survived #341 (which swept root
+#          `agents/`) and ux32 (which swept `bundles/**`) -- and this recipe
+#          reported "23 found, 3 locations" the whole time, with no signal
+#          that other agent directories existed at all. A clean verdict that
+#          is silent about its own blind spot is worse than a noisy one.
+#        - Discovery output gained `location_counts` (per-directory counts),
+#          `scan_patterns` and `excluded_parts`; `location` is now DERIVED
+#          from each file's own parent directory rather than hardcoded, so a
+#          new `agents/` directory names itself in the report the first time
+#          it appears. `search_locations`, `agents_found` (with `path`,
+#          `relative_path`, `name`, `location`), `total_count` and `errors`
+#          keep their shape -- downstream steps are unchanged.
+#        - The report now MUST print the coverage line (total + every
+#          location with its count + the exclusion set) in both the executive
+#          summary and the metadata, so an under-count is visible in the
+#          output rather than silent.
+#        - Discovery only. No check, threshold, severity or verdict rule
+#          changed. On a repo whose agents all live in the three old
+#          locations, output is identical.
 # v1.5.1 - Prompt text caught up with the v1.4.0 example policy. The
 #          quick-approval and synthesize-report prompts still invited the
 #          model to offer "add <example> blocks" as optional polish, so a
@@ -142,6 +174,12 @@ description: |
   
   Produces a validation report with findings categorized by severity and actionable remediation.
   
+  **Discovery scope (v1.6.0):** every `agents/*.md` anywhere in the repo, excluding
+  `test-fixtures/`, `tests/`, `node_modules/`, `.git/`, `.venv/` and `docs/` -- the
+  same scope `validate-bundle-repo.yaml` and the repo-wide guard test use. The report
+  names every location it walked and the total it found, so under-coverage shows up in
+  the output instead of hiding behind a clean verdict.
+
   **v1.2.0 Improvements:**
   - Deterministic quality classification before LLM analysis
   - Explicit PASS thresholds - no more "always finding something"
@@ -150,7 +188,7 @@ description: |
   
   This recipe helps maintain agent quality across the Amplifier ecosystem by codifying
   the audit criteria discovered in manual reviews.
-version: "1.5.1"
+version: "1.6.0"
 author: "Amplifier Foundation Team"
 tags: ["agents", "validation", "quality", "audit", "tools", "descriptions"]
 
@@ -221,19 +259,60 @@ steps:
       import json
       from pathlib import Path
 
+      # --- Agent-discovery scope (v1.6.0) ------------------------------------
+      # This set is COPIED, not approximated, from the two places that already
+      # agree on it. Do not fork a third list here.
+      #
+      #   1. `recipes/validate-bundle-repo.yaml`, step `agent-description-
+      #      validation`: `EXCLUDED_DIRS = {"test-fixtures", "tests",
+      #      "node_modules", ".git", ".venv"}` over
+      #      `rglob("*/agents/*.md") + glob("agents/*.md")`.
+      #   2. `tests/test_anchors_bundles_dry.py`, `AGENT_SCAN_EXCLUDED_PARTS`
+      #      (added by lane 6phe): the same five plus `docs`, because `docs/`
+      #      holds frozen lane records that quote violations verbatim as
+      #      evidence and must never be rewritten.
+      #
+      # Before v1.6.0 this step walked only `agents/`, `behaviors/*/agents/`
+      # and `bundles/*/agents/` -- 23 files here, while the other two scopes
+      # saw 32. That asymmetry is the ROOT CAUSE of a recurrence chain: 11
+      # `<example>` violators under `experiments/**/agents/` survived both
+      # #341 (which swept root `agents/`) and ux32 (which swept `bundles/**`),
+      # because the recipe most people run never looked there, and reported a
+      # clean "23 found, 3 locations" while doing it.
+      EXCLUDED_PARTS = {
+          "test-fixtures",
+          "tests",
+          "node_modules",
+          ".git",
+          ".venv",
+          "docs",
+      }
+
+      # The glob pair, reported in the output so a reader can reproduce the scan.
+      SCAN_PATTERNS = ["<repo>/**/agents/*.md", "<repo>/agents/*.md"]
+
       def discover_agents(repo_path: str) -> dict:
-          """Discover all agent definition files in a repository."""
+          """Discover every agent definition file in a repository.
+
+          Repo-wide by design: any `agents/` directory at any depth, minus
+          EXCLUDED_PARTS. A location that is missing from this walk is a
+          location the validator cannot report on, so the walk must not be a
+          hand-maintained list of the places agents happened to live.
+          """
           results = {
               "phase": "discovery",
               "repo_path": repo_path,
               "agents_found": [],
               "total_count": 0,
               "search_locations": [],
+              "location_counts": {},
+              "scan_patterns": SCAN_PATTERNS,
+              "excluded_parts": sorted(EXCLUDED_PARTS),
               "errors": []
           }
 
           path = Path(repo_path).expanduser().resolve()
-          
+
           if not path.exists():
               results["errors"].append({
                   "type": "path_error",
@@ -242,57 +321,44 @@ steps:
               print(json.dumps(results))
               return results
 
-          # Direct agents/ directory
-          agents_dir = path / "agents"
-          if agents_dir.exists() and agents_dir.is_dir():
-              results["search_locations"].append(str(agents_dir))
-              for agent_file in agents_dir.glob("*.md"):
-                  results["agents_found"].append({
-                      "path": str(agent_file),
-                      "relative_path": str(agent_file.relative_to(path)),
-                      "name": agent_file.stem,
-                      "location": "agents/"
-                  })
+          # rglob("*/agents/*.md") reaches every nested agents/ directory;
+          # glob("agents/*.md") adds the repo-root one, which the rglob
+          # pattern's leading `*/` cannot match.
+          candidates = list(path.rglob("*/agents/*.md")) + list((path / "agents").glob("*.md"))
 
-          # Check behaviors/*/agents/ pattern
-          behaviors_dir = path / "behaviors"
-          if behaviors_dir.exists():
-              for behavior in behaviors_dir.iterdir():
-                  if behavior.is_dir():
-                      behavior_agents = behavior / "agents"
-                      if behavior_agents.exists() and behavior_agents.is_dir():
-                          results["search_locations"].append(str(behavior_agents))
-                          for agent_file in behavior_agents.glob("*.md"):
-                              results["agents_found"].append({
-                                  "path": str(agent_file),
-                                  "relative_path": str(agent_file.relative_to(path)),
-                                  "name": agent_file.stem,
-                                  "location": f"behaviors/{behavior.name}/agents/"
-                              })
+          seen = set()
+          for agent_file in sorted(candidates):
+              relative = agent_file.relative_to(path)
+              if EXCLUDED_PARTS & set(relative.parts):
+                  continue
+              resolved = agent_file.resolve()
+              if resolved in seen:
+                  continue
+              seen.add(resolved)
 
-          # Also check for standalone agent files in bundles/
-          bundles_dir = path / "bundles"
-          if bundles_dir.exists():
-              for bundle in bundles_dir.iterdir():
-                  if bundle.is_dir():
-                      bundle_agents = bundle / "agents"
-                      if bundle_agents.exists() and bundle_agents.is_dir():
-                          results["search_locations"].append(str(bundle_agents))
-                          for agent_file in bundle_agents.glob("*.md"):
-                              results["agents_found"].append({
-                                  "path": str(agent_file),
-                                  "relative_path": str(agent_file.relative_to(path)),
-                                  "name": agent_file.stem,
-                                  "location": f"bundles/{bundle.name}/agents/"
-                              })
+              # "location" is the containing directory, repo-relative, with a
+              # trailing slash -- e.g. "agents/", "bundles/anchors/agents/".
+              # Derived from the path rather than hardcoded, so a new agents/
+              # directory names itself in the report the first time it appears.
+              location = relative.parent.as_posix() + "/"
+              results["agents_found"].append({
+                  "path": str(agent_file),
+                  "relative_path": relative.as_posix(),
+                  "name": agent_file.stem,
+                  "location": location
+              })
+              results["location_counts"][location] = results["location_counts"].get(location, 0) + 1
 
+          results["search_locations"] = [str(path / loc) for loc in sorted(results["location_counts"])]
+          results["location_counts"] = dict(sorted(results["location_counts"].items()))
           results["total_count"] = len(results["agents_found"])
-          
+
           if results["total_count"] == 0:
               results["errors"].append({
                   "type": "no_agents",
                   "message": "No agent files found in repository",
-                  "searched": results["search_locations"] or ["agents/", "behaviors/*/agents/", "bundles/*/agents/"]
+                  "searched": SCAN_PATTERNS,
+                  "excluded_parts": sorted(EXCLUDED_PARTS)
               })
 
           print(json.dumps(results))
@@ -957,11 +1023,22 @@ steps:
     agent: "foundation:zen-architect"
     mode: "REVIEW"
     condition: "{{quality_classification.requires_llm_analysis}} == false"
-    depends_on: ["set-default-approval-summary"]
+    depends_on: ["set-default-approval-summary", "agent-discovery"]
     prompt: |
       All agents in this repository meet quality thresholds. Provide a brief approval summary.
 
       **Repository Path:** {{repo_path}}
+
+      **Discovery Coverage (v1.6.0 -- restate this, do not omit it):**
+      - Agents discovered: {{discovery_results.total_count}}
+      - Per-location counts: {{discovery_results.location_counts}}
+      - Scan patterns: {{discovery_results.scan_patterns}}
+      - Excluded parts: {{discovery_results.excluded_parts}}
+
+      A PASS is only meaningful alongside the scope it was reached over. An
+      approval that says "all agents pass" without saying WHICH agents were
+      looked at is exactly the shape that let 11 violators survive two
+      repo-wide sweeps.
 
       **Quality Classification Results:**
       ```json
@@ -995,6 +1072,9 @@ steps:
       ## ✅ PASS - All Agents Meet Quality Standards
       
       **Summary:** [1-2 sentences]
+
+      **Coverage:** [total] agents across [N] locations ([list them with
+      counts]); excluded [excluded_parts]
       
       **What's Done Well:**
       - [list 2-3 positive patterns]
@@ -1260,9 +1340,35 @@ steps:
       
       - **Overall Verdict**: [Select from above based on quality_level]
       - **Repository**: [path]
-      - **Agents Found**: X total
+      - **Agents Found**: X total across N locations
       - **Quality Breakdown**: X good, Y polish, Z needs_work, W critical
       - **Issues**: X errors, Y warnings, Z suggestions
+
+      ### Coverage (REQUIRED -- never omit, never summarise away)
+
+      Immediately after the bullets above, print the coverage block, taken
+      verbatim from `discovery_results`:
+
+      ```
+      Scanned: <scan_patterns>, excluding <excluded_parts>
+      Discovered: <total_count> agent files across <len(location_counts)> locations
+      ```
+
+      then a row per entry of `location_counts`, in the order given:
+
+      | Location | Agents |
+      |----------|--------|
+      | agents/  | 16     |
+
+      **Why this is mandatory:** a validator that under-counts silently is
+      worse than one that fails loudly. Before v1.6.0 this recipe walked
+      three hardcoded directories, reported "23 found, 3 locations" on a repo
+      that had 32 agent files in 6 locations, and gave a reader no way to
+      notice -- which is how 11 violators under `experiments/**/agents/`
+      survived two repo-wide sweeps. Printing the patterns, the exclusions,
+      the per-location counts and the total makes the scope auditable from
+      the report alone. Do NOT collapse this to a single number, and do NOT
+      drop locations that contributed zero findings.
 
       ## Quality Classification Summary
 
@@ -1345,7 +1451,14 @@ steps:
 
       ## Metadata
       - **Validated**: [timestamp]
-      - **Recipe**: validate-agents v1.5.1
+      - **Recipe**: validate-agents v1.6.0
+      - **Discovery scope**: repo-wide `agents/*.md`. State the
+        `scan_patterns` and the `excluded_parts` from `discovery_results`
+        verbatim.
+      - **Agents discovered**: `total_count` total across the locations in
+        `location_counts` -- list every location with its count again here,
+        so the metadata alone answers "what did this run actually look at?"
+        without the reader scrolling back.
       - **Quality Thresholds**: see
         `foundation:context/shared/description-authoring-principles.md`
         (canonical -- not restated here). Gates: no structural errors

--- a/tests/test_anchors_bundles_dry.py
+++ b/tests/test_anchors_bundles_dry.py
@@ -262,3 +262,121 @@ class TestAgentDescriptionsCarryNoExampleBlocks:
             "(description-authoring-principles.md V3, #340). Offenders: "
             + "; ".join(offenders)
         )
+
+
+# --- Discovery-scope parity (xe1u) -----------------------------------------
+# The three places in this repo that answer "which files are agent
+# definitions?" must give the SAME answer. When they did not, the cost was a
+# three-sweep recurrence: `validate-agents` walked three hardcoded directories
+# and found 23 agents; `validate-bundle-repo` and `_agent_files` above globbed
+# the repo and found 32 (45 before the `experiments/` deletion). The 11
+# `<example>` violators that lived in the 9-file difference survived #341 and
+# ux32 because the recipe most people run never looked at them -- and reported
+# a clean "23 found, 3 locations" the whole time.
+#
+# 6phe closed the gap in the guard; xe1u closed it in `validate-agents`
+# (v1.6.0). These tests are the tripwire that keeps it closed. A shared
+# discovery *implementation* was considered and declined -- see
+# `docs/lanes/xe1u-validate-agents-discovery/DONE-NOTE.md` -- so proven parity
+# is the mechanism standing in for it.
+VALIDATE_AGENTS_RECIPE = REPO_ROOT / "recipes" / "validate-agents.yaml"
+VALIDATE_BUNDLE_REPO_RECIPE = REPO_ROOT / "recipes" / "validate-bundle-repo.yaml"
+
+# `validate-bundle-repo` excludes the five; the guard and `validate-agents`
+# add `docs` on top, because `docs/` holds frozen lane records that quote
+# violations verbatim as evidence and must never be rewritten. That one
+# documented delta is asserted explicitly below rather than papered over --
+# it excludes zero files today (there is no `docs/**/agents/` directory), so
+# all three walks still return the same set.
+DOCUMENTED_EXCLUSION_DELTA = {"docs"}
+
+
+def _literal_set(text: str, name: str) -> list[set[str]]:
+    """Every `NAME = {...}` set literal in `text`, in source order."""
+    import ast
+
+    return [
+        set(ast.literal_eval(match.group(1)))
+        for match in re.finditer(rf"\b{name}\s*=\s*(\{{[^}}]*\}})", text)
+    ]
+
+
+def _run_recipe_discovery_step() -> set[str]:
+    """Execute `validate-agents`' agent-discovery step and return its findings.
+
+    Executed, not re-implemented. A test that reimplements the glob would pass
+    while the recipe diverged, which is the failure mode being guarded.
+    """
+    import json
+    import subprocess
+    import sys
+    import tempfile
+
+    lines = VALIDATE_AGENTS_RECIPE.read_text(encoding="utf-8").splitlines()
+    step = next(i for i, line in enumerate(lines) if line.strip() == '- id: "agent-discovery"')
+    start = next(
+        i
+        for i in range(step, len(lines))
+        if lines[i].strip() == "\"${AMPLIFIER_PYTHON:-python3}\" << 'EOF'"
+    )
+    end = next(i for i in range(start + 1, len(lines)) if lines[i].strip() == "EOF")
+    body = "\n".join(line[6:] for line in lines[start + 1 : end])
+    body = body.replace("{{repo_path}}", str(REPO_ROOT))
+
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(body)
+        script = handle.name
+    completed = subprocess.run(
+        [sys.executable, script], capture_output=True, text=True, check=True
+    )
+    payload = json.loads(completed.stdout)
+    return {agent["relative_path"] for agent in payload["agents_found"]}
+
+
+class TestDiscoveryScopeParity:
+    """One answer to "which files are agents?", across all three scopes."""
+
+    def test_exclusion_sets_agree_across_both_recipes_and_this_guard(self) -> None:
+        """A fourth exclusion list is how the first divergence started."""
+        agents_sets = _literal_set(
+            VALIDATE_AGENTS_RECIPE.read_text(encoding="utf-8"), "EXCLUDED_PARTS"
+        )
+        assert len(agents_sets) == 1, (
+            "validate-agents.yaml must declare exactly one EXCLUDED_PARTS set, "
+            f"found {len(agents_sets)}"
+        )
+        assert agents_sets[0] == AGENT_SCAN_EXCLUDED_PARTS, (
+            "validate-agents.yaml's EXCLUDED_PARTS must equal this module's "
+            f"AGENT_SCAN_EXCLUDED_PARTS. recipe={sorted(agents_sets[0])} "
+            f"guard={sorted(AGENT_SCAN_EXCLUDED_PARTS)}"
+        )
+
+        repo_sets = _literal_set(
+            VALIDATE_BUNDLE_REPO_RECIPE.read_text(encoding="utf-8"), "EXCLUDED_DIRS"
+        )
+        assert repo_sets, "validate-bundle-repo.yaml declares no EXCLUDED_DIRS set"
+        assert all(found == repo_sets[0] for found in repo_sets), (
+            "validate-bundle-repo.yaml's EXCLUDED_DIRS literals disagree with each "
+            f"other: {[sorted(found) for found in repo_sets]}"
+        )
+        assert AGENT_SCAN_EXCLUDED_PARTS - repo_sets[0] == DOCUMENTED_EXCLUSION_DELTA, (
+            "The only permitted difference between validate-bundle-repo's "
+            "EXCLUDED_DIRS and the wider scope is the documented "
+            f"{sorted(DOCUMENTED_EXCLUSION_DELTA)}. Actual extra: "
+            f"{sorted(AGENT_SCAN_EXCLUDED_PARTS - repo_sets[0])}"
+        )
+        assert not repo_sets[0] - AGENT_SCAN_EXCLUDED_PARTS, (
+            "validate-bundle-repo excludes something the wider scope does not: "
+            f"{sorted(repo_sets[0] - AGENT_SCAN_EXCLUDED_PARTS)}"
+        )
+
+    def test_validate_agents_discovers_exactly_the_guards_agent_files(self) -> None:
+        """Proven parity, by running the recipe's own step -- not asserted."""
+        from_recipe = _run_recipe_discovery_step()
+        from_guard = {path.relative_to(REPO_ROOT).as_posix() for path in _agent_files()}
+        assert from_recipe == from_guard, (
+            "validate-agents' discovery and this guard's _agent_files must find "
+            "the same files. In recipe not guard: "
+            f"{sorted(from_recipe - from_guard)}; in guard not recipe: "
+            f"{sorted(from_guard - from_recipe)}"
+        )


### PR DESCRIPTION
Closes the discovery gap `6phe` named as its finding F3.

## The problem

`recipes/validate-agents.yaml`'s `agent-discovery` step walked a hand-maintained list of three directories. `recipes/validate-bundle-repo.yaml` and `tests/test_anchors_bundles_dry.py`'s `_agent_files()` both glob the repo. On this repo: **23 files vs 32.**

That asymmetry is the root cause of a three-sweep recurrence chain — 11 `<example>` violators under `experiments/**/agents/` survived **#341** (`1b16a7d`, swept root `agents/`) and **ux32** (`200dfe6`, swept `bundles/**`) because the recipe most people run never looked there. And it reported a clean `"23 found, 3 locations"` the whole time, with no signal that other agent directories existed at all.

## The change

Discovery now globs `rglob("*/agents/*.md") + glob("agents/*.md")` and drops excluded parts, using **`6phe`'s existing `AGENT_SCAN_EXCLUDED_PARTS` verbatim** (`tests/test_anchors_bundles_dry.py:52-69`) — not a second list.

- `discovery_results` gained `location_counts`, `scan_patterns`, `excluded_parts`
- `location` is **derived** from each file's parent directory, so a new `agents/` tree names itself the first time it appears
- `synthesize-report` and `quick-approval` must now print a coverage block (patterns, exclusions, total, per-location counts)
- **Discovery only.** No check, threshold, severity or verdict rule changed. On a repo whose agents all live in the three old locations, output is identical.

## Before / after — both measured by running the recipe

| | BEFORE | AFTER |
|---|---|---|
| version | v1.5.1 | v1.6.0 |
| `run_id` | `run-c26b396f2f1e` | `run-67388a546d75` |
| discovered | **23** | **32** |
| locations | 3 | 6 |
| **verdict** | **PASS** | **FAIL** |

Newly walked: `context/agents/` (4), `examples/agents/` (1), `experiments/build-up/agents/` (4). The 32 files match `6phe`'s `evidence/scope-parity.txt` set exactly — all three scopes now agree.

## ⚠️ The verdict did NOT stay PASS — and it is reported, not fixed

```
4x ERROR   NO_FRONTMATTER   context/agents/{delegation-instructions,multi-agent-patterns,
                                            session-repair-knowledge,session-storage-knowledge}.md
1x WARNING NO_TOOLS_SECTION examples/agents/file-responder.md
0 findings  experiments/build-up/agents/  (4 files -- the tree that started the chain is clean)
```

**These are not dirty agents.** The four are *context documents* in a directory named `agents/` — loaded as `context:` by `behaviors/agents.yaml:44-45` and `behaviors/tasks.yaml:18-19`, `@`-mentioned by `agents/session-analyst.md:369-370`. Nothing spawns them, so `NO_FRONTMATTER`'s "agent won't load" describes an event that cannot occur. The defect is the glob classifying by *directory name*.

Per the item's scope-out: **reported, left unfixed, and the recipe was not weakened to restore PASS.** The correct fix (discover by path, classify by `meta:` presence — matching the loader's own contract) is a separate item.

## Shared-helper question — **declined**, with a cheap substitute built instead

A shared discovery implementation is not cheap: recipe steps are self-contained heredocs with no import mechanism, and routing discovery through `amplifier_foundation` would make *scope* depend on an import the recipe explicitly allows to be missing (its own `structural-validation` step degrades to a no-op on `ImportError`).

Built instead: **`TestDiscoveryScopeParity`** — compares the exclusion-set literals across both recipes and the guard, and **executes the recipe's own discovery step** to prove the file sets match (a test that re-implemented the glob would pass while the recipe diverged).

**Fail-before:** both guards fail against the unmodified recipe, naming all 9 missing files. **Pass-after:** `8 passed` (was 6).

## Verification

- Suite: `2 failed, 2017 passed, 3 skipped` — the two are the known pre-existing failures (`test_sources`, `test_grpc_adapter_main`), untouched here
- `validate-bundle-repo` deliberately **not** run, so `6phe`'s F1 artifact-rewrite side effect could not fire; `git status` confirms only the two source files changed

Full record + evidence: `docs/lanes/xe1u-validate-agents-discovery/`

Draft — **do not merge**; the manager re-runs the before/after counts.
