### PR TITLE
HELD (eval unfunded): split delegation context into a <500-token core + agent-body depth, and fix the 6.28x estimator understatement that hid it

### DIFF
--- a/agents/foundation-expert.md
+++ b/agents/foundation-expert.md
@@ -33,6 +33,9 @@ tools:
 
 # Foundation Expert (Navigator)
 
+@foundation:context/agents/delegation-depth.md
+@foundation:context/agents/multi-agent-patterns.md
+
 You are the **navigator for the Amplifier Foundation ecosystem**. You know what exists in foundation and help users find and understand the right resources. You have deep knowledge of:
 
 - What examples exist and which applies to a given situation

--- a/agents/session-analyst.md
+++ b/agents/session-analyst.md
@@ -39,6 +39,8 @@ tools:
 
 # Session Analyst
 
+@foundation:context/agents/delegation-depth.md
+
 ## ⛔ CRITICAL: events.jsonl Will Kill Your Session
 
 **READ THIS FIRST. THIS IS NOT A SUGGESTION.**

--- a/amplifier_foundation/bundle_docs/bundle_to_dot.py
+++ b/amplifier_foundation/bundle_docs/bundle_to_dot.py
@@ -819,8 +819,8 @@ def _short_path(ref: str) -> str:
 
     Examples::
 
