### PR TITLE
fix(bundle): foundation's ROOT body was documentation prose sent as system instruction (A) + pin the tool-skills double-mount semantics (C)

### DIFF
--- a/bundle.md
+++ b/bundle.md
@@ -3,13 +3,25 @@ bundle:
   name: foundation
   version: 2.1.2
   description: |
-    Foundation bundle with enhanced delegate tool.
-    
-    Features:
-    - Two-parameter context inheritance (context_depth + context_scope)
-    - Session resume (use full session_id from delegate calls)
-    - Fixed tool inheritance (explicit declarations always honored)
+    The standard Amplifier foundation with the enhanced delegate tool for
+    agent orchestration.
+
+    Key features:
+    - Delegate tool: two-parameter context control (context_depth + context_scope)
+      - context_depth: HOW MUCH to inherit -- "none" | "recent" | "all"
+      - context_scope: WHICH content to include -- "conversation" | "agents" | "full"
+    - Session resume: continue agent sessions with the full session_id returned
+      by a delegate call
+    - Tool inheritance: explicit agent declarations are always honored
     - Multi-agent collaboration patterns
+    - MCP support: Model Context Protocol integration. To use MCP servers,
+      create `.amplifier/mcp.json` with an "mcpServers" object mapping a server
+      name to its {"url": "..."} entry.
+
+    NOTE: this bundle is composed as a ROOT, so everything below the frontmatter
+    is sent to the model as system instruction (docs/BUNDLE_GUIDE.md). Bundle
+    documentation belongs here in `description` (metadata, never sent), never in
+    the body. The body is the single @mention of the shared instruction file.
 
 includes:
   # Ecosystem expert behaviors (provides @amplifier: and @core: namespaces)
@@ -85,42 +97,5 @@ agents:
     - foundation:web-research
     - foundation:zen-architect
 ---
-
-# Foundation Bundle v2.0
-
-This bundle provides the standard Amplifier foundation with the enhanced delegate tool for agent orchestration.
-
-## Key Features
-
-| Feature | Description |
-|---------|-------------|
-| **Delegate tool** | Two-parameter context control (depth + scope) |
-| **Session resume** | Continue agent sessions with full session_id |
-| **Tool inheritance** | Explicit declarations always honored |
-| **MCP support** | Model Context Protocol integration (configure via mcp.json) |
-
-## Delegate Tool
-
-```python
-# Context depth: HOW MUCH to inherit
-context_depth: "none" | "recent" | "all"
-
-# Context scope: WHICH content to include
-context_scope: "conversation" | "agents" | "full"
-```
-
-## MCP Configuration
-
-To use MCP servers, create `.amplifier/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "your-server": {
-      "url": "https://example.com/mcp"
-    }
-  }
-}
-```
 
 @foundation:context/shared/common-system-base.md

