### PR TITLE
fix(recipes): the context-token estimator understated by 6.28x and landed exactly on its own ERROR boundary (v3.14.0)

### DIFF
--- a/docs/lanes/j05m-estimator-salvage/DONE-NOTE.md
+++ b/docs/lanes/j05m-estimator-salvage/DONE-NOTE.md
@@ -1,0 +1,249 @@
+# Lane `j05m` — salvage the validator token-estimator fix from held #369
+
+**Work item:** `model_performance-j05m` (project `model_performance`)
+**Repo / branch:** `microsoft/amplifier-foundation` @ `lane/j05m-estimator-salvage`
+**Draft PR:** [#371](https://github.com/microsoft/amplifier-foundation/pull/371) — head `6e701862fb871ae71cae8a1fd5de874105ad8bf5`
+**Base:** `origin/main` = `aac89ea` at claim time
+**Outcome:** **A. RESOLVED** — all five deliverables DONE, none NOT-POSSIBLE.
+**Spend:** **$0.00** of a **$0.00** authority (`0 runs × 0 arms × $0 / 1.00 = $0.00`). Residue $0.00.
+
+---
+
+## 1. Spend, to the cent
+
+| item | arithmetic | cost |
+|---|---|---|
+| Recipe re-run (BEFORE, v3.13.0) | deterministic step body, 0 LLM calls | $0.00 |
+| Recipe re-run (AFTER, v3.14.0) | deterministic step body, 0 LLM calls | $0.00 |
+| Fail-before / pass-after test runs | local pytest | $0.00 |
+| Full suite (2,051 tests) | local pytest | $0.00 |
+| Tokenizer calibration (tiktoken 0.12.0) | local, offline BPE | $0.00 |
+| **TOTAL** | | **$0.00** |
+
+**The cap did not bind.** The goal's authority arithmetic (`0 × 0 × $0 / 1.00 = $0.00`) closes,
+because every deliverable here is reachable deterministically. The one place money *could* have
+been spent — `validate-bundle-repo` is an LLM-driven recipe — was avoided the way lanes `cal`,
+`39z0` and `hxcl` avoided it: the `behavior-hygiene-validation` step's Python heredoc was
+extracted verbatim and executed directly. **No DTU created, no infrastructure registered, nothing
+to tear down.**
+
+## 2. Deliverables
+
+| # | deliverable | state |
+|---|---|---|
+| 1 | Draft PR on foundation carrying **only** the estimator fix, with `git diff --name-only` quoted in the body | **DONE** — [#371](https://github.com/microsoft/amplifier-foundation/pull/371) |
+| 2 | FAIL-BEFORE on a known-token fixture, tokenizer/calibration named, both numbers + pass/fail counts quoted | **DONE** — 6 failed/2 passed → 8 passed |
+| 3 | `validate-bundle-repo` re-run on foundation main with the fix, before/after payload lines quoted | **DONE** — ~1000 WARNING → ~6276 ERROR |
+| 4 | #369's description records the extraction | **DONE** — verified by readback |
+| 5 | Suite green + ruff clean, minus the two known pre-existing failures | **DONE** — 2,046 passed, 3 skipped, 2 pre-existing failed |
+
+## 3. What was extracted, and how the exclusion was enforced
+
+`#369`'s estimator work and its delegation split rode in **one commit** (`3d676d6` on
+`lane/8rug-foundation-root-hygiene-b`, head confirmed against `git ls-remote` before touching
+anything — the goal warned a wrong-target checkout failed silently in this batch). A clean
+cherry-pick was therefore impossible; this is a **hunk-level extraction against `origin/main`**.
+
+Method: `git checkout origin/lane/8rug-foundation-root-hygiene-b -- recipes/validate-bundle-repo.yaml`.
+That is exactly the estimator and nothing else, verified rather than assumed —
+`git diff origin/main origin/lane/8rug-...-b -- recipes/validate-bundle-repo.yaml` is **4 hunks**:
+
+| hunk | content |
+|---|---|
+| `@@ -1,9 +1,32 @@` | v3.14.0 changelog entry |
+| `@@ -384,6 +407,12 @@` | the TOKEN ESTIMATION footnote (the calibration) |
+| `@@ -461,7 +490,7 @@` | `version: "3.13.0"` → `"3.14.0"` |
+| `@@ -1966,32 +1995,67 @@` | the estimator block itself |
+
+**Zero delegation-split files** in the final diff — checked mechanically, not by eye:
+
+```
+$ git diff --cached --name-only | grep -E 'delegation-instructions|delegation-core|delegation-depth|behaviors/agents\.yaml|behaviors/tasks\.yaml'
+clean -- no delegation-split file in the diff
+```
+
+`#369`'s own `tests/test_behavior_context_budget.py` was **deliberately NOT taken**. Of its 33
+tests only two concern the estimator; the rest assert the split's files and routing
+(`delegation-core.md` exists, `agents.yaml` loads only the core, depth is @-mentioned from
+`foundation-expert`/`session-analyst`). Worse, its
+`test_no_behavior_exceeds_the_error_budget` would **fail on main with this fix applied** —
+`agents.yaml` is 6,276 tokens and only the split brings it under 1,000. Importing it would have
+smuggled the NO-SHIP in as a red test. A fresh, estimator-only suite was written instead:
+`tests/test_context_include_estimator.py` (8 tests).
+
+Only two other files came along, and both are the estimator:
+`tests/test_module_dep_resolvability_check.py` (the `3.13.0 → 3.14.0` version pin, which would
+otherwise fail) and my own lane artifacts under `docs/lanes/j05m-estimator-salvage/`.
+
+## 4. The ruler — chars/4, and the calibration named
+
+The goal granted the honest option: *"if the recipe must stay dependency-free, a chars/4
+heuristic, calibrated and footnoted, is acceptable — but NAME the calibration."*
+
+**Choice: chars/4 (`len(content) // 4`), unchanged.** Reason: the recipe is a self-contained
+YAML executed by `${AMPLIFIER_PYTHON:-python3}` with no guaranteed third-party packages, and
+`estimate_tokens()` is used by *other* rules in the same step — swapping the unit would silently
+move every other threshold in the file. The defect was never the unit; it was **a flat per-file
+guess standing in for a file the repo can read**.
+
+**Calibration (tiktoken 0.12.0), footnoted in the recipe at the TOKEN ESTIMATION comment:**
+
+| measured | chars/4 | o200k_base | cl100k_base | chars/4 error |
+|---|---|---|---|---|
+| the two files the defect was hiding | **6,276** | 5,402 | 5,466 | **+16.2%** / +14.8% |
+| fixture `context/agents/session-storage-knowledge.md` | **2,490** | 2,648 | 2,635 | **−6.0%** / −5.5% |
+| *the old estimator, same fixture* | *500* | 2,648 | 2,635 | **−81.1%** |
+
+Repo-wide spread across this repo's context markdown (n=31 files ≥1500 bytes), chars/4 ÷
+o200k_base: **min 0.940, median 1.128, max 1.312**.
+
+**Stated plainly so nobody over-claims:** chars/4 is **not** uniformly within ±10% of a real
+tokenizer. It runs ~13–16% **high** on prose markdown — the *conservative* direction for a budget
+gate: it fires early, never late. The deliverable's ±10% bar is met **on the fixture**, and the
+fixture is a real file from the very directory the defect lived in, chosen before the ratio was
+known to be favourable and disclosed alongside the full repo-wide spread above. The tokenizer
+cross-check is a real assertion in the suite
+(`test_measured_count_is_within_10pct_of_a_real_tokenizer`), skipped when tiktoken is absent so
+CI stays dependency-free.
+
+## 5. Fail-before / pass-after
+
+`tests/test_context_include_estimator.py` **executes the recipe's own step body** (extracted from
+the YAML heredoc and run as a subprocess) rather than re-implementing the resolution logic. A
+re-implementation agrees with itself while the recipe drifts — which is precisely the failure
+mode under investigation.
+
+| recipe | result |
+|---|---|
+| **v3.13.0** (`origin/main`, tests unchanged) | **6 failed, 2 passed** |
+| **v3.14.0** (this PR) | **8 passed** |
+
+```
+E       assert 1000 == (2 * 2490)     # test_two_such_includes_now_trip_the_error_gate
+E       assert '_candidate_relpaths' in '# validate-bundle-repo.yaml\n# …Validator Recipe v3.13.0…'
+FAILED test_namespace_qualified_include_is_measured_not_guessed
+FAILED test_at_prefixed_namespace_include_is_also_measured
+FAILED test_unresolvable_include_keeps_the_flat_fallback_and_says_so
+FAILED test_url_style_refs_are_not_split_on_their_scheme_colon
+FAILED test_two_such_includes_now_trip_the_error_gate
+FAILED test_recipe_declares_the_estimator_fix
+```
+
+The 2 that pass on both sides are the tokenizer cross-check (a property of the fixture, not the
+recipe) and the negative guard `test_measured_include_is_not_flagged_as_an_estimate` (main never
+sets those keys). Both are guards for the new behaviour, not fail-before evidence, and are
+labelled as such.
+
+Files: `evidence/estimator-tests-FAIL-BEFORE.txt`, `evidence/estimator-tests-PASS-AFTER.txt`.
+
+## 6. Recipe re-run on foundation main — and three consequences the manager must see
+
+**BEFORE (v3.13.0):**
+```
+behaviors_checked 12   errors 0   warnings 2
+WARN agents  context_tokens_high | context.include totals ~1000 tokens (>500 WARNING threshold)
+WARN tasks   context_tokens_high | context.include totals ~1000 tokens (>500 WARNING threshold)
+```
+**AFTER (v3.14.0):**
+```
+behaviors_checked 12   errors 2   warnings 1
+ERR  agents  context_tokens_excessive | context.include totals ~6276 tokens (>1000 ERROR threshold)
+ERR  tasks   context_tokens_excessive | context.include totals ~6276 tokens (>1000 ERROR threshold)
+WARN foundation-expert context_tokens_high | context.include totals ~566 tokens (>500 WARNING threshold)
+```
+
+1. **They do not stay WARNINGs — they become ERRORs.** The goal text anticipated "the two
+   `context_tokens_high` WARNINGs … now reporting the true ~6k magnitude". `6,276 > 1,000`, so
+   they correctly escalate to `context_tokens_excessive`. **The magnitude is the true one and so
+   is the severity.** Recording the deviation from the goal's wording explicitly rather than
+   quietly satisfying it.
+2. **So `validate-bundle-repo` now reports 2 ERRORs against foundation main.** That is the defect
+   being *surfaced*, not introduced — those 6,276 tokens were already in every foundation-root
+   system prompt; only the ruler changed. The fix that clears them is the split **held in #369**,
+   which this PR deliberately does not carry. **Checked, not assumed:**
+   `grep -rn "validate-bundle-repo" .github/ Makefile*` returns nothing, so merging does not red
+   CI.
+3. **A third, previously invisible finding surfaced:** `behaviors/foundation-expert.yaml`
+   includes `foundation:context/bundle-awareness.md`, also charged a silent flat 500. Measured,
+   it is **566** → over the 500-token WARNING bar. New information, correctly surfaced, nobody's
+   regression.
+
+**Regen side effect (`6phe` F1) — checked.** Only the one step body was executed, never the full
+recipe, so `bundle-overview-regen-write` never ran. `git status` after both runs showed no
+`bundle.dot`/`bundle.png` modification. Nothing reverted because nothing was rewritten.
+
+## 7. Suite and lint
+
+```
+2,046 passed, 3 skipped, 2 failed in 22.60s
+FAILED tests/test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes
+FAILED tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file
+```
+
+Both are the **known pre-existing failures** named in the goal, and I re-confirmed them myself
+rather than taking the claim on faith: a detached `git worktree` at `origin/main` on this host
+reproduces both (`evidence/pre-existing-failures-at-origin-main.txt`). Neither is claimed as mine
+nor as fixed.
+
+`ruff check tests/ recipes/` → **All checks passed!** · `ruff format` applied to the new test file.
+
+**Byte-identity / default-mode:** not applicable and not faked. This change touches
+`recipes/*.yaml` and `tests/*.py` only — no runtime code, no bundle context, no agent body. There
+is no system-prompt surface for a stash-compare to differ on. `git diff --name-only` (§3) is the
+proof.
+
+## 8. #369's description
+
+Updated at the **top** of the body (not buried at the end of a 12.5 KB description), verbatim
+required sentence included:
+
+> **estimator fix extracted to #371; this PR now carries only the held split.**
+
+Plus the mechanical note that matters to whoever lands these: because the two changes shared
+commit `3d676d6`, `#369`'s branch **still physically contains** the estimator. If #371 merges
+first, rebase `8rug`'s branch and drop the estimator hunks; if `8rug` is ever revived and merged
+first, close #371 as already-landed. #369 remains HELD / NO-SHIP either way.
+
+**`gh pr edit` does not work on this repo** — it fails with
+`GraphQL: Projects (classic) is being deprecated … (repository.pullRequest.projectCards)` and
+**silently changes nothing** (body byte count unchanged at 12,534). This is a live trap for other
+lanes: the command exits, prints a warning, and the edit is not applied. The working path is the
+REST API: `gh api --method PATCH repos/<owner>/<repo>/pulls/<n> --input <json>`. Readback after
+that: 13,520 bytes, note present at line 3. Original body preserved at
+`evidence/pr369-body-BEFORE.md`.
+
+## 9. Deviations, and one proposed correction
+
+- **Deviation (recorded, not silent):** deliverable 3's wording expects two `context_tokens_high`
+  WARNINGs "now reporting the true ~6k magnitude". They report the true magnitude *and* correctly
+  escalate to ERROR. See §6.1.
+- **Deviation:** #369's test file was not extracted; a purpose-built estimator-only suite replaced
+  it. Rationale in §3.
+- **No proposed diff to `ai-notes/00-what-we-know.md`.** This lane produced no measurement that
+  contradicts or extends anything in it. The `gh pr edit` trap in §8 is a *tooling* finding for
+  the manager's batch notes, not a program finding, so it is recorded here rather than proposed as
+  an edit to a file another lane owns.
+
+## 10. What remains open
+
+- **#371 is a draft and must not be merged by this lane** (procedure 4). The manager verifies the
+  fail-before and merges.
+- **Landing order matters** (§8). Merging #371 makes `validate-bundle-repo` report 2 true ERRORs
+  against main until #369's split — or some other reduction of `agents.yaml`/`tasks.yaml` — lands.
+  Not a CI break (§6.2), but a visible red in any manual validator run.
+
+## Evidence index — `docs/lanes/j05m-estimator-salvage/evidence/`
+
+| file | what |
+|---|---|
+| `behavior-hygiene-BEFORE-main.json` | raw step payload, recipe v3.13.0 |
+| `behavior-hygiene-AFTER-main-plus-fix.json` | raw step payload, recipe v3.14.0 |
+| `recipe-rerun-BEFORE-AFTER.md` | the two payloads read side by side |
+| `estimator-tests-FAIL-BEFORE.txt` | 6 failed / 2 passed against v3.13.0 |
+| `estimator-tests-PASS-AFTER.txt` | 8 passed against v3.14.0 |
+| `tokenizer-calibration.txt` | chars/4 vs o200k_base / cl100k_base, + repo-wide spread |
+| `full-suite-AFTER.txt` | 2,046 passed, 3 skipped, 2 pre-existing failed |
+| `pre-existing-failures-at-origin-main.txt` | the same 2 reproduced at `origin/main` |
+| `pr369-body-BEFORE.md` | #369's description before the extraction note |
+| `publication-readback.txt` | `git ls-remote` + `gh pr list` readback for `DONE.json` |
+| `../replay_step.py` | the $0 step-body harness (copied unmodified from lane `dfni`) |

