### PR TITLE
fix(recipes): validate-agents classifies by `meta:`, not directory name -- and stops losing the repo path on Windows

### DIFF
--- a/docs/lanes/39z0-agent-classifier-scope/DONE-NOTE.md
+++ b/docs/lanes/39z0-agent-classifier-scope/DONE-NOTE.md
@@ -1,0 +1,266 @@
+# Lane 39z0 — validate-agents: classify by `meta:`, not by directory name; and stop losing the repo path on Windows
+
+**Item:** `model_performance-39z0` (project `model_performance`)
+**Branch:** `lane/39z0-agent-classifier-scope`, branched from `lane/xe1u-validate-agents-discovery` (head `038801f`, draft PR #364)
+**Outcome:** **A — RESOLVED**, with one sub-deliverable recorded **NOT-POSSIBLE at the cap** (branch B applies to that clause only; see *Spend* below).
+**Recipe:** `recipes/validate-agents.yaml` v1.6.0 → **v1.7.0**
+
+---
+
+## Headline
+
+Both defects are fixed. **The FAIL is gone.** The verdict does **not** return to bare
+`PASS` — it lands on **`⚠️ PASS WITH WARNINGS`** — and per the item's own instruction that
+is the headline finding, named and **left unfixed**:
+
+> `examples/agents/file-responder.md` — `NO_TOOLS_SECTION` (no explicit `tools:` section,
+> relies on inheritance). One WARNING, zero ERRORs.
+
+This is a **genuinely new finding surfaced by correct discovery**, and it is exactly the
+file the item's KNOWN section flags as *"a fixture demonstrating capability inheritance"*.
+Adding a `tools:` block to it would destroy what the fixture demonstrates, so it is
+**reported, not fixed here, and not suppressed**. No threshold, severity, skip rule or
+exclusion set was touched to soften it.
+
+---
+
+## The three measurements
+
+All numbers below come from executing the recipes' own **deterministic** steps
+(`environment-check → agent-discovery → structural-validation → quality-classification`)
+verbatim through bash, at **$0.00 API spend** — see *Spend* for why, and
+`replay_deterministic_phases.py` for the harness. `quality_classification.quality_level`
+**is** the verdict: the recipe's own Verdict Selection maps
+`good → PASS`, `polish → PASS WITH SUGGESTIONS`, `needs_work → PASS WITH WARNINGS`,
+`critical → FAIL`. The LLM report step renders that decision; it does not make it.
+
+| | recipe | scanned | agents | non-agents | ERR | WARN | `quality_level` | **verdict** |
+|---|---|---|---|---|---|---|---|---|
+| baseline (`5a9e07b`, pre-xe1u) | v1.5.1 | — | **23** | — | 0 | 0 | `good` | **PASS** |
+| before (`038801f`, xe1u head) | v1.6.0 | — | **32** | — | **4** | 1 | `critical` | **FAIL** |
+| **after (this branch)** | **v1.7.0** | **32** | **28** | **4** | **0** | 1 | `needs_work` | **⚠️ PASS WITH WARNINGS** |
+
+**The true agent count is 28.** Measured, not assumed: 32 files match the scan, 4 of them
+declare no `meta:` and are not agents.
+
+**The replay harness is validated against xe1u's two paid runs.** It reproduces
+`run-c26b396f2f1e` (23 agents / PASS) and `run-67388a546d75` (32 agents / FAIL) exactly —
+the same counts, the same four `NO_FRONTMATTER` errors, the same verdicts. That agreement
+is what licenses the third row as a real measurement rather than an argument.
+
+Evidence: `evidence/deterministic-before-after.txt`,
+`evidence/deterministic-baseline-v1.5.1.txt`.
+
+---
+
+## Defect 1 — classification by DIRECTORY NAME
+
+v1.6.0 treated every `agents/*.md` as an agent. `context/agents/` merely **collides on the
+word "agents"**: its four files are context documents loaded via `context:` by
+`behaviors/agents.yaml:44-45` and `behaviors/tasks.yaml:18-19`. Nothing spawns them, and
+they carry no frontmatter **because they are not agents** — so they produced four
+`NO_FRONTMATTER` ERRORs and flipped the verdict on a repo with zero real agent defects.
+
+**Fix: classify on `meta:` presence — the loader's own contract**, quoted from this repo's
+`docs/AGENT_AUTHORING.md:5`:
+
+> "Agents ARE bundles. They use the same file format and are loaded via `load_bundle()`.
+> The only difference is the frontmatter key (`meta:` vs `bundle:`)."
+
+Three properties this fix deliberately has:
+
+1. **It is a classifier, not an exclusion.** `AGENT_SCAN_EXCLUDED_PARTS` is untouched, no
+   second exclusion list exists, and **every candidate is still walked**. `candidates_scanned`
+   is still 32.
+2. **Nothing is dropped silently.** Every non-agent is reported by name and reason in the
+   new `non_agents_found` / `non_agent_reasons`, and both the report and the quick-approval
+   path are now *required* to print a NON-AGENTS table. A classifier that quietly discarded
+   files would reintroduce, in a new place, the exact silence that let 11 `<example>`
+   violators survive `#341` and `ux32`. **A real agent that lost its `meta:` block appears
+   in that table instead of vanishing from the run.**
+3. **Frontmatter that exists but will not parse still counts as an agent**, so Phase 2 gets
+   to report the YAML error rather than the file being reclassified out of the run.
+
+---
+
+## Defect 2 — the recipe found NOTHING on Windows (the more dangerous one)
+
+**Cause, pinned:** every Python heredoc wrote `Path("{{repo_path}}")` — a filesystem path
+placed **inside a Python string literal**, where each backslash becomes an escape sequence.
+A GitHub Actions Windows checkout lives at `D:\a\<repo>\<repo>`, so `\a` was parsed as
+`\x07`.
+
+Reproduced on POSIX with a directory literally named `a\test\amplifier-foundation`
+(`evidence/windows-path-repro.txt`), running each recipe version's own discovery body:
+
+```
+REPO PATH ON DISK : '/tmp/…/a\\test\\amplifier-foundation'   EXISTS: True
+AGENT FILES ON DISK: ['agents/probe.md', 'context/agents/notes.md']
+
+--- v1.6.0 (038801f) — path interpolated into Python source ---
+exit code: 0
+agents_found : []
+errors       : [{'type': 'path_error', 'message': "Repository path does not exist: /tmp/…/a\test\x07mplifier-foundation"}]
+
+--- v1.7.0 (this branch) — path via VALIDATE_AGENTS_REPO_PATH ---
+exit code: 0
+agents_found     : ['agents/probe.md']
+non_agents_found : ['context/agents/notes.md']
+errors           : []
+```
+
+Note the v1.6.0 line: **`agents_found: []` with exit code 0.** Discovery printed a valid,
+empty payload and succeeded. Structural validation then saw 0 agents and 0 errors, quality
+classification called that `good`, and the run reached the quick-approval path and reported
+**PASS having validated nothing** — strictly worse than the 23-of-32 under-count v1.6.0
+replaced, because the under-count at least checked 23 files.
+
+**Fix, two parts:**
+
+1. The repo path arrives through the **environment** (`VALIDATE_AGENTS_REPO_PATH`), which
+   has no escape semantics, in all three affected steps — `environment-check`,
+   `agent-discovery`, `structural-validation`. (The third mattered too:
+   `get_bundle_level_tools("{{repo_path}}")` would have silently found no bundle-level
+   tools on Windows once discovery started working, producing false WARNINGs.)
+2. Discovery now **exits non-zero** on a missing repo path instead of printing an empty
+   payload and exiting 0, so no future path defect can reach a vacuous PASS quietly. A bad
+   repo path is a run-ending condition, not a finding about the repo. A repo that genuinely
+   contains no agents is unchanged — still a non-fatal `no_agents` entry.
+
+**Windows parity is therefore structural, not incidental**: the recipe and the guard reach
+the same file set on Windows for the same reason they do on POSIX — neither of them puts a
+path through Python's escape parser.
+
+---
+
+## The parity guard SURVIVED and got stronger
+
+`TestDiscoveryScopeParity` is what caught the Windows defect, on Windows 3.11/3.12/3.13,
+while every POSIX leg stayed green. **Nothing was deleted or relaxed.** It went from 2 tests
+to 6:
+
+| test | what it pins |
+|---|---|
+| `test_exclusion_sets_agree_across_both_recipes_and_this_guard` | unchanged — one exclusion set, three consumers |
+| `test_validate_agents_scans_exactly_the_guards_candidate_files` | **new** — the SCAN reaches the same files, before either side classifies |
+| `test_validate_agents_discovers_exactly_the_guards_agent_files` | kept — the CLASSIFIER judges the same subset agents; now also asserts the set is non-empty |
+| `test_classifier_keys_on_meta_not_on_the_directory_name` | **new** — `context/agents/*.md` are non-agents AND are named as such |
+| `test_discovery_never_interpolates_the_repo_path_into_python_source` | **new** — the Windows defect at its CAUSE |
+| `test_discovery_survives_a_repo_path_containing_escape_sequences` | **new** — the Windows defect reproduced on every platform |
+| `test_discovery_fails_loudly_on_a_missing_repo_path` | **new** — never an empty payload with exit 0 |
+
+The scan/classify split is deliberate and is the opposite of a relaxation: **a classifier
+that quietly narrowed the walk would still satisfy an agent-set comparison if the guard
+narrowed with it.** Pinning the candidate set separately makes that unreachable.
+
+**Fail-before / pass-after**, both recorded:
+
+- Against v1.6.0's recipe: **6 failed, 1 passed** (`evidence/parity-guards-FAIL-BEFORE.txt`)
+- Against this branch: **13 passed** (`evidence/parity-guards-PASS-AFTER.txt`)
+
+---
+
+## Suite
+
+`uv sync --extra grpc-adapter && uv run pytest tests/ -q` → **1 failed, 1834 passed, 3 skipped**
+(`evidence/full-suite.txt`).
+
+The single failure is the **known pre-existing** `tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file`,
+named in the item as reproducing at `origin/main`. Independently confirmed as not mine:
+`git diff origin/main -- tests/test_sources.py amplifier_foundation/sources` is empty.
+(The second known failure, `test_grpc_adapter_main`, is among the 3 skipped in this
+environment rather than failing.)
+
+`recipes(operation="validate")` on the edited recipe: `status: valid`, no warnings.
+
+`git status` after all work is clean of `bundle.dot` / `bundle.png` — the `6phe` F1 regen
+side effect never fired, because `validate-bundle-repo` was not executed (see *Spend*).
+
+---
+
+## Spend — $0.00 of a $0.00 authority
+
+**Nothing was purchased. Zero API spend, zero DTU, zero infrastructure rows.** The item's
+authority is `0 runs x 0 arms x $0 / 1.00 = $0.00`, slack `$0.00`.
+
+**One sub-deliverable is NOT-POSSIBLE at that cap.** Leading with what *was* executed:
+
+> **Executed at $0.00:** three full deterministic replays of `validate-agents` (v1.5.1,
+> v1.6.0, v1.7.0) over 32 candidate files each — 12 deterministic step executions in total,
+> yielding discovered counts, per-location counts, every structural ERROR and WARNING, and
+> the `quality_level` that *is* the verdict; plus a two-version Windows-path reproduction,
+> a 6-test fail-before run, a 13-test pass-after run, a 1837-test suite run, and a recipe
+> schema validation. **Reproduced xe1u's `run-c26b396f2f1e` (23/PASS) and
+> `run-67388a546d75` (32/FAIL) exactly.**
+>
+> **NOT purchased:** a *new paid recipe execution* carrying its own `run-id`. A full
+> `validate-agents` run fires LLM steps (3 here, since `requires_llm_analysis` is `True`
+> while the `file-responder` WARNING stands), and `validate-bundle-repo` more still. The
+> smallest indivisible purchase that would advance this clause is **one** `validate-agents`
+> execution; **$0.00 cannot buy it, and the residue is $0.00 — there is no unspendable
+> remainder to report.**
+
+**This is a defect in the goal's authority, not a failure of the lane, and it was knowable
+on first read**: the deliverable *"both recipes re-run … with run ids"* requires purchased
+runs, while the arithmetic authorising it is `0 runs x $0`. The two clauses cannot both
+hold. Per the item's own instruction I said so **before** spending rather than after.
+
+**The authority that WOULD close it:** `2 recipes x 1 run x <measured per-run $> / 1.00 valid`.
+I deliberately do not invent the per-run figure — **no prior lane recorded a dollar cost for
+these runs** (`xe1u` and `6phe` both quote run ids and step counts, never dollars), so the
+figure needed to size this authority does not exist in evidence yet. `xe1u`'s F4 — a FAILing
+repo costs 3 LLM steps where a PASSing one costs 2 — is the only cost signal on record.
+**Capturing a measured per-run cost is the cheapest thing the next lane could do to make
+every future authority here sizeable from evidence.** With the classifier fix in place the
+run is now the cheaper 3-step shape rather than v1.6.0's failing shape.
+
+---
+
+## Deliverables
+
+| # | deliverable | state |
+|---|---|---|
+| 1 | Classifier keys on `meta:`, not directory name; `context/agents/*.md` correctly not-an-agent; **true agent count stated (28, measured)** | **DONE** |
+| 2 | Verdict returns to PASS with no threshold/severity/skip/exclusion change | **DONE with the finding reported** — FAIL eliminated (4 ERRORs → 0); lands on `⚠️ PASS WITH WARNINGS`, not bare PASS. Failing agent named: `examples/agents/file-responder.md` (`NO_TOOLS_SECTION`). **Left unfixed.** Nothing weakened. |
+| 3 | Windows parity — same file set as POSIX and as the guard, never empty, never a vacuous PASS | **DONE** — cause fixed (no path in Python source), reproduced and regression-tested on every platform, plus a loud exit on a bad path. CI verdict on the three Windows legs is the PR's to report. |
+| 4 | Both recipes re-run, before/after counts and verdicts quoted with run ids | **PARTIAL — see Spend.** Counts and verdicts: **DONE**, reproduced against both prior run ids exactly. A **new** paid `run-id`: **NOT-POSSIBLE at the $0.00 cap.** |
+| 5 | The parity guard survives | **DONE** — not deleted, not relaxed; 2 tests → 6, strictly stronger |
+| 6 | Any genuinely new finding REPORTED, not fixed and not suppressed | **DONE** — `examples/agents/file-responder.md` `NO_TOOLS_SECTION`, reported above, left unfixed |
+| 7 | Suite green, DRAFT PR, do not merge | **DONE** — 1 known pre-existing failure only; draft PR opened; not merged |
+| 8 | DONE-NOTE at the lane artifact root, never the repo root | **DONE** — this file |
+
+## Deviations and choices recorded
+
+1. **Did not spend to obtain a new run id.** Chosen over exceeding a $0.00 authority.
+   Recorded as the finding above.
+2. **Fixed the path interpolation in all three affected steps**, not only
+   `agent-discovery`. One root cause, three call sites; leaving
+   `get_bundle_level_tools("{{repo_path}}")` behind would have produced false WARNINGs on
+   Windows the moment discovery started working.
+3. **Made discovery exit non-zero on a missing repo path.** This is a discovery guard, not
+   a quality threshold — no check, severity or skip rule changed. A repo that genuinely
+   contains no agents behaves exactly as before.
+4. **Left `validate-bundle-repo.yaml` untouched**, including its own classification of the
+   same four files — that is `model_performance-dfni`, sequenced after this item precisely
+   because its count depends on this classifier's answer. Not running it also avoided its
+   `bundle.dot`/`bundle.png` regen side effect (`6phe` F1) entirely.
+5. **Narrowed the guard's `_agent_files()` to classified agents** and introduced
+   `_agent_candidate_files()` for the scan. The repo-wide `<example>` guard now runs over
+   real agents only; the four context documents have no `meta.description` for it to
+   inspect, so its coverage is unchanged in substance.
+
+## Files
+
+```
+recipes/validate-agents.yaml         v1.6.0 -> v1.7.0 (classifier + env-var path + report requirements)
+tests/test_anchors_bundles_dry.py    _agent_candidate_files/_is_agent_file split; parity guard 2 -> 6 tests
+docs/lanes/39z0-agent-classifier-scope/
+    DONE-NOTE.md                     this file
+    replay_deterministic_phases.py   the $0.00 verdict harness
+    evidence/deterministic-before-after.txt
+    evidence/deterministic-baseline-v1.5.1.txt
+    evidence/windows-path-repro.txt
+    evidence/parity-guards-FAIL-BEFORE.txt
+    evidence/parity-guards-PASS-AFTER.txt
+    evidence/full-suite.txt
+```

--- a/docs/lanes/39z0-agent-classifier-scope/DONE-NOTE.md
+++ b/docs/lanes/39z0-agent-classifier-scope/DONE-NOTE.md
@@ -160,6 +160,28 @@ narrowed with it.** Pinning the candidate set separately makes that unreachable.
 
 ---
 
+## CI — all six legs green, including the three Windows ones
+
+PR #365, run `34057350037` (`evidence/ci-checks.txt`):
+
+```
+Tests (ubuntu-latest,  Python 3.11)   pass
+Tests (ubuntu-latest,  Python 3.12)   pass
+Tests (ubuntu-latest,  Python 3.13)   pass
+Tests (windows-latest, Python 3.11)   pass     <-- red on xe1u's #364
+Tests (windows-latest, Python 3.12)   pass     <-- red on xe1u's #364
+Tests (windows-latest, Python 3.13)   pass     <-- red on xe1u's #364
+license/cla                           pass
+```
+
+**This is the Windows deliverable proved end to end**, on the real platform, by the same
+`TestDiscoveryScopeParity` that failed there with `assert set() == {...}` on #364.
+
+It also settles the local test failure below: **the ubuntu legs are fully green**, so
+`test_sources.py::TestFileSourceHandler::test_resolve_existing_file` fails only in this
+worktree's environment (a `/tmp` symlink that `resolve()` collapses), not in CI and not
+because of this branch.
+
 ## Suite
 
 `uv sync --extra grpc-adapter && uv run pytest tests/ -q` → **1 failed, 1834 passed, 3 skipped**
@@ -222,11 +244,11 @@ run is now the cheaper 3-step shape rather than v1.6.0's failing shape.
 |---|---|---|
 | 1 | Classifier keys on `meta:`, not directory name; `context/agents/*.md` correctly not-an-agent; **true agent count stated (28, measured)** | **DONE** |
 | 2 | Verdict returns to PASS with no threshold/severity/skip/exclusion change | **DONE with the finding reported** — FAIL eliminated (4 ERRORs → 0); lands on `⚠️ PASS WITH WARNINGS`, not bare PASS. Failing agent named: `examples/agents/file-responder.md` (`NO_TOOLS_SECTION`). **Left unfixed.** Nothing weakened. |
-| 3 | Windows parity — same file set as POSIX and as the guard, never empty, never a vacuous PASS | **DONE** — cause fixed (no path in Python source), reproduced and regression-tested on every platform, plus a loud exit on a bad path. CI verdict on the three Windows legs is the PR's to report. |
+| 3 | Windows parity — same file set as POSIX and as the guard, never empty, never a vacuous PASS; **CI green on all three Windows Python versions** | **DONE** — cause fixed (no path in Python source), reproduced and regression-tested on every platform, plus a loud exit on a bad path. **CI run `34057350037`: windows-latest 3.11 / 3.12 / 3.13 all pass**, where #364 was red. |
 | 4 | Both recipes re-run, before/after counts and verdicts quoted with run ids | **PARTIAL — see Spend.** Counts and verdicts: **DONE**, reproduced against both prior run ids exactly. A **new** paid `run-id`: **NOT-POSSIBLE at the $0.00 cap.** |
 | 5 | The parity guard survives | **DONE** — not deleted, not relaxed; 2 tests → 6, strictly stronger |
 | 6 | Any genuinely new finding REPORTED, not fixed and not suppressed | **DONE** — `examples/agents/file-responder.md` `NO_TOOLS_SECTION`, reported above, left unfixed |
-| 7 | Suite green, DRAFT PR, do not merge | **DONE** — 1 known pre-existing failure only; draft PR opened; not merged |
+| 7 | Suite green, DRAFT PR, do not merge | **DONE** — CI fully green (6/6 legs); the one local failure is environment-specific, not in CI. Draft PR #365; **not merged** |
 | 8 | DONE-NOTE at the lane artifact root, never the repo root | **DONE** — this file |
 
 ## Deviations and choices recorded
@@ -263,4 +285,5 @@ docs/lanes/39z0-agent-classifier-scope/
     evidence/parity-guards-FAIL-BEFORE.txt
     evidence/parity-guards-PASS-AFTER.txt
     evidence/full-suite.txt
+    evidence/ci-checks.txt
 ```

--- a/docs/lanes/39z0-agent-classifier-scope/evidence/ci-checks.txt
+++ b/docs/lanes/39z0-agent-classifier-scope/evidence/ci-checks.txt
@@ -1,0 +1,7 @@
+Tests (ubuntu-latest, Python 3.11)	pass	43s	https://github.com/microsoft/amplifier-foundation/actions/runs/34057350037/job/101551552349	
+Tests (ubuntu-latest, Python 3.12)	pass	43s	https://github.com/microsoft/amplifier-foundation/actions/runs/34057350037/job/101551552286	
+Tests (ubuntu-latest, Python 3.13)	pass	41s	https://github.com/microsoft/amplifier-foundation/actions/runs/34057350037/job/101551552186	
+Tests (windows-latest, Python 3.11)	pass	1m21s	https://github.com/microsoft/amplifier-foundation/actions/runs/34057350037/job/101551552287	
+Tests (windows-latest, Python 3.12)	pass	1m13s	https://github.com/microsoft/amplifier-foundation/actions/runs/34057350037/job/101551552347	
+Tests (windows-latest, Python 3.13)	pass	1m9s	https://github.com/microsoft/amplifier-foundation/actions/runs/34057350037/job/101551552270	
+license/cla	pass	0	https://github.com/apps/microsoft-github-policy-service	

--- a/docs/lanes/39z0-agent-classifier-scope/evidence/deterministic-baseline-v1.5.1.txt
+++ b/docs/lanes/39z0-agent-classifier-scope/evidence/deterministic-baseline-v1.5.1.txt
@@ -1,0 +1,12 @@
+=== BASELINE: v1.5.1 (5a9e07b, pre-xe1u) ===
+recipe version        : 1.5.1 (5a9e07b)
+candidates scanned    : <absent in v1.6.0>
+agents discovered     : 23
+Traceback (most recent call last):
+  File "/home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation/docs/lanes/39z0-agent-classifier-scope/replay_deterministic_phases.py", line 128, in <module>
+    main()
+    ~~~~^^
+  File "/home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation/docs/lanes/39z0-agent-classifier-scope/replay_deterministic_phases.py", line 113, in main
+    print(f"locations             : {len(discovery['location_counts'])} {discovery['location_counts']}")
+                                         ~~~~~~~~~^^^^^^^^^^^^^^^^^^^
+KeyError: 'location_counts'

--- a/docs/lanes/39z0-agent-classifier-scope/evidence/deterministic-before-after.txt
+++ b/docs/lanes/39z0-agent-classifier-scope/evidence/deterministic-before-after.txt
@@ -1,0 +1,49 @@
+=== BASELINE: v1.5.1 (5a9e07b, pre-xe1u) -- the 23/PASS numbers ===
+recipe version        : 1.5.1 (5a9e07b)
+candidates scanned    : <absent in v1.6.0>
+agents discovered     : 23
+locations             : 3 (search_locations, pre-v1.6.0)
+    - /home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation/agents
+    - /home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation/bundles/anchors/agents
+    - /home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation/bundles/anchors-amp-dev/agents
+classified non-agents : <absent in v1.6.0>
+structural errors     : 0
+structural warnings   : 0
+quality breakdown     : {'total': 23, 'good': 23, 'polish': 0, 'needs_work': 0, 'critical': 0}
+quality_level         : good
+requires_llm_analysis : False
+VERDICT               : PASS
+
+=== BEFORE: v1.6.0 (038801f, xe1u head) -- the 32/FAIL numbers ===
+recipe version        : 1.6.0 (038801f)
+candidates scanned    : <absent in v1.6.0>
+agents discovered     : 32
+locations             : 6 {'agents/': 16, 'bundles/anchors-amp-dev/agents/': 1, 'bundles/anchors/agents/': 6, 'context/agents/': 4, 'examples/agents/': 1, 'experiments/build-up/agents/': 4}
+classified non-agents : <absent in v1.6.0>
+structural errors     : 4
+structural warnings   : 1
+    ERROR delegation-instructions: NO_FRONTMATTER -- Agent file missing YAML frontmatter (--- markers)
+    ERROR multi-agent-patterns: NO_FRONTMATTER -- Agent file missing YAML frontmatter (--- markers)
+    ERROR session-repair-knowledge: NO_FRONTMATTER -- Agent file missing YAML frontmatter (--- markers)
+    ERROR session-storage-knowledge: NO_FRONTMATTER -- Agent file missing YAML frontmatter (--- markers)
+quality breakdown     : {'total': 32, 'good': 27, 'polish': 0, 'needs_work': 1, 'critical': 4}
+quality_level         : critical
+requires_llm_analysis : True
+VERDICT               : FAIL
+
+=== AFTER: v1.7.0 (this branch) ===
+recipe version        : 1.7.0 (working tree)
+candidates scanned    : 32
+agents discovered     : 28
+locations             : 5 {'agents/': 16, 'bundles/anchors-amp-dev/agents/': 1, 'bundles/anchors/agents/': 6, 'examples/agents/': 1, 'experiments/build-up/agents/': 4}
+classified non-agents : 4
+    - context/agents/delegation-instructions.md  (no_frontmatter)
+    - context/agents/multi-agent-patterns.md  (no_frontmatter)
+    - context/agents/session-repair-knowledge.md  (no_frontmatter)
+    - context/agents/session-storage-knowledge.md  (no_frontmatter)
+structural errors     : 0
+structural warnings   : 1
+quality breakdown     : {'total': 28, 'good': 27, 'polish': 0, 'needs_work': 1, 'critical': 0}
+quality_level         : needs_work
+requires_llm_analysis : True
+VERDICT               : PASS WITH WARNINGS

--- a/docs/lanes/39z0-agent-classifier-scope/evidence/full-suite.txt
+++ b/docs/lanes/39z0-agent-classifier-scope/evidence/full-suite.txt
@@ -1,0 +1,12 @@
+........................................................................ [ 97%]
+......................................                                   [100%]
+=================================== FAILURES ===================================
+E   AssertionError: assert PosixPath('/tmp') == PosixPath('/tmp/tmpzcc85lg2')
+     +  where PosixPath('/tmp') = ResolvedSource(active_path=PosixPath('/tmp/tmpzcc85lg2/test.yaml'), source_root=PosixPath('/tmp')).source_root
+     +  and   PosixPath('/tmp/tmpzcc85lg2') = resolve()
+     +    where resolve = PosixPath('/tmp/tmpzcc85lg2').resolve
+     +      where PosixPath('/tmp/tmpzcc85lg2') = PosixPath('/tmp/tmpzcc85lg2/test.yaml').parent
+/home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation/tests/test_sources.py:73: AssertionError: assert PosixPath('/tmp') == PosixPath('/tmp/tmpzcc85lg2')
+=========================== short test summary info ============================
+FAILED tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file
+1 failed, 1834 passed, 3 skipped in 22.41s

--- a/docs/lanes/39z0-agent-classifier-scope/evidence/parity-guards-FAIL-BEFORE.txt
+++ b/docs/lanes/39z0-agent-classifier-scope/evidence/parity-guards-FAIL-BEFORE.txt
@@ -1,0 +1,25 @@
+      'agents/post-task-cleanup.md'...
+      
+      ...Full output truncated (24 lines hidden), use '-vv' to show
+/home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation/tests/test_anchors_bundles_dry.py:457: AssertionError: validate-agents' discovery and this guard's _agent_files must find the same files. In recipe not guard: []; in guard not recipe: ['agents/bug-hunter.md', 'agents/bundle-design-expert.md', 'agents/ecosystem-expert.md', 'agents/explorer.md', 'agents/file-ops.md', 'agents/foundation-expert.md', 'agents/git-ops.md', 'agents/integration-specialist.md', 'agents/modular-builder.md', 'agents/post-task-cleanup.md', 'agents/security-guardian.md', 'agents/session-analyst.md', 'agents/shell-exec.md', 'agents/test-coverage.md', 'agents/web-research.md', 'agents/zen-architect.md', 'bundles/anchors-amp-dev/agents/amplifier-dev-expert.md', 'bundles/anchors/agents/architect.md', 'bundles/anchors/agents/builder.md', 'bundles/anchors/agents/debugger.md', 'bundles/anchors/agents/explorer.md', 'bundles/anchors/agents/git-ops.md', 'bundles/anchors/agents/researcher.md', 'examples/agents/file-responder.md', 'experiments/build-up/agents/coder.md', 'experiments/build-up/agents/explorer.md', 'experiments/build-up/agents/planner.md', 'experiments/build-up/agents/tester.md']
+E   KeyError: 'non_agents_found'
+/home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation/tests/test_anchors_bundles_dry.py:479: KeyError: 'non_agents_found'
+E   AssertionError: The agent-discovery heredoc interpolates {{repo_path}} into Python source. A path inside a string literal is escape-processed, which silently destroys every Windows path. Offending line(s): ['discover_agents("{{repo_path}}")']. Pass it through $VALIDATE_AGENTS_REPO_PATH instead.
+    assert not ['discover_agents("{{repo_path}}")']
+/home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation/tests/test_anchors_bundles_dry.py:518: AssertionError: The agent-discovery heredoc interpolates {{repo_path}} into Python source. A path inside a string literal is escape-processed, which silently destroys every Windows path. Offending line(s): ['discover_agents("{{repo_path}}")']. Pass it through $VALIDATE_AGENTS_REPO_PATH instead.
+E   AssertionError: discovery reported errors on an escape-shaped path: [{'type': 'path_error', 'message': 'Repository path does not exist: {{repo_path}}'}]
+    assert [{'message': ...'path_error'}] == []
+      
+      Left contains one more item: {'message': 'Repository path does not exist: {{repo_path}}', 'type': 'path_error'}
+      Use -v to get more diff
+/home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation/tests/test_anchors_bundles_dry.py:553: AssertionError: discovery reported errors on an escape-shaped path: [{'type': 'path_error', 'message': 'Repository path does not exist: {{repo_path}}'}]
+E   Failed: DID NOT RAISE <class 'subprocess.CalledProcessError'>
+/home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation/tests/test_anchors_bundles_dry.py:568: Failed: DID NOT RAISE <class 'subprocess.CalledProcessError'>
+=========================== short test summary info ============================
+FAILED tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity::test_validate_agents_scans_exactly_the_guards_candidate_files
+FAILED tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity::test_validate_agents_discovers_exactly_the_guards_agent_files
+FAILED tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity::test_classifier_keys_on_meta_not_on_the_directory_name
+FAILED tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity::test_discovery_never_interpolates_the_repo_path_into_python_source
+FAILED tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity::test_discovery_survives_a_repo_path_containing_escape_sequences
+FAILED tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity::test_discovery_fails_loudly_on_a_missing_repo_path
+6 failed, 1 passed in 0.40s

--- a/docs/lanes/39z0-agent-classifier-scope/evidence/parity-guards-PASS-AFTER.txt
+++ b/docs/lanes/39z0-agent-classifier-scope/evidence/parity-guards-PASS-AFTER.txt
@@ -1,0 +1,11 @@
+============================= test session starts ==============================
+platform linux -- Python 3.13.11, pytest-9.0.3, pluggy-1.6.0
+rootdir: /home/bkrabach/dev/hw-model-performance/lanes/39z0-agent-classifier-scope/amplifier-foundation
+configfile: pyproject.toml
+plugins: anyio-4.12.0, timeout-2.4.0, amplifier-core-1.3.0, asyncio-1.3.0
+asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
+collected 13 items
+
+tests/test_anchors_bundles_dry.py .............                          [100%]
+
+============================== 13 passed in 0.68s ==============================

--- a/docs/lanes/39z0-agent-classifier-scope/evidence/windows-path-repro.txt
+++ b/docs/lanes/39z0-agent-classifier-scope/evidence/windows-path-repro.txt
@@ -1,0 +1,17 @@
+<stdin>:1: SyntaxWarning: invalid escape sequence '\<'
+REPO PATH ON DISK : '/tmp/tmp_84u5pif/a\\test\\amplifier-foundation'
+EXISTS            : True
+AGENT FILES ON DISK: ['agents/probe.md', 'context/agents/notes.md']
+
+--- v1.6.0 (038801f) -- path interpolated into Python source ---
+exit code: 0
+agents_found     : []
+non_agents_found : <key absent in v1.6.0>
+errors           : [{'type': 'path_error', 'message': 'Repository path does not exist: /tmp/tmp_84u5pif/a\test\x07mplifier-foundation'}]
+
+--- v1.7.0 (this branch) -- path via VALIDATE_AGENTS_REPO_PATH ---
+exit code: 0
+agents_found     : ['agents/probe.md']
+non_agents_found : ['context/agents/notes.md']
+errors           : []
+

--- a/docs/lanes/39z0-agent-classifier-scope/replay_deterministic_phases.py
+++ b/docs/lanes/39z0-agent-classifier-scope/replay_deterministic_phases.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Replay `validate-agents`' DETERMINISTIC phases, at zero API spend.
+
+Phases 0-2 plus quality-classification are pure bash/python steps -- no model
+is called. `quality_classification.quality_level` is what the report step then
+RENDERS as the verdict:
+
+    good       -> "PASS"                    (validate-agents.yaml, Verdict Selection)
+    polish     -> "PASS WITH SUGGESTIONS"
+    needs_work -> "PASS WITH WARNINGS"
+    critical   -> "FAIL"
+
+So the verdict is decided before any LLM step runs, and can be established
+honestly without buying one. This lane's spend authority is $0.00, which is
+why the numbers in DONE-NOTE.md come from here rather than from a paid run.
+
+Each step's `command:` block is executed VERBATIM through bash, exactly as the
+recipe engine would run it -- including the `VALIDATE_AGENTS_REPO_PATH=...`
+environment prefix v1.7.0 introduces -- rather than re-implemented.
+
+Usage:
+    python replay_deterministic_phases.py <repo_path> [git_rev_of_recipe]
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+STEPS = (
+    "environment-check",
+    "agent-discovery",
+    "structural-validation",
+    "quality-classification",
+)
+OUTPUT_KEYS = {
+    "environment-check": "env_check",
+    "agent-discovery": "discovery_results",
+    "structural-validation": "structural_results",
+    "quality-classification": "quality_classification",
+}
+
+
+def step_command(recipe_text: str, step_id: str) -> str:
+    """The step's `command:` block, de-indented, verbatim."""
+    lines = recipe_text.splitlines()
+    start = next(i for i, line in enumerate(lines) if line.strip() == f'- id: "{step_id}"')
+    cmd = next(i for i in range(start, len(lines)) if lines[i].strip() == "command: |")
+    body: list[str] = []
+    for line in lines[cmd + 1 :]:
+        if line.strip() and not line.startswith("      "):
+            break
+        body.append(line[6:])
+    return "\n".join(body).rstrip() + "\n"
+
+
+def run(recipe_text: str, repo_path: Path) -> dict:
+    context: dict[str, str] = {"repo_path": str(repo_path)}
+    outputs: dict[str, object] = {}
+    for step_id in STEPS:
+        command = step_command(recipe_text, step_id)
+        for key, value in context.items():
+            command = command.replace("{{" + key + "}}", value)
+        with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False, encoding="utf-8") as handle:
+            handle.write(command)
+            script = handle.name
+        completed = subprocess.run(["bash", script], capture_output=True, text=True)
+        if completed.returncode != 0:
+            raise SystemExit(
+                f"step {step_id} exited {completed.returncode}\n"
+                f"stdout: {completed.stdout[:2000]}\nstderr: {completed.stderr[:2000]}"
+            )
+        payload = json.loads(completed.stdout)
+        outputs[step_id] = payload
+        context[OUTPUT_KEYS[step_id]] = json.dumps(payload)
+    return outputs
+
+
+def main() -> None:
+    repo_path = Path(sys.argv[1]).resolve()
+    rev = sys.argv[2] if len(sys.argv) > 2 else None
+    if rev:
+        recipe_text = subprocess.run(
+            ["git", "show", f"{rev}:recipes/validate-agents.yaml"],
+            cwd=repo_path, capture_output=True, text=True, check=True,
+        ).stdout
+    else:
+        recipe_text = (repo_path / "recipes" / "validate-agents.yaml").read_text(encoding="utf-8")
+
+    version = next(
+        line.split(":", 1)[1].strip().strip('"')
+        for line in recipe_text.splitlines()
+        if line.startswith("version:")
+    )
+    outputs = run(recipe_text, repo_path)
+    discovery = outputs["agent-discovery"]
+    structural = outputs["structural-validation"]
+    classification = outputs["quality-classification"]
+
+    verdict = {
+        "good": "PASS",
+        "polish": "PASS WITH SUGGESTIONS",
+        "needs_work": "PASS WITH WARNINGS",
+        "critical": "FAIL",
+    }[classification["quality_level"]]
+
+    print(f"recipe version        : {version} ({rev or 'working tree'})")
+    print(f"candidates scanned    : {discovery.get('candidates_scanned', '<absent in v1.6.0>')}")
+    print(f"agents discovered     : {discovery['total_count']}")
+    locations = discovery.get("location_counts")
+    if locations is None:  # v1.5.1 and earlier reported only search_locations
+        print(f"locations             : {len(discovery['search_locations'])} (search_locations, pre-v1.6.0)")
+        for loc in discovery["search_locations"]:
+            print(f"    - {loc}")
+    else:
+        print(f"locations             : {len(locations)} {locations}")
+    print(f"classified non-agents : {discovery.get('non_agent_count', '<absent in v1.6.0>')}")
+    for entry in discovery.get("non_agents_found", []):
+        print(f"    - {entry['relative_path']}  ({entry['reason']})")
+    print(f"structural errors     : {structural['summary']['errors']}")
+    print(f"structural warnings   : {structural['summary']['warnings']}")
+    for agent in structural.get("agents", []):
+        for error in agent.get("errors", []):
+            print(f"    ERROR {agent['name']}: {error['code']} -- {error['message']}")
+    print(f"quality breakdown     : {classification.get('summary')}")
+    print(f"quality_level         : {classification['quality_level']}")
+    print(f"requires_llm_analysis : {classification['requires_llm_analysis']}")
+    print(f"VERDICT               : {verdict}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/lanes/xe1u-validate-agents-discovery/DONE-NOTE.md
+++ b/docs/lanes/xe1u-validate-agents-discovery/DONE-NOTE.md
@@ -1,0 +1,322 @@
+# Lane xe1u -- `validate-agents` discovery widened (23 -> 32)
+
+**Item:** `model_performance-xe1u` (project `model_performance`)
+**Branch:** `lane/xe1u-validate-agents-discovery` off `origin/main` @ `5a9e07b`
+**Outcome:** **A. RESOLVED** -- every deliverable DONE. Nothing was cut by the cap.
+**Landing stage:** draft PR only. Per the goal's LANDING STAGE clause, a deliverable
+whose final state needs a merge is satisfied here as *demonstrated fail-before /
+pass-after and shipped for landing*; the merge is the manager's next stage.
+
+**Headline:** widening discovery flipped the verdict **PASS -> FAIL**, and the goal
+anticipated exactly this. The four newly-surfaced ERRORs are **not dirty agents** --
+they are four *context documents* that live in a directory named `agents/`. Reported,
+**left unfixed**, per the scope-out. The recipe was **not** weakened to restore PASS.
+
+---
+
+## Deliverables
+
+| # | Deliverable | State |
+|---|---|---|
+| 1 | Discovery widened to every `**/agents/*.md`, using 6phe's existing exclusion set (quoted) | **DONE** |
+| 2 | Before/after discovered counts, both measured by running the recipe | **DONE** -- 23 -> **32** |
+| 3 | Verdict stays PASS | **DONE as reported: it did NOT.** PASS -> FAIL, headline finding F1, left unfixed |
+| 4 | Report metadata names search locations AND discovered total | **DONE** |
+| 5 | Shared-helper question answered either way | **DONE** -- shared implementation **DECLINED with reason**; a cheap *parity guard* implemented instead |
+| 6 | Suite green, draft PR, not merged | **DONE** |
+| 7 | DONE-NOTE at the lane artifact root | **DONE** (this file) |
+
+---
+
+## 1. Discovery widened -- and where the exclusion set was read from
+
+`recipes/validate-agents.yaml`, step `agent-discovery`, previously walked a
+hand-maintained list of three places (`agents/`, `behaviors/*/agents/`,
+`bundles/*/agents/`). It now globs the repo and drops excluded parts:
+
+```python
+candidates = list(path.rglob("*/agents/*.md")) + list((path / "agents").glob("*.md"))
+```
+
+**The exclusion set was copied, not invented.** Quoting the source verbatim --
+`tests/test_anchors_bundles_dry.py:52-69` (added by lane 6phe):
+
+```python
+# The validator's own agent-discovery scope, copied deliberately rather than
+# approximated. `@foundation:recipes/validate-bundle-repo.yaml`'s
+# `agent-description-validation` step globs
+# `rglob("*/agents/*.md") + glob("agents/*.md")` and drops any path containing
+# one of these parts. Two validators disagreeing about which files exist is
+# exactly how the 11 `experiments/` violators survived #341 and ux32:
+# `validate-agents` discovers 23 agents and never walks `experiments/`, while
+# `validate-bundle-repo` discovers 45 and does. This guard follows the wider
+# one. `docs` is added on top of the validator's set: `docs/` holds frozen lane
+# records that quote violations verbatim as evidence and must never be rewritten.
+AGENT_SCAN_EXCLUDED_PARTS = {
+    "test-fixtures",
+    "tests",
+    "node_modules",
+    ".git",
+    ".venv",
+    "docs",
+}
+```
+
+That six-element set is now `EXCLUDED_PARTS` in the recipe, byte-for-byte, with the
+provenance in a comment above it. **No second list was created** -- and
+`TestDiscoveryScopeParity` (below) fails the build if one ever appears.
+
+## 2. Before / after -- both measured by running the recipe
+
+| | BEFORE | AFTER |
+|---|---|---|
+| Recipe version | v1.5.1 (unmodified) | v1.6.0 (this branch) |
+| `run_id` | `run-c26b396f2f1e` | `run-67388a546d75` |
+| `total_count` | **23** | **32** |
+| `search_locations` | 3 | 6 |
+| `quality_level` | `good` | `critical` |
+| **Verdict** | **PASS** | **FAIL** |
+
+Per-location counts, from the AFTER run's `location_counts`:
+
+| Location | Agents | |
+|---|---|---|
+| `agents/` | 16 | walked before |
+| `bundles/anchors/agents/` | 6 | walked before |
+| `bundles/anchors-amp-dev/agents/` | 1 | walked before |
+| `context/agents/` | 4 | **newly walked** |
+| `examples/agents/` | 1 | **newly walked** |
+| `experiments/build-up/agents/` | 4 | **newly walked** |
+
+**32 is measured, not assumed** -- and it is the *same 32 files*, by path, as
+6phe's `evidence/scope-parity.txt` ("validator scope ... 32 agents / guard (c)
+scope ... 32 agents / identical sets: True"). All three scopes now agree.
+
+Full run records: [`evidence/before-validate-agents-run.txt`](evidence/before-validate-agents-run.txt),
+[`evidence/after-validate-agents-run.txt`](evidence/after-validate-agents-run.txt),
+and [`evidence/after-deterministic-phases.json`](evidence/after-deterministic-phases.json)
+(the discovery/structural/classification output re-derived locally, no LLM step, so
+the numbers above are reproducible for $0).
+
+## 3. The verdict did NOT stay PASS -- and that is finding F1
+
+The goal's own words: *"If it does not stay PASS, that is the headline finding:
+report exactly which newly-walked agent fails and why, and leave it unfixed."*
+
+`structural summary: total 32, passed 28, errors 4, warnings 1`
+
+```
+4x ERROR  NO_FRONTMATTER
+    context/agents/delegation-instructions.md
+    context/agents/multi-agent-patterns.md
+    context/agents/session-repair-knowledge.md
+    context/agents/session-storage-knowledge.md
+
+1x WARNING NO_TOOLS_SECTION
+    examples/agents/file-responder.md
+```
+
+**Zero findings in `experiments/build-up/agents/` (4 files)** -- the tree that
+started this whole chain is clean, confirming 6phe fixed the content. That is the
+widened scan's good news, and it is only visible because the scan now reaches it.
+
+Details, and why nothing was fixed, in **Findings** below.
+
+## 4. Under-coverage is now visible in the output
+
+`discovery_results` gained three fields -- `location_counts`, `scan_patterns`,
+`excluded_parts` -- and `location` is now **derived** from each file's own parent
+directory instead of hardcoded, so a new `agents/` tree names itself in the report
+the first time it appears rather than the day someone remembers to add it.
+
+The `synthesize-report` prompt now *requires* a Coverage block in both the executive
+summary and the metadata: patterns scanned, parts excluded, total, and a row per
+location with its count. The `quick-approval` fast path (the one a PASSing repo
+actually reads) restates the same coverage line.
+
+The AFTER report emitted it:
+
+```
+- **Agents discovered**: 32 total across 6 locations -- agents/ 16,
+  bundles/anchors-amp-dev/agents/ 1, bundles/anchors/agents/ 6, context/agents/ 4, ...
+- excluded_parts: .git, .venv, docs, node_modules, test-fixtures, tests
+```
+
+The BEFORE report's *"Agents Found: 23 total across 3 search locations"* is the
+anti-pattern this replaces: complete-looking, and silent about nine files.
+
+## 5. The shared-helper question -- **DECLINED**, with the reason
+
+**A shared discovery implementation is NOT cheap, and I did not build one.**
+
+Two routes exist and both are worse than the divergence they would fix:
+
+1. **A recipe-engine `include` / step-library concept.** Recipe steps are
+   self-contained heredocs interpolated as strings; there is no import mechanism
+   between two `.yaml` recipes. Adding one restructures the step contract -- which
+   the goal names explicitly as the "say so and leave it" case.
+2. **A Python helper in `amplifier_foundation/`, imported by both.** This looks
+   cheap and is a trap. `validate-agents`' own `structural-validation` step already
+   documents why, in code:
+
+   > `amplifier_foundation` is not guaranteed to be importable in every
+   > environment this recipe runs in (it is run against third-party bundle
+   > repos). Degrade to a no-op rather than killing the whole run.
+
+   Discovery cannot degrade to a no-op -- a discovery that silently finds nothing is
+   the exact failure this lane exists to remove. Making the *scope* depend on an
+   import that is explicitly allowed to be missing would trade a visible
+   under-count for an invisible one.
+
+**Implemented instead (cheap, and it actually closes the hole):
+`TestDiscoveryScopeParity`** in `tests/test_anchors_bundles_dry.py` -- two guards
+that run on every CI job:
+
+- `test_exclusion_sets_agree_across_both_recipes_and_this_guard` -- parses the set
+  literals out of both recipes and compares them to `AGENT_SCAN_EXCLUDED_PARTS`. A
+  fourth list, or a drifting third, fails the build by name. The one permitted
+  delta (`docs`, present in the guard and `validate-agents`, absent from
+  `validate-bundle-repo`) is asserted **explicitly** rather than tolerated.
+- `test_validate_agents_discovers_exactly_the_guards_agent_files` -- **executes the
+  recipe's own discovery step** and compares its file set to `_agent_files()`. A test
+  that re-implemented the glob would keep passing while the recipe diverged, which is
+  precisely the failure mode being guarded.
+
+**Fail-before / pass-after** (both committed):
+
+```
+$ git stash push -- recipes/validate-agents.yaml   # guards vs the OLD recipe
+FAILED ...TestDiscoveryScopeParity::test_exclusion_sets_agree_across_both_recipes_and_this_guard
+FAILED ...TestDiscoveryScopeParity::test_validate_agents_discovers_exactly_the_guards_agent_files
+2 failed in 0.09s
+```
+
+The second failure named all nine missing files:
+
+```
+In recipe not guard: []; in guard not recipe:
+['context/agents/delegation-instructions.md', 'context/agents/multi-agent-patterns.md',
+ 'context/agents/session-repair-knowledge.md', 'context/agents/session-storage-knowledge.md',
+ 'examples/agents/file-responder.md', 'experiments/build-up/agents/coder.md',
+ 'experiments/build-up/agents/explorer.md', 'experiments/build-up/agents/planner.md',
+ 'experiments/build-up/agents/tester.md']
+```
+
+After: `8 passed in 0.13s` (was 6 tests; +2).
+[`evidence/parity-guards-FAIL-BEFORE.txt`](evidence/parity-guards-FAIL-BEFORE.txt),
+[`evidence/parity-guards-PASS-AFTER.txt`](evidence/parity-guards-PASS-AFTER.txt).
+
+## 6. Suite
+
+`2 failed, 2017 passed, 3 skipped` -- and the two failures are **exactly the two the
+goal names as pre-existing on this host**, neither touched by this branch:
+`tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file` and
+`tests/test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes`.
+[`evidence/full-suite.txt`](evidence/full-suite.txt).
+
+`git status` after all runs shows only the two source files plus this lane
+directory. **`validate-bundle-repo` was deliberately NOT run in this lane**, so
+6phe's F1 regen side effect (`bundle.dot` / `bundle.png` rewritten
+unconditionally) could not fire. Verified rather than assumed.
+
+---
+
+## Spend
+
+**Authority: $0 -- arithmetic `0 runs x 0 arms x $0 / 1.00 = $0.00`, slack $0.00.**
+
+**That arithmetic closes, and the authoring rule's failure mode cannot arise here**:
+this item buys *no measurement runs at all* -- there is no run-count/price pair to
+mis-size. It is a recipe edit, a guard test, and two recipe runs, which the goal
+carves out of the cap explicitly ("if a run costs API spend, RECORD it rather than
+treating it as free"). **Nothing was dropped for want of budget; branch B was never
+reached.**
+
+**API spend actually incurred, recorded rather than treated as free:**
+
+| Run | Recipe | LLM steps executed | Metered cost |
+|---|---|---|---|
+| `run-c26b396f2f1e` | `validate-agents` v1.5.1 (BEFORE) | 2 -- `quick-approval`, `synthesize-report`; `description-quality-check` and `tool-access-analysis` **skipped** (`requires_llm_analysis == false`) | not separately metered by the runner |
+| `run-67388a546d75` | `validate-agents` v1.6.0 (AFTER) | 3 -- `description-quality-check`, `tool-access-analysis`, `synthesize-report`; `quick-approval` **skipped** (same condition, now false the other way) | not separately metered by the runner |
+
+Five LLM steps across two runs. The runner reports no per-run cost figure, so the
+executed step count and the skips are recorded rather than a dollar amount invented.
+
+**Note for the manager, since it is a real cost signal:** widening discovery moved
+this repo off the quick-approval fast path. A FAILing run costs *more* LLM steps than
+a PASSing one (3 vs 2), because the two conditional deep-analysis phases now fire.
+That is a consequence of finding F1, and it reverses the moment F1 is resolved.
+
+No DTU, no container, no other infrastructure was created. Nothing in the infra
+ledger for this lane; nothing to tear down.
+
+---
+
+## Findings
+
+**F1 (headline) -- `context/agents/` is a path collision, not four broken agents.**
+The four `NO_FRONTMATTER` ERRORs are *context documents*, not agent definitions.
+Evidence, gathered rather than assumed:
+
+- `behaviors/agents.yaml:44-45` and `behaviors/tasks.yaml:18-19` list
+  `delegation-instructions.md` and `multi-agent-patterns.md` under `context:` --
+  never under `agents:`.
+- `agents/session-analyst.md:369-370` `@`-mentions the two session-knowledge files
+  as context.
+- `context/agents/` means *context about agents*, not *agents*. Nothing ever spawns
+  them, so `NO_FRONTMATTER`'s "agent won't load" describes an event that cannot
+  occur.
+
+The defect is in the **discovery predicate's semantics**: `**/agents/*.md` uses the
+*directory name* as the type signal, conflating definitions with context that
+happens to live beside them. `AGENT_SCAN_EXCLUDED_PARTS` does not exclude `context`,
+and correctly so -- excluding it would hide a real agent tree the day someone adds
+one.
+
+**Left unfixed, deliberately.** Adding frontmatter would be worse than the finding:
+it would make four context docs advertise themselves as spawnable agents. The
+architecturally correct fix is a type discriminator matching the loader's own
+contract -- *discover by path, classify by `meta:` presence; a `.md` under an
+`agents/` directory with no `meta:` is skipped as not-an-agent, not errored*. That
+neither weakens a check nor invents a second exclusion list. **It is a separate
+item**, and it is the one thing that would restore PASS honestly.
+
+**F2 -- `validate-bundle-repo`'s "32 agents, errors: []" is quietly wrong on the
+same 32 files.** The two recipes now agree on *scope* and still disagree on
+*content*: `validate-bundle-repo`'s `agent-description-validation` step reads only
+`meta.description` (`extract_description()` returns `""` when frontmatter is
+absent), so a file with **no frontmatter at all** scores 0 tokens, 0 `<example>`,
+0 `<commentary>` and passes clean. It therefore counted the four context docs as
+checked agents and reported `errors: []` (6phe, `run-864d8d1c009a`). Two
+consequences: its headline count of 32 is inflated by 4 -- **the true agent count in
+this repo is 28** -- and it cannot detect a genuinely broken or missing frontmatter
+in any agent. Reported, not fixed; it is content-check scope, not discovery scope.
+
+**F3 -- `examples/agents/file-responder.md` has no `tools:` section (WARNING).**
+Benign and arguably correct: the fixture exists to demonstrate spawn-capability
+*inheritance* from an agent `.md` (`examples/23_spawn_with_agents.py:200` maps the
+name to a literal file path). Declaring `tools: []` would erase the behaviour being
+demonstrated. Reported, not fixed.
+
+**F4 -- a FAILing repo costs more LLM steps than a PASSing one.** See the spend
+note above. Worth knowing before anyone widens discovery on a larger repo.
+
+---
+
+## Deviations from the goal
+
+1. **Deliverable 3 ("the verdict must stay PASS") was not met, by design.** The goal
+   predicted PASS on the premise "all agents are clean post-6phe". That premise
+   holds for every *agent* -- all 28 are clean, including all 4 in
+   `experiments/build-up/`. It does not hold for four *non-agents* the widened glob
+   now walks. The goal's own branch for this case was taken: report which files
+   fail and why, leave them unfixed, do not weaken anything. Recorded, not absorbed.
+2. **The shared-helper question was answered "no", and something cheaper was built
+   instead.** The goal accepts a stated "no, because X" as complete. I went slightly
+   further and added the parity guards, because they are cheap (two tests, no engine
+   change) and they are what actually prevents the divergence from recurring. If the
+   reviewer considers the extra test out of scope, it is severable in one commit --
+   the recipe change stands alone.
+3. **`validate-bundle-repo` was not re-run.** 6phe's `run-864d8d1c009a` already
+   records its side of the parity, this lane does not change that recipe, and
+   running it risks 6phe's F1 artifact-rewrite side effect for no new information.

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/after-deterministic-phases.json
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/after-deterministic-phases.json
@@ -1,0 +1,88 @@
+{
+  "discovery": {
+    "phase": "discovery",
+    "repo_path": "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation",
+    "total_count": 32,
+    "search_locations": [
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/agents",
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/bundles/anchors-amp-dev/agents",
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/bundles/anchors/agents",
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/context/agents",
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/examples/agents",
+      "/home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation/experiments/build-up/agents"
+    ],
+    "location_counts": {
+      "agents/": 16,
+      "bundles/anchors-amp-dev/agents/": 1,
+      "bundles/anchors/agents/": 6,
+      "context/agents/": 4,
+      "examples/agents/": 1,
+      "experiments/build-up/agents/": 4
+    },
+    "scan_patterns": [
+      "<repo>/**/agents/*.md",
+      "<repo>/agents/*.md"
+    ],
+    "excluded_parts": [
+      ".git",
+      ".venv",
+      "docs",
+      "node_modules",
+      "test-fixtures",
+      "tests"
+    ],
+    "errors": []
+  },
+  "structural_summary": {
+    "total": 32,
+    "passed": 28,
+    "errors": 4,
+    "warnings": 1
+  },
+  "structural_findings": [
+    {
+      "path": "context/agents/delegation-instructions.md",
+      "errors": [
+        "NO_FRONTMATTER"
+      ],
+      "warnings": []
+    },
+    {
+      "path": "context/agents/multi-agent-patterns.md",
+      "errors": [
+        "NO_FRONTMATTER"
+      ],
+      "warnings": []
+    },
+    {
+      "path": "context/agents/session-repair-knowledge.md",
+      "errors": [
+        "NO_FRONTMATTER"
+      ],
+      "warnings": []
+    },
+    {
+      "path": "context/agents/session-storage-knowledge.md",
+      "errors": [
+        "NO_FRONTMATTER"
+      ],
+      "warnings": []
+    },
+    {
+      "path": "examples/agents/file-responder.md",
+      "errors": [],
+      "warnings": [
+        "NO_TOOLS_SECTION"
+      ]
+    }
+  ],
+  "quality_level": "critical",
+  "requires_llm_analysis": true,
+  "class_summary": {
+    "total": 32,
+    "good": 27,
+    "polish": 0,
+    "needs_work": 1,
+    "critical": 4
+  }
+}

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/after-validate-agents-run.txt
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/after-validate-agents-run.txt
@@ -1,0 +1,53 @@
+AFTER  --  validate-agents v1.6.0 (widened discovery), same repo, same host, same day
+run_id:        run-67388a546d75
+session_id:    10ba26d6554c4252-20260906-123907_recipe
+repo_path:     /home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation
+status:        completed
+
+discovery_results.total_count:       32          (was 23)
+discovery_results.search_locations:  6           (was 3)
+discovery_results.scan_patterns:     ["<repo>/**/agents/*.md", "<repo>/agents/*.md"]
+discovery_results.excluded_parts:    [".git", ".venv", "docs", "node_modules", "test-fixtures", "tests"]
+discovery_results.location_counts:
+  agents/                          16   (walked before)
+  bundles/anchors/agents/           6   (walked before)
+  bundles/anchors-amp-dev/agents/   1   (walked before)
+  context/agents/                   4   NEWLY WALKED
+  examples/agents/                  1   NEWLY WALKED
+  experiments/build-up/agents/      4   NEWLY WALKED
+
+This set is IDENTICAL to the 32 files in 6phe's
+docs/lanes/6phe-experiments-example-sweep/evidence/scope-parity.txt
+("validator scope ... 32 agents / guard (c) scope ... 32 agents / identical sets: True").
+All three scopes now agree.
+
+structural summary:  total 32, passed 28, errors 4, warnings 1
+quality_level:       critical   (was "good")
+requires_llm_analysis: true     (was false)
+classification:      good 27, polish 0, needs_work 1, critical 4
+
+VERDICT (synthesize-report): FAIL   <-- CHANGED from PASS
+
+NEWLY-SURFACED FINDINGS -- REPORTED, NOT FIXED (goal scope-out):
+
+  4x ERROR  NO_FRONTMATTER
+      context/agents/delegation-instructions.md
+      context/agents/multi-agent-patterns.md
+      context/agents/session-repair-knowledge.md
+      context/agents/session-storage-knowledge.md
+
+  1x WARNING NO_TOOLS_SECTION
+      examples/agents/file-responder.md
+
+  0 findings in experiments/build-up/agents/ (4 files) -- confirms 6phe cleaned
+    the content to zero; the widened scan's good news.
+
+LLM steps EXECUTED (3):  description-quality-check, tool-access-analysis, synthesize-report
+LLM steps SKIPPED  (1):  quick-approval (condition requires_llm_analysis == false)
+  -- note the inversion vs the BEFORE run, which executed quick-approval and
+     skipped the other two.
+
+REPRODUCE THE DETERMINISTIC PART FOR $0:
+  the discovery / structural / classification steps are pure bash+python.
+  after-deterministic-phases.json in this directory is their exact output,
+  re-derived locally from the same recipe file with no LLM step involved.

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/before-validate-agents-run.txt
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/before-validate-agents-run.txt
@@ -1,0 +1,28 @@
+BEFORE  --  validate-agents v1.5.1 (unmodified, at lane branch point = origin/main 5a9e07b)
+run_id:        run-c26b396f2f1e
+session_id:    6fd60e5f3961435a-20260906-123542_recipe
+repo_path:     /home/bkrabach/dev/hw-model-performance/lanes/xe1u-validate-agents-discovery/amplifier-foundation
+status:        completed
+
+discovery_results.total_count:        23
+discovery_results.search_locations:   3
+  agents/                          16 agents
+  bundles/anchors/agents/           6 agents
+  bundles/anchors-amp-dev/agents/   1 agent
+
+quality_classification.quality_level:        good
+quality_classification.requires_llm_analysis: false
+quality_classification.summary: {good: 23, polish: 0, needs_work: 0, critical: 0, total: 23}
+
+VERDICT (synthesize-report): PASS
+  "Agents Found: 23 total across 3 search locations"
+  "Quality Breakdown: 23 good, 0 polish, 0 needs_work, 0 critical"
+  "Issues: 0 errors, 0 warnings, 2 optional suggestions"
+
+LLM steps EXECUTED (2):  quick-approval, synthesize-report
+LLM steps SKIPPED  (2):  description-quality-check, tool-access-analysis
+                         (skipped by condition: requires_llm_analysis == false)
+
+THE BLIND SPOT THIS RUN DEMONSTRATES: the report says "23 found, 3 locations"
+and carries NO signal that other agent directories exist in the repo. Nine
+further files match the wider validator scope and were never walked.

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/full-suite.txt
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/full-suite.txt
@@ -1,0 +1,11 @@
+FULL SUITE -- lane branch (validate-agents v1.6.0 + parity guards)
+command: python -m pytest -q
+
+  Enable tracemalloc to get traceback where the object was allocated.
+  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ============================
+FAILED tests/test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes
+FAILED tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file
+2 failed, 2017 passed, 3 skipped, 1 warning in 20.38s

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/parity-guards-FAIL-BEFORE.txt
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/parity-guards-FAIL-BEFORE.txt
@@ -1,0 +1,54 @@
+FAIL-BEFORE -- new parity guards run against validate-agents v1.5.1 (unmodified recipe, guards applied)
+command: python -m pytest tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity -q
+
+FF                                                                       [100%]
+=================================== FAILURES ===================================
+_ TestDiscoveryScopeParity.test_exclusion_sets_agree_across_both_recipes_and_this_guard _
+
+self = <tests.test_anchors_bundles_dry.TestDiscoveryScopeParity object at 0xfe7b49302f00>
+
+    def test_exclusion_sets_agree_across_both_recipes_and_this_guard(self) -> None:
+        """A fourth exclusion list is how the first divergence started."""
+        agents_sets = _literal_set(
+            VALIDATE_AGENTS_RECIPE.read_text(encoding="utf-8"), "EXCLUDED_PARTS"
+        )
+>       assert len(agents_sets) == 1, (
+            "validate-agents.yaml must declare exactly one EXCLUDED_PARTS set, "
+            f"found {len(agents_sets)}"
+        )
+E       AssertionError: validate-agents.yaml must declare exactly one EXCLUDED_PARTS set, found 0
+E       assert 0 == 1
+E        +  where 0 = len([])
+
+tests/test_anchors_bundles_dry.py:344: AssertionError
+_ TestDiscoveryScopeParity.test_validate_agents_discovers_exactly_the_guards_agent_files _
+
+self = <tests.test_anchors_bundles_dry.TestDiscoveryScopeParity object at 0xfe7b49060aa0>
+
+    def test_validate_agents_discovers_exactly_the_guards_agent_files(self) -> None:
+        """Proven parity, by running the recipe's own step -- not asserted."""
+        from_recipe = _run_recipe_discovery_step()
+        from_guard = {path.relative_to(REPO_ROOT).as_posix() for path in _agent_files()}
+>       assert from_recipe == from_guard, (
+            "validate-agents' discovery and this guard's _agent_files must find "
+            "the same files. In recipe not guard: "
+            f"{sorted(from_recipe - from_guard)}; in guard not recipe: "
+            f"{sorted(from_guard - from_recipe)}"
+        )
+E       AssertionError: validate-agents' discovery and this guard's _agent_files must find the same files. In recipe not guard: []; in guard not recipe: ['context/agents/delegation-instructions.md', 'context/agents/multi-agent-patterns.md', 'context/agents/session-repair-knowledge.md', 'context/agents/session-storage-knowledge.md', 'examples/agents/file-responder.md', 'experiments/build-up/agents/coder.md', 'experiments/build-up/agents/explorer.md', 'experiments/build-up/agents/planner.md', 'experiments/build-up/agents/tester.md']
+E       assert {'agents/bug-...pert.md', ...} == {'agents/bug-...pert.md', ...}
+E         
+E         Extra items in the right set:
+E         'context/agents/multi-agent-patterns.md'
+E         'experiments/build-up/agents/coder.md'
+E         'experiments/build-up/agents/explorer.md'
+E         'context/agents/session-repair-knowledge.md'
+E         'experiments/build-up/agents/planner.md'...
+E         
+E         ...Full output truncated (5 lines hidden), use '-vv' to show
+
+tests/test_anchors_bundles_dry.py:377: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity::test_exclusion_sets_agree_across_both_recipes_and_this_guard
+FAILED tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity::test_validate_agents_discovers_exactly_the_guards_agent_files
+2 failed in 0.09s

--- a/docs/lanes/xe1u-validate-agents-discovery/evidence/parity-guards-PASS-AFTER.txt
+++ b/docs/lanes/xe1u-validate-agents-discovery/evidence/parity-guards-PASS-AFTER.txt
@@ -1,0 +1,5 @@
+PASS-AFTER -- whole guard module against validate-agents v1.6.0 (widened discovery)
+command: python -m pytest tests/test_anchors_bundles_dry.py -q
+
+........                                                                 [100%]
+8 passed in 0.13s

--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -3,6 +3,38 @@
 # Validates agent definitions in a bundle repository for quality, tool access, and structural requirements
 #
 # CHANGELOG:
+# v1.6.0 - Agent discovery is now REPO-WIDE, matching the other two scopes
+#          in this repo instead of diverging from them. Phase 1 walked a
+#          hand-maintained list of three places (`agents/`,
+#          `behaviors/*/agents/`, `bundles/*/agents/`); it now globs
+#          `rglob("*/agents/*.md") + glob("agents/*.md")` and drops any path
+#          containing an excluded part -- the identical pair
+#          `validate-bundle-repo.yaml`'s `agent-description-validation` step
+#          uses, and the identical exclusion set
+#          `tests/test_anchors_bundles_dry.py`'s AGENT_SCAN_EXCLUDED_PARTS
+#          uses (its five plus `docs`).
+#        - WHY: the narrow walk was the ROOT CAUSE of a recurrence chain. On
+#          amplifier-foundation it discovered 23 agents while the other two
+#          scopes saw 32, so 11 `<example>` violators under
+#          `experiments/**/agents/` survived #341 (which swept root
+#          `agents/`) and ux32 (which swept `bundles/**`) -- and this recipe
+#          reported "23 found, 3 locations" the whole time, with no signal
+#          that other agent directories existed at all. A clean verdict that
+#          is silent about its own blind spot is worse than a noisy one.
+#        - Discovery output gained `location_counts` (per-directory counts),
+#          `scan_patterns` and `excluded_parts`; `location` is now DERIVED
+#          from each file's own parent directory rather than hardcoded, so a
+#          new `agents/` directory names itself in the report the first time
+#          it appears. `search_locations`, `agents_found` (with `path`,
+#          `relative_path`, `name`, `location`), `total_count` and `errors`
+#          keep their shape -- downstream steps are unchanged.
+#        - The report now MUST print the coverage line (total + every
+#          location with its count + the exclusion set) in both the executive
+#          summary and the metadata, so an under-count is visible in the
+#          output rather than silent.
+#        - Discovery only. No check, threshold, severity or verdict rule
+#          changed. On a repo whose agents all live in the three old
+#          locations, output is identical.
 # v1.5.1 - Prompt text caught up with the v1.4.0 example policy. The
 #          quick-approval and synthesize-report prompts still invited the
 #          model to offer "add <example> blocks" as optional polish, so a
@@ -142,6 +174,12 @@ description: |
   
   Produces a validation report with findings categorized by severity and actionable remediation.
   
+  **Discovery scope (v1.6.0):** every `agents/*.md` anywhere in the repo, excluding
+  `test-fixtures/`, `tests/`, `node_modules/`, `.git/`, `.venv/` and `docs/` -- the
+  same scope `validate-bundle-repo.yaml` and the repo-wide guard test use. The report
+  names every location it walked and the total it found, so under-coverage shows up in
+  the output instead of hiding behind a clean verdict.
+
   **v1.2.0 Improvements:**
   - Deterministic quality classification before LLM analysis
   - Explicit PASS thresholds - no more "always finding something"
@@ -150,7 +188,7 @@ description: |
   
   This recipe helps maintain agent quality across the Amplifier ecosystem by codifying
   the audit criteria discovered in manual reviews.
-version: "1.5.1"
+version: "1.6.0"
 author: "Amplifier Foundation Team"
 tags: ["agents", "validation", "quality", "audit", "tools", "descriptions"]
 
@@ -221,19 +259,60 @@ steps:
       import json
       from pathlib import Path
 
+      # --- Agent-discovery scope (v1.6.0) ------------------------------------
+      # This set is COPIED, not approximated, from the two places that already
+      # agree on it. Do not fork a third list here.
+      #
+      #   1. `recipes/validate-bundle-repo.yaml`, step `agent-description-
+      #      validation`: `EXCLUDED_DIRS = {"test-fixtures", "tests",
+      #      "node_modules", ".git", ".venv"}` over
+      #      `rglob("*/agents/*.md") + glob("agents/*.md")`.
+      #   2. `tests/test_anchors_bundles_dry.py`, `AGENT_SCAN_EXCLUDED_PARTS`
+      #      (added by lane 6phe): the same five plus `docs`, because `docs/`
+      #      holds frozen lane records that quote violations verbatim as
+      #      evidence and must never be rewritten.
+      #
+      # Before v1.6.0 this step walked only `agents/`, `behaviors/*/agents/`
+      # and `bundles/*/agents/` -- 23 files here, while the other two scopes
+      # saw 32. That asymmetry is the ROOT CAUSE of a recurrence chain: 11
+      # `<example>` violators under `experiments/**/agents/` survived both
+      # #341 (which swept root `agents/`) and ux32 (which swept `bundles/**`),
+      # because the recipe most people run never looked there, and reported a
+      # clean "23 found, 3 locations" while doing it.
+      EXCLUDED_PARTS = {
+          "test-fixtures",
+          "tests",
+          "node_modules",
+          ".git",
+          ".venv",
+          "docs",
+      }
+
+      # The glob pair, reported in the output so a reader can reproduce the scan.
+      SCAN_PATTERNS = ["<repo>/**/agents/*.md", "<repo>/agents/*.md"]
+
       def discover_agents(repo_path: str) -> dict:
-          """Discover all agent definition files in a repository."""
+          """Discover every agent definition file in a repository.
+
+          Repo-wide by design: any `agents/` directory at any depth, minus
+          EXCLUDED_PARTS. A location that is missing from this walk is a
+          location the validator cannot report on, so the walk must not be a
+          hand-maintained list of the places agents happened to live.
+          """
           results = {
               "phase": "discovery",
               "repo_path": repo_path,
               "agents_found": [],
               "total_count": 0,
               "search_locations": [],
+              "location_counts": {},
+              "scan_patterns": SCAN_PATTERNS,
+              "excluded_parts": sorted(EXCLUDED_PARTS),
               "errors": []
           }
 
           path = Path(repo_path).expanduser().resolve()
-          
+
           if not path.exists():
               results["errors"].append({
                   "type": "path_error",
@@ -242,57 +321,44 @@ steps:
               print(json.dumps(results))
               return results
 
-          # Direct agents/ directory
-          agents_dir = path / "agents"
-          if agents_dir.exists() and agents_dir.is_dir():
-              results["search_locations"].append(str(agents_dir))
-              for agent_file in agents_dir.glob("*.md"):
-                  results["agents_found"].append({
-                      "path": str(agent_file),
-                      "relative_path": str(agent_file.relative_to(path)),
-                      "name": agent_file.stem,
-                      "location": "agents/"
-                  })
+          # rglob("*/agents/*.md") reaches every nested agents/ directory;
+          # glob("agents/*.md") adds the repo-root one, which the rglob
+          # pattern's leading `*/` cannot match.
+          candidates = list(path.rglob("*/agents/*.md")) + list((path / "agents").glob("*.md"))
 
-          # Check behaviors/*/agents/ pattern
-          behaviors_dir = path / "behaviors"
-          if behaviors_dir.exists():
-              for behavior in behaviors_dir.iterdir():
-                  if behavior.is_dir():
-                      behavior_agents = behavior / "agents"
-                      if behavior_agents.exists() and behavior_agents.is_dir():
-                          results["search_locations"].append(str(behavior_agents))
-                          for agent_file in behavior_agents.glob("*.md"):
-                              results["agents_found"].append({
-                                  "path": str(agent_file),
-                                  "relative_path": str(agent_file.relative_to(path)),
-                                  "name": agent_file.stem,
-                                  "location": f"behaviors/{behavior.name}/agents/"
-                              })
+          seen = set()
+          for agent_file in sorted(candidates):
+              relative = agent_file.relative_to(path)
+              if EXCLUDED_PARTS & set(relative.parts):
+                  continue
+              resolved = agent_file.resolve()
+              if resolved in seen:
+                  continue
+              seen.add(resolved)
 
-          # Also check for standalone agent files in bundles/
-          bundles_dir = path / "bundles"
-          if bundles_dir.exists():
-              for bundle in bundles_dir.iterdir():
-                  if bundle.is_dir():
-                      bundle_agents = bundle / "agents"
-                      if bundle_agents.exists() and bundle_agents.is_dir():
-                          results["search_locations"].append(str(bundle_agents))
-                          for agent_file in bundle_agents.glob("*.md"):
-                              results["agents_found"].append({
-                                  "path": str(agent_file),
-                                  "relative_path": str(agent_file.relative_to(path)),
-                                  "name": agent_file.stem,
-                                  "location": f"bundles/{bundle.name}/agents/"
-                              })
+              # "location" is the containing directory, repo-relative, with a
+              # trailing slash -- e.g. "agents/", "bundles/anchors/agents/".
+              # Derived from the path rather than hardcoded, so a new agents/
+              # directory names itself in the report the first time it appears.
+              location = relative.parent.as_posix() + "/"
+              results["agents_found"].append({
+                  "path": str(agent_file),
+                  "relative_path": relative.as_posix(),
+                  "name": agent_file.stem,
+                  "location": location
+              })
+              results["location_counts"][location] = results["location_counts"].get(location, 0) + 1
 
+          results["search_locations"] = [str(path / loc) for loc in sorted(results["location_counts"])]
+          results["location_counts"] = dict(sorted(results["location_counts"].items()))
           results["total_count"] = len(results["agents_found"])
-          
+
           if results["total_count"] == 0:
               results["errors"].append({
                   "type": "no_agents",
                   "message": "No agent files found in repository",
-                  "searched": results["search_locations"] or ["agents/", "behaviors/*/agents/", "bundles/*/agents/"]
+                  "searched": SCAN_PATTERNS,
+                  "excluded_parts": sorted(EXCLUDED_PARTS)
               })
 
           print(json.dumps(results))
@@ -957,11 +1023,22 @@ steps:
     agent: "foundation:zen-architect"
     mode: "REVIEW"
     condition: "{{quality_classification.requires_llm_analysis}} == false"
-    depends_on: ["set-default-approval-summary"]
+    depends_on: ["set-default-approval-summary", "agent-discovery"]
     prompt: |
       All agents in this repository meet quality thresholds. Provide a brief approval summary.
 
       **Repository Path:** {{repo_path}}
+
+      **Discovery Coverage (v1.6.0 -- restate this, do not omit it):**
+      - Agents discovered: {{discovery_results.total_count}}
+      - Per-location counts: {{discovery_results.location_counts}}
+      - Scan patterns: {{discovery_results.scan_patterns}}
+      - Excluded parts: {{discovery_results.excluded_parts}}
+
+      A PASS is only meaningful alongside the scope it was reached over. An
+      approval that says "all agents pass" without saying WHICH agents were
+      looked at is exactly the shape that let 11 violators survive two
+      repo-wide sweeps.
 
       **Quality Classification Results:**
       ```json
@@ -995,6 +1072,9 @@ steps:
       ## ✅ PASS - All Agents Meet Quality Standards
       
       **Summary:** [1-2 sentences]
+
+      **Coverage:** [total] agents across [N] locations ([list them with
+      counts]); excluded [excluded_parts]
       
       **What's Done Well:**
       - [list 2-3 positive patterns]
@@ -1260,9 +1340,35 @@ steps:
       
       - **Overall Verdict**: [Select from above based on quality_level]
       - **Repository**: [path]
-      - **Agents Found**: X total
+      - **Agents Found**: X total across N locations
       - **Quality Breakdown**: X good, Y polish, Z needs_work, W critical
       - **Issues**: X errors, Y warnings, Z suggestions
+
+      ### Coverage (REQUIRED -- never omit, never summarise away)
+
+      Immediately after the bullets above, print the coverage block, taken
+      verbatim from `discovery_results`:
+
+      ```
+      Scanned: <scan_patterns>, excluding <excluded_parts>
+      Discovered: <total_count> agent files across <len(location_counts)> locations
+      ```
+
+      then a row per entry of `location_counts`, in the order given:
+
+      | Location | Agents |
+      |----------|--------|
+      | agents/  | 16     |
+
+      **Why this is mandatory:** a validator that under-counts silently is
+      worse than one that fails loudly. Before v1.6.0 this recipe walked
+      three hardcoded directories, reported "23 found, 3 locations" on a repo
+      that had 32 agent files in 6 locations, and gave a reader no way to
+      notice -- which is how 11 violators under `experiments/**/agents/`
+      survived two repo-wide sweeps. Printing the patterns, the exclusions,
+      the per-location counts and the total makes the scope auditable from
+      the report alone. Do NOT collapse this to a single number, and do NOT
+      drop locations that contributed zero findings.
 
       ## Quality Classification Summary
 
@@ -1345,7 +1451,14 @@ steps:
 
       ## Metadata
       - **Validated**: [timestamp]
-      - **Recipe**: validate-agents v1.5.1
+      - **Recipe**: validate-agents v1.6.0
+      - **Discovery scope**: repo-wide `agents/*.md`. State the
+        `scan_patterns` and the `excluded_parts` from `discovery_results`
+        verbatim.
+      - **Agents discovered**: `total_count` total across the locations in
+        `location_counts` -- list every location with its count again here,
+        so the metadata alone answers "what did this run actually look at?"
+        without the reader scrolling back.
       - **Quality Thresholds**: see
         `foundation:context/shared/description-authoring-principles.md`
         (canonical -- not restated here). Gates: no structural errors

--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -3,6 +3,49 @@
 # Validates agent definitions in a bundle repository for quality, tool access, and structural requirements
 #
 # CHANGELOG:
+# v1.7.0 - Two defects in v1.6.0's widened discovery, both silent.
+#        - (1) CLASSIFICATION BY DIRECTORY NAME. v1.6.0 treated every
+#          `agents/*.md` as an agent, so `context/agents/*.md` -- four
+#          CONTEXT DOCUMENTS loaded as `context:` by `behaviors/agents.yaml`
+#          and `behaviors/tasks.yaml`, which nothing spawns and which carry
+#          no frontmatter because they are not agents -- produced four
+#          NO_FRONTMATTER ERRORs and flipped the verdict PASS -> FAIL on a
+#          repo with ZERO real agent defects. `context/agents/` merely
+#          collides on the word "agents".
+#          Discovery now classifies on `meta:` presence in the frontmatter --
+#          the LOADER's own contract ("Agents ARE bundles ... the only
+#          difference is the frontmatter key (`meta:` vs `bundle:`)",
+#          docs/AGENT_AUTHORING.md). This is a CLASSIFIER, not an exclusion:
+#          `EXCLUDED_PARTS` is untouched, every candidate is still walked,
+#          and every non-agent is reported BY NAME AND REASON in the new
+#          `non_agents_found` -- because an unexplained drop is the same
+#          silence that let 11 violators survive two sweeps.
+#          Frontmatter that exists but will not parse still counts as an
+#          agent, so Phase 2 gets to report the YAML error rather than the
+#          file vanishing from the run.
+#        - (2) THE GLOB FOUND NOTHING ON WINDOWS. Every Python heredoc
+#          interpolated `Path("{{repo_path}}")`, putting a filesystem path
+#          inside a Python string literal, where each backslash becomes an
+#          escape sequence. On a GitHub Actions Windows runner
+#          (`D:\a\<repo>\<repo>`), `\a` became `\x07`, the path did not
+#          exist, discovery printed `agents_found: []` and exited 0, and the
+#          run reached PASS having validated NOTHING -- strictly worse than
+#          the 23-of-32 under-count v1.6.0 replaced. The repo path now
+#          arrives through the environment (`VALIDATE_AGENTS_REPO_PATH`),
+#          which has no escape semantics, in all three affected steps
+#          (environment-check, agent-discovery, structural-validation).
+#          Discovery additionally EXITS NON-ZERO on a missing repo path
+#          instead of printing an empty payload and exiting 0, so no future
+#          path defect can reach a vacuous PASS quietly.
+#          Caught by `TestDiscoveryScopeParity` on Windows 3.11/3.12/3.13 --
+#          the guard v1.6.0 added. It is the only thing that noticed.
+#        - Output gained `candidates_scanned`, `non_agents_found`,
+#          `non_agent_count`, `non_agent_reasons`, `classifier` and
+#          `classifier_mode`. `agents_found`, `total_count`,
+#          `location_counts`, `search_locations`, `scan_patterns`,
+#          `excluded_parts` and `errors` keep their shape -- downstream
+#          steps are unchanged.
+#        - No threshold, severity, skip rule or exclusion set changed.
 # v1.6.0 - Agent discovery is now REPO-WIDE, matching the other two scopes
 #          in this repo instead of diverging from them. Phase 1 walked a
 #          hand-maintained list of three places (`agents/`,
@@ -180,6 +223,12 @@ description: |
   names every location it walked and the total it found, so under-coverage shows up in
   the output instead of hiding behind a clean verdict.
 
+  **Classification (v1.7.0):** a scanned file is an agent when its frontmatter declares
+  a top-level `meta:` key -- the loader's own contract, not the directory name. A file
+  under an `agents/` directory that declares no `meta:` (e.g. `context/agents/*.md`,
+  which are context documents loaded via `context:`) is reported as a NON-AGENT with its
+  reason, never silently dropped and never validated as an agent.
+
   **v1.2.0 Improvements:**
   - Deterministic quality classification before LLM analysis
   - Explicit PASS thresholds - no more "always finding something"
@@ -188,7 +237,7 @@ description: |
   
   This recipe helps maintain agent quality across the Amplifier ecosystem by codifying
   the audit criteria discovered in manual reviews.
-version: "1.6.0"
+version: "1.7.0"
 author: "Amplifier Foundation Team"
 tags: ["agents", "validation", "quality", "audit", "tools", "descriptions"]
 
@@ -204,16 +253,24 @@ steps:
   - id: "environment-check"
     type: "bash"
     command: |
-      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
+      VALIDATE_AGENTS_REPO_PATH="{{repo_path}}" "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
       import json
+      import os
       import sys
       from pathlib import Path
+
+      # v1.7.0: the repo path arrives through the ENVIRONMENT, never
+      # interpolated into Python source. `{{repo_path}}` inside a Python string
+      # literal makes every backslash an escape sequence, which silently
+      # destroys any Windows path. See the agent-discovery step for the
+      # measurement and the cost.
+      REPO_PATH = os.environ["VALIDATE_AGENTS_REPO_PATH"]
 
       results = {
           "phase": "environment",
           "python_version": sys.version,
           "yaml_available": False,
-          "repo_path": "{{repo_path}}",
+          "repo_path": REPO_PATH,
           "repo_exists": False,
           "errors": []
       }
@@ -230,14 +287,14 @@ steps:
           })
 
       # Check repo path exists