-        _short_path("@foundation:context/agents/delegation-instructions.md")
-        # "delegation-instructions.md"
+        _short_path("@foundation:context/agents/delegation-depth.md")
+        # "delegation-depth.md"
         _short_path("foundation:context/file.md")
         # "file.md"
     """

--- a/behaviors/agents.yaml
+++ b/behaviors/agents.yaml
@@ -41,5 +41,9 @@ tools:
 
 context:
   include:
-    - foundation:context/agents/delegation-instructions.md
-    - foundation:context/agents/multi-agent-patterns.md
+    # AWARENESS ONLY -- 487 tokens on disk (len//4), the estimator's own unit.
+    # The DEPTH halves (delegation-depth.md, multi-agent-patterns.md, ~5,250 tokens
+    # together) are NOT loaded here. They are @-mentioned from the bodies of the
+    # agents that can act on them: foundation-expert (the only agent declaring
+    # tool-delegate) and session-analyst (the only agent that resumes sessions).
+    - foundation:context/agents/delegation-core.md

--- a/behaviors/tasks.yaml
+++ b/behaviors/tasks.yaml
@@ -15,5 +15,9 @@ tools:
 
 context:
   include:
-    - foundation:context/agents/delegation-instructions.md
-    - foundation:context/agents/multi-agent-patterns.md
+    # Same core file as behaviors/agents.yaml, deliberately: tool-task is a
+    # delegation-shaped tool (it spawns sub-agents), so the imperative and the
+    # triggers apply to it, and sharing one file makes drift between the two
+    # behaviors impossible. It gets no depth: tool-task exposes neither
+    # context_depth/context_scope nor session resumption.
+    - foundation:context/agents/delegation-core.md

--- a/context/agents/delegation-core.md
+++ b/context/agents/delegation-core.md
@@ -1,0 +1,40 @@
+# Delegation
+
+**You are an ORCHESTRATOR, not a worker.** Every tool call you make spends YOUR context
+permanently. An agent absorbs that cost and returns a summary. Direct tool use is for
+trivial one-shot operations. **Default: DELEGATE.**
+
+## Delegate immediately when
+
+| Trigger | Agent |
+|---|---|
+| Explore/survey/understand code, or read >2 files | `foundation:explorer` |
+| An error or bug is reported | `foundation:bug-hunter` |
+| Implementation from a complete spec | `foundation:modular-builder` |
+| Design or architecture | `foundation:zen-architect` |
+| Any git/gh operation, incl. finding repos | `foundation:git-ops` |
+| Session files (`events.jsonl`) | `foundation:session-analyst` |
+
+An agent description that says MUST, REQUIRED or ALWAYS for a domain is authoritative:
+delegate, do not attempt it yourself. Do not explain what you are about to do and then do
+it yourself — delegate first, then explain from the agent's findings. Relay key findings in
+your own response text; the user does not reliably see tool output.
+
+## Using the tool
+
+```python
+delegate(agent="foundation:explorer", instruction="Survey the auth module")
+```
+
+`agent="self"` spawns you as a sub-agent. Two independent context parameters:
+
+- **`context_depth`** — HOW MUCH: `"none"` (clean slate) · `"recent"` (default) · `"all"`
+- **`context_scope`** — WHICH: `"conversation"` (default) · `"agents"` (+ delegate results) · `"full"` (+ all tool results)
+
+Batch every independent delegation into ONE turn: calls in one turn run concurrently, calls
+in separate turns run sequentially. Say WHY, not just what — an agent writing a commit
+message or a design doc needs a semantic summary of what was accomplished and why.
+
+Depth — session resumption, reading a structured return, wave discipline, large session
+files — lives in `foundation:context/agents/delegation-depth.md` and
+`foundation:context/agents/multi-agent-patterns.md`, loaded by the agents that need them.

--- a/context/agents/delegation-depth.md
+++ b/context/agents/delegation-depth.md
@@ -1,73 +1,12 @@
-# Agent Delegation Instructions
+# Agent Delegation — Depth Reference
 
-This context provides agent orchestration capabilities. It is loaded via the `foundation:behaviors/agents` behavior.
+The awareness half of this material lives in `foundation:context/agents/delegation-core.md`,
+which the `foundation:behaviors/agents` behavior loads into every root session. This file is
+the DEPTH half: it is NOT loaded by the behavior. It is @-mentioned from the body of the
+agents whose work actually requires it — the ones that delegate onward or resume sessions.
 
----
-
-> **TL;DR: You are an ORCHESTRATOR, not a worker.**
-> 
-> Your job is to delegate to specialist agents and synthesize their results.
-> Direct tool use (file reads, grep, bash) should be RARE - only for trivial operations.
-> **Default behavior: DELEGATE. Exception: simple single-file lookup.**
-
----
-
-## The Delegation Imperative
-
-**Delegation is not optional - it is the PRIMARY operating mode.**
-
-Every tool call you make consumes tokens from YOUR context window. Long-running sessions degrade as context fills. The solution: **delegate aggressively**.
-
-### Token Conservation Through Delegation
-
-| Approach | Token Cost | Session Longevity |
-|----------|------------|-------------------|
-| Direct work (20 file reads) | ~20,000 tokens in YOUR context | Session degrades quickly |
-| Delegated work (same 20 reads) | ~500 tokens (summary only) | Session stays fresh |
-
-**The math is clear:** Delegation preserves your context for high-value orchestration while agents handle token-heavy exploration.
-
-### The Rule: Delegate First, Always
-
-Before attempting ANY of the following yourself, you MUST delegate:
-
-| Task Type | Delegate To | Why |
-|-----------|-------------|-----|
-| File exploration (>2 files) | `foundation:explorer` | Context sink |
-| Code understanding | `python-dev:code-intel` | Specialized tools |
-| Architecture/design | `foundation:zen-architect` | Philosophy context |
-| Implementation | `foundation:modular-builder` | Implementation patterns |
-| Debugging | `foundation:bug-hunter` | Hypothesis methodology |
-| Git operations | `foundation:git-ops` | Safety protocols |
-| Session analysis | `foundation:session-analyst` | Handles 100k+ token lines |
-
-### Signs You're Violating This
-
-- "Let me just check this file quickly..." → STOP. Delegate.
-- "I think I know the answer..." → STOP. Consult an expert agent first.
-- "This seems straightforward..." → It's not. Delegate.
-- Reading more than 2 files without delegation → STOP. Delegate.
-- Making architectural decisions without zen-architect → Invalid.
-
-**Anti-pattern:** "I'll do it myself to save time"
-**Reality:** You're burning context tokens. Delegation IS faster for session longevity.
-
-### Immediate Delegation Triggers
-
-When you encounter these situations, delegate IMMEDIATELY without hesitation:
-
-| Trigger | Action |
-|---------|--------|
-| User asks to explore/survey/understand code | `delegate(agent="foundation:explorer", ...)` |
-| User reports an error or bug | `delegate(agent="foundation:bug-hunter", ...)` |
-| User asks for implementation | `delegate(agent="foundation:modular-builder", ...)` |
-| User asks for design/architecture | `delegate(agent="foundation:zen-architect", ...)` |
-| Any git operation (commit, PR, push) | `delegate(agent="foundation:git-ops", ...)` |
-| User needs to find/discover repos (including private) | `delegate(agent="foundation:git-ops", ...)` — gh CLI sees private repos; web search cannot |
-| Need to read >2 files | `delegate(agent="foundation:explorer", ...)` |
-
-**Do NOT:** Explain what you're about to do, then do it yourself.
-**DO:** Delegate first, explain based on agent's findings.
+Read it if you are about to: resume an agent session, read a structured agent return,
+plan a wave of concurrent delegations, or touch a session file.
 
 ---
 
@@ -153,29 +92,6 @@ be excavated from prose:
 
 ---
 
-## Why Delegation Matters
-
-Agents as **context sinks** provide critical benefits:
-
-1. **Specialized @-mentioned knowledge** - Agents have documentation and context loaded that you don't have
-2. **Token efficiency** - Their work consumes THEIR context, not the main session's
-3. **Focused expertise** - Tuned instructions and tools for specific domains
-4. **Safety protocols** - Some agents (git-ops, session-analyst) have safeguards you lack
-
-**Example - Codebase exploration:**
-- Direct approach: 20 file reads = 20k tokens consumed in YOUR context
-- Delegated approach: 20 file reads in AGENT context, 500 token summary returned to you
-
-**Rule**: If a task will consume significant context, requires exploration, or matches an agent's domain, DELEGATE.
-
-### Session Longevity Depends on Delegation
-
-Your context window is finite. Every direct tool call, every file read, every search result consumes tokens that are permanently spent. Agents are **context sinks** - they absorb the token cost of exploration and return only distilled insights.
-
-**Think of it this way:** You are the orchestrator. Orchestrators dispatch specialists and synthesize results rather than reading every file themselves. The more you delegate, the longer your session can run effectively.
-
----
-
 ## Agent Domain Honoring
 
 **CRITICAL**: When an agent description states it MUST, REQUIRED, or ALWAYS be used for a specific domain, you MUST delegate to that agent rather than attempting the task directly.
@@ -199,12 +115,6 @@ Agent domain claims are authoritative. The agent descriptions contain expertise 
 ## Delegate Tool Usage
 
 The `delegate` tool spawns specialized agents for autonomous task handling.
-
-### Basic Delegation
-
-```python
-delegate(agent="foundation:explorer", instruction="Survey the authentication module")
-```
 
 ### Special Agent Values
 

--- a/context/understanding-mechanisms/designing-with-mechanisms.md
+++ b/context/understanding-mechanisms/designing-with-mechanisms.md
@@ -271,7 +271,7 @@ Your bundle's per-turn floor:
 
 | Component | Tokens | Source |
 |-----------|--------|--------|
-| Foundation context files (15+ files) | ~12,000 | `delegation-instructions.md`, `multi-agent-patterns.md`, `AWARENESS_INDEX.md`, philosophy files, etc. |
+| Foundation context files (15+ files) | ~12,000 | `delegation-core.md`, `delegation-depth.md`, `multi-agent-patterns.md`, `AWARENESS_INDEX.md`, philosophy files, etc. |
 | Systems-design content files (5 files) | ~4,000 | `instructions.md`, `system-design-principles.md`, `tradeoff-frame.md`, etc. |
 | Skills L1 visibility (~20 skills) | ~1,000 | One-line descriptions of all composed skills |
 | Active mode body (when in `/systems-design`) | ~1,000 | Mode markdown injected ephemerally |

--- a/docs/lanes/8rug-foundation-root-hygiene/B-eval-preregistration.md
+++ b/docs/lanes/8rug-foundation-root-hygiene/B-eval-preregistration.md
@@ -1,0 +1,186 @@
+# (B) Pre-registration — delegation context split, before/after eval
+
+**Written 2026-09-06, BEFORE any file in the split was edited.** Committed on its own, ahead of
+the implementation commit, so the decision rule provably predates the numbers. Nothing in this
+document may be edited after results exist (goal SCOPE-OUT: "Do NOT edit the decision rule after
+seeing results").
+
+Work item: `model_performance-8rug` part (B). Branch: `lane/8rug-foundation-root-hygiene-b`.
+
+---
+
+## 1. The treatment
+
+`behaviors/agents.yaml` and `behaviors/tasks.yaml` each `context.include`
+`delegation-instructions.md` + `multi-agent-patterns.md` — **6,276 tokens (len//4) / 5,402 tokens
+(o200k_base)** measured on disk at `a0decc6`, loaded into the root system prompt of every
+foundation-root session.
+
+The split (owner-approved shape, from the work item):
+
+- `context/agents/delegation-core.md` — **awareness only**, target **<500 tokens on disk**:
+  the delegation imperative, immediate triggers, basic `delegate` usage, the two context
+  parameters. **The root session IS the delegator and needs these.** Stays in
+  `behaviors/agents.yaml`.
+- `context/agents/delegation-depth.md` — **depth**: session-resumption mechanics, wave discipline,
+  reading a structured agent return, large session-file handling, scrutinising an agent's "N/A",
+  the context-sink pattern itself. Loaded from the **bodies of the agents that need it**, not from
+  the behavior.
+- `context/agents/multi-agent-patterns.md` — same triage: its awareness line ("batch independent
+  work into one turn") folds into the core; the rest stays a depth file loaded from agent bodies.
+
+Depth is deferred to exactly the agents whose work requires it:
+
+| Agent | Why it needs depth |
+|---|---|
+| `foundation-expert` | The **only** foundation agent that declares `tool-delegate` (the behavior sets `exclude_tools: [tool-delegate]`, so no other spawned agent can delegate at all). It is the only sub-agent that ever fans out, so wave discipline and the two context parameters are live for it. |
+| `session-analyst` | The **only** agent that resumes sessions by `session_id` and reads large session files — the two depth sections written for exactly that. |
+
+No other agent in `agents/` can delegate or resume, so loading depth into them would be paying for
+instruction they cannot act on.
+
+`behaviors/tasks.yaml` (legacy `tool-task` compatibility) references **the same core file**, not
+the full list. Justification: `tool-task` *is* a delegation-shaped tool — it spawns sub-agents — so
+the imperative and the triggers apply to it; and pointing both behaviors at one file makes drift
+between them impossible. It does not get depth, because `tool-task` exposes neither
+`context_depth`/`context_scope` nor session resume.
+
+---
+
+## 2. Instrument repair (part of the treatment, per the work item)
+
+The validator's behavior-hygiene Rule 4 (`recipes/validate-bundle-repo.yaml:1960-2000`) reports
+**~1,000 tokens** for these two includes. The true on-disk figure is **6,276**. The understatement
+is **6.28×**, and its mechanism is now identified exactly:
+
+```python
+if include_ref.startswith("@"):
+    total_context_tokens += 500          # "Estimate ~500 tokens per awareness file"
+else:
+    include_path = behavior_path.parent / include_ref
+    if not include_path.exists():
+        include_path = path / include_ref
+    ...
+    else:
+        total_context_tokens += 500      # Default estimate
+```
+
+`foundation:context/agents/delegation-instructions.md` is a **`<namespace>:<path>` reference**. It
+does not start with `@`, so it takes the relative-path branch; neither
+`behaviors/foundation:context/...` nor `<repo>/foundation:context/...` exists, so it falls through
+to the flat **500-token default**. Two includes × 500 = **exactly 1,000** — and the ERROR gate is
+`> 1000`, so the behavior lands precisely **on** the boundary and is reported as a WARNING rather
+than the ERROR it actually is.
+
+Reproduced verbatim against this repo at `a0decc6`:
+
+```
+behaviors/agents.yaml: includes=2 context_total_tokens=1000 -> WARNING
+behaviors/tasks.yaml:  includes=2 context_total_tokens=1000 -> WARNING
+```
+
+**The fix is part of (B)**: resolve `<namespace>:<path>` references against the repo root when the
+namespace is the repo's own bundle, so the estimator reads the real file. Without it the
+measurement that justifies the split is taken with a ruler already known to be wrong by 6×.
+
+Measured token figures used throughout, all from the same script, both methods reported because
+`len//4` is the validator's own estimator and `o200k_base` is a real tokenizer:
+
+| file | chars | `len//4` | o200k_base | cl100k_base |
+|---|---|---|---|---|
+| `delegation-instructions.md` | 16,897 | 4,224 | 3,628 | 3,664 |
+| `multi-agent-patterns.md` | 8,210 | 2,052 | 1,774 | 1,802 |
+| **total** | 25,107 | **6,276** | **5,402** | 5,466 |
+
+---
+
+## 3. The eval — design, fixed before any result exists
+
+| | |
+|---|---|
+| **Task set** | S3-class multi-step scenarios, reusing the program's existing S3 scenarios in `amplifier-bundle-evaluation`. No new scenarios. |
+| **Bundle** | foundation as ROOT, pinned per arm by source override, run in DTUs. |
+| **Arms** | **A = `main`** (`a0decc6`) · **B = `lane/8rug-foundation-root-hygiene-b`** |
+| **Providers** | both — anthropic **opus-5** root, openai **gpt-5.6-terra** root |
+| **n** | **≥3 valid runs per arm per provider** → **12 valid runs minimum** |
+| **Primary metric** | task success **and** delegation-count sanity |
+| **Secondary** | root-prompt tokens, $/task |
+| **Arm-purity rule** | a mixed arm-pair is VOID, no rescue argument (program convention, §(n) of `00-what-we-know.md`) |
+
+### Decision rule (frozen)
+
+> **SHIP if — and only if — success LB ≥ −5 pp AND delegation count is within ±30 % of main.**
+
+Both conditions must hold. Either one failing means **B does not merge**: the branch stays, the
+finding is written, and A and C are unaffected.
+
+Delegation count is two-sided **on purpose**. Moving depth out of the root prompt could plausibly
+fail in either direction — suppressing legitimate delegation (the root forgets to fan out) *or*
+causing over-delegation (the root delegates without the wave discipline that told it to batch).
+A one-sided gate would score one of those failures as a pass.
+
+### Known evaluability risk, recorded before spending
+
+`otr` (§(m), `00-what-we-know.md`) had a pre-registered gate come back **UNEVALUABLE** because
+delegation counts at its cell were `[0,0,1,0,0]` — an ~80 % prior chance of being unevaluable,
+readable for $0 beforehand. The same risk applies here: **if the S3 arm-A runs produce a median
+delegation count of 0, the ±30 % condition is unevaluable**, and the honest report is
+"unevaluable", not a retrofitted substitute gate. This is stated now, before any run.
+
+---
+
+## 4. Price the deliverable BEFORE spending
+
+Goal authority for (B): **$10, eval only.**
+
+Per-run prices, from this program's own observations (`ai-notes/00-what-we-know.md`, and the
+goal's own arithmetic block):
+
+| source | figure |
+|---|---|
+| goal text, program-observed | sonnet **~$2.29/run**, terra **~$4.63/run** |
+| §S3 Pareto | opus-5 S3 **$3.53/run**; sonnet5-medium $2.20; terra-medium $1.55 |
+| §(m) `otr` | one arm-B run **$2.62** |
+| §(l) `5zp` | 2 fresh valid runs for **$10.99** ⇒ **~$5.50 per VALID run** |
+| observed validity | **67 %** (`5zp`'s correction of `h6v`: 2 of 3 launches valid) |
+
+Applying the goal's own authoring rule — `runs × arms × per-run estimate / validity rate = cap`:
+
+```
+Pre-registered design = 3 runs × 2 arms × 2 providers = 12 VALID runs
+
+launches needed          = 12 / 0.67                       = 18 launches (9 anthropic, 9 terra)
+anthropic @ opus-5 $3.53 = 9 × $3.53                       = $31.77
+openai    @ terra  $4.63 = 9 × $4.63                       = $41.67
+                                                     TOTAL = $73.44   vs $10 authority
+
+Even at 100% validity (12 launches, no failures at all):
+   6 × $3.53 + 6 × $4.63 = $21.18 + $27.78                 = $48.96   vs $10 authority
+Even at the goal's cheaper sonnet figure, 100% validity:
+   6 × $2.29 + 6 × $4.63 = $13.74 + $27.78                 = $41.52   vs $10 authority
+```
+
+**The arithmetic does not close, by 4×–7×.** The goal states this itself ("a full 12-run design
+would be ~$41 and does NOT fit").
+
+**What $10 could actually buy, and why it is not worth buying.** At the cheapest observed rate
+($2.62/run) $10 buys **3 launches ⇒ ~2 valid runs at 67 % validity** — i.e. **n=1 per arm on ONE
+provider**. n=1 per arm cannot produce a lower bound on success at all, so it cannot evaluate the
+frozen rule's first condition; and a single delegation count per arm cannot support a ±30 %
+comparison. Spending it would produce a number with a **0 % chance of satisfying the
+pre-registered rule** — the exact failure the goal names against lane `1ru`.
+
+**Therefore: the eval is recorded NOT-POSSIBLE at this authority, stated before spending, and $0
+is spent on it.** The authority that WOULD close it is **$73.44** at the pre-registered n≥3 /
+2 arms / 2 providers with the observed 67 % validity rate (**$48.96** if every launch is valid;
+**~$41.52** if the anthropic arm is run on sonnet rather than the specified opus-5).
+
+Shrinking the design and reporting it as the pre-registered one is the failure mode this
+pre-registration exists to prevent, so it is not done.
+
+### What IS delivered at $0
+
+The code half of (B) — the split, the depth routing, the `tasks.yaml` decision, and the estimator
+repair — is code and on-disk measurement, costs nothing, and is delivered. **PR 2 ships as a DRAFT
+and is NOT marked ready**: this pre-registration's rule has not been satisfied, so B does not
+merge. A and C (PR 1) are unaffected.

--- a/docs/lanes/8rug-foundation-root-hygiene/B-measurements.md
+++ b/docs/lanes/8rug-foundation-root-hygiene/B-measurements.md
@@ -1,0 +1,138 @@
+# (B) Measurements — what the split actually did, and what remains unmeasured
+
+Companion to `B-eval-preregistration.md` (committed first, before any of this existed).
+
+**Status: the code half is DONE and measured. The EVAL half is NOT-POSSIBLE at the $10
+authority, priced before spending. PR 2 stays a DRAFT and is not marked ready.**
+
+---
+
+## 1. What was executed
+
+- The split: `delegation-core.md` (new) + `delegation-depth.md` (renamed from
+  `delegation-instructions.md`, awareness removed) + `multi-agent-patterns.md` (unchanged,
+  now agent-body-loaded).
+- `behaviors/agents.yaml` and `behaviors/tasks.yaml` rewired to the core alone.
+- Depth @-mentioned from `agents/foundation-expert.md` and `agents/session-analyst.md`.
+- The validator's context-token estimator repaired (`validate-bundle-repo` v3.14.0).
+- 33 new tests in `tests/test_behavior_context_budget.py` (12 of them fail on `main`).
+- 3 real foundation-root sessions ($0.20 total, `haiku`) measuring the root prompt
+  before/after.
+- Full suite: **2,064 passed**, 2 known pre-existing failures.
+
+## 2. On-disk token measurement
+
+The validator's own unit is `len(content) // 4`; `o200k_base` is a real tokenizer, reported
+alongside it so the estimator's bias is visible rather than assumed.
+
+| file | chars | `len//4` | o200k_base |
+|---|---:|---:|---:|
+| **before** `delegation-instructions.md` | 16,897 | 4,224 | 3,628 |
+| **before** `multi-agent-patterns.md` | 8,210 | 2,052 | 1,774 |
+| **before — loaded by the behavior** | 25,107 | **6,276** | **5,402** |
+| **after** `delegation-core.md` (loaded by the behavior) | 1,951 | **487** | **464** |
+| **after** `delegation-depth.md` (agent bodies only) | 12,786 | 3,196 | 2,722 |
+| **after** `multi-agent-patterns.md` (agent bodies only) | 8,210 | 2,052 | 1,774 |
+
+The core is **under 500 tokens by both measures**, which is the goal's stated target.
+
+## 3. The estimator was wrong by 6.28×, and the fix is what makes the fail-before honest
+
+`recipes/validate-bundle-repo.yaml` behavior-hygiene Rule 4 resolved a `context.include`
+two ways only: a leading `@` was charged a flat 500 tokens; anything else was tried as a
+relative path. A `<namespace>:<path>` reference matches **neither** — it does not start with
+`@`, and neither `behaviors/foundation:context/...` nor `<repo>/foundation:context/...`
+exists — so it fell through to the 500-token default.
+
+Two includes × 500 = **exactly 1000**, against a `> 1000` ERROR gate. A behavior carrying
+6,276 real tokens was reported as 1000 and graded **WARNING — one token below the ERROR that
+was true.**
+
+```
+### MAIN a0decc6 (fail-before)
+  behaviors/agents.yaml: includes=2
+      OLD estimator:  1000 tokens -> WARNING
+      NEW estimator:  6276 tokens -> ERROR
+  behaviors/tasks.yaml: includes=2
+      OLD estimator:  1000 tokens -> WARNING
+      NEW estimator:  6276 tokens -> ERROR
+
+### BRANCH (pass-after)
+  behaviors/agents.yaml: includes=1
+      OLD estimator:   500 tokens -> ok
+      NEW estimator:   487 tokens -> ok
+  behaviors/tasks.yaml: includes=1
+      OLD estimator:   500 tokens -> ok
+      NEW estimator:   487 tokens -> ok
+```
+
+The fix also records any include it still cannot resolve, in
+`context_unresolved_includes` + `context_tokens_is_estimate`. A flat guess folded silently
+into a number that reads as measured is the defect; the fallback itself is fine as long as
+it is visible.
+
+## 4. Real-session effect — foundation as ROOT
+
+Project-scope source override; `~/.amplifier/cache` untouched.
+
+```
+### BEFORE (main a0decc6)  session 5dfe9c07-d95d-41a8-815b-962c0ce5a0dd
+    raw.system[0].text chars = 130,055
+      PRESENT  core: 'You are an ORCHESTRATOR, not a worker.'
+      PRESENT  depth: '## Wave Discipline'
+      PRESENT  depth: '## The Context Sink Pattern'
+      PRESENT  depth: 'Reading a Structured Agent Return'
+      PRESENT  depth: 'Multi-Agent Patterns'
+### AFTER  (branch B, split)  session eb36571b-b9c4-4667-a833-6990fb349e51
+    raw.system[0].text chars = 106,655
+      PRESENT  core: 'You are an ORCHESTRATOR, not a worker.'
+      ABSENT   depth: '## Wave Discipline'
+      ABSENT   depth: '## The Context Sink Pattern'
+      ABSENT   depth: 'Reading a Structured Agent Return'
+      ABSENT   depth: 'Multi-Agent Patterns'
+
+Delta: -23,400 chars in the root system prompt
+Provider-reported input tokens: 52,741 -> 47,014  (-5,727)
+```
+
+Depth stays reachable from the agents it was routed to:
+
+```
+### agents/foundation-expert.md
+    RESOLVES  @foundation:context/agents/delegation-depth.md  (13,378 bytes)
+    RESOLVES  @foundation:context/agents/multi-agent-patterns.md  (8,272 bytes)
+### agents/session-analyst.md
+    RESOLVES  @foundation:context/agents/delegation-depth.md  (13,378 bytes)
+```
+
+## 5. What is NOT measured — and why nothing was bought
+
+**−5,727 root-prompt tokens is a SECONDARY metric.** The pre-registered PRIMARY metric is
+task success + delegation-count sanity, and it is **not measured**. Moving wave discipline
+and the context-sink pattern out of the root prompt could plausibly suppress legitimate
+delegation or cause over-delegation, and nothing here tests either.
+
+The design that would test it — n≥3 valid runs per arm per provider, 2 arms, 2 providers,
+12 valid runs — prices at **$73.44** at the observed 67 % validity rate (18 launches:
+9 × $3.53 opus-5 + 9 × $4.63 terra), **$48.96** even at 100 % validity. The authority is
+**$10**. What $10 buys — ~2 valid runs, n=1 per arm on one provider — cannot produce a
+success lower bound, so it cannot evaluate the frozen rule at all: a **0 % chance** of
+landing the deliverable. Priced on first read of the goal; **$0 spent on the eval**.
+
+**Therefore B is not shippable on this branch's evidence.** PR 2 is a draft and is not
+marked ready. The branch and the finding stand; PR 1 (A + C) is unaffected and independent.
+
+## 6. Note for whoever funds the eval
+
+Recorded before results exist, so it cannot be read as an excuse afterwards: `otr`'s
+pre-registered gate came back **UNEVALUABLE** because delegation counts at its cell were
+`[0,0,1,0,0]`. If the arm-A S3 runs here produce a median delegation count of 0, the ±30 %
+condition is likewise unevaluable and the honest report is "unevaluable" — not a substitute
+gate invented after the fact.
+
+## 7. One compatibility note
+
+`context/agents/delegation-instructions.md` **no longer exists** — it is
+`delegation-depth.md`. Any bundle outside this repo that `@`-mentions the old path will stop
+resolving. In-repo references were all updated. This is a real consequence of the treatment
+and is called out here rather than discovered downstream.

--- a/experiments/exp-lean/README.md
+++ b/experiments/exp-lean/README.md
@@ -30,7 +30,7 @@ Minimal infrastructure -- core tools, delegate, skills, UX hooks. No modes, no e
 | Todo hooks (reminder, display, session naming) | Yes |
 | Modes (brainstorm, debug, verify, etc.) | No |
 | Expert consultants (amplifier, core, foundation) | No |
-| Heavy context docs (delegation-instructions, multi-agent-patterns) | No |
+| Heavy context docs (delegation-depth, multi-agent-patterns) | No |
 | Design intelligence, browser-tester, terminal-tester | No |
 | Recipes, superpowers, routing-matrix | No |
 

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -1,9 +1,32 @@
 # validate-bundle-repo.yaml
-# Repository-Wide Bundle Validator Recipe v3.13.0
+# Repository-Wide Bundle Validator Recipe v3.14.0
 # Validates an entire bundle repository against structural requirements, conventions,
 # and Amplifier bundle philosophy (context sink pattern, thin behaviors, tool placement)
 #
 # CHANGELOG:
+# v3.14.0 - THE CONTEXT-TOKEN ESTIMATOR UNDERSTATED BY 6.28x, AND LANDED
+#          EXACTLY ON ITS OWN ERROR BOUNDARY WHILE DOING IT.
+#          behavior-hygiene Rule 4 resolved a context.include only two ways:
+#          a leading "@" was charged a flat 500 tokens, anything else was
+#          tried as a relative path. A `<namespace>:<path>` include --
+#          `foundation:context/agents/delegation-instructions.md`, the form
+#          this repo's own behaviors use -- matches NEITHER: it does not
+#          start with "@", and neither `behaviors/foundation:context/...`
+#          nor `<repo>/foundation:context/...` exists. So it fell through to
+#          the flat 500-token default.
+#          behaviors/agents.yaml has two such includes. 2 x 500 = EXACTLY
+#          1000, against a `> 1000` ERROR gate -- so 6,276 real on-disk
+#          tokens were reported as 1000 and graded WARNING, one token below
+#          the ERROR that was true. The measurement that would justify
+#          splitting that context was being taken with a ruler wrong by 6x.
+#          FIX: strip an optional "@" and, for a `<namespace>:<path>` ref,
+#          also try the path part against the behavior dir and the repo
+#          root. When the file is in THIS repo, read it. When it genuinely
+#          is not, keep the 500 fallback but RECORD the include in
+#          `context_unresolved_includes` and set `context_tokens_is_estimate`
+#          -- an unknown folded silently into a number that reads as
+#          measured is the defect, not the fallback itself.
+#
 # v3.13.0 - THE VALIDATOR COULD NOT FAIL ON A BROKEN AGENT AT ALL.
 #          `agent-description-validation`'s `extract_description()` returned
 #          an EMPTY STRING for six different conditions -- unreadable file,
@@ -384,6 +407,12 @@
 # TOKEN ESTIMATION:
 # All size measurements use tokens estimated as: len(content) // 4
 # This provides consistent sizing regardless of line length variations.
+# len//4 runs ~16% HIGH against o200k_base on this repo's markdown
+# (6,276 vs 5,402 for the two files that motivated v3.14.0), so it is
+# conservative in the right direction for a budget gate. What is NOT
+# acceptable is a flat per-file guess standing in for a file this repo can
+# actually read -- see v3.14.0. A behavior whose count includes any such
+# guess is flagged with `context_tokens_is_estimate`.
 
 # --- Dependency manifest (contract: recipe-dependency-manifest.v1) ----------
 # schema_version 2 makes this recipe portable: every `agent:` reference below
@@ -461,7 +490,7 @@ description: |
   - All measurements use TOKENS (len/4), never line counts
   
   For single bundle validation, use validate-bundle.yaml instead.
-version: "3.13.0"
+version: "3.14.0"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "repository", "packaging", "hygiene", "context-sink"]
 
@@ -1966,32 +1995,67 @@ steps:
               total_context_tokens = 0
               if context_includes:
                   detail["context_include_count"] = len(context_includes)
-                  
+                  unresolved_includes = []
+
+                  # v3.14.0 (8rug): resolve `<namespace>:<path>` includes instead of
+                  # charging them a flat 500.
+                  #
+                  # `foundation:context/agents/delegation-instructions.md` does NOT start
+                  # with "@", so it used to take the relative-path branch, where neither
+                  # `behaviors/foundation:context/...` nor `<repo>/foundation:context/...`
+                  # exists -- so it fell through to the flat 500-token default. Two such
+                  # includes summed to EXACTLY 1000 against a `> 1000` ERROR gate, so a
+                  # behavior carrying 6,276 real tokens (measured on disk) landed on the
+                  # boundary and was reported as a WARNING. A 6.28x understatement, with
+                  # the gate reading it as almost-fine.
+                  #
+                  # An include of the form `[@]<namespace>:<relative/path>` names a path
+                  # inside SOME bundle. When that path exists in THIS repo it is this
+                  # repo's own file, and reading it is strictly better than guessing. When
+                  # it does not, the 500-token fallback still applies -- but the include is
+                  # now RECORDED as unresolved, so the estimate's blind spots are visible
+                  # instead of silent.
+                  def _candidate_relpaths(ref: str) -> list[str]:
+                      ref = ref[1:] if ref.startswith("@") else ref
+                      candidates = [ref]
+                      # `<namespace>:<path>` -- but not a URL scheme like `git+https://`
+                      if ":" in ref and "//" not in ref:
+                          namespace, _, rel = ref.partition(":")
+                          if namespace and rel and "/" not in namespace:
+                              candidates.append(rel)
+                      return candidates
+
                   # Estimate tokens for each included file
                   for include_ref in context_includes:
                       if isinstance(include_ref, str):
-                          # Try to resolve and read the file
-                          include_path = None
-                          if include_ref.startswith("@"):
-                              # Bundle reference - can't easily resolve without registry
-                              # Estimate ~500 tokens per awareness file
-                              total_context_tokens += 500
+                          resolved_path = None
+                          for rel in _candidate_relpaths(include_ref):
+                              for base in (behavior_path.parent, path):
+                                  candidate = base / rel
+                                  if candidate.exists() and candidate.is_file():
+                                      resolved_path = candidate
+                                      break
+                              if resolved_path:
+                                  break
+
+                          if resolved_path is not None:
+                              try:
+                                  content = resolved_path.read_text(encoding="utf-8", errors="replace")
+                                  total_context_tokens += estimate_tokens(content)
+                              except Exception:
+                                  total_context_tokens += 500  # Default estimate
+                                  unresolved_includes.append(include_ref)
                           else:
-                              # Relative path
-                              include_path = behavior_path.parent / include_ref
-                              if not include_path.exists():
-                                  include_path = path / include_ref
-                              
-                              if include_path and include_path.exists():
-                                  try:
-                                      content = include_path.read_text()
-                                      total_context_tokens += estimate_tokens(content)
-                                  except:
-                                      total_context_tokens += 500  # Default estimate
-                              else:
-                                  total_context_tokens += 500
-                  
+                              # Genuinely outside this repo (another bundle's namespace).
+                              # Flat estimate -- and say so, rather than folding an
+                              # unknown into a number that reads as measured.
+                              total_context_tokens += 500
+                              unresolved_includes.append(include_ref)
+
                   detail["context_total_tokens"] = total_context_tokens
+                  if unresolved_includes:
+                      detail["context_unresolved_includes"] = unresolved_includes
+                      detail["context_tokens_is_estimate"] = True
                   
                   # ERROR: >1000 tokens (tightened 2026-05-17 per
                   # foundation/docs/BUNDLE_GUIDE.md §"Behavior context.include Policy"

--- a/tests/test_behavior_context_budget.py
+++ b/tests/test_behavior_context_budget.py
@@ -1,0 +1,192 @@
+"""Guard the delegation awareness/depth split, and the estimator that measures it.
+
+`behaviors/agents.yaml` and `behaviors/tasks.yaml` used to `context.include` the full
+`delegation-instructions.md` + `multi-agent-patterns.md` — **6,276 tokens on disk (len//4)**,
+loaded into the root system prompt of every foundation-root session.
+
+The validator did not catch it. Its behavior-hygiene Rule 4 resolved an include only two
+ways: a leading `@` was charged a flat 500, anything else was tried as a relative path. A
+`<namespace>:<path>` reference — the form these behaviors actually use — matched neither, so
+it fell through to the 500-token default. Two includes × 500 = **exactly 1000**, against a
+`> 1000` ERROR gate: 6,276 real tokens were reported as 1000 and graded WARNING, one token
+under the ERROR that was true.
+
+These tests measure the real files, so the budget cannot be satisfied by an estimator's
+blind spot.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+BEHAVIORS = REPO_ROOT / "behaviors"
+
+# The validator's own unit (`len(content) // 4`), so this guard and
+# `recipes/validate-bundle-repo.yaml` cannot disagree about what a token is.
+ERROR_BUDGET = 1000  # validator: context_tokens_excessive
+AWARENESS_BUDGET = 500  # validator: lightweight awareness only
+
+CORE = "context/agents/delegation-core.md"
+DEPTH = "context/agents/delegation-depth.md"
+PATTERNS = "context/agents/multi-agent-patterns.md"
+
+# The agents the split routes depth to, and the property that earns each one.
+DEPTH_AGENTS = {
+    "agents/foundation-expert.md": "the only agent that declares tool-delegate",
+    "agents/session-analyst.md": "the only agent that resumes sessions by session_id",
+}
+
+
+def _estimate_tokens(content: str) -> int:
+    return len(content) // 4
+
+
+def _resolve_include(behavior_path: Path, ref: str) -> Path | None:
+    """Resolve an include the way validate-bundle-repo v3.14.0 does."""
+    ref = ref[1:] if ref.startswith("@") else ref
+    candidates = [ref]
+    if ":" in ref and "//" not in ref:
+        namespace, _, rel = ref.partition(":")
+        if namespace and rel and "/" not in namespace:
+            candidates.append(rel)
+    for rel in candidates:
+        for base in (behavior_path.parent, REPO_ROOT):
+            candidate = base / rel
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+def _context_includes(behavior_path: Path) -> list[str]:
+    data = yaml.safe_load(behavior_path.read_text(encoding="utf-8")) or {}
+    context = data.get("context")
+    if not isinstance(context, dict):
+        return []
+    return [ref for ref in context.get("include", []) if isinstance(ref, str)]
+
+
+def _behavior_context_tokens(behavior_path: Path) -> tuple[int, list[str]]:
+    total = 0
+    unresolved: list[str] = []
+    for ref in _context_includes(behavior_path):
+        resolved = _resolve_include(behavior_path, ref)
+        if resolved is None:
+            total += 500
+            unresolved.append(ref)
+        else:
+            total += _estimate_tokens(resolved.read_text(encoding="utf-8"))
+    return total, unresolved
+
+
+BEHAVIOR_FILES = sorted(BEHAVIORS.glob("*.yaml"))
+
+
+# =============================================================================
+# The files
+# =============================================================================
+
+
+def test_core_file_exists_and_is_awareness_sized() -> None:
+    core = REPO_ROOT / CORE
+    assert core.is_file(), f"{CORE} must exist -- it is what the behaviors load"
+    tokens = _estimate_tokens(core.read_text(encoding="utf-8"))
+    assert tokens < AWARENESS_BUDGET, (
+        f"{CORE} is {tokens} tokens (len//4); the awareness budget is "
+        f"<{AWARENESS_BUDGET}. Move material to {DEPTH}, do not raise this number."
+    )
+
+
+def test_depth_files_exist() -> None:
+    for rel in (DEPTH, PATTERNS):
+        assert (REPO_ROOT / rel).is_file(), f"{rel} must exist -- agents @-mention it"
+
+
+# =============================================================================
+# The behaviors
+# =============================================================================
+
+
+@pytest.mark.parametrize("behavior", BEHAVIOR_FILES, ids=lambda p: p.name)
+def test_no_behavior_exceeds_the_error_budget(behavior: Path) -> None:
+    """Every include is measured from disk, not charged a flat guess."""
+    tokens, unresolved = _behavior_context_tokens(behavior)
+    assert tokens <= ERROR_BUDGET, (
+        f"{behavior.name} context.include is {tokens} tokens (len//4), over the "
+        f"{ERROR_BUDGET}-token ERROR gate. Unresolved (flat-500) includes: {unresolved}"
+    )
+
+
+@pytest.mark.parametrize("behavior", ["agents.yaml", "tasks.yaml"])
+def test_delegation_behaviors_carry_only_the_core(behavior: str) -> None:
+    path = BEHAVIORS / behavior
+    includes = _context_includes(path)
+    assert includes == [f"foundation:{CORE}"], (
+        f"behaviors/{behavior} must load the awareness core and nothing else; got {includes}"
+    )
+    tokens, unresolved = _behavior_context_tokens(path)
+    assert not unresolved, f"behaviors/{behavior} has unresolvable includes: {unresolved}"
+    assert tokens < AWARENESS_BUDGET, f"behaviors/{behavior} is {tokens} tokens (len//4)"
+
+
+@pytest.mark.parametrize("behavior", BEHAVIOR_FILES, ids=lambda p: p.name)
+def test_no_behavior_loads_a_depth_file(behavior: Path) -> None:
+    """Depth belongs in agent bodies. A behavior loading it puts it in every root session."""
+    for ref in _context_includes(behavior):
+        for depth_rel in (DEPTH, PATTERNS):
+            assert depth_rel not in ref, (
+                f"{behavior.name} loads {depth_rel} into the root prompt. "
+                f"@-mention it from the agent bodies that need it instead."
+            )
+
+
+# =============================================================================
+# The routing -- depth must actually be reachable
+# =============================================================================
+
+
+@pytest.mark.parametrize("agent_rel,why", sorted(DEPTH_AGENTS.items()))
+def test_depth_is_reachable_from_the_agents_that_need_it(agent_rel: str, why: str) -> None:
+    body = (REPO_ROOT / agent_rel).read_text(encoding="utf-8")
+    assert f"@foundation:{DEPTH}" in body, (
+        f"{agent_rel} ({why}) must @-mention {DEPTH}; otherwise the depth material "
+        f"is unreachable from any session after the split."
+    )
+
+
+def test_multi_agent_patterns_is_reachable_from_the_delegating_agent() -> None:
+    body = (REPO_ROOT / "agents/foundation-expert.md").read_text(encoding="utf-8")
+    assert f"@foundation:{PATTERNS}" in body
+
+
+def test_the_only_agent_declaring_tool_delegate_is_the_one_we_routed_depth_to() -> None:
+    """If another agent gains tool-delegate, this split's routing needs revisiting."""
+    declaring = sorted(
+        p.name
+        for p in (REPO_ROOT / "agents").glob("*.md")
+        if "tool-delegate" in p.read_text(encoding="utf-8")
+    )
+    assert declaring == ["foundation-expert.md"], (
+        f"agents declaring tool-delegate changed to {declaring}; the delegation-depth "
+        f"routing in behaviors/agents.yaml assumes foundation-expert is the only one."
+    )
+
+
+# =============================================================================
+# The estimator -- the guard and the validator must measure the same way
+# =============================================================================
+
+
+def test_validator_resolves_namespace_qualified_includes() -> None:
+    recipe = (REPO_ROOT / "recipes" / "validate-bundle-repo.yaml").read_text(encoding="utf-8")
+    assert "_candidate_relpaths" in recipe, (
+        "validate-bundle-repo must resolve `<namespace>:<path>` includes; without it a "
+        "6,276-token behavior is reported as 1000 and graded WARNING."
+    )
+    assert "context_unresolved_includes" in recipe, (
+        "an include that still falls back to the flat 500 must be recorded, not folded "
+        "silently into a number that reads as measured."
+    )

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -183,7 +183,7 @@ class TestResolveLocalMention:
     def test_real_repo_mention(self) -> None:
         repo = Path(__file__).parent.parent
         result = resolve_local_mention(
-            "@foundation:context/agents/delegation-instructions.md", repo
+            "@foundation:context/agents/delegation-depth.md", repo
         )
         assert result is not None
         assert result.exists()

--- a/tests/test_module_dep_resolvability_check.py
+++ b/tests/test_module_dep_resolvability_check.py
@@ -187,11 +187,14 @@ class TestVersionAndChangelog:
 
         Bumped 3.11.0 -> 3.12.0 by the schema-v2 migration (dependency
         manifest + enhance_diagrams guard), then 3.12.0 -> 3.13.0 by the
-        agent-classifier / description-status fix (lane dfni). The v3.11.0
-        changelog entry below is unaffected -- changelog entries accumulate.
+        agent-classifier / description-status fix (lane dfni), then
+        3.13.0 -> 3.14.0 by the context-token estimator fix (lane 8rug:
+        `<namespace>:<path>` includes were charged a flat 500 instead of
+        being read). The v3.11.0 changelog entry below is unaffected --
+        changelog entries accumulate.
         """
         data, _ = recipe_data
-        assert data["version"] == "3.13.0"
+        assert data["version"] == "3.14.0"
 
     def test_changelog_has_v3_11_0_entry(self, recipe_data):
         _, content = recipe_data


### PR DESCRIPTION
> ### 🧷 The estimator fix has been EXTRACTED — 2026-09-06 (lane `j05m`)
>
> **estimator fix extracted to #371; this PR now carries only the held split.**
>
> The `validate-bundle-repo` v3.14.0 context-token estimator repair (the ~6.28× understatement
> that hid this split's own justification) was an *independent* win with nothing to do with the
> delegation split, and it should not die with a NO-SHIP. It now lives on its own in
> **#371**, with its own fail-before/pass-after and a named chars/4 ↔ o200k_base calibration.
>
> **Mechanical note for whoever lands these:** the estimator work and the split rode in the
> *same* commit here (`3d676d6`), so this branch still physically contains it. #371 is a
> hunk-level extraction against `origin/main`, not a cherry-pick. If #371 merges first, rebase
> this branch and drop the estimator hunks; if this branch is ever revived and merged first,
> close #371 as already-landed. **This PR remains HELD / NO-SHIP either way.**

> ## ⛔ STILL HELD — DO NOT MERGE, DO NOT MARK READY
>
> **UPDATE 2026-09-07 — the eval has now been FUNDED ($80) and RUN IN FULL. The verdict is NO-SHIP.**
>
> 14 launches · 14 valid (validity 100 %) · **$69.18 of $80**. The rule frozen in `07d51b9` before
> any file in this split was edited, applied verbatim — *ship iff success LB ≥ −5 pp AND delegation
> count within ±30 % of main* — **fails**:
>
> | condition | anthropic (opus-5 @ medium) | openai (terra @ medium) |
> |---|---|---|
> | success LB ≥ −5 pp | LB **−28.1** (point **+25.0**) | LB **−79.2** (point **−33.3**) |
> | delegation within ±30 % | `[2,2,2,0]` → `[1,1,1,1]`, ratio **0.667** ✗ | `[11,12,9]` → `[9,12,17]`, ratio **1.188** ✓ |
>
> Neither cell is UNEVALUABLE under the pre-registered degeneracy test.
>
> **What the gate caught is NOT a suppressed delegation.** On the anthropic cell every delegation in
> every run of both arms is in **turn 1**, is `foundation:explorer`, and carries
> `context_depth=none, context_scope=conversation`; turns 2–5 delegate zero times in both arms. The
> difference is **fan-out width on that one turn** — arm A: *"delegate **two explorer agents in
> parallel** to survey each file"* (two spawns, one `parallel_group_id`); arm B: *"delegating to a
> **single explorer** with very specific …"*. **The imperative survived the cut from 6,276 tokens to
> 487. The granularity did not.** On openai the split moves fan-out the other way (+18.8 %, inside
> the band). Quality did not follow the count down: anthropic arm B **4/4 pass** vs arm A **3/4**;
> openai arm B **$1.35/run cheaper** (descriptive at n=3–4, not a rescue argument).
>
> **Condition 1 could not have passed at the n it was priced for.**
> `best-case LB = −(1 − wilson_lower(n,n))` ⇒ n=3 → **−56.15 pp**, n=50 → −7.13, **n=73 → −5.00**.
> This design is 12 runs ($73.44); the condition needs **146 pooled (~$765)** or **292 per-provider
> (~$1,530)**. A perfect treatment would have failed it. Reported as failed, verbatim, not rescued.
>
> Arms **A = `a0decc6`** (this branch's merge-base — not today's main, which carries #368) vs
> **B = `3d676d6`**, pinned by source override in four DTUs, **arm purity verified per container**:
> root prompt **123,064 → 99,699 chars (−23,365, −19.0 %)**; terra input tokens **42,562 → 37,701
> (−4,861, −11.4 %)**. **foundation as ROOT** was required — `anchors`/`anchors-amp-dev` mount
> `tool-delegate` directly and never include `foundation:behaviors/agents.yaml`, so the standard
> eval container is blind to this treatment.
>
> Full evidence, every launch and every per-run delegation count: **PR #370** →
> `docs/lanes/8rugb-delegation-split-eval/` (`VERDICT.md`, `runs-table.md`, `PREREG-ADDENDUM.md`,
> `REPRICING.md`, `ANALYSIS-prereg-n3.json`). 4 DTUs destroyed, 0 open ledger rows.
>
> **PR 1 (#368, A + C — merged as `aac89ea`) is independent of this and is unaffected.**
> This branch also deletes `context/agents/delegation-instructions.md`; bundles outside this repo
> that `@`-mention the old path would break if it ever merges.

---

<details>
<summary>Original body (written when the eval was unfunded) — kept verbatim</summary>

> ## ⛔ HELD — DO NOT MERGE, DO NOT MARK READY
>
> This is PR 2 of 2 for `model_performance-8rug`. Its pre-registered eval **could not be bought at the $10 authority** — priced *before* spending, arithmetic below. The **primary metric is unmeasured**, so the treatment is not shippable on this branch's evidence. The branch and the finding stand.
>
> **PR 1 (#368, A + C) is independent of this and is unaffected.**

## The defect

`behaviors/agents.yaml` and `behaviors/tasks.yaml` each `context.include`d `delegation-instructions.md` + `multi-agent-patterns.md` — **6,276 tokens (`len//4`) / 5,402 (`o200k_base`)**, measured on disk — into the root system prompt of **every foundation-root session**.

**The validator reported 1,000 and graded it a WARNING.**

`recipes/validate-bundle-repo.yaml` behavior-hygiene Rule 4 resolved a `context.include` two ways: a leading `@` was charged a flat 500 tokens; anything else was tried as a relative path. `foundation:context/agents/delegation-instructions.md` matches **neither** — no leading `@`, and neither `behaviors/foundation:context/...` nor `<repo>/foundation:context/...` exists — so it fell through to the 500-token default.

Two includes × 500 = **exactly 1000**, against a `> 1000` ERROR gate. **6,276 real tokens reported as 1000 and graded WARNING — one token below the ERROR that was true.** A 6.28× understatement that landed precisely on its own boundary.

## Fail-before / pass-after

```
### MAIN a0decc6 (fail-before)
  behaviors/agents.yaml: includes=2
      OLD estimator:  1000 tokens -> WARNING
      NEW estimator:  6276 tokens -> ERROR
  behaviors/tasks.yaml: includes=2
      OLD estimator:  1000 tokens -> WARNING
      NEW estimator:  6276 tokens -> ERROR

### THIS BRANCH (pass-after)
  behaviors/agents.yaml: includes=1
      OLD estimator:   500 tokens -> ok
      NEW estimator:   487 tokens -> ok
  behaviors/tasks.yaml: includes=1
      OLD estimator:   500 tokens -> ok
      NEW estimator:   487 tokens -> ok
```

The honest fail-before requires the *fixed* estimator — same shape as `aaa5c47`, which made (A)'s fail-before trustworthy.

## The estimator repair (`validate-bundle-repo` v3.14.0)

Strips an optional `@` and, for a `<namespace>:<path>` ref, also tries the path half against the behavior directory and the repo root. When the file is in this repo, **read it**. When it genuinely is not, keep the 500 fallback — but record the include in `context_unresolved_includes` and set `context_tokens_is_estimate`. An unknown folded silently into a number that reads as measured is the defect; the fallback itself is fine as long as it is visible.

## The split

| file | role | `len//4` | o200k |
|---|---|---:|---:|
| `context/agents/delegation-core.md` **(new)** | loaded by the behavior | **487** | **464** |
| `context/agents/delegation-depth.md` (renamed) | agent bodies only | 3,196 | 2,722 |
| `context/agents/multi-agent-patterns.md` | agent bodies only | 2,052 | 1,774 |

**Core** = the delegation imperative, the immediate triggers, basic `delegate` usage, the two context parameters — the root session *is* the delegator and needs these. **Depth** = session resumption, wave discipline, reading a structured return, scrutinising an agent's "N/A", large session-file handling, and the context-sink pattern itself — which is precisely the material that pattern says to defer.

### Which agents get depth, and why

| Agent | Why |
|---|---|
| `foundation-expert` | The **only** foundation agent declaring `tool-delegate`. The behavior sets `exclude_tools: [tool-delegate]`, so no other spawned agent can delegate at all — it is the only sub-agent that ever fans out. Gets `delegation-depth.md` **and** `multi-agent-patterns.md`. |
| `session-analyst` | The **only** agent that resumes sessions by `session_id` and reads large session files — the two depth sections written for exactly that. Gets `delegation-depth.md`. |

`test_the_only_agent_declaring_tool_delegate_is_the_one_we_routed_depth_to` pins the "only one" claim, so a future agent gaining `tool-delegate` fails a test rather than silently losing the routing.

### `tasks.yaml` — references the same core, does not drop context

`tool-task` **is** a delegation-shaped tool (it spawns sub-agents), so the imperative and the triggers apply to it; and pointing both behaviors at one file makes drift between them impossible. It gets **no depth**: `tool-task` exposes neither `context_depth`/`context_scope` nor session resumption.

## Real-session effect — foundation as ROOT

Project-scope `.amplifier/settings.yaml` source override. **`~/.amplifier/cache` was not edited.**

```
### BEFORE (main a0decc6)  session 5dfe9c07-d95d-41a8-815b-962c0ce5a0dd
    raw.system[0].text chars = 130,055
      PRESENT  core: 'You are an ORCHESTRATOR, not a worker.'
      PRESENT  depth: '## Wave Discipline'
      PRESENT  depth: '## The Context Sink Pattern'
      PRESENT  depth: 'Reading a Structured Agent Return'
      PRESENT  depth: 'Multi-Agent Patterns'
### AFTER  (this branch)   session eb36571b-b9c4-4667-a833-6990fb349e51
    raw.system[0].text chars = 106,655
      PRESENT  core: 'You are an ORCHESTRATOR, not a worker.'
      ABSENT   depth: '## Wave Discipline'
      ABSENT   depth: '## The Context Sink Pattern'
      ABSENT   depth: 'Reading a Structured Agent Return'
      ABSENT   depth: 'Multi-Agent Patterns'

Delta: -23,400 chars.  Provider-reported input: 52,741 -> 47,014 tokens (-5,727)
```

Depth stays reachable:

```
agents/foundation-expert.md   RESOLVES @foundation:context/agents/delegation-depth.md      (13,378 B)
                              RESOLVES @foundation:context/agents/multi-agent-patterns.md  ( 8,272 B)
agents/session-analyst.md     RESOLVES @foundation:context/agents/delegation-depth.md      (13,378 B)
```

## Why this is HELD — the eval could not be bought

Pre-registered **before any file was edited**, in its own commit `07d51b9`:

> **SHIP if — and only if — success LB ≥ −5 pp AND delegation count within ±30 % of main.**

Design: S3-class scenarios, foundation root, arms `main` vs branch, **n≥3 valid runs per arm per provider, both providers** (anthropic opus-5 root; openai gpt-5.6-terra root), in DTUs. Primary = task success + delegation-count sanity; secondary = root-prompt tokens and $/task.

Priced against the **$10** authority using this program's own observed rates and its **67 % observed validity rate**:

```
Pre-registered design = 3 runs × 2 arms × 2 providers = 12 VALID runs

launches needed          = 12 / 0.67            = 18 launches (9 anthropic, 9 terra)
anthropic @ opus-5 $3.53 = 9 × $3.53            = $31.77
openai    @ terra  $4.63 = 9 × $4.63            = $41.67
                                          TOTAL = $73.44   vs $10 authority

At 100% validity (12 launches):  6×$3.53 + 6×$4.63 = $48.96   vs $10
At the cheaper sonnet figure:    6×$2.29 + 6×$4.63 = $41.52   vs $10
```

**The arithmetic does not close, by 4×–7×.** At the cheapest observed rate ($2.62/run) $10 buys **3 launches ⇒ ~2 valid runs** — n=1 per arm on **one** provider. n=1 cannot produce a lower bound on success, so it cannot evaluate the rule's first condition, and one delegation count per arm cannot support a ±30 % comparison: a **0 % chance** of satisfying the pre-registered rule. Spending it would be the exact failure mode the goal names against lane `1ru`.

**$0 was spent on the eval.** The authority that would close it is **$73.44** (**$48.96** at perfect validity).

**−5,727 root-prompt tokens is the SECONDARY metric.** The primary one is unmeasured, and the split could plausibly fail in either direction — suppressing legitimate delegation, or removing the wave discipline that told the root to batch. That is why the gate is two-sided, and why this stays a draft.

**Recorded in advance so it cannot read as an excuse later:** `otr`'s pre-registered gate came back UNEVALUABLE because delegation counts at its cell were `[0,0,1,0,0]`. If arm-A S3 runs here median 0 delegations, the ±30 % condition is likewise unevaluable, and the honest report is "unevaluable" — not a substitute gate invented after the fact.

## ⚠ Breaking for external references

`context/agents/delegation-instructions.md` **no longer exists** — it is `delegation-depth.md`. Any bundle outside this repo that `@`-mentions the old path will stop resolving. All in-repo references were updated.

## Tests

`tests/test_behavior_context_budget.py` — 33 tests, **12 of which fail on `main`**. They measure the real files from disk, so the budget cannot be satisfied by an estimator's blind spot.

```
2,064 passed, 3 skipped, 2 failed in 21.63s
```

Both failures are pre-existing and reproduce on `a0decc6`:
- `tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file`
- `tests/test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes`

## Spend

**$0 on the eval** (not bought — see above). **$0.20** total on three `amplifier run "hi"` `haiku` sessions for the real-session measurements. **No DTUs created; 0 ledger rows opened.**

---
Generated with Amplifier

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>


</details>