--- a/docs/lanes/j05m-estimator-salvage/evidence/behavior-hygiene-AFTER-main-plus-fix.json
+++ b/docs/lanes/j05m-estimator-salvage/evidence/behavior-hygiene-AFTER-main-plus-fix.json
@@ -1,0 +1,125 @@
+{
+  "phase": "behavior_hygiene",
+  "behaviors_checked": 12,
+  "errors": [
+    {
+      "behavior": "agents",
+      "type": "context_tokens_excessive",
+      "message": "context.include totals ~6276 tokens (>1000 ERROR threshold)",
+      "severity": "ERROR",
+      "fix": "Move heavy context to one of: expert agent body (@-mention in agent .md), mode contribution (contributes.context in mode YAML or @-mention in mode body), or skill (load_skill on demand). Behaviors should only carry lightweight awareness <500 tokens."
+    },
+    {
+      "behavior": "tasks",
+      "type": "context_tokens_excessive",
+      "message": "context.include totals ~6276 tokens (>1000 ERROR threshold)",
+      "severity": "ERROR",
+      "fix": "Move heavy context to one of: expert agent body (@-mention in agent .md), mode contribution (contributes.context in mode YAML or @-mention in mode body), or skill (load_skill on demand). Behaviors should only carry lightweight awareness <500 tokens."
+    }
+  ],
+  "warnings": [
+    {
+      "behavior": "foundation-expert",
+      "type": "context_tokens_high",
+      "message": "context.include totals ~566 tokens (>500 WARNING threshold)",
+      "severity": "WARNING",
+      "fix": "Justify universal relevance, or move to a context-sink mechanism (agent body, mode contribution, skill). The 500-token bar is for awareness pointers only."
+    }
+  ],
+  "info": [],
+  "behavior_details": [
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/redaction.yaml",
+      "name": "redaction",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/bundle-design.yaml",
+      "name": "bundle-design",
+      "issues": [],
+      "context_include_count": 1,
+      "context_total_tokens": 62,
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/foundation-expert.yaml",
+      "name": "foundation-expert",
+      "issues": [
+        "context_tokens_high"
+      ],
+      "context_include_count": 1,
+      "context_total_tokens": 566,
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/todo-reminder.yaml",
+      "name": "todo-reminder",
+      "issues": [],
+      "tool_count": 1
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/logging.yaml",
+      "name": "logging",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/progress-monitor.yaml",
+      "name": "progress-monitor",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/streaming-ui.yaml",
+      "name": "streaming-ui",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/amplifier-dev.yaml",
+      "name": "amplifier-dev",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/sessions.yaml",
+      "name": "sessions",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/status-context.yaml",
+      "name": "status-context",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/agents.yaml",
+      "name": "agents",
+      "issues": [
+        "context_tokens_excessive"
+      ],
+      "context_include_count": 2,
+      "context_total_tokens": 6276,
+      "tool_count": 2
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/tasks.yaml",
+      "name": "tasks",
+      "issues": [
+        "context_tokens_excessive"
+      ],
+      "context_include_count": 2,
+      "context_total_tokens": 6276,
+      "tool_count": 1
+    }
+  ],
+  "passed": false,
+  "summary": {
+    "behaviors_checked": 12,
+    "errors": 2,
+    "warnings": 1,
+    "clean_behaviors": 10
+  }
+}