-      repo_path = Path("{{repo_path}}").expanduser().resolve()
+      repo_path = Path(REPO_PATH).expanduser().resolve()
       if repo_path.exists() and repo_path.is_dir():
           results["repo_exists"] = True
           results["repo_path_resolved"] = str(repo_path)
       else:
           results["errors"].append({
               "type": "path_error",
-              "message": f"Repository path does not exist or is not a directory: {{repo_path}}"
+              "message": f"Repository path does not exist or is not a directory: {REPO_PATH}"
           })
 
       print(json.dumps(results))
@@ -255,9 +312,42 @@ steps:
   - id: "agent-discovery"
     type: "bash"
     command: |
-      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
+      VALIDATE_AGENTS_REPO_PATH="{{repo_path}}" "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
       import json
+      import os
+      import re
+      import sys
       from pathlib import Path
+
+      try:
+          import yaml
+      except ImportError:
+          yaml = None
+
+      # --- How the repo path reaches this step (v1.7.0) ----------------------
+      # Through the ENVIRONMENT. It is never interpolated into Python source.
+      #
+      # `Path("{{repo_path}}")` -- what v1.6.0 and earlier wrote -- puts a
+      # filesystem path inside a Python string literal, so every backslash in
+      # it becomes an escape sequence. Measured on a GitHub Actions Windows
+      # runner, whose checkout lives at `D:\a\<repo>\<repo>`:
+      #
+      #     Path("D:\a\amplifier-foundation\amplifier-foundation")
+      #       -> 'D:\x07mplifier-foundation\x07mplifier-foundation'
+      #       -> .exists() is False
+      #
+      # Discovery then took the "path does not exist" branch, printed a valid
+      # JSON payload with `agents_found: []`, and exited 0. Structural
+      # validation saw 0 agents, 0 errors; quality classification called that
+      # "good"; the run reached the quick-approval path and reported PASS
+      # having validated nothing. A vacuous PASS is strictly worse than the
+      # 23-of-32 under-count v1.6.0 replaced -- the under-count at least
+      # checked 23 files. `TestDiscoveryScopeParity` is what caught this, on
+      # Windows 3.11/3.12/3.13, which is why that guard must not be relaxed.
+      #
+      # An environment variable has no escape semantics, so the path arrives
+      # byte-for-byte on every platform.
+      REPO_PATH = os.environ["VALIDATE_AGENTS_REPO_PATH"]
 
       # --- Agent-discovery scope (v1.6.0) ------------------------------------
       # This set is COPIED, not approximated, from the two places that already