--- a/docs/lanes/8rug-foundation-root-hygiene/C-compose-semantics-finding.md
+++ b/docs/lanes/8rug-foundation-root-hygiene/C-compose-semantics-finding.md
@@ -1,0 +1,107 @@
+# (C) `tool-skills` double mount — compose-semantics finding
+
+**Verdict: NOT A BUG. Nothing is silently dropped.** The double mount is safe, but it is
+safe *because of one specific merge rule*, and that dependency was undocumented and
+untested until now. This document records the measurement; `tests/test_tool_skills_double_mount.py`
+pins it.
+
+Measured on `main` @ `a0decc6`, 2026-09-06. **Measured before anything was changed**, per the
+goal's "do NOT fix (C) before measuring it".
+
+## The two mounts
+
+| # | Declared in | What it contributes |
+|---|---|---|
+| 1 | `behaviors/agents.yaml:36-40` | `config.skills: [amplifier-foundation@main#subdirectory=skills]` — foundation's OWN skills dir |
+| 2 | root `bundle.md:33` → `amplifier-bundle-skills@main#subdirectory=behaviors/skills.yaml` | `config.skills: [amplifier-bundle-skills@main#subdirectory=skills]` (curated collection) + `config.visibility` |
+
+Both name the same `module: tool-skills` and, importantly, the **same `source`**
+(`amplifier-bundle-skills@main#subdirectory=modules/tool-skills`). The comment in
+`agents.yaml` — "Register foundation's own skills directory for discovery" — is accurate: it
+is a *config contribution*, not a competing module implementation.
+
+## What `Bundle.compose()` actually does with a duplicate module id
+
+`amplifier_foundation/bundle/_dataclass.py:250` → `merge_module_lists()`
+(`amplifier_foundation/dicts/merge.py:79`) keys module configs by `id or module`, so the two
+declarations collapse to **one** entry. On collision it calls `deep_merge()`, which resolves
+per value type:
+
+| Config value type | Rule | Consequence here |
+|---|---|---|
+| `dict` | recurse | `visibility` (only mount 2 has it) survives |
+| `list` | **concatenate, deduplicated, parent first** | **both** `skills` entries survive |
+| scalar | later replaces earlier | `source` — later wins, harmless only because both agree |
+
+The list rule is not incidental. It was introduced by `70d521f` ("fix: concatenate lists in
+`deep_merge` instead of replacing — fixes silent config loss in bundle composition", #120),
+whose docstring names *this exact pair*:
+
+> This ensures that composing two behaviors that declare the same module
+> (e.g. tool-skills) with list-typed config values (e.g. config.skills,
+> config.search_paths) accumulates all entries rather than silently dropping
+> the parent's list.
+
+So the double mount was already repaired at the merge layer before this lane looked at it.
+
+## Effective composed config (measured)
+
+`behaviors/agents.yaml` composed with the external skills behavior, in root `bundle.md` order
+(agents at line 27 → skills.yaml at line 33):
+
+```json
+{
+  "module": "tool-skills",
+  "source": "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills",
+  "config": {
+    "skills": [
+      "git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=skills",
+      "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=skills"
+    ],
+    "visibility": { "enabled": true, "inject_role": "user",
+                    "visibility_token_budget": 5000, "ephemeral": true, "priority": 20 }
+  }
+}
+```
+
+Reverse order yields the same set (order of the list flips; membership does not).
+
+## Real-session confirmation
+
+`amplifier run "hi" --bundle foundation` (foundation as ROOT, via a project-scope source
+override — `~/.amplifier/cache` untouched), session `268a6e56-d64d-4958-9ea4-2c2bdfd94a2e`.
+Presence in the live `hooks-skills-visibility` list:
+
+```
+bundle-to-dot                  present=True   <- behaviors/agents.yaml mount (foundation skills dir)
+creating-amplifier-modules     present=True   <- behaviors/agents.yaml mount (foundation skills dir)
+per-repo-conventions           present=True   <- behaviors/agents.yaml mount (foundation skills dir)
+image-vision                   present=True   <- bundle.md:33 skills.yaml mount (curated collection)
+```
+
+Both mounts' skills reach the model. Nothing is dropped end to end.
+
+## Why a test was still warranted
+
+The double mount depends on a merge rule that is invisible at both declaration sites and has
+**no failure signal** if it regresses: the skills simply stop being discoverable, with no error.
+Disabling list-concat in `deep_merge` (simulating the pre-#120 behavior) makes 2 of the 7 new
+tests fail:
+
+```
+FAILED tests/test_tool_skills_double_mount.py::test_double_mount_keeps_both_skills_dirs_in_bundle_md_order
+FAILED tests/test_tool_skills_double_mount.py::test_double_mount_keeps_both_skills_dirs_in_reverse_order
+2 failed, 5 passed
+```
+
+Restored: 7 passed.
+
+## Residual risk (not fixed — recorded)
+
+The two mounts are order-insensitive **only because they name the same `source`**. `source` is a
+scalar, so if the two declarations ever diverge, whichever composes last silently wins and the
+other becomes dead text with no diagnostic. `test_both_mounts_agree_on_the_module_source` pins
+that agreement so a future divergence fails a test instead of a session.
+
+No code change was made for (C). Per the goal: "A double mount that merges correctly is a
+finding, not a bug."

--- a/docs/lanes/8rug-foundation-root-hygiene/DONE-NOTE.md
+++ b/docs/lanes/8rug-foundation-root-hygiene/DONE-NOTE.md
@@ -1,0 +1,200 @@
+# DONE-NOTE — lane `8rug-foundation-root-hygiene`
+
+Work item: `model_performance-8rug` (project `model_performance`) — foundation ROOT bundle
+hygiene, owner-approved for all three parts.
+
+**Terminal outcome: (B) RESOLVED AT THE CAP.** A and C are DONE and shipped. B's code half is
+DONE and measured; B's **eval is NOT-POSSIBLE at the $10 authority**, priced before spending,
+with the arithmetic recorded. That is branch B of the goal's three outcomes, and it resolves.
+
+---
+
+## Deliverables
+
+| # | Deliverable | State |
+|---|---|---|
+| A1 | Root `bundle.md` body is the single `@mention`; prose in frontmatter `description:`; fail-before via the fixed validator | **DONE** |
+| A2 | Real-session check — foundation as ROOT, `raw.system` head is common-system-base, no feature table | **DONE** |
+| C1 | Compose-semantics finding stated in the PR body either way, with a test asserting the effective `tool-skills` config | **DONE** |
+| C2 | Real-session check — foundation's skills discoverable | **DONE** |
+| B1 | Pre-registered eval, written before editing | **DONE** (commit `07d51b9`) |
+| B2 | The split: `delegation-core.md` <500 tokens on disk, depth loaded from named agent bodies, same triage for `multi-agent-patterns.md` | **DONE** |
+| B3 | `tasks.yaml` references the same core, or drops context — justified | **DONE** (references the core) |
+| B4 | The ~6× estimator understatement fixed, on-disk measurement quoted | **DONE** (6.28×, `validate-bundle-repo` v3.14.0) |
+| B5 | **The eval itself: n≥3/arm, both providers, decision rule evaluated** | **NOT-POSSIBLE — cap** |
+| B6 | DTUs destroyed, ledger 0 open rows, spend arithmetic in the PR body | **DONE** (no DTUs created, 0 rows opened) |
+
+### B5 — NOT-POSSIBLE, leading with what WAS executed
+
+**Executed before this refusal:** the complete code half of B — a 487-token core file, the
+depth split, the agent-body routing for two named agents, the `tasks.yaml` decision, and the
+estimator repair; **33 new tests** (12 of which fail on `main`); a full suite at **2,064
+passed**; the estimator fail-before/pass-after matrix (`1000 → WARNING` vs `6276 → ERROR` on
+main; `487 → ok` on branch); and **3 real foundation-root sessions** measuring the root
+prompt at **130,055 → 106,655 chars, 52,741 → 47,014 provider-reported input tokens
+(−5,727)**. What was *not* bought is the eval that would test the primary metric.
+
+The pre-registered design is 3 runs × 2 arms × 2 providers = **12 valid runs**. At the
+program's observed **67 %** validity that is **18 launches**; at the observed per-run prices
+(**$3.53** opus-5 S3, **$4.63** terra) that is **9 × $3.53 + 9 × $4.63 = $73.44**. Even at
+100 % validity it is **$48.96**; even substituting the cheaper sonnet figure, **$41.52**.
+**The authority is $10.**
+
+What $10 could buy — 3 launches at the cheapest observed rate ($2.62/run) ⇒ **~2 valid runs =
+n=1 per arm on one provider** — cannot produce a lower bound on success, so it cannot
+evaluate the rule's first condition at all, and a single delegation count per arm cannot
+support the ±30 % comparison. **0 % chance of landing the deliverable.** Priced on first read
+of the goal; **$0 spent on the eval**; design not shrunk and re-labelled.
+
+**The authority that WOULD close it: $73.44** (`12 valid runs / 0.67 validity = 18 launches ×
+blended $4.08 = $73.44`), or **$48.96** if every launch is valid.
+
+**Residue and the smallest useful purchase it could not buy:** the full **$10** is unspent.
+The smallest purchase that would advance B5 is a *complete* n≥3 both-provider arm pair —
+**$73.44**. There is no smaller indivisible purchase that produces an evaluable result
+against the frozen rule, so the entire authority is unspendable for this deliverable.
+
+---
+
+## Published
+
+| PR | Branch | Contents | State |
+|---|---|---|---|
+| [#368](https://github.com/microsoft/amplifier-foundation/pull/368) | `lane/8rug-foundation-root-hygiene` | **A + C** | **ready for review** (gates hold) |
+| [#369](https://github.com/microsoft/amplifier-foundation/pull/369) | `lane/8rug-foundation-root-hygiene-b` | **B** | **DRAFT — HELD**, eval unfunded |
+
+Neither is merged. The manager verifies the fail-befores and merges.
+
+---
+
+## Findings
+
+### 1. (A) Foundation's ROOT body was 499 chars of documentation prose — sent as system instruction
+
+`docs/BUNDLE_GUIDE.md:138`: *"Everything below the frontmatter is sent to the model as system
+instruction. It is not documentation, and it is not free."* Root `bundle.md` carried a
+`# Foundation Bundle v2.0` title, a feature table and an MCP config sample below the
+frontmatter, **ahead of** `@foundation:context/shared/common-system-base.md`.
+
+Same class as the notify-README defect fixed by app-cli #315/#316 — this time in the
+composition base every non-anchors bundle inherits.
+
+```
+check_body_is_instruction("bundle.md")
+  main a0decc6 : FLAG, prose_chars 499  "no second-person address -- reads as documentation"
+  this branch  : OK,   prose_chars 0    "body carries no prose (mentions/scaffolding only)"
+repo-wide body-instruction-check: 1 prose_below_frontmatter WARNING -> 0, over 32 files
+```
+
+Real session, foundation as ROOT: `raw.system[0].text` head went from
+`# Foundation Bundle v2.0 / This bundle provides... | Feature | Description |` to
+`@foundation:context/shared/common-system-base.md → # Primary Core Instructions / You are
+Amplifier...`. **130,055 → 129,178 chars.**
+
+### 2. (C) The `tool-skills` double mount is a FINDING, not a bug — and nothing is dropped
+
+Measured **before** touching anything, as the goal required. `merge_module_lists` collapses
+the two declarations by module id; `deep_merge` **concatenates** list-typed config, so both
+`skills` sources survive in **both** compose orders, and `visibility` (contributed by only one
+mount) survives too. A live foundation-root session lists all three foundation skills
+alongside the curated collection. **No code changed for (C).**
+
+But the safety is load-bearing on one invisible rule — the list-concat added in `70d521f`
+(#120), which fails **silently** if it regresses (the skills just stop being discoverable).
+`tests/test_tool_skills_double_mount.py` pins it: disabling list-concat fails 2 of its 7
+tests.
+
+**Residual risk recorded, not fixed:** the two mounts are order-insensitive *only* because
+they name the same `source`, and `source` is a scalar (later wins). A test now pins that
+agreement.
+
+### 3. (B) The validator understated by 6.28× — and landed exactly on its own ERROR boundary
+
+Rule 4 resolved a `context.include` two ways: leading `@` → flat 500 tokens; otherwise → try
+as a relative path. A `<namespace>:<path>` ref matches **neither**, so it took the 500
+default. Two includes × 500 = **exactly 1000**, against a `> 1000` ERROR gate: **6,276 real
+on-disk tokens reported as 1000 and graded WARNING — one token below the ERROR that was
+true.** The measurement that would justify splitting the context was being taken with a ruler
+wrong by 6×, in the direction that made the problem invisible.
+
+### 4. Cross-cutting: three defects in this lane, one shape
+
+(A) a validator whose extractor returned an empty string that satisfied every check
+(`aaa5c47`, fixed before this lane); (B) an estimator whose fallback produced a number that
+read as measured; (C) a merge rule whose regression produces no error at all. **In each case
+the instrument reported "fine" for a condition it could not observe.** The (B) fix therefore
+does more than raise a number — it makes an unresolvable include *say so*
+(`context_unresolved_includes`, `context_tokens_is_estimate`), because a guess folded silently
+into a measured-looking total is the actual defect.
+
+---
+
+## Spend
+
+| item | cost |
+|---|---|
+| (A) real-session checks — 2 × `amplifier run "hi"`, `haiku` | $0.14 |
+| (B) real-session check — 1 × `amplifier run "hi"`, `haiku` | $0.06 |
+| First orientation run before pinning a cheap provider (default opus, 161k input) | $1.01 |
+| **(B) eval** | **$0.00 — NOT bought, priced at $73.44 against a $10 authority** |
+| **Total** | **$1.21** |
+
+**Authority: $10, for B's eval only.** The eval was not bought, so **$10 of the eval
+authority is unspent**. The $1.21 above is the goal's "$0 — code + tests + local sessions"
+category; it is reported rather than rounded to zero because it is real money.
+
+**Infrastructure: none.** No DTUs created, no Gitea instances, **0 ledger rows opened**, so
+nothing to tear down:
+
+```
+$ awk -F'\t' '$4=="open"' <batch>/infra.tsv | wc -l   # this lane contributed 0 rows
+```
+
+---
+
+## Deviations and choices recorded
+
+1. **Two branches, not one.** The goal requires two PRs with independent merge fates. PR 2 is
+   branched from `origin/main`, not from PR 1, so A/C can merge while B is held.
+2. **`haiku` for the real-session checks.** The first run cost **$1.01** at the default
+   provider with 161k input tokens (the host's global `bundle.app` list composed onto the
+   root). Subsequent runs pin `-p haiku` and set `bundle.app: []` in project-scope settings —
+   which also makes the measurement *cleaner*, since it measures foundation-as-ROOT rather
+   than foundation-plus-this-host's-app-bundles.
+3. **`~/.amplifier/cache` never edited.** Source override via a project-scope
+   `.amplifier/settings.yaml` in a scratch directory (`/tmp/8rug-rootcheck`), which takes
+   precedence over global settings. The host is shared with live lanes.
+4. **`infra_ledger.sh sweep` never run.** No infrastructure was created, so
+   `lane_teardown.sh` had nothing to claim or tear down.
+5. **Two test files touched that this lane did not otherwise own**, both because the rename
+   made them false: `tests/test_frontmatter.py` (used `delegation-instructions.md` as a live
+   example of a resolvable mention) and `tests/test_module_dep_resolvability_check.py` (pins
+   the recipe version, bumped 3.13.0 → 3.14.0). Neither assertion's *subject* changed.
+6. **Pre-existing suite failures not claimed:** `test_sources.py::test_resolve_existing_file`
+   and `test_grpc_adapter_main.py::test_non_isinstance_object_with_mount_passes` — both
+   reproduce on `a0decc6` with this lane's changes stashed, verified explicitly.
+7. **`examples/agents/file-responder.md`'s `NO_TOOLS_SECTION` warning left alone** — it is a
+   fixture demonstrating capability inheritance, per the goal's KNOWN section.
+
+## What remains open
+
+- **B5.** The pre-registered eval is unbought. B does not merge without it. `#369` carries the
+  frozen rule, the design, and the price; whoever funds **$73.44** can run it against the
+  branch unchanged.
+- **Evaluability risk on B5, recorded before results exist:** if arm-A S3 runs median 0
+  delegations, the ±30 % condition is unevaluable and the honest report is "unevaluable" — not
+  a substitute gate invented afterwards (`otr`'s failure mode).
+- **Breaking for external references:** `context/agents/delegation-instructions.md` no longer
+  exists on `#369`'s branch. In-repo references were updated; bundles outside this repo that
+  `@`-mention the old path would break if B ever merges.
+
+## Capture root
+
+`/home/bkrabach/dev/openai-evals-team-ci/.amplifier/evaluation/treatment-validation/2026-09-06-8rug/`
+
+```
+A-before-raw-system-head.txt        A-after-raw-system-head.txt
+A-before-after-bundle-md-check.json A-after-body-instruction-check.json
+C-skills-discoverable.txt           B-estimator-before-after.txt
+B-root-prompt-before-after.txt      B-depth-reachable-from-agents.txt
+```

--- a/tests/test_tool_skills_double_mount.py
+++ b/tests/test_tool_skills_double_mount.py
@@ -1,0 +1,175 @@
+"""Pin the compose semantics of the tool-skills DOUBLE MOUNT.
+
+`tool-skills` is mounted twice in a foundation-root session:
+
+1. `behaviors/agents.yaml` mounts it to register foundation's OWN skills
+   directory (`config.skills` -> amplifier-foundation#subdirectory=skills).
+2. The root `bundle.md` includes
+   `amplifier-bundle-skills@main#subdirectory=behaviors/skills.yaml`, which
+   mounts the same module id with the curated collection plus `visibility`.
+
+Two mounts of one module id is only safe because `deep_merge` CONCATENATES
+list-typed config values instead of replacing them (added in 70d521f, PR #120,
+whose commit message names this exact silent-config-loss failure). If that
+behavior ever regresses to "later list replaces earlier list", ONE of the two
+skills directories is silently dropped and no error is raised anywhere -- the
+skills simply stop being discoverable.
+
+These tests assert the EFFECTIVE composed config, in both orders, so the
+regression is caught at the seam rather than in a user's session.
+
+Measured on main a0decc6: nothing is dropped. The double mount is a FINDING
+(a load-bearing dependency on list-concat semantics), not a defect.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from amplifier_foundation.bundle import Bundle
+
+REPO_ROOT = Path(__file__).parent.parent
+AGENTS_BEHAVIOR = REPO_ROOT / "behaviors" / "agents.yaml"
+
+FOUNDATION_SKILLS_SOURCE = (
+    "git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=skills"
+)
+CURATED_SKILLS_SOURCE = (
+    "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=skills"
+)
+TOOL_SKILLS_MODULE_SOURCE = (
+    "git+https://github.com/microsoft/amplifier-bundle-skills"
+    "@main#subdirectory=modules/tool-skills"
+)
+
+# Verbatim copy of the tool block of
+# amplifier-bundle-skills@main#subdirectory=behaviors/skills.yaml as read on
+# 2026-09-06. Inlined rather than fetched so this test stays hermetic (no
+# network, no cache dependency). If the upstream behavior changes shape, this
+# fixture is what needs updating -- and the mismatch is the point of the test.
+EXTERNAL_SKILLS_BEHAVIOR: dict[str, Any] = {
+    "bundle": {"name": "skills-behavior", "version": "1.0.0"},
+    "tools": [
+        {
+            "module": "tool-skills",
+            "source": TOOL_SKILLS_MODULE_SOURCE,
+            "config": {
+                "skills": [CURATED_SKILLS_SOURCE],
+                "visibility": {
+                    "enabled": True,
+                    "inject_role": "user",
+                    "visibility_token_budget": 5000,
+                    "ephemeral": True,
+                    "priority": 20,
+                },
+            },
+        }
+    ],
+}
+
+
+def _load_yaml_bundle(path: Path) -> Bundle:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return Bundle.from_dict(data, base_path=path.parent)
+
+
+def _tool_skills_entries(bundle: Bundle) -> list[dict[str, Any]]:
+    return [t for t in bundle.tools if t.get("module") == "tool-skills"]
+
+
+def _skills_config(bundle: Bundle) -> list[str]:
+    entries = _tool_skills_entries(bundle)
+    assert len(entries) == 1, f"expected exactly one tool-skills mount, got {entries}"
+    return list(entries[0].get("config", {}).get("skills", []))
+
+
+# =============================================================================
+# The declarations themselves (guards against a silent edit upstream of compose)
+# =============================================================================
+
+
+def test_agents_behavior_registers_foundation_skills_dir() -> None:
+    """behaviors/agents.yaml must still be the mount that owns foundation's skills."""
+    agents = _load_yaml_bundle(AGENTS_BEHAVIOR)
+    entries = _tool_skills_entries(agents)
+    assert len(entries) == 1, "behaviors/agents.yaml must mount tool-skills exactly once"
+    assert entries[0]["config"]["skills"] == [FOUNDATION_SKILLS_SOURCE]
+
+
+def test_both_mounts_agree_on_the_module_source() -> None:
+    """Module `source` is a SCALAR -- deep_merge lets the later mount win.
+
+    The two mounts are only order-insensitive because they name the SAME source.
+    If they ever diverge, whichever composes last silently wins and the other
+    declaration becomes dead text.
+    """
+    agents = _load_yaml_bundle(AGENTS_BEHAVIOR)
+    agents_source = _tool_skills_entries(agents)[0]["source"]
+    external_source = EXTERNAL_SKILLS_BEHAVIOR["tools"][0]["source"]
+    assert agents_source == external_source == TOOL_SKILLS_MODULE_SOURCE
+
+
+# =============================================================================
+# The effective composed config -- the thing a session actually mounts
+# =============================================================================
+
+
+def test_double_mount_keeps_both_skills_dirs_in_bundle_md_order() -> None:
+    """Root bundle.md order: behaviors/agents (line 27) BEFORE skills.yaml (line 33)."""
+    agents = _load_yaml_bundle(AGENTS_BEHAVIOR)
+    external = Bundle.from_dict(EXTERNAL_SKILLS_BEHAVIOR)
+
+    composed = agents.compose(external)
+
+    assert _skills_config(composed) == [
+        FOUNDATION_SKILLS_SOURCE,
+        CURATED_SKILLS_SOURCE,
+    ]
+
+
+def test_double_mount_keeps_both_skills_dirs_in_reverse_order() -> None:
+    """Order must not decide which skills directory survives."""
+    agents = _load_yaml_bundle(AGENTS_BEHAVIOR)
+    external = Bundle.from_dict(EXTERNAL_SKILLS_BEHAVIOR)
+
+    composed = external.compose(agents)
+
+    assert set(_skills_config(composed)) == {
+        FOUNDATION_SKILLS_SOURCE,
+        CURATED_SKILLS_SOURCE,
+    }
+
+
+def test_double_mount_preserves_visibility_config_from_the_curated_mount() -> None:
+    """A dict-typed config key contributed by only one mount must survive too."""
+    agents = _load_yaml_bundle(AGENTS_BEHAVIOR)
+    external = Bundle.from_dict(EXTERNAL_SKILLS_BEHAVIOR)
+
+    composed = agents.compose(external)
+    config = _tool_skills_entries(composed)[0]["config"]
+
+    assert config["visibility"]["enabled"] is True
+    assert config["visibility"]["visibility_token_budget"] == 5000
+
+
+def test_double_mount_collapses_to_a_single_module_entry() -> None:
+    """merge_module_lists keys by module id -- two declarations, one mount."""
+    agents = _load_yaml_bundle(AGENTS_BEHAVIOR)
+    external = Bundle.from_dict(EXTERNAL_SKILLS_BEHAVIOR)
+
+    composed = agents.compose(external)
+
+    assert len(_tool_skills_entries(composed)) == 1
+
+
+def test_duplicate_source_is_deduplicated_not_repeated() -> None:
+    """Composing a mount with itself must not double its skills list."""
+    agents = _load_yaml_bundle(AGENTS_BEHAVIOR)
+    twin = _load_yaml_bundle(AGENTS_BEHAVIOR)
+
+    composed = agents.compose(twin)
+
+    assert _skills_config(composed) == [FOUNDATION_SKILLS_SOURCE]


### PR DESCRIPTION
## What this fixes

**(A) Foundation's ROOT bundle body was 499 characters of documentation prose — and that prose was the system instruction.**

`docs/BUNDLE_GUIDE.md:138`:

> **Everything below the frontmatter is sent to the model as system instruction.** It is not documentation, and it is not free.
> ...
> Do **not** write a description of the bundle. That is what the frontmatter `description:` field is for — it is manifest metadata and is never sent to the model.

Root `bundle.md` carried a `# Foundation Bundle v2.0` title, a "Key Features" table, a delegate-parameter snippet and an MCP config sample below the frontmatter — *ahead of* `@foundation:context/shared/common-system-base.md`. So every foundation-root session opened its system prompt with product documentation.

This is the same defect class as the notify-README body that app-cli **#315** (`dab0f7c`) and **#316** (`1e47c38`) fixed. This is that defect in the composition base **every non-anchors bundle inherits**.

The prose is **not deleted** — it moves into the frontmatter `description:`. The body becomes the single `@mention` it should always have been.

**(C) The `tool-skills` double mount was measured before anything was touched. It is a finding, not a bug — no code changed.** Details below.

## (A) Fail-before / pass-after

Measured with the validator **fixed in `aaa5c47`** — its extractor previously returned an empty string that satisfied every check, so these counts are honest only now.

`check_body_is_instruction` on `bundle.md`:

| | verdict | prose_chars | reason |
|---|---|---|---|
| **main `a0decc6`** | `FLAG` | **499** | `no second-person address -- reads as documentation, not instruction` |
| **this branch** | `OK` | **0** | `body carries no prose (mentions/scaffolding only)` |

Flagged preview on main:

```
This bundle provides the standard Amplifier foundation with the enhanced delegate tool for agent orchestration.
| Feature | Description |
|---------|-------------|
| **Delegate tool** | Two-parameter ...
```

Repo-wide `body-instruction-check` (same code the recipe step runs, `validate-bundle-repo.yaml:4224`):

```json
main a0decc6 : {"files_checked": 32, "warnings": [{"type":"prose_below_frontmatter","file":"bundle.md","prose_chars":499}]}
this branch  : {"files_checked": 32, "warnings": []}
```

## (A) Real-session check — foundation as ROOT

`amplifier run "hi" --bundle foundation` from a scratch dir carrying a **project-scope** `.amplifier/settings.yaml` source override (`bundle.added.foundation: file://<worktree>`, `bundle.app: []`). **`~/.amplifier/cache` was not edited.**

`llm:request.data.raw.system[0].text`, head:

**Before** — session `5dfe9c07-d95d-41a8-815b-962c0ce5a0dd`, total **130,055** chars:

```
# Foundation Bundle v2.0

This bundle provides the standard Amplifier foundation with the enhanced delegate tool for agent orchestration.

## Key Features

| Feature | Description |
|---------|-------------|
| **Delegate tool** | Two-parameter context control (depth + scope) |
...
```

**After** — session `268a6e56-d64d-4958-9ea4-2c2bdfd94a2e`, total **129,178** chars:

```
@foundation:context/shared/common-system-base.md

---

<context_file paths="@foundation:context/shared/common-system-base.md → .../context/shared/common-system-base.md">
# Primary Core Instructions

You are Amplifier, an AI powered Microsoft CLI tool.
...
```

No feature table. The first content is common-system-base. (The bare `@mention` line itself remains — that is how mention expansion renders; the resolved file follows immediately.)

## (C) Compose-semantics finding — `tool-skills` is mounted twice

Full write-up: `docs/lanes/8rug-foundation-root-hygiene/C-compose-semantics-finding.md`.

**Measured first, per the spec. Verdict: nothing is silently dropped.**

- `behaviors/agents.yaml:36-40` contributes `config.skills: [amplifier-foundation#subdirectory=skills]`
- `bundle.md:33` → `amplifier-bundle-skills#subdirectory=behaviors/skills.yaml` contributes `config.skills: [amplifier-bundle-skills#subdirectory=skills]` + `config.visibility`

`Bundle.compose()` (`_dataclass.py:250`) → `merge_module_lists()` keys by `id or module`, so the two collapse to **one** mount, and `deep_merge()` resolves the config: dicts recurse, **lists concatenate with dedup**, scalars are replaced by the later value. Effective composed config:

```json
{"module":"tool-skills",
 "source":"...amplifier-bundle-skills@main#subdirectory=modules/tool-skills",
 "config":{"skills":["...amplifier-foundation@main#subdirectory=skills",
                     "...amplifier-bundle-skills@main#subdirectory=skills"],
           "visibility":{"enabled":true,...,"visibility_token_budget":5000}}}
```

Both orders keep both entries.

**Why a test was still warranted.** The double mount is safe *only* because of the list-concat rule added in `70d521f` (#120) — a rule invisible at both declaration sites, with **no failure signal** if it regresses (the skills just stop being discoverable). `tests/test_tool_skills_double_mount.py` pins it. Disabling list-concat in `deep_merge`:

```
FAILED tests/test_tool_skills_double_mount.py::test_double_mount_keeps_both_skills_dirs_in_bundle_md_order
FAILED tests/test_tool_skills_double_mount.py::test_double_mount_keeps_both_skills_dirs_in_reverse_order
2 failed, 5 passed
```

Restored: `7 passed`.

**Residual risk, recorded not fixed:** the two mounts are order-insensitive only because they name the **same `source`**. `source` is a scalar, so a future divergence means whichever composes last silently wins. `test_both_mounts_agree_on_the_module_source` turns that into a test failure instead of a session mystery.

## (C) Real-session check — foundation's skills are discoverable

Same session `268a6e56`, live `hooks-skills-visibility` list:

```
bundle-to-dot                  present=True   <- behaviors/agents.yaml mount (foundation skills dir)
creating-amplifier-modules     present=True   <- behaviors/agents.yaml mount (foundation skills dir)
per-repo-conventions           present=True   <- behaviors/agents.yaml mount (foundation skills dir)
image-vision                   present=True   <- bundle.md:33 skills.yaml mount (curated collection)
```

Both mounts reach the model.

## Tests

```
2038 passed, 3 skipped, 2 failed in 21.46s
```

Both failures are **pre-existing and reproduce unchanged on `a0decc6`** with this branch's changes stashed:

- `tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file`
- `tests/test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes`

## Spend

$0.14 — two `amplifier run "hi"` sessions on `haiku` for the real-session checks ($0.07 each). No DTUs, no ledger rows.

## Scope

This is PR 1 of 2 for `model_performance-8rug`. PR 2 carries **(B)** — the `delegation-instructions.md` split — and is gated on its own pre-registered eval. A and C are independent of that eval and land on verification.

---
Generated with Amplifier

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