--- a/docs/lanes/j05m-estimator-salvage/evidence/behavior-hygiene-BEFORE-main.json
+++ b/docs/lanes/j05m-estimator-salvage/evidence/behavior-hygiene-BEFORE-main.json
@@ -1,0 +1,115 @@
+{
+  "phase": "behavior_hygiene",
+  "behaviors_checked": 12,
+  "errors": [],
+  "warnings": [
+    {
+      "behavior": "agents",
+      "type": "context_tokens_high",
+      "message": "context.include totals ~1000 tokens (>500 WARNING threshold)",
+      "severity": "WARNING",
+      "fix": "Justify universal relevance, or move to a context-sink mechanism (agent body, mode contribution, skill). The 500-token bar is for awareness pointers only."
+    },
+    {
+      "behavior": "tasks",
+      "type": "context_tokens_high",
+      "message": "context.include totals ~1000 tokens (>500 WARNING threshold)",
+      "severity": "WARNING",
+      "fix": "Justify universal relevance, or move to a context-sink mechanism (agent body, mode contribution, skill). The 500-token bar is for awareness pointers only."
+    }
+  ],
+  "info": [],
+  "behavior_details": [
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/redaction.yaml",
+      "name": "redaction",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/bundle-design.yaml",
+      "name": "bundle-design",
+      "issues": [],
+      "context_include_count": 1,
+      "context_total_tokens": 500,
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/foundation-expert.yaml",
+      "name": "foundation-expert",
+      "issues": [],
+      "context_include_count": 1,
+      "context_total_tokens": 500,
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/todo-reminder.yaml",
+      "name": "todo-reminder",
+      "issues": [],
+      "tool_count": 1
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/logging.yaml",
+      "name": "logging",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/progress-monitor.yaml",
+      "name": "progress-monitor",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/streaming-ui.yaml",
+      "name": "streaming-ui",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/amplifier-dev.yaml",
+      "name": "amplifier-dev",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/sessions.yaml",
+      "name": "sessions",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/status-context.yaml",
+      "name": "status-context",
+      "issues": [],
+      "tool_count": 0
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/agents.yaml",
+      "name": "agents",
+      "issues": [
+        "context_tokens_high"
+      ],
+      "context_include_count": 2,
+      "context_total_tokens": 1000,
+      "tool_count": 2
+    },
+    {
+      "path": "/home/bkrabach/dev/hw-model-performance/lanes/j05m-estimator-salvage/amplifier-foundation/behaviors/tasks.yaml",
+      "name": "tasks",
+      "issues": [
+        "context_tokens_high"
+      ],
+      "context_include_count": 2,
+      "context_total_tokens": 1000,
+      "tool_count": 1
+    }
+  ],
+  "passed": true,
+  "summary": {
+    "behaviors_checked": 12,
+    "errors": 0,
+    "warnings": 2,
+    "clean_behaviors": 12
+  }
+}

--- a/docs/lanes/j05m-estimator-salvage/evidence/estimator-tests-FAIL-BEFORE.txt
+++ b/docs/lanes/j05m-estimator-salvage/evidence/estimator-tests-FAIL-BEFORE.txt
@@ -1,0 +1,41 @@
+### FAIL-BEFORE -- recipes/validate-bundle-repo.yaml restored to origin/main (v3.13.0); tests/test_context_include_estimator.py unchanged
+
+    def test_two_such_includes_now_trip_the_error_gate(fixture_repo: Path, fixture_tokens: int) -> None:
+        """2 x flat-500 = exactly 1000, one token under the `> 1000` ERROR. Measured, it is not."""
+        second = fixture_repo / "context" / "agents" / "second.md"
+        shutil.copyfile(FIXTURE_SOURCE, second)
+        (fixture_repo / "behaviors" / "known-tokens.yaml").write_text(
+            "name: known-tokens\n"
+            "description: fixture behavior with two namespace-qualified includes\n"
+            "context:\n"
+            "  include:\n"
+            f"    - foundation:context/agents/{FIXTURE_SOURCE.name}\n"
+            "    - foundation:context/agents/second.md\n",
+            encoding="utf-8",
+        )
+        result = _run_step(fixture_repo)
+        detail = _detail(result, "known-tokens")
+>       assert detail["context_total_tokens"] == 2 * fixture_tokens
+E       assert 1000 == (2 * 2490)
+
+tests/test_context_include_estimator.py:204: AssertionError
+____________________ test_recipe_declares_the_estimator_fix ____________________
+
+    def test_recipe_declares_the_estimator_fix() -> None:
+        recipe = RECIPE.read_text(encoding="utf-8")
+>       assert "_candidate_relpaths" in recipe, (
+            "validate-bundle-repo must resolve `<namespace>:<path>` includes; without it a "
+            "6,276-token behavior is reported as 1000 and graded WARNING."
+        )
+E       AssertionError: validate-bundle-repo must resolve `<namespace>:<path>` includes; without it a 6,276-token behavior is reported as 1000 and graded WARNING.
+E       assert '_candidate_relpaths' in '# validate-bundle-repo.yaml\n# Repository-Wide Bundle Validator Recipe v3.13.0\n# Validates an entire bundle reposito...efault-repo-conventions", "set-default-recipe-validation", "bundle-doc-regen-detail", "bundle-overview-regen-write"]\n'
+
+tests/test_context_include_estimator.py:240: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_context_include_estimator.py::test_namespace_qualified_include_is_measured_not_guessed
+FAILED tests/test_context_include_estimator.py::test_at_prefixed_namespace_include_is_also_measured
+FAILED tests/test_context_include_estimator.py::test_unresolvable_include_keeps_the_flat_fallback_and_says_so
+FAILED tests/test_context_include_estimator.py::test_url_style_refs_are_not_split_on_their_scheme_colon
+FAILED tests/test_context_include_estimator.py::test_two_such_includes_now_trip_the_error_gate
+FAILED tests/test_context_include_estimator.py::test_recipe_declares_the_estimator_fix
+6 failed, 2 passed in 0.43s

--- a/docs/lanes/j05m-estimator-salvage/evidence/estimator-tests-PASS-AFTER.txt
+++ b/docs/lanes/j05m-estimator-salvage/evidence/estimator-tests-PASS-AFTER.txt
@@ -1,0 +1,3 @@
+### PASS-AFTER -- recipes/validate-bundle-repo.yaml at v3.14.0 (estimator fix applied)
+........                                                                 [100%]
+8 passed in 0.42s

--- a/docs/lanes/j05m-estimator-salvage/evidence/full-suite-AFTER.txt
+++ b/docs/lanes/j05m-estimator-salvage/evidence/full-suite-AFTER.txt
@@ -1,0 +1,30 @@
+            test_file = Path(tmpdir) / "test.yaml"
+            test_file.write_text("name: test")
+    
+            handler = FileSourceHandler(base_path=Path(tmpdir))
+            parsed = ParsedURI(
+                scheme="file", host="", path=str(test_file), ref="", subpath=""
+            )
+            result = await handler.resolve(parsed, Path(tmpdir) / "cache")
+    
+            # FileSourceHandler.resolve() calls Path.resolve() internally. On
+            # Windows, tempfile.TemporaryDirectory() may hand back a path
+            # containing an 8.3 short component (e.g. "RUNNER~1") while
+            # resolve() returns the canonical long form (e.g. "runneradmin").
+            # Both spellings name the same file/directory, so resolve the
+            # expected side too rather than comparing raw/short vs.
+            # canonical/long.
+            assert result.active_path == test_file.resolve()
+            # source_root is the parent directory for non-cached files
+>           assert result.source_root == test_file.parent.resolve()
+E           AssertionError: assert PosixPath('/tmp') == PosixPath('/tmp/tmp2fmgiple')
+E            +  where PosixPath('/tmp') = ResolvedSource(active_path=PosixPath('/tmp/tmp2fmgiple/test.yaml'), source_root=PosixPath('/tmp')).source_root
+E            +  and   PosixPath('/tmp/tmp2fmgiple') = resolve()
+E            +    where resolve = PosixPath('/tmp/tmp2fmgiple').resolve
+E            +      where PosixPath('/tmp/tmp2fmgiple') = PosixPath('/tmp/tmp2fmgiple/test.yaml').parent
+
+tests/test_sources.py:73: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes
+FAILED tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file
+2 failed, 2046 passed, 3 skipped in 22.60s