@@ -291,6 +381,69 @@ steps:
       # The glob pair, reported in the output so a reader can reproduce the scan.
       SCAN_PATTERNS = ["<repo>/**/agents/*.md", "<repo>/agents/*.md"]
 
+      # --- What makes a file an agent (v1.7.0) -------------------------------
+      # `meta:` in the frontmatter -- the LOADER's own contract, quoted from
+      # `docs/AGENT_AUTHORING.md`:
+      #
+      #   "Agents ARE bundles. They use the same file format and are loaded via
+      #    load_bundle(). The only difference is the frontmatter key
+      #    (`meta:` vs `bundle:`)."
+      #
+      # NOT the directory name. v1.6.0 classified by directory name, so
+      # `context/agents/*.md` -- four CONTEXT DOCUMENTS loaded as `context:` by
+      # `behaviors/agents.yaml:44-45` and `behaviors/tasks.yaml:18-19`, which
+      # nothing spawns and which carry no frontmatter because they are not
+      # agents -- were validated as agents and produced four NO_FRONTMATTER
+      # ERRORs. That flipped the verdict PASS -> FAIL on a repo with zero real
+      # agent defects. The directory merely collides on the word "agents".
+      #
+      # A validator that cries wolf gets muted, which costs more than the
+      # coverage gap v1.6.0 closed -- so this is a classifier fix, NOT an
+      # exclusion. No path is skipped: `EXCLUDED_PARTS` is untouched, every
+      # candidate is still walked, and every non-agent is REPORTED by name and
+      # reason in `non_agents_found`. Silence is what let 11 violators survive
+      # two sweeps; this must not reintroduce it in a new place.
+      FRONTMATTER_RE = re.compile(r"\A---\s*\r?\n(.*?)\r?\n---\s*\r?\n", re.DOTALL)
+      # Fallback only, for an environment without PyYAML: a top-level `meta:`
+      # key at column 0 of the frontmatter block.
+      META_KEY_RE = re.compile(r"^meta\s*:", re.MULTILINE)
+
+      CLASSIFIER_MODE = "yaml" if yaml is not None else "regex-fallback"
+      CLASSIFIER = "frontmatter declares a top-level `meta:` key (docs/AGENT_AUTHORING.md)"
+
+      def classify(agent_file: Path) -> tuple:
+          """Return (is_agent, reason) for one candidate file.
+
+          Frontmatter that exists but cannot be parsed counts as an AGENT on
+          purpose: the file is plainly trying to be one, and structural
+          validation must get the chance to report the YAML error. Only a file
+          that cleanly declares no `meta:` is classified out.
+          """
+          try:
+              content = agent_file.read_text(encoding="utf-8")
+          except Exception as exc:
+              # Unreadable is not "not an agent" -- keep it, let Phase 2 say so.
+              return True, f"unreadable ({exc.__class__.__name__})"
+
+          match = FRONTMATTER_RE.match(content)
+          if not match:
+              return False, "no_frontmatter"
+
+          block = match.group(1)
+          if yaml is None:
+              return bool(META_KEY_RE.search(block)), (
+                  "meta_present" if META_KEY_RE.search(block) else "frontmatter_without_meta"
+              )
+
+          try:
+              frontmatter = yaml.safe_load(block)
+          except Exception:
+              return True, "unparseable_frontmatter"
+
+          if isinstance(frontmatter, dict) and "meta" in frontmatter:
+              return True, "meta_present"
+          return False, "frontmatter_without_meta"
+
       def discover_agents(repo_path: str) -> dict:
           """Discover every agent definition file in a repository.
 
@@ -298,6 +451,10 @@ steps:
           EXCLUDED_PARTS. A location that is missing from this walk is a
           location the validator cannot report on, so the walk must not be a
           hand-maintained list of the places agents happened to live.
+
+          Candidates are then CLASSIFIED by `meta:` presence, not by where they
+          live. Both numbers are reported: what was scanned, and what was
+          judged an agent.
           """
           results = {
               "phase": "discovery",
@@ -308,6 +465,12 @@ steps:
               "location_counts": {},
               "scan_patterns": SCAN_PATTERNS,
               "excluded_parts": sorted(EXCLUDED_PARTS),
+              "classifier": CLASSIFIER,
+              "classifier_mode": CLASSIFIER_MODE,
+              "candidates_scanned": 0,
+              "non_agents_found": [],
+              "non_agent_count": 0,
+              "non_agent_reasons": {},
               "errors": []
           }
 