--- a/docs/lanes/j05m-estimator-salvage/evidence/pr369-body-BEFORE.md
+++ b/docs/lanes/j05m-estimator-salvage/evidence/pr369-body-BEFORE.md
@@ -1,0 +1,204 @@
+> ## ⛔ STILL HELD — DO NOT MERGE, DO NOT MARK READY
+>
+> **UPDATE 2026-09-07 — the eval has now been FUNDED ($80) and RUN IN FULL. The verdict is NO-SHIP.**
+>
+> 14 launches · 14 valid (validity 100 %) · **$69.18 of $80**. The rule frozen in `07d51b9` before
+> any file in this split was edited, applied verbatim — *ship iff success LB ≥ −5 pp AND delegation
+> count within ±30 % of main* — **fails**:
+>
+> | condition | anthropic (opus-5 @ medium) | openai (terra @ medium) |
+> |---|---|---|
+> | success LB ≥ −5 pp | LB **−28.1** (point **+25.0**) | LB **−79.2** (point **−33.3**) |
+> | delegation within ±30 % | `[2,2,2,0]` → `[1,1,1,1]`, ratio **0.667** ✗ | `[11,12,9]` → `[9,12,17]`, ratio **1.188** ✓ |
+>
+> Neither cell is UNEVALUABLE under the pre-registered degeneracy test.
+>
+> **What the gate caught is NOT a suppressed delegation.** On the anthropic cell every delegation in
+> every run of both arms is in **turn 1**, is `foundation:explorer`, and carries
+> `context_depth=none, context_scope=conversation`; turns 2–5 delegate zero times in both arms. The
+> difference is **fan-out width on that one turn** — arm A: *"delegate **two explorer agents in
+> parallel** to survey each file"* (two spawns, one `parallel_group_id`); arm B: *"delegating to a
+> **single explorer** with very specific …"*. **The imperative survived the cut from 6,276 tokens to
+> 487. The granularity did not.** On openai the split moves fan-out the other way (+18.8 %, inside
+> the band). Quality did not follow the count down: anthropic arm B **4/4 pass** vs arm A **3/4**;
+> openai arm B **$1.35/run cheaper** (descriptive at n=3–4, not a rescue argument).
+>
+> **Condition 1 could not have passed at the n it was priced for.**
+> `best-case LB = −(1 − wilson_lower(n,n))` ⇒ n=3 → **−56.15 pp**, n=50 → −7.13, **n=73 → −5.00**.
+> This design is 12 runs ($73.44); the condition needs **146 pooled (~$765)** or **292 per-provider
+> (~$1,530)**. A perfect treatment would have failed it. Reported as failed, verbatim, not rescued.
+>
+> Arms **A = `a0decc6`** (this branch's merge-base — not today's main, which carries #368) vs
+> **B = `3d676d6`**, pinned by source override in four DTUs, **arm purity verified per container**:
+> root prompt **123,064 → 99,699 chars (−23,365, −19.0 %)**; terra input tokens **42,562 → 37,701
+> (−4,861, −11.4 %)**. **foundation as ROOT** was required — `anchors`/`anchors-amp-dev` mount
+> `tool-delegate` directly and never include `foundation:behaviors/agents.yaml`, so the standard
+> eval container is blind to this treatment.
+>
+> Full evidence, every launch and every per-run delegation count: **PR #370** →
+> `docs/lanes/8rugb-delegation-split-eval/` (`VERDICT.md`, `runs-table.md`, `PREREG-ADDENDUM.md`,
+> `REPRICING.md`, `ANALYSIS-prereg-n3.json`). 4 DTUs destroyed, 0 open ledger rows.
+>
+> **PR 1 (#368, A + C — merged as `aac89ea`) is independent of this and is unaffected.**
+> This branch also deletes `context/agents/delegation-instructions.md`; bundles outside this repo
+> that `@`-mention the old path would break if it ever merges.
+
+---
+
+<details>
+<summary>Original body (written when the eval was unfunded) — kept verbatim</summary>
+
+> ## ⛔ HELD — DO NOT MERGE, DO NOT MARK READY
+>
+> This is PR 2 of 2 for `model_performance-8rug`. Its pre-registered eval **could not be bought at the $10 authority** — priced *before* spending, arithmetic below. The **primary metric is unmeasured**, so the treatment is not shippable on this branch's evidence. The branch and the finding stand.
+>
+> **PR 1 (#368, A + C) is independent of this and is unaffected.**
+
+## The defect
+
+`behaviors/agents.yaml` and `behaviors/tasks.yaml` each `context.include`d `delegation-instructions.md` + `multi-agent-patterns.md` — **6,276 tokens (`len//4`) / 5,402 (`o200k_base`)**, measured on disk — into the root system prompt of **every foundation-root session**.
+
+**The validator reported 1,000 and graded it a WARNING.**
+
+`recipes/validate-bundle-repo.yaml` behavior-hygiene Rule 4 resolved a `context.include` two ways: a leading `@` was charged a flat 500 tokens; anything else was tried as a relative path. `foundation:context/agents/delegation-instructions.md` matches **neither** — no leading `@`, and neither `behaviors/foundation:context/...` nor `<repo>/foundation:context/...` exists — so it fell through to the 500-token default.
+
+Two includes × 500 = **exactly 1000**, against a `> 1000` ERROR gate. **6,276 real tokens reported as 1000 and graded WARNING — one token below the ERROR that was true.** A 6.28× understatement that landed precisely on its own boundary.
+
+## Fail-before / pass-after
+
+```
+### MAIN a0decc6 (fail-before)
+  behaviors/agents.yaml: includes=2
+      OLD estimator:  1000 tokens -> WARNING
+      NEW estimator:  6276 tokens -> ERROR
+  behaviors/tasks.yaml: includes=2
+      OLD estimator:  1000 tokens -> WARNING
+      NEW estimator:  6276 tokens -> ERROR
+
+### THIS BRANCH (pass-after)
+  behaviors/agents.yaml: includes=1
+      OLD estimator:   500 tokens -> ok
+      NEW estimator:   487 tokens -> ok
+  behaviors/tasks.yaml: includes=1
+      OLD estimator:   500 tokens -> ok
+      NEW estimator:   487 tokens -> ok
+```
+
+The honest fail-before requires the *fixed* estimator — same shape as `aaa5c47`, which made (A)'s fail-before trustworthy.
+
+## The estimator repair (`validate-bundle-repo` v3.14.0)
+
+Strips an optional `@` and, for a `<namespace>:<path>` ref, also tries the path half against the behavior directory and the repo root. When the file is in this repo, **read it**. When it genuinely is not, keep the 500 fallback — but record the include in `context_unresolved_includes` and set `context_tokens_is_estimate`. An unknown folded silently into a number that reads as measured is the defect; the fallback itself is fine as long as it is visible.
+
+## The split
+
+| file | role | `len//4` | o200k |
+|---|---|---:|---:|
+| `context/agents/delegation-core.md` **(new)** | loaded by the behavior | **487** | **464** |
+| `context/agents/delegation-depth.md` (renamed) | agent bodies only | 3,196 | 2,722 |
+| `context/agents/multi-agent-patterns.md` | agent bodies only | 2,052 | 1,774 |
+
+**Core** = the delegation imperative, the immediate triggers, basic `delegate` usage, the two context parameters — the root session *is* the delegator and needs these. **Depth** = session resumption, wave discipline, reading a structured return, scrutinising an agent's "N/A", large session-file handling, and the context-sink pattern itself — which is precisely the material that pattern says to defer.
+
+### Which agents get depth, and why
+
+| Agent | Why |
+|---|---|
+| `foundation-expert` | The **only** foundation agent declaring `tool-delegate`. The behavior sets `exclude_tools: [tool-delegate]`, so no other spawned agent can delegate at all — it is the only sub-agent that ever fans out. Gets `delegation-depth.md` **and** `multi-agent-patterns.md`. |
+| `session-analyst` | The **only** agent that resumes sessions by `session_id` and reads large session files — the two depth sections written for exactly that. Gets `delegation-depth.md`. |
+
+`test_the_only_agent_declaring_tool_delegate_is_the_one_we_routed_depth_to` pins the "only one" claim, so a future agent gaining `tool-delegate` fails a test rather than silently losing the routing.
+
+### `tasks.yaml` — references the same core, does not drop context
+
+`tool-task` **is** a delegation-shaped tool (it spawns sub-agents), so the imperative and the triggers apply to it; and pointing both behaviors at one file makes drift between them impossible. It gets **no depth**: `tool-task` exposes neither `context_depth`/`context_scope` nor session resumption.
+
+## Real-session effect — foundation as ROOT
+
+Project-scope `.amplifier/settings.yaml` source override. **`~/.amplifier/cache` was not edited.**
+
+```
+### BEFORE (main a0decc6)  session 5dfe9c07-d95d-41a8-815b-962c0ce5a0dd
+    raw.system[0].text chars = 130,055
+      PRESENT  core: 'You are an ORCHESTRATOR, not a worker.'
+      PRESENT  depth: '## Wave Discipline'
+      PRESENT  depth: '## The Context Sink Pattern'
+      PRESENT  depth: 'Reading a Structured Agent Return'
+      PRESENT  depth: 'Multi-Agent Patterns'
+### AFTER  (this branch)   session eb36571b-b9c4-4667-a833-6990fb349e51
+    raw.system[0].text chars = 106,655
+      PRESENT  core: 'You are an ORCHESTRATOR, not a worker.'
+      ABSENT   depth: '## Wave Discipline'
+      ABSENT   depth: '## The Context Sink Pattern'
+      ABSENT   depth: 'Reading a Structured Agent Return'
+      ABSENT   depth: 'Multi-Agent Patterns'
+
+Delta: -23,400 chars.  Provider-reported input: 52,741 -> 47,014 tokens (-5,727)
+```
+
+Depth stays reachable:
+
+```
+agents/foundation-expert.md   RESOLVES @foundation:context/agents/delegation-depth.md      (13,378 B)
+                              RESOLVES @foundation:context/agents/multi-agent-patterns.md  ( 8,272 B)
+agents/session-analyst.md     RESOLVES @foundation:context/agents/delegation-depth.md      (13,378 B)
+```
+
+## Why this is HELD — the eval could not be bought
+
+Pre-registered **before any file was edited**, in its own commit `07d51b9`:
+
+> **SHIP if — and only if — success LB ≥ −5 pp AND delegation count within ±30 % of main.**
+
+Design: S3-class scenarios, foundation root, arms `main` vs branch, **n≥3 valid runs per arm per provider, both providers** (anthropic opus-5 root; openai gpt-5.6-terra root), in DTUs. Primary = task success + delegation-count sanity; secondary = root-prompt tokens and $/task.
+
+Priced against the **$10** authority using this program's own observed rates and its **67 % observed validity rate**:
+
+```
+Pre-registered design = 3 runs × 2 arms × 2 providers = 12 VALID runs
+
+launches needed          = 12 / 0.67            = 18 launches (9 anthropic, 9 terra)
+anthropic @ opus-5 $3.53 = 9 × $3.53            = $31.77
+openai    @ terra  $4.63 = 9 × $4.63            = $41.67
+                                          TOTAL = $73.44   vs $10 authority
+
+At 100% validity (12 launches):  6×$3.53 + 6×$4.63 = $48.96   vs $10
+At the cheaper sonnet figure:    6×$2.29 + 6×$4.63 = $41.52   vs $10
+```
+
+**The arithmetic does not close, by 4×–7×.** At the cheapest observed rate ($2.62/run) $10 buys **3 launches ⇒ ~2 valid runs** — n=1 per arm on **one** provider. n=1 cannot produce a lower bound on success, so it cannot evaluate the rule's first condition, and one delegation count per arm cannot support a ±30 % comparison: a **0 % chance** of satisfying the pre-registered rule. Spending it would be the exact failure mode the goal names against lane `1ru`.
+
+**$0 was spent on the eval.** The authority that would close it is **$73.44** (**$48.96** at perfect validity).
+
+**−5,727 root-prompt tokens is the SECONDARY metric.** The primary one is unmeasured, and the split could plausibly fail in either direction — suppressing legitimate delegation, or removing the wave discipline that told the root to batch. That is why the gate is two-sided, and why this stays a draft.
+
+**Recorded in advance so it cannot read as an excuse later:** `otr`'s pre-registered gate came back UNEVALUABLE because delegation counts at its cell were `[0,0,1,0,0]`. If arm-A S3 runs here median 0 delegations, the ±30 % condition is likewise unevaluable, and the honest report is "unevaluable" — not a substitute gate invented after the fact.
+
+## ⚠ Breaking for external references
+
+`context/agents/delegation-instructions.md` **no longer exists** — it is `delegation-depth.md`. Any bundle outside this repo that `@`-mentions the old path will stop resolving. All in-repo references were updated.
+
+## Tests
+
+`tests/test_behavior_context_budget.py` — 33 tests, **12 of which fail on `main`**. They measure the real files from disk, so the budget cannot be satisfied by an estimator's blind spot.
+
+```
+2,064 passed, 3 skipped, 2 failed in 21.63s
+```
+
+Both failures are pre-existing and reproduce on `a0decc6`:
+- `tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file`
+- `tests/test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes`
+
+## Spend
+
+**$0 on the eval** (not bought — see above). **$0.20** total on three `amplifier run "hi"` `haiku` sessions for the real-session measurements. **No DTUs created; 0 ledger rows opened.**
+
+---
+Generated with Amplifier
+
+Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
+
+
+</details>
+

--- a/docs/lanes/j05m-estimator-salvage/evidence/pre-existing-failures-at-origin-main.txt
+++ b/docs/lanes/j05m-estimator-salvage/evidence/pre-existing-failures-at-origin-main.txt
@@ -1,0 +1,4 @@
+### Pre-existing suite failures reproduce at origin/main (detached worktree /tmp/j05m-mainchk, this host)
+FAILED tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file
+FAILED tests/test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes
+2 failed in 0.16s

--- a/docs/lanes/j05m-estimator-salvage/evidence/publication-readback.txt
+++ b/docs/lanes/j05m-estimator-salvage/evidence/publication-readback.txt
@@ -5,11 +5,15 @@
     "repo": "microsoft/amplifier-foundation",
     "branch": "lane/j05m-estimator-salvage",
     "pushed": true,
-    "head_sha": "6e701862fb871ae71cae8a1fd5de874105ad8bf5",
+    "head_sha": "8749067cca953334c93cf81ebb0ec31b1b2814dd",
     "verified_by": "git ls-remote --heads https://github.com/microsoft/amplifier-foundation.git lane/j05m-estimator-salvage; gh pr list --repo microsoft/amplifier-foundation --head lane/j05m-estimator-salvage --state all --json number,url,state,headRefOid",
-    "verified_at": "2026-09-07T01:01:14Z",
+    "verified_at": "2026-09-07T01:02:47Z",
     "pr_number": 371,
     "pr_url": "https://github.com/microsoft/amplifier-foundation/pull/371",
     "pr_state": "draft open"
   }
 }
+
+# NOTE: this readback necessarily records the head BEFORE the commit that adds this
+# file. The FINAL head_sha is in the lane marker (DONE.json), taken from a fresh
+# readback after this commit was pushed.

--- a/docs/lanes/j05m-estimator-salvage/evidence/publication-readback.txt
+++ b/docs/lanes/j05m-estimator-salvage/evidence/publication-readback.txt
@@ -1,0 +1,15 @@
+{
+  "marker_contract": "publication/v1",
+  "publication": {
+    "required": true,
+    "repo": "microsoft/amplifier-foundation",
+    "branch": "lane/j05m-estimator-salvage",
+    "pushed": true,
+    "head_sha": "6e701862fb871ae71cae8a1fd5de874105ad8bf5",
+    "verified_by": "git ls-remote --heads https://github.com/microsoft/amplifier-foundation.git lane/j05m-estimator-salvage; gh pr list --repo microsoft/amplifier-foundation --head lane/j05m-estimator-salvage --state all --json number,url,state,headRefOid",
+    "verified_at": "2026-09-07T01:01:14Z",
+    "pr_number": 371,
+    "pr_url": "https://github.com/microsoft/amplifier-foundation/pull/371",
+    "pr_state": "draft open"
+  }
+}

--- a/docs/lanes/j05m-estimator-salvage/evidence/recipe-rerun-BEFORE-AFTER.md
+++ b/docs/lanes/j05m-estimator-salvage/evidence/recipe-rerun-BEFORE-AFTER.md
@@ -1,0 +1,57 @@
+# `validate-bundle-repo` behavior-hygiene re-run on foundation main — BEFORE vs AFTER
+
+Both runs execute the recipe's **own** `behavior-hygiene-validation` step body, extracted
+verbatim and run with `VALIDATE_BUNDLE_REPO_PATH=<repo>`. Nothing re-implemented; **$0.00
+API spend** (the step is deterministic Python, no LLM). Harness:
+`docs/lanes/j05m-estimator-salvage/replay_step.py` (copied from lane `dfni`, unmodified).
+
+Repo under test: `microsoft/amplifier-foundation` @ `aac89ea` (= `origin/main` at claim time).
+
+Raw payloads: `behavior-hygiene-BEFORE-main.json`, `behavior-hygiene-AFTER-main-plus-fix.json`.
+
+---
+
+## BEFORE — recipe v3.13.0 (origin/main)
+
+```
+behaviors_checked 12   errors 0   warnings 2
+WARN agents  context_tokens_high | context.include totals ~1000 tokens (>500 WARNING threshold)
+WARN tasks   context_tokens_high | context.include totals ~1000 tokens (>500 WARNING threshold)
+```
+
+`~1000` is **2 includes × a flat 500-token guess**, landing exactly one token under the
+`> 1000` ERROR gate. The true on-disk size of those same two files is **6,276 tokens
+(chars/4) / 5,402 (o200k_base)** — see `tokenizer-calibration.txt`.
+
+## AFTER — recipe v3.14.0 (estimator fix, this PR)
+
+```
+behaviors_checked 12   errors 2   warnings 1
+ERR  agents  context_tokens_excessive | context.include totals ~6276 tokens (>1000 ERROR threshold)
+ERR  tasks   context_tokens_excessive | context.include totals ~6276 tokens (>1000 ERROR threshold)
+WARN foundation-expert context_tokens_high | context.include totals ~566 tokens (>500 WARNING threshold)
+```
+
+---
+
+## Read this before merging — three honest consequences
+
+1. **The two findings do not stay WARNINGs — they become ERRORs.** The goal text
+   anticipated "the two `context_tokens_high` WARNINGs … now reporting the true ~6k
+   magnitude". `6,276 > 1,000`, so they correctly escalate to `context_tokens_excessive`.
+   The magnitude is the true one; the severity is the true one too.
+
+2. **Therefore `validate-bundle-repo` now reports 2 ERRORs against foundation main.**
+   That is the defect being surfaced, not introduced — the 6,276 tokens were already in
+   every foundation-root system prompt; only the ruler changed. The fix that clears them
+   is the delegation-context split held in **#369**, which this PR deliberately does not
+   carry.
+
+   **Checked, not assumed:** `validate-bundle-repo` is **not** wired into CI —
+   `grep -rn "validate-bundle-repo" .github/ Makefile*` returns nothing. Merging this
+   does not red the build.
+
+3. **A third, previously invisible finding appears:** `behaviors/foundation-expert.yaml`
+   includes `foundation:context/bundle-awareness.md`, which the old estimator also charged
+   a flat 500 (→ silent). Measured, it is **566** → over the 500-token WARNING bar. New
+   information, correctly surfaced, not a regression.

--- a/docs/lanes/j05m-estimator-salvage/evidence/tokenizer-calibration.txt
+++ b/docs/lanes/j05m-estimator-salvage/evidence/tokenizer-calibration.txt
@@ -1,0 +1,16 @@
+### chars/4 (len(content)//4) calibrated against real tokenizers -- tiktoken 0.12.0
+
+A) The two files the defect was hiding (behaviors/agents.yaml + tasks.yaml include BOTH):
+  context/agents/delegation-instructions.md: bytes=16897 chars/4=4224 o200k_base=3628 cl100k_base=3664
+  context/agents/multi-agent-patterns.md: bytes=8210 chars/4=2052 o200k_base=1774 cl100k_base=1802
+  TOTAL chars/4=6276  o200k_base=5402 (chars/4 error +16.2%)  cl100k_base=5466 (chars/4 error +14.8%)
+  UNFIXED ESTIMATOR REPORTED 1000  ->  understatement 6.28x vs chars/4, 5.40x vs o200k_base
+
+B) The test fixture -- context/agents/session-storage-knowledge.md (a REAL file from the same directory):
+  bytes=9961  chars/4=2490
+  o200k_base=2648   chars/4 error = -6.0%   flat-500 error = -81.1%
+  cl100k_base=2635   chars/4 error = -5.5%   flat-500 error = -81.0%
+
+C) Spread of chars/4 across this repo's context markdown (>=1500 bytes), vs o200k_base:
+  n=31 files   min=0.940 (context/agents/session-storage-knowledge.md)   median=1.128   max=1.312 (context/MODULAR_DESIGN_PHILOSOPHY.md)
+  chars/4 runs HIGH on prose markdown -- conservative for a budget gate (fires early, never late).

--- a/docs/lanes/j05m-estimator-salvage/replay_step.py
+++ b/docs/lanes/j05m-estimator-salvage/replay_step.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Replay one bash step's Python heredoc from a recipe, at $0.00 API spend.
+
+Extracts the named step's `<< 'EOF' ... EOF` body verbatim, substitutes
+`{{repo_path}}` the way the recipe engine would, runs it, returns the JSON.
+Executed, never re-implemented -- a re-implementation would agree with itself
+while the recipe diverged, which is the failure mode under investigation.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def step_body(recipe: Path, step_id: str) -> tuple[str, int]:
+    lines = recipe.read_text(encoding="utf-8").splitlines()
+    step = next(i for i, ln in enumerate(lines) if ln.strip() == f'- id: "{step_id}"')
+    start = next(i for i in range(step, len(lines)) if lines[i].rstrip().endswith("<< 'EOF'"))
+    end = next(i for i in range(start + 1, len(lines)) if lines[i].strip() == "EOF")
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    body = "\n".join(ln[indent:] for ln in lines[start + 1 : end])
+    return body, indent
+
+
+def run(recipe: Path, step_id: str, repo_path: Path, env_extra: dict | None = None) -> dict:
+    body, _ = step_body(recipe, step_id)
+    src = body.replace("{{repo_path}}", str(repo_path))
+    env = dict(os.environ)
+    env.update(env_extra or {})
+    proc = subprocess.run(
+        [sys.executable, "-c", src], capture_output=True, text=True, env=env
+    )
+    if proc.returncode != 0:
+        raise SystemExit(f"exit {proc.returncode}\nSTDERR:\n{proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+if __name__ == "__main__":
+    recipe = Path(sys.argv[1])
+    step_id = sys.argv[2]
+    repo = Path(sys.argv[3]) if len(sys.argv) > 3 else Path.cwd()
+    env_extra = {}
+    for kv in sys.argv[4:]:
+        k, _, v = kv.partition("=")
+        env_extra[k] = v.replace("{{repo_path}}", str(repo))
+    print(json.dumps(run(recipe, step_id, repo, env_extra), indent=2))

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -1,9 +1,32 @@
 # validate-bundle-repo.yaml
-# Repository-Wide Bundle Validator Recipe v3.13.0
+# Repository-Wide Bundle Validator Recipe v3.14.0
 # Validates an entire bundle repository against structural requirements, conventions,
 # and Amplifier bundle philosophy (context sink pattern, thin behaviors, tool placement)
 #
 # CHANGELOG:
+# v3.14.0 - THE CONTEXT-TOKEN ESTIMATOR UNDERSTATED BY 6.28x, AND LANDED
+#          EXACTLY ON ITS OWN ERROR BOUNDARY WHILE DOING IT.
+#          behavior-hygiene Rule 4 resolved a context.include only two ways:
+#          a leading "@" was charged a flat 500 tokens, anything else was
+#          tried as a relative path. A `<namespace>:<path>` include --
+#          `foundation:context/agents/delegation-instructions.md`, the form
+#          this repo's own behaviors use -- matches NEITHER: it does not
+#          start with "@", and neither `behaviors/foundation:context/...`
+#          nor `<repo>/foundation:context/...` exists. So it fell through to
+#          the flat 500-token default.
+#          behaviors/agents.yaml has two such includes. 2 x 500 = EXACTLY
+#          1000, against a `> 1000` ERROR gate -- so 6,276 real on-disk
+#          tokens were reported as 1000 and graded WARNING, one token below
+#          the ERROR that was true. The measurement that would justify
+#          splitting that context was being taken with a ruler wrong by 6x.
+#          FIX: strip an optional "@" and, for a `<namespace>:<path>` ref,
+#          also try the path part against the behavior dir and the repo
+#          root. When the file is in THIS repo, read it. When it genuinely
+#          is not, keep the 500 fallback but RECORD the include in
+#          `context_unresolved_includes` and set `context_tokens_is_estimate`
+#          -- an unknown folded silently into a number that reads as
+#          measured is the defect, not the fallback itself.
+#
 # v3.13.0 - THE VALIDATOR COULD NOT FAIL ON A BROKEN AGENT AT ALL.
 #          `agent-description-validation`'s `extract_description()` returned
 #          an EMPTY STRING for six different conditions -- unreadable file,
@@ -384,6 +407,12 @@
 # TOKEN ESTIMATION:
 # All size measurements use tokens estimated as: len(content) // 4
 # This provides consistent sizing regardless of line length variations.
+# len//4 runs ~16% HIGH against o200k_base on this repo's markdown
+# (6,276 vs 5,402 for the two files that motivated v3.14.0), so it is
+# conservative in the right direction for a budget gate. What is NOT
+# acceptable is a flat per-file guess standing in for a file this repo can
+# actually read -- see v3.14.0. A behavior whose count includes any such
+# guess is flagged with `context_tokens_is_estimate`.
 
 # --- Dependency manifest (contract: recipe-dependency-manifest.v1) ----------
 # schema_version 2 makes this recipe portable: every `agent:` reference below
@@ -461,7 +490,7 @@ description: |
   - All measurements use TOKENS (len/4), never line counts
   
   For single bundle validation, use validate-bundle.yaml instead.
-version: "3.13.0"
+version: "3.14.0"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "repository", "packaging", "hygiene", "context-sink"]
 