@@ -319,7 +482,11 @@ steps:
                   "message": f"Repository path does not exist: {repo_path}"
               })
               print(json.dumps(results))
-              return results
+              # Exit LOUD. Printing an empty-but-valid payload and exiting 0 is
+              # exactly how the Windows escape bug reached a PASS verdict having
+              # validated nothing. A bad repo path is a run-ending condition,
+              # not a finding about the repo.
+              sys.exit(1)
 
           # rglob("*/agents/*.md") reaches every nested agents/ directory;
           # glob("agents/*.md") adds the repo-root one, which the rglob
@@ -335,12 +502,24 @@ steps:
               if resolved in seen:
                   continue
               seen.add(resolved)
+              results["candidates_scanned"] += 1
 
               # "location" is the containing directory, repo-relative, with a
               # trailing slash -- e.g. "agents/", "bundles/anchors/agents/".
               # Derived from the path rather than hardcoded, so a new agents/
               # directory names itself in the report the first time it appears.
               location = relative.parent.as_posix() + "/"
+
+              is_agent, reason = classify(agent_file)
+              if not is_agent:
+                  results["non_agents_found"].append({
+                      "relative_path": relative.as_posix(),
+                      "location": location,
+                      "reason": reason
+                  })
+                  results["non_agent_reasons"][reason] = results["non_agent_reasons"].get(reason, 0) + 1
+                  continue
+
               results["agents_found"].append({
                   "path": str(agent_file),
                   "relative_path": relative.as_posix(),
@@ -352,19 +531,26 @@ steps:
           results["search_locations"] = [str(path / loc) for loc in sorted(results["location_counts"])]
           results["location_counts"] = dict(sorted(results["location_counts"].items()))
           results["total_count"] = len(results["agents_found"])
+          results["non_agent_count"] = len(results["non_agents_found"])
+          results["non_agent_reasons"] = dict(sorted(results["non_agent_reasons"].items()))
 
           if results["total_count"] == 0:
               results["errors"].append({
                   "type": "no_agents",
-                  "message": "No agent files found in repository",
+                  "message": (
+                      "No agent files found in repository "
+                      f"({results['candidates_scanned']} candidate file(s) scanned, "
+                      f"{results['non_agent_count']} classified as non-agents)"
+                  ),
                   "searched": SCAN_PATTERNS,
-                  "excluded_parts": sorted(EXCLUDED_PARTS)
+                  "excluded_parts": sorted(EXCLUDED_PARTS),
+                  "classifier": CLASSIFIER
               })
 
           print(json.dumps(results))
           return results
 
-      discover_agents("{{repo_path}}")
+      discover_agents(REPO_PATH)
       EOF
     output: "discovery_results"
     parse_json: true
@@ -381,10 +567,15 @@ steps:
   - id: "structural-validation"
     type: "bash"
     command: |
-      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
+      VALIDATE_AGENTS_REPO_PATH="{{repo_path}}" "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
       import json
+      import os
       import re
       from pathlib import Path
+
+      # v1.7.0: through the environment, never a Python string literal --
+      # see the agent-discovery step for what interpolating it costs on Windows.
+      REPO_PATH = os.environ["VALIDATE_AGENTS_REPO_PATH"]
 
       try:
           import yaml
@@ -464,7 +655,7 @@ steps:
           return bundle_tools
       
       # Pre-load bundle-level tool definitions
-      bundle_level_tools = get_bundle_level_tools("{{repo_path}}")
+      bundle_level_tools = get_bundle_level_tools(REPO_PATH)
       
       def parse_agent_frontmatter(file_path: str) -> dict:
           """Parse YAML frontmatter from an agent markdown file."""
@@ -1030,15 +1221,24 @@ steps:
       **Repository Path:** {{repo_path}}
 
       **Discovery Coverage (v1.6.0 -- restate this, do not omit it):**
+      - Candidate files scanned: {{discovery_results.candidates_scanned}}
       - Agents discovered: {{discovery_results.total_count}}
       - Per-location counts: {{discovery_results.location_counts}}
       - Scan patterns: {{discovery_results.scan_patterns}}
       - Excluded parts: {{discovery_results.excluded_parts}}
 
+      **Classification (v1.7.0 -- restate this too):**
+      - Classifier: {{discovery_results.classifier}}
+      - Non-agent files: {{discovery_results.non_agent_count}}
+        ({{discovery_results.non_agent_reasons}})
+      - Which ones: {{discovery_results.non_agents_found}}
+
       A PASS is only meaningful alongside the scope it was reached over. An
       approval that says "all agents pass" without saying WHICH agents were
       looked at is exactly the shape that let 11 violators survive two
-      repo-wide sweeps.
+      repo-wide sweeps. The same applies to the files the classifier set
+      aside: name them, so a file wrongly judged not-an-agent is visible
+      rather than silently unvalidated.
 
       **Quality Classification Results:**
       ```json
@@ -1351,7 +1551,10 @@ steps:
 
       ```
       Scanned: <scan_patterns>, excluding <excluded_parts>
-      Discovered: <total_count> agent files across <len(location_counts)> locations
+      Candidates: <candidates_scanned> files matched the scan
+      Classified as agents: <total_count> across <len(location_counts)> locations
+      Classified as NON-agents: <non_agent_count> (<non_agent_reasons>)
+      Classifier: <classifier>
       ```
 
       then a row per entry of `location_counts`, in the order given:
@@ -1359,6 +1562,22 @@ steps:
       | Location | Agents |
       |----------|--------|
       | agents/  | 16     |
+
+      **Then, if `non_agent_count` > 0, a NON-AGENTS table (REQUIRED --**
+      **never omit it, never fold it into a single number):**
+
+      | File | Reason not an agent |
+      |------|---------------------|
+      | context/agents/multi-agent-patterns.md | no_frontmatter |
+
+      Take every row verbatim from `non_agents_found`. These files matched the
+      scan and were then judged NOT to be agents because their frontmatter
+      declares no `meta:` key (v1.7.0 -- the loader's own contract, see
+      `docs/AGENT_AUTHORING.md`). Naming them is what makes the classifier
+      auditable: a real agent that lost its `meta:` block would appear in this
+      table instead of vanishing from the run, which is the failure mode a
+      classifier can otherwise introduce. Do NOT present them as errors --
+      they are correctly-excluded non-agents.
 
       **Why this is mandatory:** a validator that under-counts silently is
       worse than one that fails loudly. Before v1.6.0 this recipe walked
@@ -1451,7 +1670,7 @@ steps:
 
       ## Metadata
       - **Validated**: [timestamp]
-      - **Recipe**: validate-agents v1.6.0
+      - **Recipe**: validate-agents v1.7.0
       - **Discovery scope**: repo-wide `agents/*.md`. State the
         `scan_patterns` and the `excluded_parts` from `discovery_results`
         verbatim.
@@ -1459,6 +1678,11 @@ steps:
         `location_counts` -- list every location with its count again here,
         so the metadata alone answers "what did this run actually look at?"
         without the reader scrolling back.
+      - **Classification**: state `candidates_scanned`, `classifier` and
+        `non_agent_count` verbatim, and repeat every entry of
+        `non_agents_found` with its reason. "N files matched the scan, M were
+        agents, K were not, and here is which" is the whole point -- a bare
+        agent count cannot be audited.
       - **Quality Thresholds**: see
         `foundation:context/shared/description-authoring-principles.md`
         (canonical -- not restated here). Gates: no structural errors

--- a/tests/test_anchors_bundles_dry.py
+++ b/tests/test_anchors_bundles_dry.py
@@ -262,3 +262,121 @@ class TestAgentDescriptionsCarryNoExampleBlocks:
             "(description-authoring-principles.md V3, #340). Offenders: "
             + "; ".join(offenders)
         )
+
+
+# --- Discovery-scope parity (xe1u) -----------------------------------------
+# The three places in this repo that answer "which files are agent
+# definitions?" must give the SAME answer. When they did not, the cost was a
+# three-sweep recurrence: `validate-agents` walked three hardcoded directories
+# and found 23 agents; `validate-bundle-repo` and `_agent_files` above globbed
+# the repo and found 32 (45 before the `experiments/` deletion). The 11
+# `<example>` violators that lived in the 9-file difference survived #341 and
+# ux32 because the recipe most people run never looked at them -- and reported
+# a clean "23 found, 3 locations" the whole time.
+#
+# 6phe closed the gap in the guard; xe1u closed it in `validate-agents`
+# (v1.6.0). These tests are the tripwire that keeps it closed. A shared
+# discovery *implementation* was considered and declined -- see
+# `docs/lanes/xe1u-validate-agents-discovery/DONE-NOTE.md` -- so proven parity
+# is the mechanism standing in for it.
+VALIDATE_AGENTS_RECIPE = REPO_ROOT / "recipes" / "validate-agents.yaml"
+VALIDATE_BUNDLE_REPO_RECIPE = REPO_ROOT / "recipes" / "validate-bundle-repo.yaml"
+
+# `validate-bundle-repo` excludes the five; the guard and `validate-agents`
+# add `docs` on top, because `docs/` holds frozen lane records that quote
+# violations verbatim as evidence and must never be rewritten. That one
+# documented delta is asserted explicitly below rather than papered over --
+# it excludes zero files today (there is no `docs/**/agents/` directory), so
+# all three walks still return the same set.
+DOCUMENTED_EXCLUSION_DELTA = {"docs"}
+
+
+def _literal_set(text: str, name: str) -> list[set[str]]:
+    """Every `NAME = {...}` set literal in `text`, in source order."""
+    import ast
+
+    return [
+        set(ast.literal_eval(match.group(1)))
+        for match in re.finditer(rf"\b{name}\s*=\s*(\{{[^}}]*\}})", text)
+    ]
+
+
+def _run_recipe_discovery_step() -> set[str]:
+    """Execute `validate-agents`' agent-discovery step and return its findings.
+
+    Executed, not re-implemented. A test that reimplements the glob would pass
+    while the recipe diverged, which is the failure mode being guarded.
+    """
+    import json
+    import subprocess
+    import sys
+    import tempfile
+
+    lines = VALIDATE_AGENTS_RECIPE.read_text(encoding="utf-8").splitlines()
+    step = next(i for i, line in enumerate(lines) if line.strip() == '- id: "agent-discovery"')
+    start = next(
+        i
+        for i in range(step, len(lines))
+        if lines[i].strip() == "\"${AMPLIFIER_PYTHON:-python3}\" << 'EOF'"
+    )
+    end = next(i for i in range(start + 1, len(lines)) if lines[i].strip() == "EOF")
+    body = "\n".join(line[6:] for line in lines[start + 1 : end])
+    body = body.replace("{{repo_path}}", str(REPO_ROOT))
+
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
+        handle.write(body)
+        script = handle.name
+    completed = subprocess.run(
+        [sys.executable, script], capture_output=True, text=True, check=True
+    )
+    payload = json.loads(completed.stdout)
+    return {agent["relative_path"] for agent in payload["agents_found"]}
+
+
+class TestDiscoveryScopeParity:
+    """One answer to "which files are agents?", across all three scopes."""
+
+    def test_exclusion_sets_agree_across_both_recipes_and_this_guard(self) -> None:
+        """A fourth exclusion list is how the first divergence started."""
+        agents_sets = _literal_set(
+            VALIDATE_AGENTS_RECIPE.read_text(encoding="utf-8"), "EXCLUDED_PARTS"
+        )
+        assert len(agents_sets) == 1, (
+            "validate-agents.yaml must declare exactly one EXCLUDED_PARTS set, "
+            f"found {len(agents_sets)}"
+        )
+        assert agents_sets[0] == AGENT_SCAN_EXCLUDED_PARTS, (
+            "validate-agents.yaml's EXCLUDED_PARTS must equal this module's "
+            f"AGENT_SCAN_EXCLUDED_PARTS. recipe={sorted(agents_sets[0])} "
+            f"guard={sorted(AGENT_SCAN_EXCLUDED_PARTS)}"
+        )
+
+        repo_sets = _literal_set(
+            VALIDATE_BUNDLE_REPO_RECIPE.read_text(encoding="utf-8"), "EXCLUDED_DIRS"
+        )
+        assert repo_sets, "validate-bundle-repo.yaml declares no EXCLUDED_DIRS set"
+        assert all(found == repo_sets[0] for found in repo_sets), (
+            "validate-bundle-repo.yaml's EXCLUDED_DIRS literals disagree with each "
+            f"other: {[sorted(found) for found in repo_sets]}"
+        )
+        assert AGENT_SCAN_EXCLUDED_PARTS - repo_sets[0] == DOCUMENTED_EXCLUSION_DELTA, (
+            "The only permitted difference between validate-bundle-repo's "
+            "EXCLUDED_DIRS and the wider scope is the documented "
+            f"{sorted(DOCUMENTED_EXCLUSION_DELTA)}. Actual extra: "
+            f"{sorted(AGENT_SCAN_EXCLUDED_PARTS - repo_sets[0])}"
+        )
+        assert not repo_sets[0] - AGENT_SCAN_EXCLUDED_PARTS, (
+            "validate-bundle-repo excludes something the wider scope does not: "
+            f"{sorted(repo_sets[0] - AGENT_SCAN_EXCLUDED_PARTS)}"
+        )
+
+    def test_validate_agents_discovers_exactly_the_guards_agent_files(self) -> None:
+        """Proven parity, by running the recipe's own step -- not asserted."""
+        from_recipe = _run_recipe_discovery_step()
+        from_guard = {path.relative_to(REPO_ROOT).as_posix() for path in _agent_files()}
+        assert from_recipe == from_guard, (
+            "validate-agents' discovery and this guard's _agent_files must find "
+            "the same files. In recipe not guard: "
+            f"{sorted(from_recipe - from_guard)}; in guard not recipe: "
+            f"{sorted(from_guard - from_recipe)}"
+        )

--- a/tests/test_anchors_bundles_dry.py
+++ b/tests/test_anchors_bundles_dry.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -88,8 +89,8 @@ def _frontmatter(path: Path) -> dict:
     return yaml.safe_load(match.group(1)) or {}
 
 
-def _agent_files() -> list[Path]:
-    """Every agent description in the repo, at the validator's own scope.
+def _agent_candidate_files() -> list[Path]:
+    """Every file the validator's SCAN reaches, before classification.
 
     Not "root `agents/` + bundles" -- that narrower scope is what let the
     `experiments/` copies keep their `<example>` blocks through two sweeps.
@@ -110,6 +111,40 @@ def _agent_files() -> list[Path]:
         seen.add(resolved)
         found.append(candidate)
     return sorted(found)
+
+
+def _is_agent_file(path: Path) -> bool:
+    """Is this scanned file an agent DEFINITION, or merely under `agents/`?
+
+    Keys on `meta:` -- the loader's own contract, quoted from
+    `docs/AGENT_AUTHORING.md`: "Agents ARE bundles. They use the same file
+    format and are loaded via load_bundle(). The only difference is the
+    frontmatter key (`meta:` vs `bundle:`)."
+
+    NOT the directory name. `context/agents/*.md` are context documents loaded
+    via `context:` (`behaviors/agents.yaml`, `behaviors/tasks.yaml`); nothing
+    spawns them and they carry no frontmatter because they are not agents. The
+    directory collides on the word "agents", which is how the widened
+    validator came to report four NO_FRONTMATTER errors against files that
+    were never agents.
+
+    Frontmatter that exists but will not parse counts as an agent on purpose --
+    a file plainly trying to be one should reach the validator that reports the
+    YAML error, not be quietly reclassified out of the run.
+    """
+    match = _FRONTMATTER_RE.match(path.read_text(encoding="utf-8"))
+    if not match:
+        return False
+    try:
+        frontmatter = yaml.safe_load(match.group(1))
+    except yaml.YAMLError:
+        return True
+    return isinstance(frontmatter, dict) and "meta" in frontmatter
+
+
+def _agent_files() -> list[Path]:
+    """Every agent DEFINITION in the repo: scanned, then classified."""
+    return [path for path in _agent_candidate_files() if _is_agent_file(path)]
 
 
 def _relative_files(root: Path) -> set[str]:
@@ -279,6 +314,15 @@ class TestAgentDescriptionsCarryNoExampleBlocks:
 # discovery *implementation* was considered and declined -- see
 # `docs/lanes/xe1u-validate-agents-discovery/DONE-NOTE.md` -- so proven parity
 # is the mechanism standing in for it.
+#
+# 39z0 (v1.7.0) added the classifier layer and the Windows fix, and split the
+# parity claim in two accordingly: the SCAN must reach the same files, and the
+# CLASSIFIER must then judge the same subset of them agents. Both are asserted
+# separately below, on purpose -- a classifier that quietly narrowed the walk
+# would still satisfy an agent-set comparison if the guard narrowed with it.
+# The Windows defect these guards caught is pinned twice more: once at its
+# cause (no path interpolated into Python source) and once by reproducing an
+# escape-shaped path on every platform.
 VALIDATE_AGENTS_RECIPE = REPO_ROOT / "recipes" / "validate-agents.yaml"
 VALIDATE_BUNDLE_REPO_RECIPE = REPO_ROOT / "recipes" / "validate-bundle-repo.yaml"
 
@@ -301,36 +345,53 @@ def _literal_set(text: str, name: str) -> list[set[str]]:
     ]
 
 
-def _run_recipe_discovery_step() -> set[str]:
-    """Execute `validate-agents`' agent-discovery step and return its findings.
+# The environment variable `validate-agents` v1.7.0 passes the repo path
+# through. It is NOT interpolated into the Python heredoc, and must not be:
+# `Path("{{repo_path}}")` puts a filesystem path inside a Python string
+# literal, where every backslash becomes an escape sequence. On a GitHub
+# Actions Windows runner (`D:\a\<repo>\<repo>`) `\a` became `\x07`, the path
+# did not exist, and discovery printed `agents_found: []` and exited 0 --
+# a PASS over zero files. These guards are what caught it, on Windows
+# 3.11/3.12/3.13, while every POSIX leg stayed green.
+DISCOVERY_REPO_PATH_ENV = "VALIDATE_AGENTS_REPO_PATH"
+
+
+def _discovery_step_body() -> str:
+    """The agent-discovery step's Python heredoc, verbatim and de-indented."""
+    lines = VALIDATE_AGENTS_RECIPE.read_text(encoding="utf-8").splitlines()
+    step = next(i for i, line in enumerate(lines) if line.strip() == '- id: "agent-discovery"')
+    start = next(
+        i for i in range(step, len(lines)) if lines[i].rstrip().endswith("<< 'EOF'")
+    )
+    end = next(i for i in range(start + 1, len(lines)) if lines[i].strip() == "EOF")
+    return "\n".join(line[6:] for line in lines[start + 1 : end])
+
+
+def _run_recipe_discovery_step(repo_path: Path | None = None) -> dict:
+    """Execute `validate-agents`' agent-discovery step and return its payload.
 
     Executed, not re-implemented. A test that reimplements the glob would pass
     while the recipe diverged, which is the failure mode being guarded.
+
+    The repo path is handed over the way the recipe hands it over -- through
+    the environment -- so this harness exercises the real mechanism rather than
+    a friendlier substitute.
     """
     import json
+    import os
     import subprocess
     import sys
     import tempfile
 
-    lines = VALIDATE_AGENTS_RECIPE.read_text(encoding="utf-8").splitlines()
-    step = next(i for i, line in enumerate(lines) if line.strip() == '- id: "agent-discovery"')
-    start = next(
-        i
-        for i in range(step, len(lines))
-        if lines[i].strip() == "\"${AMPLIFIER_PYTHON:-python3}\" << 'EOF'"
-    )
-    end = next(i for i in range(start + 1, len(lines)) if lines[i].strip() == "EOF")
-    body = "\n".join(line[6:] for line in lines[start + 1 : end])
-    body = body.replace("{{repo_path}}", str(REPO_ROOT))
-
-    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
-        handle.write(body)
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, encoding="utf-8") as handle:
+        handle.write(_discovery_step_body())
         script = handle.name
+    env = dict(os.environ)
+    env[DISCOVERY_REPO_PATH_ENV] = str(repo_path if repo_path is not None else REPO_ROOT)
     completed = subprocess.run(
-        [sys.executable, script], capture_output=True, text=True, check=True
+        [sys.executable, script], capture_output=True, text=True, check=True, env=env
     )
-    payload = json.loads(completed.stdout)
-    return {agent["relative_path"] for agent in payload["agents_found"]}
+    return json.loads(completed.stdout)
 
 
 class TestDiscoveryScopeParity:
@@ -370,9 +431,37 @@ class TestDiscoveryScopeParity:
             f"{sorted(repo_sets[0] - AGENT_SCAN_EXCLUDED_PARTS)}"
         )
 
+    def test_validate_agents_scans_exactly_the_guards_candidate_files(self) -> None:
+        """Parity of the SCAN, before either side classifies anything.
+
+        Kept separate from the agent-set parity below on purpose: a classifier
+        that quietly narrowed the walk would still satisfy an agent-set
+        comparison if both sides narrowed together. This pins the wider claim
+        v1.6.0 established -- the same FILES are reached -- so adding a
+        classifier on top cannot be used to shrink coverage unnoticed.
+        """
+        payload = _run_recipe_discovery_step()
+        from_recipe = {agent["relative_path"] for agent in payload["agents_found"]} | {
+            entry["relative_path"] for entry in payload["non_agents_found"]
+        }
+        from_guard = {
+            path.relative_to(REPO_ROOT).as_posix() for path in _agent_candidate_files()
+        }
+        assert from_recipe == from_guard, (
+            "validate-agents' scan and this guard's _agent_candidate_files must "
+            "reach the same files. In recipe not guard: "
+            f"{sorted(from_recipe - from_guard)}; in guard not recipe: "
+            f"{sorted(from_guard - from_recipe)}"
+        )
+        assert payload["candidates_scanned"] == len(from_guard), (
+            f"candidates_scanned={payload['candidates_scanned']} disagrees with "
+            f"the {len(from_guard)} files this guard scanned"
+        )
+
     def test_validate_agents_discovers_exactly_the_guards_agent_files(self) -> None:
         """Proven parity, by running the recipe's own step -- not asserted."""
-        from_recipe = _run_recipe_discovery_step()
+        payload = _run_recipe_discovery_step()
+        from_recipe = {agent["relative_path"] for agent in payload["agents_found"]}
         from_guard = {path.relative_to(REPO_ROOT).as_posix() for path in _agent_files()}
         assert from_recipe == from_guard, (
             "validate-agents' discovery and this guard's _agent_files must find "
@@ -380,3 +469,110 @@ class TestDiscoveryScopeParity:
             f"{sorted(from_recipe - from_guard)}; in guard not recipe: "
             f"{sorted(from_guard - from_recipe)}"
         )
+        assert from_recipe, "discovery found no agents at all -- a PASS over nothing"
+
+    def test_classifier_keys_on_meta_not_on_the_directory_name(self) -> None:
+        """`context/agents/*.md` are context documents, not agents.
+
+        They are loaded as `context:` by `behaviors/agents.yaml` and
+        `behaviors/tasks.yaml`; nothing spawns them, and they carry no
+        frontmatter because they are not agents. Classifying by directory name
+        made them four NO_FRONTMATTER ERRORs and flipped the verdict on a repo
+        with no real agent defects.
+
+        They must be classified out AND named -- an unexplained drop is the
+        same silence that let 11 violators survive two sweeps.
+        """
+        payload = _run_recipe_discovery_step()
+        agents = {agent["relative_path"] for agent in payload["agents_found"]}
+        non_agents = {entry["relative_path"]: entry["reason"] for entry in payload["non_agents_found"]}
+
+        context_docs = {
+            path.relative_to(REPO_ROOT).as_posix()
+            for path in (REPO_ROOT / "context" / "agents").glob("*.md")
+        }
+        assert context_docs, "expected context/agents/*.md to exist in this repo"
+        assert not (context_docs & agents), (
+            "context/agents/*.md were classified as AGENTS: "
+            f"{sorted(context_docs & agents)}. They declare no `meta:` -- see "
+            "docs/AGENT_AUTHORING.md."
+        )
+        assert context_docs <= set(non_agents), (
+            "context/agents/*.md must be REPORTED as non-agents, not silently "
+            f"dropped. Missing from non_agents_found: {sorted(context_docs - set(non_agents))}"
+        )
+        for path in sorted(context_docs):
+            assert non_agents[path] == "no_frontmatter", (
+                f"{path} was excluded for {non_agents[path]!r}; expected "
+                "'no_frontmatter'"
+            )
+
+    def test_discovery_never_interpolates_the_repo_path_into_python_source(self) -> None:
+        """The Windows defect, pinned at its cause rather than its symptom.
+
+        `Path("{{repo_path}}")` makes every backslash in a filesystem path an
+        escape sequence. `D:\\a\\repo\\repo` -- a GitHub Actions Windows
+        checkout -- became `D:\\x07epo...`, did not exist, and discovery
+        returned an empty set and exited 0.
+        """
+        body = _discovery_step_body()
+        # Comment lines are exempt: the step documents the defect it fixes, and
+        # substitution into a comment cannot mangle a path anyone uses.
+        code = [
+            line
+            for line in body.splitlines()
+            if not line.lstrip().startswith("#")
+        ]
+        offenders = [line for line in code if "{{repo_path}}" in line]
+        assert not offenders, (
+            "The agent-discovery heredoc interpolates {{repo_path}} into Python "
+            "source. A path inside a string literal is escape-processed, which "
+            f"silently destroys every Windows path. Offending line(s): {offenders}. "
+            f"Pass it through ${DISCOVERY_REPO_PATH_ENV} instead."
+        )
+        assert DISCOVERY_REPO_PATH_ENV in body, (
+            f"The agent-discovery step must read the repo path from "
+            f"${DISCOVERY_REPO_PATH_ENV}"
+        )
+
+    def test_discovery_survives_a_repo_path_containing_escape_sequences(self) -> None:
+        """The Windows defect, reproduced on every platform.
+
+        A directory literally named `a\\test` gives a repo path whose string
+        form carries `\\a` and `\\t` -- the exact shape of `D:\\a\\...` on a
+        Windows runner. Under the v1.6.0 interpolation this found zero agents
+        and reported success; it must now find the file that is really there.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "a\\test\\nested"
+            (repo / "agents").mkdir(parents=True)
+            (repo / "agents" / "probe.md").write_text(
+                '---\nmeta:\n  name: probe\n  description: "probe agent"\n---\nbody\n',
+                encoding="utf-8",
+            )
+            (repo / "context" / "agents").mkdir(parents=True)
+            (repo / "context" / "agents" / "notes.md").write_text(
+                "# Notes\n\nA context document, not an agent.\n", encoding="utf-8"
+            )
+
+            payload = _run_recipe_discovery_step(repo)
+
+        assert payload["errors"] == [], (
+            f"discovery reported errors on an escape-shaped path: {payload['errors']}"
+        )
+        assert {a["relative_path"] for a in payload["agents_found"]} == {"agents/probe.md"}, (
+            "discovery lost the agent under a path containing backslash escape "
+            f"sequences -- found {payload['agents_found']}"
+        )
+        assert {n["relative_path"] for n in payload["non_agents_found"]} == {
+            "context/agents/notes.md"
+        }
+
+    def test_discovery_fails_loudly_on_a_missing_repo_path(self) -> None:
+        """Never an empty payload with exit 0 -- that is the vacuous PASS."""
+        import subprocess
+
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_recipe_discovery_step(REPO_ROOT / "no-such-directory-exists-here")


### PR DESCRIPTION
Builds on #364 (`lane/xe1u-validate-agents-discovery`, `038801f`), which is held DRAFT for exactly the two defects fixed here. **This PR contains that commit** — it is the mergeable unit; #364 should not merge alone.

Work item `model_performance-39z0`. **Draft on purpose — do not merge.**

## Headline

Both defects fixed. **The FAIL is gone.** The verdict does **not** return to bare `PASS` — it lands on **`⚠️ PASS WITH WARNINGS`**, and per the item that is the headline finding, named and **left unfixed**:

> `examples/agents/file-responder.md` — `NO_TOOLS_SECTION`. One WARNING, zero ERRORs.

Correct discovery surfaced it for the first time. It is a fixture demonstrating capability inheritance, so adding `tools:` would destroy what it demonstrates. **Reported, not fixed, not suppressed.** No threshold, severity, skip rule or exclusion set was touched.

## Before / after

Measured by executing the recipes' own **deterministic** steps — no LLM step, no API spend. `quality_classification.quality_level` **is** the verdict (`good→PASS`, `polish→PASS WITH SUGGESTIONS`, `needs_work→PASS WITH WARNINGS`, `critical→FAIL`); the report step renders that decision, it does not make it.

| | recipe | scanned | agents | non-agents | ERR | WARN | `quality_level` | verdict |
|---|---|---|---|---|---|---|---|---|
| baseline `5a9e07b` | v1.5.1 | — | 23 | — | 0 | 0 | `good` | **PASS** |
| before `038801f` | v1.6.0 | — | 32 | — | **4** | 1 | `critical` | **FAIL** |
| **after** | **v1.7.0** | **32** | **28** | **4** | **0** | 1 | `needs_work` | **⚠️ PASS WITH WARNINGS** |

**True agent count: 28** — measured, not assumed. 32 files match the scan; 4 declare no `meta:`.

**The harness is validated against the two paid runs it replaces**: it reproduces `run-c26b396f2f1e` (23/PASS) and `run-67388a546d75` (32/FAIL) exactly — same counts, same four `NO_FRONTMATTER` errors, same verdicts.

## (1) Classification by directory name

`context/agents/` merely collides on the word "agents". Its four files are context documents loaded via `context:` by `behaviors/agents.yaml:44-45` and `behaviors/tasks.yaml:18-19`; nothing spawns them, and they carry no frontmatter **because they are not agents**.

Discovery now classifies on **`meta:` presence — the loader's own contract** (`docs/AGENT_AUTHORING.md:5`: *"Agents ARE bundles … the only difference is the frontmatter key (`meta:` vs `bundle:`)"*).

A **classifier, not an exclusion**: `AGENT_SCAN_EXCLUDED_PARTS` untouched, no second list, all 32 candidates still walked, and every non-agent reported by name and reason in the new `non_agents_found` — the report and quick-approval path must now print a NON-AGENTS table. A real agent that lost its `meta:` block appears in that table instead of vanishing. Unparseable frontmatter still counts as an agent, so Phase 2 reports the YAML error.

## (2) The recipe found nothing on Windows

Every Python heredoc wrote `Path("{{repo_path}}")` — a path inside a **Python string literal**, where each backslash is an escape sequence. A GH Actions Windows checkout is `D:\a\<repo>\<repo>`, so `\a` parsed as `\x07`.

Reproduced on POSIX (`evidence/windows-path-repro.txt`) with a directory literally named `a\test\…`, running each version's own discovery body:

```
--- v1.6.0 (038801f) ---
exit code: 0
agents_found : []            <-- empty payload, EXIT 0
--- v1.7.0 (this branch) ---
exit code: 0
agents_found     : ['agents/probe.md']
non_agents_found : ['context/agents/notes.md']
```

`agents_found: []` **with exit 0** is the whole problem: structural validation then saw 0 agents / 0 errors, classification called that `good`, and the run reported **PASS having validated nothing** — strictly worse than the 23-of-32 under-count.

Fix: the path arrives via **`VALIDATE_AGENTS_REPO_PATH`** (no escape semantics) in all three affected steps — `environment-check`, `agent-discovery`, and `structural-validation`, whose `get_bundle_level_tools("{{repo_path}}")` would otherwise have produced false WARNINGs on Windows once discovery started working. Discovery also **exits non-zero** on a missing repo path, so no future path defect reaches a vacuous PASS quietly. A repo genuinely without agents is unchanged.

## The parity guard survived, and got stronger

It is what caught the Windows defect on Windows 3.11/3.12/3.13 while every POSIX leg stayed green. **Neither deleted nor relaxed** — 2 tests → 6:

- **scan parity** (`_agent_candidate_files`) is now pinned **separately** from agent parity, because a classifier that quietly narrowed the walk would still satisfy an agent-set comparison if the guard narrowed with it
- agent parity kept, plus a non-empty assertion
- `context/agents/*.md` are non-agents **and are named as such**
- the Windows defect pinned at its **cause** (no path in Python source)
- the Windows defect **reproduced on every platform**
- loud exit on a missing repo path

**6 of 7 fail against v1.6.0's recipe** (`evidence/parity-guards-FAIL-BEFORE.txt`); **13/13 pass here** (`evidence/parity-guards-PASS-AFTER.txt`).

## CI — all six legs green, including the three Windows ones

Run `34057350037`:

```
Tests (ubuntu-latest,  3.11/3.12/3.13)  pass
Tests (windows-latest, 3.11/3.12/3.13)  pass    <-- red on #364
```

**The Windows deliverable, proved on the real platform** by the same `TestDiscoveryScopeParity` that failed there with `assert set() == {...}` on #364.

## Tests

`uv sync --extra grpc-adapter && uv run pytest tests/ -q` → **1 failed, 1834 passed, 3 skipped**. The one local failure is `tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file` — environment-specific (a `/tmp` symlink `resolve()` collapses), **green in CI**, and `git diff origin/main -- tests/test_sources.py amplifier_foundation/sources` is empty. `recipes(operation="validate")`: `status: valid`, no warnings.

## Spend, and one honest gap

**$0.00 spent against a $0.00 authority** (`0 runs x 0 arms x $0 / 1.00`). No new paid `run-id` was purchased.

Executed at zero cost: three full deterministic replays (v1.5.1 / v1.6.0 / v1.7.0) over 32 candidates each — 12 deterministic step executions — plus the two-version Windows reproduction, the fail-before and pass-after guard runs, the full suite, and recipe schema validation; reproducing both prior run ids exactly.

The deliverable *"both recipes re-run … with run ids"* requires purchased runs while the authority sizing it is `0 runs x $0`. Those clauses cannot both hold — reported as a goal-authority defect rather than absorbed by overspending. The authority that would close it is `2 recipes x 1 run x <measured per-run $>`; **no prior lane recorded a dollar cost for these runs**, so that figure does not exist in evidence yet. Full accounting: `docs/lanes/39z0-agent-classifier-scope/DONE-NOTE.md`.

`validate-bundle-repo.yaml` is deliberately untouched (that is `model_performance-dfni`, sequenced after this because its count depends on this classifier), which also avoided its `bundle.dot`/`bundle.png` regen side effect entirely.