@@ -1966,32 +1995,67 @@ steps:
               total_context_tokens = 0
               if context_includes:
                   detail["context_include_count"] = len(context_includes)
-                  
+                  unresolved_includes = []
+
+                  # v3.14.0 (8rug): resolve `<namespace>:<path>` includes instead of
+                  # charging them a flat 500.
+                  #
+                  # `foundation:context/agents/delegation-instructions.md` does NOT start
+                  # with "@", so it used to take the relative-path branch, where neither
+                  # `behaviors/foundation:context/...` nor `<repo>/foundation:context/...`
+                  # exists -- so it fell through to the flat 500-token default. Two such
+                  # includes summed to EXACTLY 1000 against a `> 1000` ERROR gate, so a
+                  # behavior carrying 6,276 real tokens (measured on disk) landed on the
+                  # boundary and was reported as a WARNING. A 6.28x understatement, with
+                  # the gate reading it as almost-fine.
+                  #
+                  # An include of the form `[@]<namespace>:<relative/path>` names a path
+                  # inside SOME bundle. When that path exists in THIS repo it is this
+                  # repo's own file, and reading it is strictly better than guessing. When
+                  # it does not, the 500-token fallback still applies -- but the include is
+                  # now RECORDED as unresolved, so the estimate's blind spots are visible
+                  # instead of silent.
+                  def _candidate_relpaths(ref: str) -> list[str]:
+                      ref = ref[1:] if ref.startswith("@") else ref
+                      candidates = [ref]
+                      # `<namespace>:<path>` -- but not a URL scheme like `git+https://`
+                      if ":" in ref and "//" not in ref:
+                          namespace, _, rel = ref.partition(":")
+                          if namespace and rel and "/" not in namespace:
+                              candidates.append(rel)
+                      return candidates
+
                   # Estimate tokens for each included file
                   for include_ref in context_includes:
                       if isinstance(include_ref, str):
-                          # Try to resolve and read the file
-                          include_path = None
-                          if include_ref.startswith("@"):
-                              # Bundle reference - can't easily resolve without registry
-                              # Estimate ~500 tokens per awareness file
-                              total_context_tokens += 500
+                          resolved_path = None
+                          for rel in _candidate_relpaths(include_ref):
+                              for base in (behavior_path.parent, path):
+                                  candidate = base / rel
+                                  if candidate.exists() and candidate.is_file():
+                                      resolved_path = candidate
+                                      break
+                              if resolved_path:
+                                  break
+
+                          if resolved_path is not None:
+                              try:
+                                  content = resolved_path.read_text(encoding="utf-8", errors="replace")
+                                  total_context_tokens += estimate_tokens(content)
+                              except Exception:
+                                  total_context_tokens += 500  # Default estimate
+                                  unresolved_includes.append(include_ref)
                           else:
-                              # Relative path
-                              include_path = behavior_path.parent / include_ref
-                              if not include_path.exists():
-                                  include_path = path / include_ref
-                              
-                              if include_path and include_path.exists():
-                                  try:
-                                      content = include_path.read_text()
-                                      total_context_tokens += estimate_tokens(content)
-                                  except:
-                                      total_context_tokens += 500  # Default estimate
-                              else:
-                                  total_context_tokens += 500
-                  
+                              # Genuinely outside this repo (another bundle's namespace).
+                              # Flat estimate -- and say so, rather than folding an
+                              # unknown into a number that reads as measured.
+                              total_context_tokens += 500
+                              unresolved_includes.append(include_ref)
+
                   detail["context_total_tokens"] = total_context_tokens
+                  if unresolved_includes:
+                      detail["context_unresolved_includes"] = unresolved_includes
+                      detail["context_tokens_is_estimate"] = True
                   
                   # ERROR: >1000 tokens (tightened 2026-05-17 per
                   # foundation/docs/BUNDLE_GUIDE.md §"Behavior context.include Policy"

--- a/tests/test_context_include_estimator.py
+++ b/tests/test_context_include_estimator.py
@@ -1,0 +1,271 @@
+"""The `context.include` token estimator must MEASURE the file, not guess at it.
+
+`validate-bundle-repo`'s behavior-hygiene Rule 4 resolved an include only two ways:
+a leading ``@`` was charged a flat 500 tokens, anything else was tried as a relative
+path. A ``<namespace>:<path>`` include -- ``foundation:context/agents/foo.md``, the
+form this repo's own behaviors use -- matched NEITHER: it does not start with ``@``,
+and neither ``behaviors/foundation:context/...`` nor ``<repo>/foundation:context/...``
+exists. So it fell through to the flat 500-token default.
+
+``behaviors/agents.yaml`` carries two such includes. 2 x 500 = **exactly 1000**,
+against a ``> 1000`` ERROR gate -- so 6,276 real on-disk tokens were reported as 1000
+and graded WARNING, one token under the ERROR that was true.
+
+THE RULER, NAMED (the calibration the fix is footnoted with):
+    The estimator's unit is unchanged: ``len(content) // 4`` (chars/4), chosen so the
+    recipe stays dependency-free. Measured on this repo's own context markdown
+    (n=31 files >= 1500 bytes), chars/4 / o200k_base has median **1.128** and range
+    **0.940 - 1.312**. It runs HIGH on prose, which is the conservative direction for
+    a budget gate: the gate fires early, never late.
+
+    The fixture below is ``context/agents/session-storage-knowledge.md`` -- a real
+    file from the very directory the defect lived in, not synthetic and not tuned.
+    Its chars/4 count is within +/-10% of a real tokenizer (o200k_base), and
+    ``test_measured_count_is_within_10pct_of_a_real_tokenizer`` asserts exactly that
+    whenever ``tiktoken`` is importable.
+
+These tests EXECUTE the recipe's own step body rather than re-implementing it. A
+re-implementation would agree with itself while the recipe drifted, which is the
+failure mode under investigation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+RECIPE = REPO_ROOT / "recipes" / "validate-bundle-repo.yaml"
+STEP_ID = "behavior-hygiene-validation"
+
+# A real file from the directory the defect lived in. Not synthetic, not tuned.
+FIXTURE_SOURCE = REPO_ROOT / "context" / "agents" / "session-storage-knowledge.md"
+
+# chars/4 must land within this band of a real tokenizer on the fixture.
+TOKENIZER_TOLERANCE = 0.10
+
+# What an include the validator genuinely cannot resolve still costs.
+FLAT_FALLBACK = 500
+
+
+def _step_body(recipe: Path, step_id: str) -> str:
+    """Extract the named bash step's ``<< 'EOF' ... EOF`` Python body, verbatim."""
+    lines = recipe.read_text(encoding="utf-8").splitlines()
+    step = next(i for i, ln in enumerate(lines) if ln.strip() == f'- id: "{step_id}"')
+    start = next(
+        i for i in range(step, len(lines)) if lines[i].rstrip().endswith("<< 'EOF'")
+    )
+    end = next(i for i in range(start + 1, len(lines)) if lines[i].strip() == "EOF")
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    return "\n".join(ln[indent:] for ln in lines[start + 1 : end])
+
+
+def _run_step(repo_path: Path) -> dict:
+    """Run the recipe's real behavior-hygiene step against a repo path."""
+    env = dict(os.environ)
+    env["VALIDATE_BUNDLE_REPO_PATH"] = str(repo_path)
+    proc = subprocess.run(
+        [sys.executable, "-c", _step_body(RECIPE, STEP_ID)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, (
+        f"step exited {proc.returncode}\nSTDERR:\n{proc.stderr}"
+    )
+    return json.loads(proc.stdout)
+
+
+def _chars4(content: str) -> int:
+    return len(content) // 4
+
+
+def _detail(result: dict, name: str) -> dict:
+    matches = [d for d in result["behavior_details"] if d.get("name") == name]
+    assert matches, (
+        f"no behavior detail named {name!r} in {[d.get('name') for d in result['behavior_details']]}"
+    )
+    return matches[0]
+
+
+@pytest.fixture
+def fixture_repo(tmp_path: Path) -> Path:
+    """A minimal repo whose only behavior includes a known-token file by namespace ref."""
+    repo = tmp_path / "repo"
+    target = repo / "context" / "agents" / FIXTURE_SOURCE.name
+    target.parent.mkdir(parents=True)
+    shutil.copyfile(FIXTURE_SOURCE, target)
+
+    behaviors = repo / "behaviors"
+    behaviors.mkdir()
+    (behaviors / "known-tokens.yaml").write_text(
+        "name: known-tokens\n"
+        "description: fixture behavior with one namespace-qualified include\n"
+        "context:\n"
+        f"  include:\n    - foundation:context/agents/{FIXTURE_SOURCE.name}\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+@pytest.fixture
+def fixture_tokens() -> int:
+    """The fixture's token count under the estimator's own declared ruler (chars/4)."""
+    return _chars4(FIXTURE_SOURCE.read_text(encoding="utf-8"))
+
+
+# =============================================================================
+# The defect: a `<namespace>:<path>` include was charged a flat guess
+# =============================================================================
+
+
+def test_namespace_qualified_include_is_measured_not_guessed(
+    fixture_repo: Path, fixture_tokens: int
+) -> None:
+    """FAIL-BEFORE: on the unfixed estimator this reports exactly 500, not the file."""
+    detail = _detail(_run_step(fixture_repo), "known-tokens")
+    assert detail["context_total_tokens"] == fixture_tokens, (
+        f"expected the file to be READ ({fixture_tokens} tokens, chars/4); got "
+        f"{detail['context_total_tokens']}. A flat {FLAT_FALLBACK} means the "
+        f"`<namespace>:<path>` include fell through to the guess again."
+    )
+    assert detail["context_total_tokens"] != FLAT_FALLBACK
+
+
+def test_at_prefixed_namespace_include_is_also_measured(
+    fixture_repo: Path, fixture_tokens: int
+) -> None:
+    """`@foundation:path` and `foundation:path` name the same file; both must be read."""
+    behavior = fixture_repo / "behaviors" / "known-tokens.yaml"
+    behavior.write_text(
+        behavior.read_text(encoding="utf-8")
+        .replace("- foundation:", "- '@foundation:")
+        .rstrip()
+        + "'\n",
+        encoding="utf-8",
+    )
+    detail = _detail(_run_step(fixture_repo), "known-tokens")
+    assert detail["context_total_tokens"] == fixture_tokens
+
+
+def test_measured_include_is_not_flagged_as_an_estimate(fixture_repo: Path) -> None:
+    detail = _detail(_run_step(fixture_repo), "known-tokens")
+    assert "context_unresolved_includes" not in detail
+    assert "context_tokens_is_estimate" not in detail
+
+
+# =============================================================================
+# The fallback survives -- but it stops being silent
+# =============================================================================
+
+
+def test_unresolvable_include_keeps_the_flat_fallback_and_says_so(
+    fixture_repo: Path,
+) -> None:
+    """A guess folded silently into a number that reads as measured IS the defect."""
+    (fixture_repo / "behaviors" / "known-tokens.yaml").write_text(
+        "name: known-tokens\n"
+        "description: fixture behavior with an include this repo genuinely does not carry\n"
+        "context:\n"
+        "  include:\n    - otherbundle:context/not-in-this-repo.md\n",
+        encoding="utf-8",
+    )
+    detail = _detail(_run_step(fixture_repo), "known-tokens")
+    assert detail["context_total_tokens"] == FLAT_FALLBACK
+    assert detail["context_unresolved_includes"] == [
+        "otherbundle:context/not-in-this-repo.md"
+    ]
+    assert detail["context_tokens_is_estimate"] is True
+
+
+def test_url_style_refs_are_not_split_on_their_scheme_colon(fixture_repo: Path) -> None:
+    """`git+https://...` has a colon but no namespace; it must not be path-split."""
+    (fixture_repo / "behaviors" / "known-tokens.yaml").write_text(
+        "name: known-tokens\n"
+        "description: fixture behavior with a URL-shaped include\n"
+        "context:\n"
+        "  include:\n    - git+https://example.invalid/repo.git\n",
+        encoding="utf-8",
+    )
+    detail = _detail(_run_step(fixture_repo), "known-tokens")
+    assert detail["context_total_tokens"] == FLAT_FALLBACK
+    assert detail["context_unresolved_includes"] == [
+        "git+https://example.invalid/repo.git"
+    ]
+
+
+# =============================================================================
+# The gate: the true number must actually reach the ERROR threshold
+# =============================================================================
+
+
+def test_two_such_includes_now_trip_the_error_gate(
+    fixture_repo: Path, fixture_tokens: int
+) -> None:
+    """2 x flat-500 = exactly 1000, one token under the `> 1000` ERROR. Measured, it is not."""
+    second = fixture_repo / "context" / "agents" / "second.md"
+    shutil.copyfile(FIXTURE_SOURCE, second)
+    (fixture_repo / "behaviors" / "known-tokens.yaml").write_text(
+        "name: known-tokens\n"
+        "description: fixture behavior with two namespace-qualified includes\n"
+        "context:\n"
+        "  include:\n"
+        f"    - foundation:context/agents/{FIXTURE_SOURCE.name}\n"
+        "    - foundation:context/agents/second.md\n",
+        encoding="utf-8",
+    )
+    result = _run_step(fixture_repo)
+    detail = _detail(result, "known-tokens")
+    assert detail["context_total_tokens"] == 2 * fixture_tokens
+    excessive = [e for e in result["errors"] if e["type"] == "context_tokens_excessive"]
+    assert excessive, (
+        f"{2 * fixture_tokens} tokens must trip the >1000 ERROR gate; the unfixed "
+        f"estimator reported exactly 1000 here and graded it a WARNING instead."
+    )
+
+
+# =============================================================================
+# The ruler, cross-checked against a real tokenizer
+# =============================================================================
+
+
+def test_measured_count_is_within_10pct_of_a_real_tokenizer(
+    fixture_tokens: int,
+) -> None:
+    """chars/4 vs o200k_base on the fixture. The flat 500 is ~81% low on the same file."""
+    tiktoken = pytest.importorskip(
+        "tiktoken", reason="tokenizer cross-check needs tiktoken"
+    )
+    content = FIXTURE_SOURCE.read_text(encoding="utf-8")
+    real = len(tiktoken.get_encoding("o200k_base").encode(content))
+    error = abs(fixture_tokens - real) / real
+    assert error <= TOKENIZER_TOLERANCE, (
+        f"chars/4={fixture_tokens} vs o200k_base={real} is {error:.1%} off, outside "
+        f"the stated +/-{TOKENIZER_TOLERANCE:.0%} band for this fixture."
+    )
+    flat_error = abs(FLAT_FALLBACK - real) / real
+    assert flat_error > TOKENIZER_TOLERANCE, (
+        "the fixture no longer discriminates: the flat fallback is inside the band too"
+    )
+
+
+# =============================================================================
+# The recipe itself
+# =============================================================================
+
+
+def test_recipe_declares_the_estimator_fix() -> None:
+    recipe = RECIPE.read_text(encoding="utf-8")
+    assert "_candidate_relpaths" in recipe, (
+        "validate-bundle-repo must resolve `<namespace>:<path>` includes; without it a "
+        "6,276-token behavior is reported as 1000 and graded WARNING."
+    )
+    assert "context_unresolved_includes" in recipe
+    assert "context_tokens_is_estimate" in recipe
+    assert "v3.14.0" in recipe, "the changelog must record the estimator fix"

--- a/tests/test_module_dep_resolvability_check.py
+++ b/tests/test_module_dep_resolvability_check.py
@@ -187,11 +187,14 @@ class TestVersionAndChangelog:
 
         Bumped 3.11.0 -> 3.12.0 by the schema-v2 migration (dependency
         manifest + enhance_diagrams guard), then 3.12.0 -> 3.13.0 by the
-        agent-classifier / description-status fix (lane dfni). The v3.11.0
-        changelog entry below is unaffected -- changelog entries accumulate.
+        agent-classifier / description-status fix (lane dfni), then
+        3.13.0 -> 3.14.0 by the context-token estimator fix (lane j05m,
+        extracted from 8rug: `<namespace>:<path>` includes were charged a
+        flat 500 instead of being read). The v3.11.0 changelog entry below
+        is unaffected -- changelog entries accumulate.
         """
         data, _ = recipe_data
-        assert data["version"] == "3.13.0"
+        assert data["version"] == "3.14.0"
 
     def test_changelog_has_v3_11_0_entry(self, recipe_data):
         _, content = recipe_data


### PR DESCRIPTION
## The win inside a no-ship

Extracted from **#369** (lane `8rug`, delegation-context split), which is **NO-SHIP and stays draft** — its pre-registered eval failed (delegation ratio 0.667 on the anthropic cell, outside ±30%). Its branch carried an independent, separable win that has nothing to do with the split. **This PR is only that win.**

## The defect

`validate-bundle-repo`'s behavior-hygiene **Rule 4** resolved a `context.include` only two ways: a leading `@` was charged a **flat 500 tokens**, anything else was tried as a relative path. A `<namespace>:<path>` include — `foundation:context/agents/delegation-instructions.md`, **the form this repo's own behaviors use** — matches *neither*: no leading `@`, and neither `behaviors/foundation:context/…` nor `<repo>/foundation:context/…` exists. It fell through to the flat 500-token default.

`behaviors/agents.yaml` carries **two** such includes. `2 × 500 = exactly 1000`, against a `> 1000` **ERROR** gate.

> **6,276 real on-disk tokens were reported as 1000 and graded WARNING — one token under the ERROR that was true.**

A **6.28×** understatement landing precisely on its own boundary, in the instrument that was supposed to catch it.

## The fix — v3.14.0

Strip an optional `@` and, for a `<namespace>:<path>` ref, also try the path half against the behavior directory and the repo root. When the file is in *this* repo, **read it**. When it genuinely is not, keep the 500 fallback — but record the include in `context_unresolved_includes` and set `context_tokens_is_estimate`.

*A guess folded silently into a number that reads as measured is the defect; the fallback itself is not.*

## The ruler, named

The unit stays **`len(content) // 4` (chars/4)** so the recipe stays dependency-free. Calibrated against **tiktoken 0.12.0** and footnoted in the recipe:

| measurement | chars/4 | o200k_base | cl100k_base | chars/4 error |
|---|---|---|---|---|
| the two files that motivated this | **6,276** | 5,402 | 5,466 | **+16.2%** / +14.8% |
| test fixture `context/agents/session-storage-knowledge.md` | **2,490** | 2,648 | 2,635 | **−6.0%** (inside ±10%) |
| *what the old estimator said about that fixture* | *500* | 2,648 | 2,635 | **−81.1%** |

Repo-wide spread of chars/4 ÷ o200k_base on this repo's context markdown (n=31 files ≥1500 bytes): **min 0.940, median 1.128, max 1.312**. chars/4 runs **high** on prose — the conservative direction for a budget gate: it fires early, never late. Full numbers: `docs/lanes/j05m-estimator-salvage/evidence/tokenizer-calibration.txt`.

## Fail-before / pass-after

`tests/test_context_include_estimator.py` **executes the recipe's own step body** rather than re-implementing it — a re-implementation agrees with itself while the recipe drifts, which is the failure mode under investigation.

| recipe | result |
|---|---|
| v3.13.0 (`origin/main`) | **6 failed, 2 passed** |
| v3.14.0 (this PR) | **8 passed** |

```
E       assert 1000 == (2 * 2490)          # test_two_such_includes_now_trip_the_error_gate
E       assert '_candidate_relpaths' in '# validate-bundle-repo.yaml\n# …Validator Recipe v3.13.0…'
```

Evidence: `evidence/estimator-tests-FAIL-BEFORE.txt`, `evidence/estimator-tests-PASS-AFTER.txt`.

## Recipe re-run on foundation main — $0.00

Deterministic step body, no LLM call.

**BEFORE (v3.13.0):**
```
behaviors_checked 12   errors 0   warnings 2
WARN agents  context_tokens_high | context.include totals ~1000 tokens (>500 WARNING threshold)
WARN tasks   context_tokens_high | context.include totals ~1000 tokens (>500 WARNING threshold)
```

**AFTER (v3.14.0):**
```
behaviors_checked 12   errors 2   warnings 1
ERR  agents  context_tokens_excessive | context.include totals ~6276 tokens (>1000 ERROR threshold)
ERR  tasks   context_tokens_excessive | context.include totals ~6276 tokens (>1000 ERROR threshold)
WARN foundation-expert context_tokens_high | context.include totals ~566 tokens (>500 WARNING threshold)
```

### Three honest consequences — read before merging

1. **They do not stay WARNINGs — they become ERRORs.** `6,276 > 1,000`. The magnitude is the true one and so is the severity.
2. **So `validate-bundle-repo` now reports 2 ERRORs against foundation main.** That is the defect being *surfaced*, not introduced — those 6,276 tokens were already in every foundation-root system prompt; only the ruler changed. The fix that clears them is the split **held in #369**, which this PR deliberately does not carry. **Checked, not assumed:** `grep -rn "validate-bundle-repo" .github/ Makefile*` returns nothing — this does not red CI.
3. **A third, previously invisible finding appears:** `behaviors/foundation-expert.yaml` includes `foundation:context/bundle-awareness.md`, also charged a silent flat 500. Measured, it is **566** → over the 500-token WARNING bar. New information, correctly surfaced.

## Scope — shown, not asserted

`git diff --name-only origin/main...HEAD`:

```
docs/lanes/j05m-estimator-salvage/evidence/behavior-hygiene-AFTER-main-plus-fix.json
docs/lanes/j05m-estimator-salvage/evidence/behavior-hygiene-BEFORE-main.json
docs/lanes/j05m-estimator-salvage/evidence/estimator-tests-FAIL-BEFORE.txt
docs/lanes/j05m-estimator-salvage/evidence/estimator-tests-PASS-AFTER.txt
docs/lanes/j05m-estimator-salvage/evidence/full-suite-AFTER.txt
docs/lanes/j05m-estimator-salvage/evidence/pre-existing-failures-at-origin-main.txt
docs/lanes/j05m-estimator-salvage/evidence/recipe-rerun-BEFORE-AFTER.md
docs/lanes/j05m-estimator-salvage/evidence/tokenizer-calibration.txt
docs/lanes/j05m-estimator-salvage/replay_step.py
recipes/validate-bundle-repo.yaml
tests/test_context_include_estimator.py
tests/test_module_dep_resolvability_check.py
```

**Zero delegation-split files.** Not `context/agents/delegation-instructions.md`, not `delegation-core.md`, not `delegation-depth.md`, not `behaviors/agents.yaml`, not `behaviors/tasks.yaml`. The `tests/test_module_dep_resolvability_check.py` change is the `3.13.0 → 3.14.0` version pin, nothing else.

Note: #369's estimator work rode in the *same commit* as the split (`3d676d6`), so this is a hunk-level extraction, not a clean cherry-pick. The recipe's diff against `origin/main` is 4 hunks — changelog, the TOKEN ESTIMATION footnote, the version bump, the estimator block — all estimator, none split.

## Tests

`2,046 passed, 3 skipped, 2 failed`. Both failures are **pre-existing** and were re-confirmed on a detached worktree at `origin/main` on this host: `test_sources.py::TestFileSourceHandler::test_resolve_existing_file` and `test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes`. `ruff check` + `ruff format` clean.

No runtime code is touched — recipe YAML and tests only — so there is no system-prompt byte-identity surface to compare.

## Spend

**$0.00.** Authority for lane `j05m` was `0 runs × 0 arms × $0 / 1.00 = $0.00`. The recipe's LLM steps were never invoked; the deterministic `behavior-hygiene-validation` step body was extracted and executed directly.

---

🤖 Generated with Amplifier

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
