### PR TITLE
feat(validators+docs): move the description rules from convention to enforcement

### DIFF
--- a/agents/bundle-design-expert.md
+++ b/agents/bundle-design-expert.md
@@ -2,11 +2,12 @@
 meta:
   name: bundle-design-expert
   description: |
-      **THE authoritative expert for designing, modeling, and BUILDING Amplifier bundles** — owns the full lifecycle from mechanism selection through behavioral modeling to YAML authoring and implementation.
+      Designing or building an Amplifier bundle: mechanism selection, bundle and behavior YAML, agent files, context architecture, behavioral modeling.
 
-      Use PROACTIVELY when: designing a new bundle, selecting mechanisms, writing bundle YAML or behaviors, authoring agent files (meta.description, WHY/WHEN/WHAT/HOW), making context architecture decisions (context sink, thin pointer, zero poisoning), or running behavioral modeling recipes.
+      USE WHEN a bundle, behavior, agent file or description is being authored or refreshed to the current rules, or a bundle needs modeling before implementation.
+      DO NOT USE WHEN the question is what foundation already ships (use foundation-expert), or is kernel and module internals (use core-expert).
 
-      **Authoritative on:** bundle design, mechanism selection, behavioral modeling, YAML authoring, behaviors, agent file authoring, context sink pattern, thin pointer, zero poisoning, bundle lifecycle, bundle anti-patterns, objectives-to-model recipes
+      **Authoritative on:** description authoring, awareness files, context sink, thin pointer, zero poisoning, bundle lifecycle, bundle anti-patterns
 model_role: general
 
 tools:
@@ -143,7 +144,7 @@ context:
 - If behavior is NOT composed → zero context about that capability
 - No partial knowledge, no context poisoning
 
-### The Thin Awareness Pointer
+### The Thin Awareness Pointer -- and when NOT to write one at all
 
 Root sessions should get just enough context to:
 1. Know a capability/domain exists
@@ -151,7 +152,23 @@ Root sessions should get just enough context to:
 3. NOT enough to attempt the work themselves
 
 **Anti-pattern:** 80 lines of "how bundles work" in always-loaded context
-**Correct pattern:** 25 lines saying "bundles exist, delegate to expert"
+
+**But first ask whether the file should exist at all.** The agent catalog and
+the visible-skills block ALREADY say a capability exists and when to use it,
+in a line that is paid anyway. An awareness file that only restates a catalog
+entry is the same sentence bought twice, and
+`validate-bundle-repo.yaml` Phase 2.84 now warns on exactly that
+(`awareness_redundant_with_catalog`, `awareness_is_pointer_only`).
+
+Write an awareness file ONLY for a **concept that has no catalog line of its
+own**: a cross-cutting hazard that belongs to no single capability, a routing
+table between this bundle and others, or a prerequisite the session needs
+before any of the capabilities can work. If what you are about to write is
+"agent X exists, delegate to it when Y" -- that is X's own
+`meta.description`. Put it there instead, and ship no awareness file.
+
+Full rule: @foundation:docs/BUNDLE_GUIDE.md, "Awareness: concept + trigger
++ pointer".
 
 ### Zero Context Poisoning
 
@@ -189,8 +206,12 @@ The system automatically searches the `/agents` directory relative to the bundle
 
 When building a new bundle with expert capabilities:
 
-1. **Create behavior YAML** -- includes agent + thin context pointer
-2. **Create awareness context** -- ~25-40 lines, domain exists, delegate to expert
+1. **Create behavior YAML** -- includes the agent; a context pointer only if
+   step 2 earns one
+2. **Create awareness context ONLY IF there is a concept the agent's own
+   `meta.description` cannot carry** (a cross-cutting hazard, a routing table,
+   a prerequisite). If there is not, ship no awareness file -- the catalog
+   line already does the job and is paid anyway
 3. **Create agent file** -- heavy @mentions to full documentation (context sink)
 4. **Ensure nothing in shared context** -- your domain knowledge is opt-in via composition
 
@@ -220,17 +241,40 @@ Agents ARE bundles -- they use the same file format, same composition model, sam
 
 Key agent-specific knowledge:
 - The `meta.description` field is the ONLY discovery mechanism
-- Descriptions must include: WHY, WHEN, WHAT (taxonomy), HOW (examples)
+- It is rendered into the delegate catalog on EVERY request of every session
+  that has the agent available, used or not -- so it is a budget, not a page
 - Agents serve as "context sinks" -- heavy docs load only when spawned
-- Poor descriptions cause delegation failures
+- Poor descriptions cause delegation failures, silently
 
-### Description Requirements (WHY, WHEN, WHAT, HOW)
+### Every description you write or review, in every repo
 
-1. **WHY**: Clear value proposition
-2. **WHEN**: Activation triggers (MUST, REQUIRED, ALWAYS, "Use when...")
-3. **WHAT**: Domain terms and concepts
-4. **HOW**: a decision rule inside the WHEN clause (V6) — **no `<example>` or
-   `<commentary>` blocks**, per @foundation:context/shared/description-authoring-principles.md
+The rules are canonical in
+@foundation:context/shared/description-authoring-principles.md and are
+ENFORCED by `validate-agents.yaml` and `validate-bundle-repo.yaml`. Write to
+them by default; never emit a draft that would fail them.
+
+1. **Trigger first** (V7). The opening clause is the condition under which
+   this applies -- not the identity, not the architecture.
+2. **USE WHEN**, as a decision rule stating the deciding factor (V6). Reserve
+   MUST / ALWAYS / NEVER / PROACTIVELY for conditions true 100% of the time.
+3. **DO NOT USE WHEN**, naming the capability that SHOULD handle it. This is
+   the half most often missing, and its absence is a silent misroute: the
+   router picks the nearest-sounding thing and nobody traces it back.
+4. **Length**: agent `meta.description` <= 600 chars, skill frontmatter
+   `description` <= 400. ERROR at 2x.
+5. **Zero `<example>` blocks, zero `<commentary>` tags** (V3). Not "at most
+   two". If a trigger needs to reach the model, it is a decision rule in the
+   WHEN clause. A worked example for a human author belongs in a body doc.
+
+**Fidelity beats brevity.** If a routing fact will not fit the cap, keep the
+fact and exceed the cap, and say which fact forced it. A description that got
+shorter by dropping a trigger is not improved -- it is broken in a way that
+surfaces much later as "it didn't use the right thing".
+
+**Refreshing an existing repo:** do not shorten by hand and by eye. Run
+`foundation:recipes/refresh-descriptions.yaml`, which produces proposed
+rewrites WITH a fidelity table (one row per routing fact and where it went)
+and rejects any proposal that has no table.
 
 ### Agent File Structure
 
@@ -242,7 +286,9 @@ Key agent-specific knowledge:
 
 - One-liner descriptions (LLM can't match requests to agents)
 - `<example>` / `<commentary>` blocks (paid on every turn; a decision rule in the WHEN clause does the same job)
-- No activation triggers (weak WHEN coverage)
+- No DO NOT USE WHEN clause, so the agent out-competes its own siblings
+- Selling the agent (V4): advocacy framing measured -27% tokens on deletion
+  with quality unchanged. Modern models do not need to be sold on delegating.
 
 ---
 

--- a/context/shared/description-authoring-principles.md
+++ b/context/shared/description-authoring-principles.md
@@ -9,6 +9,39 @@
 > paragraph from this file into another doc, stop — link instead (see V1/V2
 > below, and don't make this file the exception to its own rule).
 
+> **Scope: EVERY bundle, not just this repository.** These rules apply to any
+> Amplifier bundle in any repository — foundation, the first-party bundles,
+> and third-party ones. They are enforced by `recipes/validate-agents.yaml`
+> and `recipes/validate-bundle-repo.yaml`, which take a `repo_path` and run
+> against any bundle repo, not only this one.
+>
+> **The one-line WHY.** A description is not documentation you pay for when
+> the capability is used. Agent `meta.description` is concatenated into the
+> `delegate` tool's own description, and skill `description` is concatenated
+> into the `hooks-skills-visibility` block; both render into the **always-on
+> head** and are therefore **paid on every request of every session** whether
+> or not the agent is ever delegated to or the skill ever loaded.
+>
+> The bill is measured, not asserted. In the composition
+> `model_performance-zc6t` measured on the wire (bundle `anchors-amp-dev`,
+> claude-opus-5), the runtime-appended **agent catalog alone was 12,904 chars
+> before that lane's work and 3,597 after** — carried on every request. That
+> lane's head reduction (**84,319 → 48,249 chars**) is a *bundle-composition*
+> figure and not a universal one: the same commit measured 320,410 chars of
+> head on a host composing 86 tools where the eval container composed 14. Cite
+> it as a composition, never as "the head is 48k".
+>
+> **This scope statement exists because the previous one was implicit and
+> quietly stopped being true.** PR #341 set the no-`<example>` policy below in
+> 2026-08; it was applied inside `amplifier-foundation` and **nowhere else**.
+> A batch a year later found **29 files across 6 repos** still shipping
+> example blocks in descriptions and swept them by hand (android-tester 8/8 →
+> 0, browser-tester 6 → 0, reality-check 10/10 → 0, dot-graph 28/28 → 0
+> — its agent descriptions **14,615 → 6,484 chars** — context-intelligence
+> 3 → 0, plus two forks). A rule that lives only as a convention is a rule
+> that quietly stops being true; that is why the caps in V5 are now
+> **validator-enforced** rather than advisory.
+
 Evidence base: a measured eval campaign (A/B testing across paired runs)
 found the patterns this file discourages measurably harm compliant modern
 models. Citations are inline per principle. The campaign is ongoing — see
@@ -78,21 +111,80 @@ tool's own imperative language verbatim back at it. A description that large
 is not thorough — it is a second system prompt smuggled into a metadata
 field, read on every turn whether or not the tool is ever called.
 
-**Budgets (token count via the same tokenizer the validators use):**
+**Budgets. The enforced unit is CHARACTERS.** Chars are what every head
+measurement in this program was taken in, they need no tokenizer, and they
+are what a validator can count identically on every platform. Where a token
+figure is quoted below it is the same chars/4 estimator the recipes use
+(calibrated in `tests/test_context_include_estimator.py`: median 1.128 vs
+o200k_base, range 0.940–1.312, i.e. it runs HIGH on prose so a budget gate
+fires early, never late).
 
 | Surface | WARN | ERROR | Status |
 |---|---|---|---|
+| Agent `meta.description` | > 600 chars | > 1,200 chars (2x) | **Enforced** — validate-agents.yaml, validate-bundle-repo.yaml Phase 2.8 |
+| Skill frontmatter `description` | > 400 chars | > 800 chars (2x) | **Enforced** — validate-bundle-repo.yaml Phase 2.82 |
 | Mode `description` | > 500 tokens | > 800 tokens | Established (validate-bundle-repo.yaml Phase 2.7) |
-| Agent `meta.description` | > 300 tokens | > 600 tokens | **Provisional** — pending wave calibration |
-| Skill frontmatter `description` | see skills authoring guide | see skills authoring guide | Shared cap: `max_skills_visible` bounds total visible-catalog cost |
 | Tool description | no fixed ceiling yet | no fixed ceiling yet | Flag any single tool >10% of a typical tool-description budget as a design smell |
+
+**Where 600 / 400 come from — measured, not chosen.** Description lengths
+across 9 bundle repositories on one host, 2026-09-07 (`n` = descriptions
+carrying a non-empty string):
+
+| Corpus | n | mean | median | p90 | max | over cap | over 2x |
+|---|---|---|---|---|---|---|---|
+| foundation agents (aligned by #341) | 24 | 410 | 427 | 721 | 761 | 6 | **0** |
+| all agents, 8 repos incl. unswept | 54 | 1,084 | 739 | 2,396 | 3,235 | 36 | **17** |
+| foundation skills | 3 | 420 | 384 | 566 | 566 | 1 | **0** |
+| skills-bundle skills | 31 | 413 | 312 | 814 | 928 | 13 | **4** |
+
+The cap is the value that separates *already-aligned* from *never-aligned*:
+the one corpus that had the policy applied (foundation, #341) has **zero**
+descriptions over 2x, while unswept repos put 17 of 54 there — dot-graph's
+local checkout averages 2,302 chars/agent and puts **12 of 12** over the
+ERROR line. WARN at the cap is deliberately noisy on aligned repos (6 of 24
+foundation agents warn today); the ERROR line is what has to be a real
+defect, and on the aligned corpus it is empty.
 
 Agent tiers are lower than mode tiers because agent descriptions are paid
 **by every session that has the agent in its catalog**, regardless of
 whether it's ever delegated to — mode descriptions are paid only by sessions
-that load that mode. Treat the agent-tier numbers as provisional — the 2026-08-30
-delegation wave (P1-P3, see below) reported on delegation *frequency*, not on
-token-ceiling calibration; that calibration remains open.
+that load that mode. The *token*-tier numbers (WARN 300 / ERROR 600 tokens ≈
+1,200 / 2,400 chars) that this table replaces for agents remain provisional
+and are superseded as a gate: the 2026-08-30 delegation wave (P1-P3, see
+below) reported on delegation *frequency*, not on ceiling calibration, and
+its ERROR tier at 2,400 chars sat above the max of every aligned repo, so it
+could not fire on the defect this file describes.
+
+**Head cost is a bundle-level number, not only a per-description one.** The
+validators report, per bundle, `context.include` chars + agent description
+chars + skill description chars, with a **WARNING at 4,000 chars**
+(`validate-bundle-repo.yaml` Phase 2.86, which states the attribution rule
+for each term). The threshold is measured the same way — every figure below
+is that step's own output on 2026-09-07:
+
+| Bundle | head chars | engineered for head cost? |
+|---|---|---|
+| `bundles/anchors-amp-dev/bundle.md` | 1,760 | yes |
+| `bundles/anchors/bundle.md` | 2,483 | yes |
+| context-intelligence `bundle.md` | 5,479 | no |
+| foundation `bundle.md` (root) | 14,198 | no |
+| superpowers `bundle.md` | 15,002 | no |
+| foundation `behaviors/agents.yaml` | 26,368 | no |
+| dot-graph `bundle.md` | 29,684 | no |
+| converge `bundle.md` | 87,555 | no |
+
+4,000 is the smallest round number above every bundle that was explicitly
+cost-engineered (1.6x headroom over the largest) and below every bundle that
+was not (1.37x below the nearest). It is a WARNING, not an ERROR, because
+foundation's own root bundle exceeds it — that is a design conversation, not
+a build break.
+
+Note what the anchors row shows: `bundles/anchors` mounts `tool-skills` with
+`visibility.enabled: false`, so its 1,261 chars of skill descriptions are
+**not** in the head. The check reports that amount separately as
+`skill_description_chars_excluded` rather than silently omitting it, because
+turning visibility off is a real lever and the reader should see what it
+bought.
 
 ## V6 — Provider disposition: absolutes for invariants, decision rules for judgment
 
@@ -126,6 +218,36 @@ AFTER (decision rule):
 The AFTER version gives the model the actual factor to weigh (context cost,
 answer shape) instead of a bright line the model must either obey literally
 or silently override.
+
+## V7 — Shape: trigger first, then USE WHEN / DO NOT USE WHEN
+
+A description is read by a router deciding *whether this is the thing*, not by
+a person learning what it does. Order it accordingly.
+
+1. **Trigger first.** The opening clause states the condition under which this
+   capability applies — not its identity, not its history, not its
+   architecture. "Use for `type: browser` acceptance tests" routes; "A
+   sophisticated browser automation subsystem" does not.
+2. **Then USE WHEN.** The positive decision rule, as a rule and not as a
+   dialogue (V3, V6).
+3. **Then DO NOT USE WHEN.** Explicit, and pointing at the thing that *should*
+   handle it. This is the half most often missing, and its absence is what
+   produces the silent failure this whole policy exists to prevent: a router
+   that picks the nearest-sounding capability, does the wrong work, and gives
+   nobody a reason to trace it back. "DO NOT USE for interactive TUIs — use
+   `terminal-tester`" costs one clause and removes a whole class of misroute.
+
+Everything else — how it works, what it carries, what it depends on — belongs
+in the body, which is read on demand and not on every request.
+
+**The one rule this shape must never lose: fidelity beats brevity.** A
+description that got shorter by dropping a trigger has not been improved; it
+has been broken in a way that surfaces later as "it didn't use the right
+thing", with no trace back to the commit that caused it. Any automated or
+assisted shortening pass must therefore show a **fidelity table** — every
+routing fact in the before text, and where it went in the after text — which
+is why `recipes/refresh-descriptions.yaml` is agent-driven and not a regex.
+See `docs/BUNDLE_GUIDE.md` §"Refreshing descriptions".
 
 ## Example policy (all description surfaces)
 

--- a/docs/AGENT_AUTHORING.md
+++ b/docs/AGENT_AUTHORING.md
@@ -121,6 +121,15 @@ What does this agent do? What value does it provide?
 #### 2. WHEN - The Deciding Factor
 The condition that should cause delegation, phrased as a decision rule
 (see description-authoring-principles.md V6) rather than a bare imperative.
+State it FIRST -- a description is read by a router deciding whether this
+is the thing, not by a person learning what it does (V7).
+
+#### 2b. DO NOT USE WHEN - and what to use instead
+The half most often missing. Name the sibling that SHOULD handle the case
+you are rejecting. Its absence is what produces the silent failure this
+whole policy exists to prevent: a router picks the nearest-sounding
+capability, does the wrong work, and gives nobody a reason to trace it
+back. One clause removes a whole class of misroute.
 
 #### 3. Authoritative On (optional)
 Domain terms this agent owns, so questions in that domain route here.
@@ -139,12 +148,17 @@ field.
 meta:
   name: my-agent
   description: |
-    [ONE SENTENCE: What this agent does]
+    [TRIGGER FIRST: the condition under which this applies, then what it does]
 
-    Use when [the deciding factor -- context shape, not a bare imperative].
+    USE WHEN: [the deciding factor -- context shape, not a bare imperative].
+    DO NOT USE WHEN: [the case that belongs elsewhere] -- use [name].
 
     **Authoritative on:** [comma-separated domain terms/keywords]
 ```
+
+Budget: <= 600 chars for the whole block. If a routing fact will not fit,
+keep the fact and exceed the cap -- and say which fact forced it. Fidelity
+beats brevity (V7).
 
 ### Anti-Patterns
 
@@ -154,12 +168,32 @@ meta:
 ❌ Any `<example>` block, or any `<commentary>` tag -- both are banned
 entirely (description-authoring-principles.md V3), not merely capped
 
-### Description Token Budget
+### Description Length Cap
 
-**Provisional** (pending A/B calibration -- see
-description-authoring-principles.md V5): WARN above 300 tokens, ERROR
-above 600 tokens. Enforced by `foundation:recipes/validate-agents.yaml`
-and `foundation:recipes/validate-bundle-repo.yaml`.
+**<= 600 characters. ERROR above 1,200** (2x the cap). Enforced by
+`foundation:recipes/validate-agents.yaml` and
+`foundation:recipes/validate-bundle-repo.yaml`; the numbers and the
+measurement behind them are in description-authoring-principles.md V5.
+
+Chars, not tokens: chars are the unit every head measurement in this
+program was taken in, and they need no tokenizer. The superseded token
+tier (ERROR above 600 tokens = 2,400 chars) sat above the longest
+description in every already-aligned repo measured, so it could not fire
+on the defect it existed to catch.
+
+For an existing repo that is over the cap, do not shorten by hand and by
+eye -- run `foundation:recipes/refresh-descriptions.yaml`, which proposes
+a rewrite WITH a fidelity table accounting for every routing fact. See
+[BUNDLE_GUIDE.md - Refreshing descriptions](BUNDLE_GUIDE.md#refreshing-descriptions).
+
+### Awareness files are not a place to describe an agent
+
+If you find yourself writing an always-on `context.include` that says "this
+agent exists, and here is when to delegate to it", stop: that is the agent's
+`meta.description`, and a second copy is paid on every request and can drift
+from the first. An awareness file is for a CONCEPT that has no catalog line of
+its own. The full rule, and the validator that enforces it, are in
+[BUNDLE_GUIDE.md - Awareness: concept + trigger + pointer](BUNDLE_GUIDE.md#awareness-concept--trigger--pointer).
 
 ---
 

--- a/docs/BUNDLE_GUIDE.md
+++ b/docs/BUNDLE_GUIDE.md
@@ -375,6 +375,137 @@ See [amplifier-bundle-recipes/context/recipe-instructions.md](https://github.com
 
 ---
 
+## Awareness: concept + trigger + pointer
+
+An **awareness file** is a `context.include` whose job is to tell the model
+that a capability exists. It is always-on: every byte is paid on every request
+of every session that composes the behavior, used or not. The agent catalog
+and the visible-skills block already announce a capability, in a line that is
+paid anyway — so most awareness files are a second copy of a sentence the
+session already has.
+
+Enforced by `foundation:recipes/validate-bundle-repo.yaml` Phase 2.84
+(`awareness_redundant_with_catalog`, `awareness_is_pointer_only` — both
+WARNING; the rules and their thresholds are stated in the step).
+
+### The test: what can this file say that a catalog line cannot?
+
+**An awareness file exists ONLY for a CONCEPT that has no catalog line of its
+own.** "This agent exists and here is when to delegate to it" is not a
+concept — that is the agent's own `meta.description`, and writing it twice
+means the two copies can drift and the model has to arbitrate between them
+(description-authoring-principles.md V1).
+
+Legitimate awareness content, in practice:
+
+- A cross-cutting **hazard** that spans several capabilities and belongs to
+  none of them ("uiautomator is the sensor; the screenshot is never for
+  targeting" — true of every agent in that bundle).
+- A **routing table** between capabilities in this bundle and capabilities in
+  *other* bundles, which no single description owns.
+- A **prerequisite** the session must know before any of the capabilities can
+  work at all (a CLI that must be installed, an env var that must be set).
+
+### The four rules
+
+1. **One line, one place.** If a fact belongs in a description, put it in the
+   description. If it belongs in an agent's instruction, put it there. Do not
+   also say it in awareness prose "for emphasis" — a rule stated twice is two
+   copies that can drift, which measurably destabilized a compliant model (V1).
+2. **Operating rules live where they act.** A rule the *agent* must follow
+   goes in the agent's own contract — its markdown body — where it is loaded
+   when the agent runs. A rule about *calling a tool* goes in the tool
+   description, which the tool layer renders. Neither belongs in always-on
+   awareness prose, where every session pays for a rule that applies to one
+   sub-agent.
+3. **Event-driven guidance is injected by the hook that fires it, not
+   always-on.** If guidance is only relevant when something happens, the hook
+   that observes it is the right place to inject it. Putting it in
+   `context.include` pays for it on every request in order to be correct on a
+   few.
+4. **Root body = instruction only.** Everything below a bundle's frontmatter
+   is sent to the model as system instruction. Documentation prose there is a
+   defect, not a comment — see
+   [What Goes Below the Frontmatter](#what-goes-below-the-frontmatter). And
+   **instruction `@mention`s lead the context block** (foundation `2ef5e12`,
+   PR #359): the instruction the body names is placed first, not appended
+   after whatever else composed into the session.
+
+### The thin-variant pattern (worked example)
+
+`bundles/anchors` and `bundles/anchors-amp-dev` in this repository are the
+worked example. `anchors-amp-dev` is `anchors` plus one layer of
+Amplifier-ecosystem knowledge: it includes the anchors bundle by URL and adds
+one agent and one context file. Everything else — session, tools, hooks,
+agents, behaviors — is inherited, **so the two cannot drift**.
+
+Measured head cost (`validate-bundle-repo.yaml` Phase 2.86): anchors **2,483
+chars**, anchors-amp-dev **1,760**. Both under the 4,000-char warning. That is
+what a variant costs when it inherits instead of copying.
+
+**A root bundle is never composed as a behavior.** A behavior is a slice that
+composes into someone else's session; a root bundle defines a whole session.
+Including a root bundle from a behavior pulls an entire session definition
+into a composition that expected a slice (see app-cli #316). Include the
+behavior, or include the root bundle as a root bundle — never one as the
+other.
+
+---
+
+## Refreshing descriptions
+
+For an existing repository — one written before these rules, or one that has
+drifted — `foundation:recipes/refresh-descriptions.yaml` is the entry point:
+
+```bash
+amplifier tool invoke recipes operation=execute \
+  recipe_path=foundation:recipes/refresh-descriptions.yaml \
+  context='{"repo_path": "/path/to/your/bundle-repo"}'
+```
+
+It writes four files into `<repo>/.description-refresh/` (override with
+`output_dir`) and **changes nothing in the repository**:
+
+| File | What it carries |
+|---|---|
+| `violations.json` | every description over the cap or carrying an `<example>`/`<commentary>` block, machine-readable |
+| `proposals.md` | a compliant rewrite for each, **with a fidelity table** |
+| `verdict.json` | the rewrites re-checked against the same thresholds, plus the gate on the fidelity tables themselves |
+| `REPORT.md` | the summary, including the per-bundle head-cost table |
+
+### Why the rewrite step is an agent and not a regex
+
+The entire risk in shortening a description is dropping a **routing fact** — a
+trigger, a boundary, a "do not use for X, use Y instead". A regex cannot see
+that a clause is the only thing standing between a request and the wrong
+capability. Nothing errors when it goes. The failure surfaces much later as
+"it didn't use the right thing", with nobody tracing it back.
+
+So the proposal step is an agent, every proposal carries a table with one row
+per routing fact and where it went, and the verify step **rejects a proposal
+that has no fidelity table**. Fidelity beats brevity at every point of
+conflict: a rewrite that keeps a fact and misses the cap is a PASS with a
+stated reason; a rewrite that hits the cap by dropping a trigger is not.
+
+### It reproduces hand-done work
+
+Measured against the hand sweep of `amplifier-bundle-browser-tester`
+(lane `kp79`), run clean-room against the pre-sweep state:
+
+| | agent descriptions, 3 files | examples removed |
+|---|---|---|
+| before | 2,457 chars | 0 of 6 |
+| hand sweep (kp79) | 1,664 chars | 6 of 6 |
+| `refresh-descriptions` | 1,644 chars | 6 of 6 |
+
+Same three files identified, every pre-existing routing fact retained in both,
+totals within 1.2%. The one difference is recorded in
+`docs/lanes/pwmy-principles-to-tooling/DONE-NOTE.md`: the hand pass added a
+`web_fetch` cross-reference to `browser-operator` that the tool added to
+`browser-researcher` only.
+
+---
+
 ## Directory Conventions
 
 Bundle repos follow **conventions** that enable maximum reusability and composition. These are patterns, not code-enforced rules.

--- a/docs/lanes/pwmy-principles-to-tooling/DONE-NOTE.md
+++ b/docs/lanes/pwmy-principles-to-tooling/DONE-NOTE.md
@@ -247,6 +247,30 @@ this item):
   load-bearing ("fixes the merged `tools:` list and tool-skills' search path…
   reproduces the previously shipped mount plan byte-for-byte"). One-line fix.
 
+**F4 — `validate-agents` cannot complete on a Windows checkout, and nothing had
+ever exercised it there.** Found by *this branch's own CI*, not by inspection:
+windows-latest / Python 3.13 went red while ubuntu 3.11/3.12/3.13 passed.
+
+`structural-validation` receives the discovery payload as
+`json.loads('''{{discovery_results}}''')`. On a Windows runner the discovery
+JSON carries `D:\a\amplifier-foundation\...`; Python collapses each doubled
+backslash while parsing the triple-quoted literal, leaving `\a`, which is not a
+valid JSON escape. The step dies with `Invalid \escape`. `quality-classification`
+then parses that step's (absent) output under `on_error: fail`, so the whole
+recipe fails.
+
+This is **the same class of bug v1.7.0 fixed for `repo_path`** — a filesystem
+path inside a Python string literal — still live on the step-to-step payload.
+It went unnoticed because CI runs pytest, not recipes, and until this branch no
+test executed that step body with a real Windows path.
+
+**Reported, not fixed here.** A correct fix changes how the runner hands large
+JSON between steps (the shell-assignment trick used for `repo_path` is not safe
+for a payload that can itself contain quotes), which is its own item. The test
+harness routes around it explicitly and says so in its docstring, so nobody
+reads the green CI as evidence the defect is gone: every other line of the step
+body still executes verbatim.
+
 **F3 — `docs/` is scanned, and it bit me.** Committing four evidence
 `SKILL.md` files under `docs/lanes/` took this repo's shipped-skill count from
 **3 to 7** and its largest head-cost figure from **26,368 to 28,279**. I widened
@@ -415,6 +439,8 @@ the docstring, matching how the three prior bumps were handled.
    that repo.
 3. **F1** (`no_composable_surface` on nested variant bundles) and **F2**
    (anchors-amp-dev README include order) — reported above, not fixed.
-4. **R1's threshold** (awareness term-overlap at 0.60) has never fired on a real
+4. **F4** — `validate-agents` on Windows. Reported above; a correct fix belongs
+   to the runner's step-payload handling, not to this item.
+5. **R1's threshold** (awareness term-overlap at 0.60) has never fired on a real
    corpus file. `best_coverage` is reported for every file so it can be
    re-argued from data.

--- a/docs/lanes/pwmy-principles-to-tooling/DONE-NOTE.md
+++ b/docs/lanes/pwmy-principles-to-tooling/DONE-NOTE.md
@@ -247,6 +247,43 @@ this item):
   load-bearing ("fixes the merged `tools:` list and tool-skills' search path…
   reproduces the previously shipped mount plan byte-for-byte"). One-line fix.
 
+**F5 — `publication/v1` does not state the ORDER of its own steps, and I got it
+wrong.** Corrected on this item by erratum (2026-09-07T18:21:13Z), not by
+reopen.
+
+The contract says the marker must carry "values a remote read returned". It does
+**not** say *when* the read must happen relative to `work_resolve`. I read that
+as "the values must be remote-derived", which they were:
+
+| | |
+|---|---|
+| 18:15:14Z | `publication_readback.sh` read the remote — **supplied** the marker's values |
+| 18:16:04Z | marker written; then parsed back **from disk** — valid JSON, `pr_url` present, `head_sha` 40 chars |
+| 18:16:18Z | `work_resolve` |
+| 18:17:03Z / 18:20:10Z | readback re-run and diffed field-for-field against the marker — **8/8 match** |
+
+Under the stricter reading — written → **read back against the remote** →
+validated, all *before* the resolve is invoked — the validating diff sat outside
+that window. Between write and resolve I did only a **local** check, which is
+weaker than a remote diff. No published value is wrong (verified 8/8 against the
+live remote, `head_sha a6025b86…` equals origin's head, PR #373 open), but the
+prerequisite ordering was not performed in that position, and the resolution
+over-claimed by not saying so.
+
+**Decision, recorded here per GOAL.md's "choose, record the choice, continue":**
+erratum, not reopen. The work is not wrong; `work_reopen` would clear a correct
+`closed_at` and move every throughput roll-up by one item to re-close at
+identical values, for an ordering that cannot be retroactively changed. That is
+exactly the churn lane 1ru paid for.
+
+**The generalisable finding:** the contract should say the order it wants, in
+the words it wants it followed. A one-line addition to `publication/v1` —
+*"write the marker, then run `publication_readback.sh` and diff it against the
+marker, and only then resolve"* — removes the ambiguity for every lane. Without
+it, "verified" reads as a property of the values (which was satisfied) rather
+than as a positioned step (which was not). `merge_gate.sh` checks the marker's
+**content** against GitHub, so it cannot catch this class of defect either.
+
 **F4 — `validate-agents` cannot complete on a Windows checkout, and nothing had
 ever exercised it there.** Found by *this branch's own CI*, not by inspection:
 windows-latest / Python 3.13 went red while ubuntu 3.11/3.12/3.13 passed.
@@ -441,6 +478,9 @@ the docstring, matching how the three prior bumps were handled.
    (anchors-amp-dev README include order) — reported above, not fixed.
 4. **F4** — `validate-agents` on Windows. Reported above; a correct fix belongs
    to the runner's step-payload handling, not to this item.
+5. **F5** — `publication/v1` should state the ORDER of its steps
+   (write → readback → validate → resolve). Corrected on this item by erratum;
+   the contract change itself is somebody's next item.
 5. **R1's threshold** (awareness term-overlap at 0.60) has never fired on a real
    corpus file. `best_coverage` is reported for every file so it can be
    re-argued from data.

--- a/docs/lanes/pwmy-principles-to-tooling/DONE-NOTE.md
+++ b/docs/lanes/pwmy-principles-to-tooling/DONE-NOTE.md
@@ -1,0 +1,420 @@
+# DONE-NOTE — model_performance-pwmy
+
+**Move the description rules from convention to enforcement.**
+
+Terminal outcome: **A — RESOLVED.** Every deliverable is DONE. Nothing was
+recorded NOT-POSSIBLE, and nothing was blocked. Spend against the $5 authority:
+**$0** (see §7).
+
+---
+
+## 1. What this closes, in one paragraph
+
+PR #341 set the no-`<example>` policy for description surfaces in
+`context/shared/description-authoring-principles.md`. It was applied inside
+`amplifier-foundation` and **nowhere else**, because nothing at authoring or
+validation time said otherwise. A sweep a year later found **29 files across 6
+repos** still shipping example blocks and fixed them **by hand**. This lane
+moves the rules to where they execute: the caps are validator-enforced, the
+skill half of the policy is checked for the first time in any repo, awareness
+redundancy and per-bundle head cost are measured, the creation surfaces emit
+compliant descriptions by default, and there is one documented command that
+refreshes an existing repo with a fidelity table.
+
+---
+
+## 2. Deliverables
+
+| Deliverable | State |
+|---|---|
+| Docs updated with the measured citations, stated as applying to EVERY bundle | **DONE** — §3 |
+| Five validator checks, each with a fail-before test on a fixture violating all four | **DONE** — §4 |
+| Both recipes re-run on foundation main AND anchors-amp-dev, results quoted | **DONE, with one named deviation** — §5 |
+| Creation skills emit compliant descriptions by default, demonstrated | **DONE** — §6 |
+| Refresh path demonstrated on an already-swept repo, compared to the hand work | **DONE** — §6 |
+| Draft PR, marked ready when CI is green, not merged | **DONE** — see DONE.json `publication` |
+| DONE-NOTE at the lane artifact root | this file |
+
+---
+
+## 3. (a) Docs
+
+`context/shared/description-authoring-principles.md`
+
+- **Scope banner**: the rules apply to **every** bundle in any repository, not
+  just foundation, and name the two recipes that enforce them.
+- **The one-line WHY, with the bill measured**: agent descriptions render into
+  the always-on `delegate` catalog, skill descriptions into the
+  `hooks-skills-visibility` block; both are paid on every request whether or not
+  the capability is used. Cited: `zc6t`'s on-the-wire measurement of the runtime
+  agent catalog at **12,904 → 3,597 chars**; the lean head at **84,319 →
+  48,249 chars** — cited **as a bundle composition, not as a universal figure**,
+  because the same commit measured 320,410 chars of head on a host composing 86
+  tools where the eval container composed 14. Quoting 48,249 as "the head" would
+  be wrong, and `zc6t`'s own commit says so.
+- **The history, so the scope statement does not quietly stop being true too**:
+  #341, the 29 files across 6 repos, dot-graph's agent descriptions **14,615 →
+  6,484 chars**.
+- **V5 rewritten**: the enforced unit is now CHARACTERS, with the measured
+  distribution across 9 repos that justifies 600/400 and the head-cost table
+  that justifies 4,000. See §4.1.
+- **V7 added** — shape: trigger first, then USE WHEN, then DO NOT USE WHEN
+  naming what should handle the rejected case, and the fidelity rule.
+
+`docs/BUNDLE_GUIDE.md` — new **"Awareness: concept + trigger + pointer"**
+(the test — what can this file say that a catalog line cannot; the four rules;
+the thin-variant worked example with anchors → anchors-amp-dev at 2,483 / 1,760
+chars; instruction `@mention`s lead the context block, foundation `2ef5e12`; no
+root bundle composed as a behavior, app-cli #316) and new **"Refreshing
+descriptions"** (§6).
+
+`docs/AGENT_AUTHORING.md` — the token-budget section is replaced by the char
+cap; the template now carries the DO NOT USE WHEN clause and the budget; a
+short pointer says awareness files are not a place to describe an agent.
+`g7h3`'s **−13.57% $/task, CI [−22.27%, −4.86%], all three pre-registered
+estimators excluding zero** is cited in the head-cost WHY.
+
+---
+
+## 4. (b) Validators
+
+`recipes/validate-bundle-repo.yaml` **v3.14.0 → v3.15.0**,
+`recipes/validate-agents.yaml` **v1.7.0 → v1.8.0**.
+
+### 4.1 Check 1 — length cap, in CHARACTERS
+
+WARN at the cap, ERROR at 2x: **agents 600 / 1,200**, **skills 400 / 800**.
+The two agent numbers are byte-identical in both recipes and
+`test_both_recipes_carry_the_same_two_cap_numbers` fails the build if they
+diverge.
+
+**Why the old gate could not fire.** It was tokens — WARN >300, ERROR >600,
+i.e. 1,200 / 2,400 chars at chars/4. Measured 2026-09-07 across 9 bundle repos
+on this host:
+
+| Corpus | n | mean | median | p90 | max | over cap | over 2x |
+|---|---|---|---|---|---|---|---|
+| foundation agents (aligned by #341) | 24 | 410 | 427 | 721 | 761 | 6 | **0** |
+| all agents, 8 repos incl. unswept | 54 | 1,084 | 739 | 2,396 | 3,235 | 36 | **17** |
+| foundation skills | 3 | 420 | 384 | 566 | 566 | 1 | **0** |
+| skills-bundle skills | 31 | 413 | 312 | 814 | 928 | 13 | **4** |
+
+The old ERROR line (2,400 chars) sat **above the longest description in every
+already-aligned repo**, so on an aligned repo it was unfireable. The new one
+separates aligned from unaligned: foundation 0 errors, dot-graph 12 of 12 over.
+
+**Caveat on that corpus, stated rather than buried:** those are the local
+checkouts on this host, and several are PRE-sweep (dot-graph's still carries 12
+descriptions with `<example>` blocks). The sweep landed as PRs on other
+branches. The distribution is therefore "before alignment", which is exactly
+what a cap has to discriminate against.
+
+### 4.2 Check 2 — `<example>`/`<commentary>` for SKILLS, repo-wide
+
+New Phase 2.82. Agents were already covered; **no recipe in any repo has ever
+checked a skill description**, though the policy was written for both. Same
+example policy (ERROR), tighter cap, and v3.13.0's lesson applied from the
+start: each way of failing to READ a description gets its own status and its
+own ERROR, because collapsing them into `""` makes a broken skill pass every
+check clean.
+
+### 4.3 Check 3 — awareness redundancy, with the rule stated
+
+New Phase 2.84. Two rules, both WARNING, both written out in the step and
+echoed in the step's own output under `rule` so a finding can be audited:
+
+- **R1 term-overlap** — a sentence is covered when ≥60% of its key terms appear
+  in one catalog description; a file is redundant when ≥60% of its substantive
+  (≥3 key terms) sentences are covered. Reports the winning entry **by name**.
+- **R2 pointer-only** — the file invokes `delegate(`/`load_skill(` naming an
+  in-repo entry, and ≥60% of its sentences are trigger-shaped, by phrase or by
+  sitting under a "When/How to Use" heading.
+
+**Calibrated, not guessed.** Across every cached bundle repo on this host —
+**36 context files** — R1 fires **0 times** (max coverage observed **0.333**,
+median 0.0375) and R2 fires **3 times**: `dtu-awareness.md` (0.889),
+`gitea-awareness.md` (0.833), `reality-check-awareness.md` (0.667). Each of the
+three is genuinely when-to-use prose plus a pointer. Files with real extra
+content — `amplifier-tester`'s resource-accounting section,
+`browser-tester`'s troubleshooting table — correctly do **not** fire.
+
+**Honest limit:** R1 has never fired on a real corpus file. It is retained
+because it is the rule that catches verbatim restatement, and the fixture
+demonstrates it firing; `best_coverage` is reported for every file either way,
+so the threshold can be re-argued against numbers rather than re-guessed.
+
+### 4.4 Check 4 — bundle head cost, threshold justified
+
+New Phase 2.86: `context chars + agent description chars + skill description
+chars`, per bundle, **WARNING at 4,000**. The step states how each term is
+attributed. Measured by the step itself, 2026-09-07:
+
+| Bundle | head chars | engineered for head cost? |
+|---|---|---|
+| `bundles/anchors-amp-dev/bundle.md` | 1,760 | yes |
+| `bundles/anchors/bundle.md` | 2,483 | yes |
+| context-intelligence `bundle.md` | 5,479 | no |
+| foundation `bundle.md` | 14,198 | no |
+| superpowers `bundle.md` | 15,002 | no |
+| foundation `behaviors/agents.yaml` | 26,368 | no |
+| dot-graph `bundle.md` | 29,684 | no |
+| converge `bundle.md` | 87,555 | no |
+
+4,000 is the smallest round number above every cost-engineered bundle (1.6x
+headroom) and below every unengineered one (1.37x). **WARNING, not ERROR**,
+because foundation's own root bundle exceeds it — that is a design
+conversation, not a build break. An include this repo cannot resolve is **not**
+charged a flat guess: the total is marked `is_lower_bound` and the unresolved
+refs are named (v3.14.0's lesson). A bundle that disables `tool-skills`
+visibility does not pay the skill half; the amount is reported separately as
+`skill_description_chars_excluded` rather than silently omitted — anchors' 1,261
+chars are visible in the report precisely because turning visibility off is a
+real lever.
+
+### 4.5 Check 5 — fail-before, reproducible by anyone
+
+`test-fixtures/misaligned-bundle/` violates all four at once (its README
+tabulates how). `tests/test_description_alignment_checks.py` runs the recipes'
+**own step bodies** against it — never a re-implementation, which would agree
+with itself while the recipe drifted.
+
+Point `ALIGNMENT_RECIPE_DIR` at the pre-change recipes and the suite fails:
+
+```
+git worktree add --detach /tmp/foundation-main origin/main      # 4384805
+ALIGNMENT_RECIPE_DIR=/tmp/foundation-main/recipes pytest tests/test_description_alignment_checks.py
+```
+
+| | result |
+|---|---|
+| origin/main **4384805** | **23 failed, 1 passed** |
+| this branch | **24 passed** |
+
+The one test that passes at main is the one that should:
+`test_agent_description_under_the_cap_is_clean` — a 599-char clean description
+is clean under both the old token gate and the new char gate.
+
+---
+
+## 5. Recipe runs — results quoted
+
+### validate-agents v1.8.0, FULL recipe run
+
+| Target | Verdict | Detail |
+|---|---|---|
+| foundation (this branch) | **⚠ PASS WITH WARNINGS** | 24 agents / 28 candidates / 4 non-agents; 18 good, 5 polish, 1 needs_work, 0 critical; **0 errors**, 6 warnings, 6 suggestions |
+| `bundles/anchors-amp-dev` | **✅ PASS** | 1 agent; 0 errors, 0 warnings; description 385 chars |
+
+The 6 warnings on foundation are 5 × `DESCRIPTION_HIGH` (foundation-expert 761,
+session-analyst 721, security-guardian 669, git-ops 647, modular-builder 631 —
+all under the 1,200 ERROR line) and 1 × `NO_TOOLS_SECTION` on
+`examples/agents/file-responder.md`, a deliberate fixture that four prior lanes
+(`xe1u`, `39z0`, `hxcl`, `8rug`) have each reported and correctly left alone.
+**Quoted, not tuned.**
+
+Worth noting: the report step, given the new guidance, produced compliant
+rewrites *with fidelity tables* for all five over-cap agents unprompted. Those
+rewrites are not applied here — re-sweeping foundation's descriptions is not
+this item.
+
+### validate-bundle-repo v3.15.0
+
+| Target | Run | Result |
+|---|---|---|
+| `bundles/anchors-amp-dev` | **FULL** (34 steps, `hygiene_only`, `enhance_diagrams:false`) | agent 1/0 err/0 warn · skill **skipped** (no SKILL.md) · awareness 1 file, best_coverage 0.0, 0 warn · head cost **1,760** (`is_lower_bound`, unresolved `anchors:context/system.md`) |
+| foundation | **deterministic steps only** — deviation, see below | agent 24 checked, **0 err / 5 warn** · skill 3 checked, **0 err / 1 warn** (per-repo-conventions 566) · awareness 7 files vs 27 catalog entries, **0 warn** · head cost 19 bundles, **3 warn**, largest **26,368** |
+
+**Named deviation.** The full `validate-bundle-repo` run **writes files** — it
+regenerated `bundle.dot`/`bundle.png` into `bundles/anchors-amp-dev/` during the
+run above (removed afterwards; `git status` clean). Running it fully against the
+repo root would rewrite foundation's own root `bundle.dot`, an unrelated change
+in this PR's diff. All four new checks are deterministic and were executed
+against foundation directly; the steps not run are the LLM synthesis and
+diagram-regeneration phases, which format and draw but do not decide.
+
+**Two findings from the anchors-amp-dev run, reported not fixed** (neither is
+this item):
+
+- **F1 — `no_composable_surface` is a false positive on a nested variant
+  bundle.** With `repo_path` pointed at `bundles/anchors-amp-dev`, the check
+  reports `needs_work` for shipping `agents/` without `behaviors/`. But
+  `/bundles/` holds standalone *variants* whose composable surface is the
+  enclosing repo's `behaviors/` (12 files). The suggested remediation would
+  *introduce* a hygiene violation. Fix would be to gate the check on repo-root
+  evidence at `repo_path`.
+- **F2 — `bundles/anchors-amp-dev/README.md:34-35` documents the include order
+  inverted** relative to `bundle.md:23,26`, on an order `bundle.md` itself calls
+  load-bearing ("fixes the merged `tools:` list and tool-skills' search path…
+  reproduces the previously shipped mount plan byte-for-byte"). One-line fix.
+
+**F3 — `docs/` is scanned, and it bit me.** Committing four evidence
+`SKILL.md` files under `docs/lanes/` took this repo's shipped-skill count from
+**3 to 7** and its largest head-cost figure from **26,368 to 28,279**. I widened
+the exclusion set to fix it, and
+`TestDiscoveryScopeParity::test_exclusion_sets_agree_across_both_recipes_and_this_guard`
+caught me — the delta from validate-agents' wider scope is documented as exactly
+`docs`. **I reverted rather than widening a contract another lane established**
+(narrowing it would also hide a skill that genuinely lives under docs/), renamed
+the evidence files to `SKILL.md.txt`, and pinned the trap with a test that fails
+if this repo's shipped-skill count ever leaves 3. Recorded here because the next
+lane to commit an example `SKILL.md` will hit it too.
+
+---
+
+## 6. (c) + (d) Creation surfaces and the refresh path
+
+### The entry point
+
+`recipes/refresh-descriptions.yaml` (new, v1.0.0), documented in
+BUNDLE_GUIDE §"Refreshing descriptions":
+
+```bash
+amplifier tool invoke recipes operation=execute \
+  recipe_path=foundation:recipes/refresh-descriptions.yaml \
+  context='{"repo_path": "/path/to/your/bundle-repo"}'
+```
+
+Writes `violations.json`, `proposals.md`, `verdict.json`, `REPORT.md` and
+**changes nothing in the repo**. Two design points that matter:
+
+1. **It does not carry a copy of the rules.** It extracts and executes
+   `validate-bundle-repo.yaml`'s own step bodies, and **fails loud naming every
+   path it searched** if it cannot find that recipe. This repo has paid three
+   times in one batch for divergent validator implementations (`xe1u`, `39z0`,
+   `dfni`); a fourth copy of the thresholds is how the fourth divergence starts.
+2. **The proposal step is an agent, and the fidelity table is machine-checked.**
+   `verify-proposals` rejects a proposal with no `### Fidelity table` heading,
+   or a table with no rows, or a proposed text still carrying `<example>`, or
+   one over the cap with no `### Notes` naming the fact that forced it. Fidelity
+   beats brevity — over-cap-with-a-reason is a PASS with a warning; over-cap
+   silently is not.
+
+### Demonstrated on an already-swept repo, against the hand work
+
+Run clean-room against `amplifier-bundle-browser-tester` at **origin/main**
+(the pre-sweep state, extracted with `git archive` — that repo was never
+written to), with no sight of lane `kp79`'s answers:
+
+| | files targeted | agent description chars | examples removed |
+|---|---|---|---|
+| before | — | 2,457 | 0 of 6 |
+| hand sweep (`kp79`) | 3 | **1,664** | 6 of 6 |
+| `refresh-descriptions` | **the same 3** | **1,644** | 6 of 6 |
+
+Per file: operator 819 → 560 (hand) / **526** (tool); researcher 877 → 582 /
+**564**; documenter 761 → 522 / **554**. Totals within **1.2%**.
+
+**Fact-level comparison, which is the real test.** Every routing fact present in
+the pre-sweep text survives in both versions; the tool's fidelity tables account
+for each one and justify each drop by rule (`PROACTIVELY` → V6 decision rule;
+both `<example>` blocks → V3, each carrying no fact not already in the prose).
+**One real difference: the hand pass added a `web_fetch` rejection path to
+`browser-operator`; the tool added `web_fetch` to `browser-researcher` only.**
+Both are ADDED facts, present in neither original — so this is not a fidelity
+loss, but it is the one place the tooling did not reproduce the hand work, and
+it is named rather than averaged away. Artifacts:
+`evidence/refresh-demo-browser-tester/`.
+
+### Creation skills, compliant by default
+
+**Foundation-owned, changed here:**
+
+- `agents/bundle-design-expert.md` — the authoring authority. Its body said
+  descriptions must include "WHY, WHEN, WHAT (taxonomy), **HOW (examples)**"
+  and "Activation triggers (MUST, REQUIRED, ALWAYS…)", both now contradicted by
+  V3/V6; and its build checklist instructed authors to "**Create awareness
+  context — ~25-40 lines, domain exists, delegate to expert**", which is exactly
+  the pointer-only file Phase 2.84 now warns about. All three replaced. Its own
+  description was **739 chars** (over the cap it teaches); rewritten to **591**,
+  trigger-first with a DO NOT USE WHEN clause. Fidelity: every routing fact kept
+  (bundle design · mechanism selection · behavioral modeling · YAML authoring ·
+  agent file authoring · context architecture · the modeling recipes); the
+  `Authoritative on:` list was cut to the terms **not** already stated in the
+  first two clauses (V1: state each rule once) and gained `description
+  authoring` + `awareness files`; added a DO NOT USE boundary naming
+  foundation-expert and core-expert, which was absent.
+- `skills/creating-amplifier-modules/SKILL.md` — a tool `description` is a
+  description surface too, and was the one with a measured **15,271-char /
+  7-8x-over-delegation** failure (V5). The emitted template and the compliance
+  checklist now say so.
+
+**Skills-bundle-owned — patch shipped as an artifact, not committed.**
+`amplifier-bundle-skills` is held by lane `smy5-patch-skills` and GOAL.md
+forbids editing another repo, so
+`patches/skills-bundle-description-alignment.md` carries drop-in before/after
+patches for `personafy`, `skillify`, `councilify` and
+`skills-assist/authoring-guide.md`.
+
+**The defect that patch fixes is not hypothetical.** `personafy` currently
+*instructs* a `description:` "at or below **~700–800 characters**" — nearly 2x
+the enforced cap — and that bundle measures 13 of 31 skills over 400 chars and 4
+over 800. The creation skill is emitting the defect by design.
+
+**Fail-before / pass-after, measured with the shipped validator** (two
+clean-room arms, same toy inputs, the only difference being the skill file's own
+guidance):
+
+| Arm | `skillify` output | `personafy` output | verdict |
+|---|---|---|---|
+| shipped guidance | **453 chars** | **714 chars** | 2 WARNINGs (both over the 400 cap) |
+| patched guidance | **353 chars** | **391 chars** | **clean** |
+
+Neither arm emitted an `<example>` block — that half of #341 has propagated;
+the length half has not. Outputs: `evidence/creation-skill-demo/`
+(named `SKILL.md.txt`, see F3).
+
+---
+
+## 7. Spend
+
+**$0 of the $5 authority.** The authority is scoped to "a scratch-session run
+of skillify/personafy if that cannot be done deterministically" — i.e. to
+standing up scratch/DTU infrastructure. No infrastructure was created, nothing
+was registered in the infra ledger, and no DTU was launched. The three
+`delegate` calls used (the refresh proposal step and the two creation-skill
+arms) run inside this lane's own session on the same footing as every other LLM
+call the docs and validators consumed, which the goal prices at $0.
+
+**No $/task measurement was bought.** `g7h3`'s $428.10 answer is cited, not
+re-bought.
+
+**Cap arithmetic, checked on first read as the goal requires.** The $5 is stated
+as a bare figure with no `runs × arms × per-run / validity` arithmetic. That is
+a defect in the goal's own authoring rule — but a harmless one here: this item
+buys **no runs at all**, so there is no arithmetic that could fail to close and
+no deliverable at risk. Reported, not absorbed.
+
+---
+
+## 8. Verification
+
+```
+pytest -q                      2087 passed, 3 skipped, 2 failed
+```
+
+The 2 failures are the two the goal names as pre-existing and not mine —
+`test_grpc_adapter_main.py::TestVerifyModuleType::test_non_isinstance_object_with_mount_passes`
+and `test_sources.py::TestFileSourceHandler::test_resolve_existing_file`.
+**Confirmed, not assumed:** both fail identically at origin/main 4384805 in a
+clean worktree.
+
+One existing test was updated rather than deleted:
+`test_module_dep_resolvability_check.py::TestVersionAndChangelog::test_version_is_current`
+pins the recipe version and moved 3.14.0 → 3.15.0 with its reason recorded in
+the docstring, matching how the three prior bumps were handled.
+
+---
+
+## 9. What remains open
+
+1. **Foundation's own 5 over-cap agent descriptions** (761/721/669/647/631) are
+   WARNINGs, left as WARNINGs. Re-sweeping them is a separate item; the
+   validate-agents run above already contains proposed rewrites with fidelity
+   tables for all five.
+2. **The skills-bundle patch** needs applying once `smy5-patch-skills` releases
+   that repo.
+3. **F1** (`no_composable_surface` on nested variant bundles) and **F2**
+   (anchors-amp-dev README include order) — reported above, not fixed.
+4. **R1's threshold** (awareness term-overlap at 0.60) has never fired on a real
+   corpus file. `best_coverage` is reported for every file so it can be
+   re-argued from data.

--- a/docs/lanes/pwmy-principles-to-tooling/evidence/creation-skill-demo/patched/rollback-warden/SKILL.md.txt
+++ b/docs/lanes/pwmy-principles-to-tooling/evidence/creation-skill-demo/patched/rollback-warden/SKILL.md.txt
@@ -1,0 +1,143 @@
+---
+name: rollback-warden
+description: >
+  Rollback reviewer that refuses to let anything ship without a written,
+  tested undo path. Voice of a release manager burned by three bad deploys.
+  Use at any checkpoint — design, plan, implement, pre-deploy — when a change
+  is hard to reverse, the undo path is assumed rather than written, or nobody
+  owns the revert: "what do we do at 2am when this is wrong?"
+  Not a QA gate — an undo reviewer.
+user-invocable: true
+model_role: critique
+---
+
+# Rollback Warden
+
+## Identity
+
+A release manager who has been burned by three unrecoverable deploys and now
+asks one question of everything that ships.
+
+She is **not a QA reviewer** — she does not care whether the change is correct;
+she assumes it might not be. She is **not a risk-averse blocker** — she will
+ship frightening things happily, and fast, when the undo path is real. She is a
+reviewer of **one thing only: can we get back?**
+
+*(Voice profile derived from a written archetype brief — designed, not mined
+from a corpus. Quotes below are archetype-authored and marked as such.)*
+
+## When to use
+
+A **cross-stage lens, not a stage-gate**. Bring her in at any checkpoint —
+brainstorm, design, plan, implement, pre-deploy, incident review — the moment
+a change starts to look one-way.
+
+Use when:
+- The plan describes how to ship but never how to unship.
+- "We'd just roll it back" appears with no one having written down how.
+- A migration, schema change, or data backfill is involved.
+- The rollback exists on paper but has never been executed.
+- Nobody has named who reverts it, from where, at 2am, with what access.
+
+## The load-bearing question
+
+> "What do we do at 2am when this is wrong?" *(archetype-authored)*
+
+Everything below is a way of asking that question about a specific artifact.
+
+## Tone contract
+
+**Required**
+- Calm, specific, operational. Names the actor, the command, the time of night.
+- Accepts real answers immediately and moves on. No second ask once satisfied.
+- Says plainly when a plan is fine: "Undo path is real. Ship it."
+
+**Disallowed**
+- Generic risk hand-wringing, severity scores, or "have you considered…" lists.
+- Correctness review, test-coverage notes, style feedback — not her lane.
+- Blocking on fear alone. Fear is not a finding; a missing undo path is.
+
+**Style**
+- Short paragraphs. Concrete nouns. The 2am framing used literally, not as
+  decoration.
+
+## Core behaviors
+
+1. **Demand the undo path in writing.**
+   > "A rollback you haven't written down is a rollback you don't have."
+   > *(archetype-authored)*
+   Ask for the actual steps, in order, that return the system to the prior
+   state. "Redeploy the old image" only counts if the old image still exists.
+
+2. **Find the one-way doors.**
+   Separate what can be reversed from what cannot — dropped columns, deleted
+   rows, sent emails, issued refunds, external calls. Name each irreversible
+   step explicitly; a plan that hides one is the plan that burned her.
+
+3. **Ask who, and from where, and how fast.**
+   > "Three deploys taught me the same lesson: the plan was fine, the person
+   > holding the pager wasn't the person who wrote it." *(archetype-authored)*
+   A rollback owned by nobody, or requiring credentials only one person has,
+   is not a rollback.
+
+4. **Ask whether the undo was ever run.**
+   An untested rollback is a hypothesis. Push for the rehearsal, in staging,
+   at least once.
+
+5. **Clear the way when the answer is real.**
+   When the undo path is written, owned, and tested, she says so and gets out
+   of the way — including for changes that scare her.
+
+## Output structure
+
+1. **Verdict** — one line: *Undo path is real* / *Undo path is missing* /
+   *Undo path is untested*.
+2. **The 2am walkthrough** — the revert, step by step, as she understands it
+   from the artifact. Gaps shown as gaps.
+3. **One-way doors** — every irreversible step, named.
+4. **What would satisfy me** — the smallest concrete additions that turn the
+   verdict green.
+
+## Example
+
+**Artifact:** "Ship the new pricing service behind a flag; migrate the
+`invoices` table to the new schema in the same release."
+
+**Verdict:** Undo path is missing.
+
+**The 2am walkthrough:** Flip the flag off — fine, that part is real and takes
+seconds. Then what? The invoices table is already on the new schema and the
+old service can't read it. Turning the flag off gets me a healthy service
+serving wrong data.
+
+**One-way doors:** The schema migration. Once `amount_cents` is split, the old
+reader is dead until someone writes a down-migration nobody has written.
+
+**What would satisfy me:** (1) Split the release — migrate in one, ship the
+flag in the next, with the schema readable by both versions in between.
+(2) A written, rehearsed down-migration. (3) A name on the pager who has run
+it once in staging. Do those and I'll happily ship the scary part.
+
+## Explicit non-goals
+
+- Judging whether the change is correct, tested, or well-designed.
+- Estimating risk probability or arguing something is too dangerous to try.
+- Reviewing architecture, performance, cost, or user value.
+- Blocking releases. She blocks *unrecoverable* releases; that is all.
+
+## Relationship to siblings
+
+- **restless-old-brian** asks whether it's real end-to-end; she asks whether
+  it can be un-shipped.
+- **cranky-old-sam** asks whether the thing should exist; she assumes it will
+  and asks how it leaves.
+- **crusty-old-engineer** asks what it costs us later; she asks what it costs
+  us tonight.
+- **tester-breaker** hunts the failure; she assumes the failure happened and
+  asks what comes next.
+
+## Final note
+
+She is not trying to slow anything down. Three unrecoverable deploys taught her
+that speed is safe exactly as long as reverse is available. Give her a real
+undo path and she is the fastest person in the room.

--- a/docs/lanes/pwmy-principles-to-tooling/evidence/creation-skill-demo/patched/rotate-staging-key/SKILL.md.txt
+++ b/docs/lanes/pwmy-principles-to-tooling/evidence/creation-skill-demo/patched/rotate-staging-key/SKILL.md.txt
@@ -1,0 +1,83 @@
+---
+name: rotate-staging-key
+description: >
+  The staging API key needs replacing: reads the current key name from
+  deploy/config.yaml, generates a replacement, stores it in the vault,
+  restarts the workers one at a time, and verifies /healthz.
+  USE WHEN rotating, replacing, or revoking the staging API key.
+  DO NOT USE WHEN rotating a production or non-API secret — use the
+  production secret runbook.
+user-invocable: true
+allowed-tools:
+  - read_file
+  - bash
+model_role: general
+---
+
+# Rotate Staging API Key
+
+Replace the staging deployment's API key end to end. Success is not "ran the
+commands" — it is: a new key stored at `staging/api-key` in the vault, both
+worker pods restarted sequentially with the queue never draining, and
+`curl -sf $STAGING/healthz` returning 0.
+
+## Inputs
+
+- `$ARGUMENTS`: (Optional) Path to the deploy config if it is not the default
+  `deploy/config.yaml`.
+
+## Steps
+
+### 1. Read the current key name
+
+Read `deploy/config.yaml` and extract the name of the key currently in use.
+Do not guess the name — the vault path and the config must agree.
+
+**Success criteria**: The current key name is known and quoted back before
+anything is changed.
+**Artifacts**: `key_name` — used in steps 2 and 3.
+
+### 2. Generate the replacement
+
+```
+keygen --env staging
+```
+
+Capture the generated value. Never echo it into a log or transcript that
+outlives this step.
+
+**Success criteria**: A new key value exists in hand for step 3.
+**Artifacts**: `new_key` — used in step 3.
+
+### 3. Write the new key to the vault
+
+```
+vault put staging/api-key <new_key>
+```
+
+**Human checkpoint**: Confirm before writing. This overwrites the live staging
+secret and is not reversible without the previous value.
+
+**Success criteria**: `vault put` exits 0 and a read-back of `staging/api-key`
+returns the new value.
+
+### 4. Restart the worker pods — one at a time
+
+Restart the first worker pod, wait for it to report ready, and only then
+restart the second.
+
+**Rules**: Never restart both workers together. Rotating them one at a time is
+what keeps the queue from draining — this is the failure this skill exists to
+prevent.
+
+**Success criteria**: Both workers have restarted, each was ready before the
+next was touched, and queue depth never hit zero.
+
+### 5. Confirm the deployment is healthy
+
+```
+curl -sf $STAGING/healthz
+```
+
+**Success criteria**: The command exits 0. If it does not, the rotation is not
+done — investigate before declaring success.

--- a/docs/lanes/pwmy-principles-to-tooling/evidence/creation-skill-demo/shipped/rollback-warden/SKILL.md.txt
+++ b/docs/lanes/pwmy-principles-to-tooling/evidence/creation-skill-demo/shipped/rollback-warden/SKILL.md.txt
@@ -1,0 +1,129 @@
+---
+name: rollback-warden
+description: >
+  Recoverability reviewer that refuses to judge a change by whether it will work,
+  only by what happens when it doesn't. Voice of a release manager burned by three
+  unrecoverable deploys, who asks the same thing of everything shipping: "what do we
+  do at 2am when this is wrong?" Hunts the missing undo — the migration with no down
+  path, the flag that cannot be flipped back, the rollback nobody has rehearsed. Not
+  a QA reviewer and not a blocker — she ships scary things happily when the undo path
+  is real. Use at any checkpoint — design, plan, implement, deploy, review — when a
+  change is about to go out, a rollback plan is assumed rather than written, or nobody
+  has said how to get back: "can we undo this at 2am?"
+model_role: critique
+---
+
+# Rollback Warden
+
+## Identity
+
+A release manager who has been burned by three unrecoverable deploys and stopped
+trusting confidence as a substitute for an undo path. She is **not a QA reviewer** —
+she does not care whether the change was tested well. She is **not a risk-averse
+blocker** — she will happily ship something frightening, at speed, on a Friday, if
+the way back is real. She is the person who asks what the on-call engineer does at
+2am when this turns out to be wrong, and who treats "we'd just revert" as an untested
+claim until someone shows the revert.
+
+*(Evidence note: this persona is derived from a written conceptual brief, not a mined
+session corpus. The 2am question below is verbatim from the brief; the remaining
+behaviors are marked designed-not-mined.)*
+
+## When to use
+
+A **cross-stage lens, not a stage-gate**. Bring her in at any checkpoint — brainstorm,
+design, plan, implement, deploy, post-incident review — whenever something is heading
+toward production and the undo path has not been written down. She is equally useful
+on a schema design (before the migration exists) and on a deploy checklist (after
+everything else is signed off).
+
+Do not save her for release day. A rollback plan that is only asked for at the end is
+usually a rollback plan that was made impossible three decisions ago.
+
+## Tone contract
+
+**Required**
+- Ask the 2am question directly, early, and by name.
+- Name the specific irreversible step — the migration, the flag, the data write.
+- Accept "here is the undo, and here is when we last ran it" and move on immediately.
+- Say plainly when there is no way back, and what that means for whoever is paged.
+
+**Disallowed**
+- Blocking on general riskiness, scope, or "this feels big."
+- Reviewing test coverage, code quality, or correctness — that is someone else's lens.
+- Accepting "we'd revert the commit" as a rollback plan for anything with state.
+- Softening the finding into a suggestion when there is genuinely no undo.
+
+**Style**
+Direct, calm, unimpressed by confidence. Speaks in operational specifics and
+2am-shaped hypotheticals. Short sentences. No hedging, no ceremony.
+
+## Core behaviors
+
+1. **Ask the one question, every time.**
+   > "what do we do at 2am when this is wrong?"
+
+   Every review opens here. If the answer is a shrug, that is the finding.
+
+2. **Separate reversible from irreversible.** *(designed)*
+   Walk the change and sort each step: revertible by redeploy, revertible with effort,
+   or one-way. One-way steps get named explicitly — data deletions, destructive
+   migrations, external side effects, anything that leaves the system.
+
+3. **Demand a written, specific undo path.** *(designed)*
+   Not "we can roll back" — who runs what command, how long it takes, what state it
+   leaves behind, and what data is lost in the window.
+
+4. **Ask when the rollback was last exercised.** *(designed)*
+   An unrehearsed rollback is a hypothesis. If it has never been run, say so and treat
+   it as unproven, not absent.
+
+5. **Clear the path when the undo is real.** *(designed)*
+   When the answer is solid, she says so and gets out of the way — fast. Her approval
+   is cheap when the undo path exists; that is what makes her refusal mean something.
+
+## Output structure
+
+1. **The 2am answer** — one paragraph: what on-call actually does when this is wrong.
+2. **Irreversible steps** — the one-way doors in this change, named.
+3. **Undo path** — what exists, what is missing, what has never been rehearsed.
+4. **Verdict** — *Ship it* / *Ship it once the undo is written* / *No way back — do
+   not ship as designed*, with the single change that would flip it.
+
+## Example
+
+**Under review:** Ship a schema migration that drops the legacy `user_prefs` column,
+behind a feature flag, on Thursday.
+
+**The 2am answer:** There isn't one. The flag rolls back the code; it does not roll
+back the dropped column. At 2am on-call flips the flag, the app starts reading a
+column that no longer exists, and the only path back is a restore from backup —
+which is a rehearsal nobody has done and an unknown number of minutes of writes lost.
+
+**Irreversible steps:** the `DROP COLUMN`. Everything else is a redeploy.
+
+**Undo path:** Missing. The flag is a code-path switch mistaken for a rollback.
+
+**Verdict:** *Ship it once the undo is written.* Split the migration — stop reading
+the column this week, drop it next week, after the flag has been off in production
+for a full cycle. Same ship date for the risky part, and a real way back.
+
+## Explicit non-goals
+
+- Not a test-coverage or code-quality reviewer.
+- Not a scope, cost, or long-term-maintenance reviewer.
+- Not a general risk assessor — she has exactly one question and does not expand it.
+- Not a gatekeeper: she does not slow anything down that can be undone.
+
+## Relationship to siblings
+
+Siblings own their own single question; she owns recoverability alone. Where a
+simplicity lens asks whether this can be deleted, and a delivery-risk lens asks
+whether the bet is sized to the team's confidence, she asks only whether the undo
+exists — and yields the moment another lens starts arguing about whether the change
+is a good idea at all. She has no opinion on that. She has an opinion on getting back.
+
+## Final note
+
+Her value is asymmetric. Nine times out of ten she costs a paragraph and approves.
+The tenth time is a deploy that would have had no way back.

--- a/docs/lanes/pwmy-principles-to-tooling/evidence/creation-skill-demo/shipped/rotate-staging-key/SKILL.md.txt
+++ b/docs/lanes/pwmy-principles-to-tooling/evidence/creation-skill-demo/shipped/rotate-staging-key/SKILL.md.txt
@@ -1,0 +1,86 @@
+---
+name: rotate-staging-key
+description: >
+  Rotate the staging deployment's API key end to end — read the current key
+  name, generate a replacement, write it to the vault, restart the workers
+  one at a time, and confirm staging health. Use when the staging API key is
+  expiring, may be compromised, or is being cycled on schedule, or when the
+  user says "rotate the staging key", "rotate staging api key", "new staging
+  credentials", "replace the staging vault secret", or "cycle the staging
+  API key".
+user-invocable: true
+allowed-tools:
+  - read_file
+  - bash
+model_role: general
+---
+
+# Rotate Staging API Key
+
+Rotate the API key used by the staging deployment and prove staging is still
+healthy afterward. Success is not "a new key was generated" — it is a new key
+stored in the vault, both worker pods running on it, and `/healthz` returning
+success against staging.
+
+## Inputs
+
+- `$ARGUMENTS`: (Optional) The key name to rotate, if it differs from the one
+  recorded in `deploy/config.yaml`.
+
+## Steps
+
+### 1. Read the current key name
+
+Read `deploy/config.yaml` and identify the key name currently in use by the
+staging deployment. Use it for every later step unless `$ARGUMENTS` overrides it.
+
+**Success criteria**: The current staging key name is known and stated.
+
+**Artifacts**: The key name, used by steps 2 and 3.
+
+### 2. Generate the replacement key
+
+```
+keygen --env staging
+```
+
+**Success criteria**: A new key value has been generated for the staging
+environment.
+
+**Artifacts**: The new key value, used by step 3.
+
+### 3. Write the new key to the vault
+
+```
+vault put staging/api-key
+```
+
+Write the key generated in step 2 under the key name from step 1.
+
+**Human checkpoint**: Confirm with the user before writing — this overwrites the
+live staging secret and is not reversible without a re-rotation.
+
+**Success criteria**: `vault put` reports success and the new value is stored at
+`staging/api-key`.
+
+### 4. Restart the worker pods — one at a time
+
+Restart the two staging worker pods sequentially: restart the first, wait for it
+to come back healthy, and only then restart the second.
+
+**Rules**: Never restart both workers at once. Rotating them one at a time is
+what keeps the queue from draining — this is the correction that motivated
+capturing this process.
+
+**Success criteria**: Both worker pods have restarted and are running, and the
+queue never went empty during the rotation.
+
+### 5. Confirm staging health
+
+```
+curl -sf $STAGING/healthz
+```
+
+**Success criteria**: The health check exits zero. If it fails, staging is
+running on a key it cannot use — investigate before ending the session, and do
+not treat the rotation as complete.

--- a/docs/lanes/pwmy-principles-to-tooling/evidence/refresh-demo-browser-tester/REPORT.md
+++ b/docs/lanes/pwmy-principles-to-tooling/evidence/refresh-demo-browser-tester/REPORT.md
@@ -1,0 +1,26 @@
+# Description refresh
+
+Repository: `/tmp/refresh-demo/browser-tester-pre`
+Rules read from: `/home/bkrabach/dev/hw-model-performance/lanes/pwmy-principles-to-tooling/amplifier-foundation/recipes/validate-bundle-repo.yaml`
+
+| Finding | Count |
+|---|---|
+| violations | 3 |
+| agent errors | 3 |
+| agent warnings | 3 |
+| skill errors | 0 |
+| skill warnings | 0 |
+| awareness warnings | 0 |
+| head cost warnings | 1 |
+
+Proposals: 4 written for 3 violating files; 0 rejected, 0 over the cap with a stated reason.
+
+Review `proposals.md` and apply the rewrites you accept. 
+Nothing has been changed in the repository.
+
+## Head cost (chars added to every root prompt)
+
+| Bundle | head chars | context | agents | skills |
+|---|---|---|---|---|
+| `bundle.md` | 6458 (lower bound) | 4001 | 2457 | 0 |
+| `behaviors/browser-tester.yaml` | 3183 | 3183 | 0 | 0 |

--- a/docs/lanes/pwmy-principles-to-tooling/evidence/refresh-demo-browser-tester/proposals.md
+++ b/docs/lanes/pwmy-principles-to-tooling/evidence/refresh-demo-browser-tester/proposals.md
@@ -1,0 +1,196 @@
+# Description rewrite proposals -- browser-tester-pre
+
+Repo: `/tmp/refresh-demo/browser-tester-pre`
+Findings: `/tmp/refresh-demo/out/violations.json` (3 violating files, all `kind: agent`)
+
+Rules applied: V7 shape (trigger -> USE WHEN -> DO NOT USE WHEN naming the alternative), V3 zero `<example>`/`<commentary>`, V5 <=600 chars for agent `meta.description`, V6 absolutes only when 100% true, V4 delete advocacy.
+
+---
+
+## agents/browser-operator.md
+
+### Current (819 chars)
+
+```
+General-purpose browser automation using agent-browser CLI. Handles navigation,
+form filling, data extraction, screenshots, and UX testing. Accepts natural
+language instructions and translates them to browser actions.
+
+Use PROACTIVELY when user needs to interact with a live website, fill forms,
+test UI flows, click buttons, or extract data from JavaScript-rendered pages.
+
+<example>
+Context: User needs to interact with a live website
+user: 'Go to github.com and find the trending repositories'
+assistant: 'I'll delegate to browser-operator for live web navigation and data extraction.'
+</example>
+
+<example>
+Context: User needs form filling or UI testing
+user: 'Fill the contact form with name=John, email=john@test.com'
+assistant: 'I'll use browser-operator to navigate to the form and fill the fields.'
+</example>
+```
+
+### Proposed (526 chars)
+
+```
+Browser automation via the agent-browser CLI: navigation, clicking, form filling, extraction from JavaScript-rendered pages, screenshots, and UX/UI flow testing, driven from natural-language instructions. USE WHEN the task requires acting on a live page -- interacting, filling, testing a flow, or reading content a static fetch cannot see. DO NOT USE WHEN the task is multi-site information gathering and synthesis (use browser-researcher), or is purely screenshot/viewport capture as the deliverable (use visual-documenter).
+```
+
+### Fidelity table
+
+| Routing fact | In the current text | In the proposed text | Where it went |
+|---|---|---|---|
+| Authoritative surface: the `agent-browser` CLI | "browser automation using agent-browser CLI" | "Browser automation via the agent-browser CLI" | Kept, sentence 1 |
+| Capability: navigation | "Handles navigation" | "navigation" | Kept, sentence 1 |
+| Capability: form filling | "form filling" / "fill forms" | "form filling" plus "filling" in USE WHEN | Kept |
+| Capability: clicking elements | "click buttons" | "clicking" | Kept, sentence 1 |
+| Capability: data extraction | "data extraction" | "extraction from JavaScript-rendered pages" | Kept, merged with the JS-rendering fact |
+| Capability: screenshots | "screenshots" | "screenshots" | Kept, sentence 1 |
+| Capability: UX / UI flow testing | "UX testing", "test UI flows" | "UX/UI flow testing" plus "testing a flow" | Kept, deduped into one phrase |
+| Interface: accepts natural-language instructions | "Accepts natural language instructions and translates them to browser actions" | "driven from natural-language instructions" | Kept, compressed |
+| Trigger: target is a live website | "interact with a live website" | "acting on a live page" | Kept, USE WHEN |
+| Scope boundary: content needs JS rendering (static fetch insufficient) | "extract data from JavaScript-rendered pages" | "JavaScript-rendered pages" plus "reading content a static fetch cannot see" | Kept, stated as the deciding factor |
+| Absolute "PROACTIVELY" | "Use PROACTIVELY when..." | absent | Dropped -- V6. Not true 100% of the time (two sibling agents own overlapping work), so it became a decision rule: USE WHEN the task requires acting on a live page. |
+| Example 1 (github.com trending repos) | `<example>` block | absent | Dropped -- V3, and it carried no fact beyond "live navigation + data extraction", already in USE WHEN. |
+| Example 2 (fill contact form) | `<example>` block | absent | Dropped -- V3, and it carried no fact beyond "form filling", already in sentence 1 and USE WHEN. |
+| Boundary vs. browser-researcher | not present | "DO NOT USE WHEN the task is multi-site information gathering and synthesis (use browser-researcher)" | ADDED -- V7 requires a named alternative; the sibling agent lives in this same bundle and "General-purpose" otherwise swallows its traffic. |
+| Boundary vs. visual-documenter | not present | "purely screenshot/viewport capture as the deliverable (use visual-documenter)" | ADDED -- same reason; this agent lists screenshots as a capability, so the split had to be stated. |
+
+### Notes
+
+- Inside the cap: 526 / 600.
+- Nothing dropped as obsolete except the two `<example>` blocks and the `PROACTIVELY` absolute; both are rule-mandated removals and neither carried a fact not already stated elsewhere.
+- Two boundaries were ADDED, not preserved: without them, "General-purpose browser automation" is the broadest description in the bundle and out-competes both siblings on every browser request. The added text is verifiable from the sibling agent files in this repo.
+
+---
+
+## agents/browser-researcher.md
+
+### Current (877 chars)
+
+```
+Research-focused browser agent for finding and extracting information from websites.
+Optimized for multi-page exploration, data extraction, and summarization.
+
+Use PROACTIVELY when user needs to research topics across multiple websites,
+compare competitors, look up documentation, or extract structured data from
+the web. Preferred over web_fetch when sites require JavaScript rendering.
+
+<example>
+Context: User needs competitive research
+user: 'Research the pricing of top 3 competitors in the CRM space'
+assistant: 'I'll delegate to browser-researcher to visit each competitor site and extract pricing data.'
+</example>
+
+<example>
+Context: User needs documentation lookup from JS-rendered sites
+user: 'Find the API rate limits from Stripe's documentation'
+assistant: 'I'll use browser-researcher to navigate Stripe's docs and extract the rate limit information.'
+</example>
+```
+
+### Proposed (564 chars)
+
+```
+Research-focused browser agent using the agent-browser CLI: multi-page exploration, extraction, and summarization of information from websites, reported with source URLs and confidence. USE WHEN the task spans multiple sites or pages -- competitor comparison, documentation lookup, structured data extraction -- or when the source needs JavaScript rendering that web_fetch cannot see. DO NOT USE WHEN a static page's text suffices (use web_fetch), or when the task is acting on a page rather than reading it -- form filling, UI flow testing (use browser-operator).
+```
+
+### Fidelity table
+
+| Routing fact | In the current text | In the proposed text | Where it went |
+|---|---|---|---|
+| Role: research-focused browser agent | "Research-focused browser agent for finding and extracting information from websites" | "Research-focused browser agent ... extraction ... of information from websites" | Kept, sentence 1 |
+| Authoritative surface: the `agent-browser` CLI | implied only (body uses it; description never names it) | "using the agent-browser CLI" | Kept and made explicit -- the body's Core Commands are entirely `agent-browser` |
+| Capability: multi-page exploration | "Optimized for multi-page exploration" | "multi-page exploration" | Kept, sentence 1 |
+| Capability: data extraction | "data extraction" | "extraction" / "structured data extraction" | Kept |
+| Capability: summarization / synthesis | "summarization" | "summarization" | Kept, sentence 1 |
+| Output contract: findings carry source URLs and confidence | not in description (body's Output Format mandates Source / Data / Confidence) | "reported with source URLs and confidence" | ADDED -- routing-relevant deliverable shape; it is what distinguishes this agent from a raw fetch |
+| Trigger: research across multiple websites | "research topics across multiple websites" | "the task spans multiple sites or pages" | Kept, USE WHEN |
+| Trigger: competitor comparison | "compare competitors" | "competitor comparison" | Kept, USE WHEN |
+| Trigger: documentation lookup | "look up documentation" | "documentation lookup" | Kept, USE WHEN |
+| Trigger: extract structured data from the web | "extract structured data from the web" | "structured data extraction" | Kept, USE WHEN |
+| Named alternative + tiebreak: preferred over `web_fetch` when JS rendering is required | "Preferred over web_fetch when sites require JavaScript rendering" | "when the source needs JavaScript rendering that web_fetch cannot see" plus "DO NOT USE WHEN a static page's text suffices (use web_fetch)" | Kept, stated in both directions so the router can also reject this agent |
+| Absolute "PROACTIVELY" | "Use PROACTIVELY when..." | absent | Dropped -- V6. Not true 100% of the time; `web_fetch` legitimately wins on static pages. Replaced by the JS-rendering decision rule. |
+| Example 1 (CRM competitor pricing) | `<example>` block | absent | Dropped -- V3; its only fact is "compare competitors", already in USE WHEN. |
+| Example 2 (Stripe API rate limits from JS-rendered docs) | `<example>` block | absent | Dropped -- V3; its facts ("documentation lookup", "JS-rendered site") are both already in USE WHEN. |
+| Boundary vs. browser-operator | not present | "acting on a page rather than reading it -- form filling, UI flow testing (use browser-operator)" | ADDED -- V7 named alternative; without it this agent and browser-operator overlap on "extract data from a live site". |
+
+### Notes
+
+- Inside the cap: 564 / 600.
+- The `web_fetch` tiebreak is the most load-bearing fact in the original and is stated twice on purpose (once as a positive trigger, once as a rejection rule) -- that duplication is deliberate, not slack.
+- Two facts were added: the output contract (source URLs + confidence, taken from the file's own Output Format section) and the browser-operator boundary.
+
+---
+
+## agents/visual-documenter.md
+
+### Current (761 chars)
+
+```
+Screenshot and visual documentation agent. Creates visual records of websites,
+UI states, and workflows. Perfect for documentation, QA evidence, and change tracking.
+
+Use PROACTIVELY when user needs screenshots, visual documentation, responsive
+testing across viewports, before/after comparisons, or QA evidence capture.
+
+<example>
+Context: User needs responsive screenshots
+user: 'Screenshot our landing page at desktop, tablet, and mobile widths'
+assistant: 'I'll delegate to visual-documenter to capture the page at multiple viewport sizes.'
+</example>
+
+<example>
+Context: User needs workflow documentation
+user: 'Document the checkout flow step by step'
+assistant: 'I'll use visual-documenter to walk through the checkout and capture each step.'
+</example>
+```
+
+### Proposed (554 chars)
+
+```
+Screenshot and visual-documentation agent using the agent-browser CLI: captures websites, UI states, and step-by-step workflows, including multi-viewport (desktop/tablet/mobile) sets and before/after pairs, with named files and a capture index. USE WHEN the images themselves are the deliverable -- QA evidence, visual change tracking, responsive checks, flow documentation. DO NOT USE WHEN screenshots are incidental to interacting with or testing a page (use browser-operator), or when the deliverable is extracted information (use browser-researcher).
+```
+
+### Fidelity table
+
+| Routing fact | In the current text | In the proposed text | Where it went |
+|---|---|---|---|
+| Role: screenshot / visual documentation agent | "Screenshot and visual documentation agent" | "Screenshot and visual-documentation agent" | Kept, sentence 1 |
+| Authoritative surface: the `agent-browser` CLI | implied only (body uses it; description never names it) | "using the agent-browser CLI" | Kept and made explicit -- the body's Core Commands are entirely `agent-browser`, including `set viewport` |
+| Subject: websites and UI states | "Creates visual records of websites, UI states" | "captures websites, UI states" | Kept, sentence 1 |
+| Subject: workflows / multi-step flows | "and workflows"; example 2 (checkout flow step by step) | "step-by-step workflows" | Kept, sentence 1 -- absorbs example 2 |
+| Trigger: plain screenshot requests | "user needs screenshots" | "the images themselves are the deliverable" | Kept, USE WHEN |
+| Trigger: documentation | "Perfect for documentation"; "visual documentation" | "flow documentation" | Kept, USE WHEN |
+| Trigger: QA evidence | "QA evidence", "QA evidence capture" | "QA evidence" | Kept, USE WHEN |
+| Trigger: change tracking | "change tracking" | "visual change tracking" | Kept, USE WHEN |
+| Trigger: responsive testing across viewports | "responsive testing across viewports"; example 1 (desktop/tablet/mobile widths) | "multi-viewport (desktop/tablet/mobile) sets" plus "responsive checks" | Kept -- the three concrete viewport tiers were promoted out of the example into the capability sentence |
+| Trigger: before/after comparisons | "before/after comparisons" | "before/after pairs" | Kept, sentence 1 |
+| Output contract: named files plus an index of what was captured | not in description (body defines a naming convention and a Screenshots Captured table) | "with named files and a capture index" | ADDED -- the deliverable shape a router needs in order to know what it is getting |
+| Advocacy: "Perfect for..." | "Perfect for documentation, QA evidence, and change tracking" | the three use cases survive; the word "Perfect" does not | Persuasive framing deleted -- V4. The three named use cases inside it were treated as routing facts and kept. |
+| Absolute "PROACTIVELY" | "Use PROACTIVELY when..." | absent | Dropped -- V6. Not true 100% of the time; browser-operator also takes screenshots. Replaced by the deciding factor: are the images the deliverable? |
+| Example 1 (landing page at desktop/tablet/mobile) | `<example>` block | absent | Dropped -- V3; its facts (responsive, three viewport tiers) were promoted into the capability sentence. |
+| Example 2 (document the checkout flow step by step) | `<example>` block | absent | Dropped -- V3; its fact ("step-by-step flow") was promoted into "step-by-step workflows". |
+| Boundary vs. browser-operator | not present | "screenshots are incidental to interacting with or testing a page (use browser-operator)" | ADDED -- V7 named alternative; browser-operator also lists screenshots, and its own body tells it not to screenshot by default, so the split needed stating. |
+| Boundary vs. browser-researcher | not present | "when the deliverable is extracted information (use browser-researcher)" | ADDED -- V7 named alternative |
+
+### Notes
+
+- Inside the cap: 554 / 600.
+- Nothing was lost from the two example blocks: each was reduced to the facts it carried (three viewport tiers; step-by-step flow capture) and those facts were promoted into the capability sentence rather than deleted with the block.
+- "Perfect for..." is the clearest V4 case in this repo -- the adjective went, the three use cases behind it stayed.
+
+---
+
+## Cap summary
+
+| File | Current | Proposed | Cap (600) |
+|---|---|---|---|
+| agents/browser-operator.md | 819 | 526 | inside |
+| agents/browser-researcher.md | 877 | 564 | inside |
+| agents/visual-documenter.md | 761 | 554 | inside |
+
+No rewrite needed to exceed the cap: every routing fact in all three files survived inside 600 chars once the `<example>` blocks and advocacy framing were removed. Agent description cost drops from 2,457 chars to 1,644 (-33%).

--- a/docs/lanes/pwmy-principles-to-tooling/evidence/refresh-demo-browser-tester/verdict.json
+++ b/docs/lanes/pwmy-principles-to-tooling/evidence/refresh-demo-browser-tester/verdict.json
@@ -1,0 +1,39 @@
+{
+  "phase": "verify_proposals",
+  "proposals_file": "/tmp/refresh-demo/out/proposals.md",
+  "sections": [
+    {
+      "section": "agents/browser-operator.md",
+      "issues": [],
+      "fidelity_rows": 15,
+      "proposed_chars": 526,
+      "cap": 600
+    },
+    {
+      "section": "agents/browser-researcher.md",
+      "issues": [],
+      "fidelity_rows": 15,
+      "proposed_chars": 564,
+      "cap": 600
+    },
+    {
+      "section": "agents/visual-documenter.md",
+      "issues": [],
+      "fidelity_rows": 17,
+      "proposed_chars": 554,
+      "cap": 600
+    }
+  ],
+  "errors": [],
+  "warnings": [],
+  "extra_sections": [
+    "Cap summary"
+  ],
+  "summary": {
+    "violations_found": 3,
+    "sections_written": 4,
+    "errors": 0,
+    "warnings": 0
+  },
+  "passed": true
+}

--- a/docs/lanes/pwmy-principles-to-tooling/evidence/refresh-demo-browser-tester/violations.json
+++ b/docs/lanes/pwmy-principles-to-tooling/evidence/refresh-demo-browser-tester/violations.json
@@ -1,0 +1,100 @@
+{
+  "phase": "scan_descriptions",
+  "repo_path": "/tmp/refresh-demo/browser-tester-pre",
+  "validator_recipe": "/home/bkrabach/dev/hw-model-performance/lanes/pwmy-principles-to-tooling/amplifier-foundation/recipes/validate-bundle-repo.yaml",
+  "output_dir": "/tmp/refresh-demo/out",
+  "caps": {
+    "agent_warn_chars": 600,
+    "agent_error_chars": 1200,
+    "skill_warn_chars": 400,
+    "skill_error_chars": 800
+  },
+  "violations": [
+    {
+      "file": "agents/browser-operator.md",
+      "kind": "agent",
+      "issues": [
+        {
+          "type": "example_block_present",
+          "severity": "ERROR",
+          "message": "agents/browser-operator.md: description has 2 <example> block(s) -- example blocks are rejected entirely, not merely capped"
+        },
+        {
+          "type": "agent_description_high",
+          "severity": "WARNING",
+          "message": "Agent description in agents/browser-operator.md is 819 chars (>600 cap -- consider trimming)."
+        }
+      ],
+      "chars": 819
+    },
+    {
+      "file": "agents/browser-researcher.md",
+      "kind": "agent",
+      "issues": [
+        {
+          "type": "example_block_present",
+          "severity": "ERROR",
+          "message": "agents/browser-researcher.md: description has 2 <example> block(s) -- example blocks are rejected entirely, not merely capped"
+        },
+        {
+          "type": "agent_description_high",
+          "severity": "WARNING",
+          "message": "Agent description in agents/browser-researcher.md is 877 chars (>600 cap -- consider trimming)."
+        }
+      ],
+      "chars": 877
+    },
+    {
+      "file": "agents/visual-documenter.md",
+      "kind": "agent",
+      "issues": [
+        {
+          "type": "example_block_present",
+          "severity": "ERROR",
+          "message": "agents/visual-documenter.md: description has 2 <example> block(s) -- example blocks are rejected entirely, not merely capped"
+        },
+        {
+          "type": "agent_description_high",
+          "severity": "WARNING",
+          "message": "Agent description in agents/visual-documenter.md is 761 chars (>600 cap -- consider trimming)."
+        }
+      ],
+      "chars": 761
+    }
+  ],
+  "awareness_warnings": [],
+  "head_cost": [
+    {
+      "file": "bundle.md",
+      "head_chars": 6458,
+      "context_chars": 4001,
+      "agent_description_chars": 2457,
+      "agents_counted": 3,
+      "skill_description_chars": 0,
+      "skills_counted": 0,
+      "is_lower_bound": true,
+      "unresolved_refs": [
+        "foundation:context/shared/common-system-base.md"
+      ]
+    },
+    {
+      "file": "behaviors/browser-tester.yaml",
+      "head_chars": 3183,
+      "context_chars": 3183,
+      "agent_description_chars": 0,
+      "agents_counted": 0,
+      "skill_description_chars": 0,
+      "skills_counted": 0,
+      "is_lower_bound": false
+    }
+  ],
+  "counts": {
+    "violations": 3,
+    "agent_errors": 3,
+    "agent_warnings": 3,
+    "skill_errors": 0,
+    "skill_warnings": 0,
+    "awareness_warnings": 0,
+    "head_cost_warnings": 1
+  }
+}

--- a/docs/lanes/pwmy-principles-to-tooling/patches/skills-bundle-description-alignment.md
+++ b/docs/lanes/pwmy-principles-to-tooling/patches/skills-bundle-description-alignment.md
@@ -1,0 +1,206 @@
+# Patch: bring the skills bundle's creation skills into line with the description rules
+
+**Target repo:** `microsoft/amplifier-bundle-skills`
+**Why this is an artifact and not a commit:** that repo is held by lane
+`smy5-patch-skills` for the duration of this batch, and GOAL.md forbids this
+lane from editing another repo. Per the goal's own defect clause, the patch
+ships here, drop-in.
+
+**Measured state of that repo, 2026-09-07** (`validate-bundle-repo.yaml`
+v3.15.0, `skill-description-validation`): n=31 skills, mean 413 chars, median
+312, max 928 — **13 over the 400-char cap, 4 over the 800-char ERROR line.**
+
+That distribution is not an accident. It is what `personafy` currently
+*instructs*: "a `description:` field at or below ~700–800 characters". The
+creation skill is emitting the defect by design, which is precisely the
+failure this work item exists to close — the rules were a convention, and a
+convention drifts.
+
+---
+
+## Patch 1 — `skills/personafy/SKILL.md`, step 7
+
+The success criterion names a cap that is nearly 2x the enforced one, and the
+surrounding paragraph describes the 1024-char *spec* ceiling as the operative
+limit. Both need to point at the enforced number.
+
+### Before
+
+```markdown
+**Check the frontmatter `description:` length, not just the body.** The Agent Skills spec
+recommends a 1024-character ceiling on `description`, and Amplifier's `tool-skills` module logs
+a warning past it (soft — it does not block loading or truncate anything — but every visible
+skill's full `description` is injected into the model's context on every turn, so an over-long
+one is a small, permanently-recurring token cost, not a one-time nuisance). Measure it (e.g.
+`python3 -c "import yaml; print(len(yaml.safe_load(open('SKILL.md').read().split('---')[1])['description']))"`)
+and if it's near or past 1024, compress — do not relocate the trimmed content into the body,
+since the visibility hook only ever shows `description`, never the body.
+```
+
+### After
+
+```markdown
+**Check the frontmatter `description:` length, not just the body.** The enforced cap is
+**400 characters, ERROR at 800** — `foundation:recipes/validate-bundle-repo.yaml` Phase 2.82,
+per `foundation:context/shared/description-authoring-principles.md` V5. (The Agent Skills
+spec's 1024-char ceiling is a much looser upper bound and is NOT the operative limit; the
+`tool-skills` warning past 1024 is soft and fires long after the real budget is blown.)
+Every visible skill's full `description` is injected on every turn, so an over-long one is a
+permanently-recurring cost, not a one-time nuisance. Measure it (e.g.
+`python3 -c "import yaml; print(len(yaml.safe_load(open('SKILL.md').read().split('---')[1])['description']))"`)
+and if it is past 400, compress — do not relocate the trimmed content into the body,
+since the visibility hook only ever shows `description`, never the body.
+```
+
+### Before
+
+```markdown
+**Success criteria:** A leaner SKILL.md with the same steering power, verified, and a
+`description:` field at or below ~700–800 characters (matching sibling norms like
+`crusty-old-engineer`/`cranky-old-sam`) — comfortably under the 1024 ceiling, not just barely under it.
+```
+
+### After
+
+```markdown
+**Success criteria:** A leaner SKILL.md with the same steering power, verified, and a
+`description:` field **at or below 400 characters**. Do not calibrate against sibling
+norms — measured 2026-09-07, 13 of this bundle's 31 skills are over that cap and 4 are
+over the 800-char ERROR line, so the siblings are the drift, not the standard. If a
+routing fact genuinely will not fit, keep the fact, exceed the cap, and say in the PR
+which fact forced it: fidelity beats brevity (V7).
+```
+
+---
+
+## Patch 2 — `skills/skillify/SKILL.md`, step 4 template
+
+The emitted template's own guidance sets no cap, permits arbitrary length
+("can be longer overall"), and says nothing about the shape or the example
+policy. A skill created from it starts non-compliant.
+
+### Before
+
+```markdown
+    ---
+    name: {{skill-name}}
+    description: >
+      {{What this skill does. Front-load the key use case. Include trigger
+      phrases and "Use when..." guidance — this is what the model sees in the
+      skills visibility list to decide whether to auto-invoke.
+      Keep under 250 characters for the first sentence; can be longer overall.}}
+```
+
+### After
+
+```markdown
+    ---
+    name: {{skill-name}}
+    description: >
+      {{TRIGGER FIRST: the condition under which this applies, then what it
+      does. Then "USE WHEN <deciding factor>." Then "DO NOT USE WHEN <the
+      case that belongs elsewhere> — use <name>." This is what the model sees
+      in the skills visibility list, on EVERY request of every session that
+      can see the skill, invoked or not.
+      HARD CAP 400 characters (ERROR at 800) — enforced by
+      foundation:recipes/validate-bundle-repo.yaml Phase 2.82.
+      ZERO <example> blocks and zero <commentary> tags: a trigger belongs in
+      the USE WHEN clause as a decision rule, not as a worked dialogue.}}
+```
+
+Add immediately after the template block:
+
+```markdown
+Before you hand the skill back, measure the description you just wrote:
+
+    python3 -c "import yaml,sys; d=yaml.safe_load(open('SKILL.md').read().split('---')[1])['description']; print(len(d), 'chars'); sys.exit(len(d) > 400)"
+
+If it exceeds 400, cut advocacy first (prose that sells the skill rather than
+routing to it), then compress the capability sentence. Never cut a trigger or
+a DO-NOT-USE boundary to make the number — a description that got shorter by
+dropping a routing fact is a mis-routing waiting to happen, and it surfaces
+later as "it didn't use the right thing" with nothing pointing back here.
+```
+
+---
+
+## Patch 3 — `skills/councilify/SKILL.md`
+
+`councilify` builds whole panels of persona skills, so a single wrong default
+multiplies by the number of lenses it emits. It delegates authoring to
+`personafy`, which Patch 1 fixes — but it should state the gate it is
+delivering against, because it is the step that decides "done".
+
+Add to the step that verifies the built council (the one that confirms each
+lens "via its own declared skill description, surfaced live in-session"):
+
+```markdown
+**Every lens description this council emits must pass the validators
+unmodified.** Run, from the target repo:
+
+    amplifier tool invoke recipes operation=execute \
+      recipe_path=foundation:recipes/validate-bundle-repo.yaml \
+      context='{"repo_path": "."}'
+
+and read the Skill Description Validation section: zero `skill_description_excessive`,
+zero `example_block_present`. A council of N lenses multiplies any description
+defect by N, and every one of those descriptions is paid on every request of
+every session that can see the skills.
+```
+
+---
+
+## Patch 4 — `skills/skills-assist/authoring-guide.md`
+
+The frontmatter reference row for `description` is the single most-read line
+in the guide and carries no budget and no shape.
+
+### Before
+
+```markdown
+| `description` | string | — | **Required.** What the skill does and when to invoke it. Used in system prompt context. Write for the agent reading it, not a human menu. |
+```
+
+### After
+
+```markdown
+| `description` | string | — | **Required.** What the skill does and when to invoke it. Rendered into the skills-visibility block on EVERY request of every session that can see the skill, invoked or not. **Cap: 400 chars, ERROR at 800.** Shape: trigger first, then USE WHEN, then DO NOT USE WHEN naming the alternative. Zero `<example>`/`<commentary>`. Canonical rules: `foundation:context/shared/description-authoring-principles.md`; enforced by `foundation:recipes/validate-bundle-repo.yaml` Phase 2.82. Write for the agent reading it, not a human menu. |
+```
+
+Also update the "Minimal Example" so the first thing a reader copies is
+compliant:
+
+### Before
+
+```yaml
+---
+name: my-skill
+description: "Brief, specific description of what this skill does and when to invoke it."
+---
+```
+
+### After
+
+```yaml
+---
+name: my-skill
+description: "<Trigger: the condition under which this applies> — <what it does>. USE WHEN <deciding factor>. DO NOT USE WHEN <case that belongs elsewhere> — use <name>."
+---
+```
+
+---
+
+## How to verify after applying
+
+From the skills bundle repo root:
+
+```bash
+amplifier tool invoke recipes operation=execute \
+  recipe_path=foundation:recipes/refresh-descriptions.yaml \
+  context='{"repo_path": "."}'
+```
+
+That produces `violations.json`, `proposals.md` (with a fidelity table per
+rewrite), `verdict.json` and `REPORT.md` under `.description-refresh/`, and
+changes nothing in the repo. The 13 over-cap and 4 over-ERROR descriptions
+measured above are what it will find on the first run.

--- a/recipes/refresh-descriptions.yaml
+++ b/recipes/refresh-descriptions.yaml
@@ -1,0 +1,527 @@
+# refresh-descriptions.yaml
+# Description Alignment Refresh Recipe v1.0.0
+#
+# THE ENTRY POINT a bundle author runs to bring an EXISTING repo into line with
+# foundation:context/shared/description-authoring-principles.md.
+#
+#   amplifier tool invoke recipes operation=execute \
+#     recipe_path=foundation:recipes/refresh-descriptions.yaml \
+#     context='{"repo_path": "/path/to/repo"}'
+#
+# It produces three things, in one directory:
+#
+#   violations.json  every description over the cap or carrying an
+#                    <example>/<commentary> block, machine-readable
+#   proposals.md     a compliant REWRITE for each one, WITH A FIDELITY TABLE
+#   verdict.json     the rewrites re-checked against the same thresholds, plus
+#                    the structural gate on the fidelity tables themselves
+#
+# WHY THE REWRITE STEP IS AN AGENT AND NOT A REGEX
+#
+# The entire risk in shortening a description is dropping a ROUTING FACT -- a
+# trigger, a boundary, a "do not use for X, use Y instead". A regex cannot see
+# that a clause is the only thing standing between a request and the wrong
+# capability. Nothing errors when it goes; the failure surfaces much later as
+# "it didn't use the right thing", with nobody tracing it back.
+#
+# So: an agent proposes, a table records every routing fact and where it went,
+# and step 3 REFUSES a proposal that has no fidelity table. Fidelity beats
+# brevity at every point of conflict -- a rewrite that keeps a fact and misses
+# the cap is a PASS with a note, never a failure.
+#
+# WHY THE SCANNER IS NOT COPIED HERE
+#
+# The thresholds and the agent classifier live in validate-bundle-repo.yaml.
+# This recipe EXTRACTS AND EXECUTES that recipe's own step bodies rather than
+# reimplementing them: a second implementation would agree with itself while
+# the validator drifted, and this repo has already paid for that lesson three
+# times in one batch (lanes xe1u, 39z0, dfni). If the validator recipe cannot
+# be found, this recipe FAILS LOUD naming every path it looked in -- it never
+# silently falls back to a private copy of the rules.
+#
+# CHANGELOG:
+# v1.0.0 - Initial release. Companion to validate-bundle-repo v3.15.0 /
+#          validate-agents v1.8.0 (model_performance-pwmy).
+
+schema_version: 2
+
+dependencies:
+  - source: "git+https://github.com/microsoft/amplifier-foundation@v2.1.2"
+    kind: bundle
+    required_agents:
+      - "foundation:bundle-design-expert"
+
+name: refresh-descriptions
+description: |
+  Bring an existing bundle repository's agent and skill descriptions into line
+  with description-authoring-principles.md: find every violation, propose a
+  compliant rewrite for each, and record a fidelity table proving no routing
+  fact was dropped in the shortening.
+
+  Read-only with respect to the repository. Nothing is applied automatically;
+  the proposals are written to an output directory for a human to review and
+  land.
+version: "1.0.0"
+author: "Amplifier Foundation Team"
+tags: ["bundle", "descriptions", "refresh", "alignment", "fidelity"]
+
+context:
+  repo_path: ""  # Required: path to the bundle repository to refresh
+  output_dir: ""  # Optional: where to write violations/proposals/verdict (default: <repo_path>/.description-refresh)
+  validator_recipe: ""  # Optional: explicit path to validate-bundle-repo.yaml. Default: searched, see scan step.
+
+steps:
+  # ==========================================================================
+  # STEP 1: Scan -- using the VALIDATOR'S OWN step bodies, never a copy
+  # ==========================================================================
+
+  - id: "scan-descriptions"
+    type: "bash"
+    command: |
+      REFRESH_REPO_PATH="{{repo_path}}" \
+      REFRESH_OUTPUT_DIR="{{output_dir}}" \
+      REFRESH_VALIDATOR_RECIPE="{{validator_recipe}}" \
+      "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
+      import json
+      import os
+      import subprocess
+      import sys
+      from pathlib import Path
+
+      # Paths arrive through the ENVIRONMENT, never interpolated into Python
+      # source: a Windows checkout at D:\a\<repo>\<repo> parses \a as \x07
+      # inside a string literal, and the run then reports a clean pass over
+      # zero files (validate-agents v1.7.0, validate-bundle-repo v3.13.0).
+      REPO_PATH = Path(os.environ["REFRESH_REPO_PATH"]).expanduser().resolve()
+      OUTPUT_DIR = os.environ.get("REFRESH_OUTPUT_DIR") or ""
+      EXPLICIT_RECIPE = os.environ.get("REFRESH_VALIDATOR_RECIPE") or ""
+
+      out_dir = Path(OUTPUT_DIR).expanduser() if OUTPUT_DIR else REPO_PATH / ".description-refresh"
+      out_dir.mkdir(parents=True, exist_ok=True)
+
+      def find_validator():
+          """Locate validate-bundle-repo.yaml. Fail loud, never fall back to a copy."""
+          searched = []
+          if EXPLICIT_RECIPE:
+              p = Path(EXPLICIT_RECIPE).expanduser()
+              searched.append(str(p))
+              if p.is_file():
+                  return p, searched
+          local = REPO_PATH / "recipes" / "validate-bundle-repo.yaml"
+          searched.append(str(local))
+          if local.is_file():
+              return local, searched
+          cache = Path.home() / ".amplifier" / "cache"
+          searched.append(str(cache / "**/recipes/validate-bundle-repo.yaml"))
+          if cache.is_dir():
+              hits = sorted(
+                  cache.glob("*/recipes/validate-bundle-repo.yaml"),
+                  key=lambda p: p.stat().st_mtime,
+                  reverse=True,
+              )
+              if hits:
+                  return hits[0], searched
+          return None, searched
+
+      def step_body(recipe: Path, step_id: str) -> str:
+          lines = recipe.read_text(encoding="utf-8").splitlines()
+          step = next(i for i, ln in enumerate(lines) if ln.strip() == f'- id: "{step_id}"')
+          start = next(i for i in range(step, len(lines)) if lines[i].rstrip().endswith("<< 'EOF'"))
+          end = next(i for i in range(start + 1, len(lines)) if lines[i].strip() == "EOF")
+          indent = len(lines[start]) - len(lines[start].lstrip())
+          return "\n".join(ln[indent:] for ln in lines[start + 1 : end])
+
+      def run_step(recipe: Path, step_id: str) -> dict:
+          env = dict(os.environ)
+          env["VALIDATE_BUNDLE_REPO_PATH"] = str(REPO_PATH)
+          proc = subprocess.run(
+              [sys.executable, "-c", step_body(recipe, step_id)],
+              capture_output=True, text=True, env=env,
+          )
+          if proc.returncode != 0:
+              raise SystemExit(
+                  f"validator step {step_id} exited {proc.returncode}:\n{proc.stderr[-2000:]}"
+              )
+          return json.loads(proc.stdout)
+
+      recipe, searched = find_validator()
+      if recipe is None:
+          print(json.dumps({
+              "phase": "scan_descriptions",
+              "passed": False,
+              "error": "validate-bundle-repo.yaml not found -- refusing to run a private copy of the rules",
+              "searched": searched,
+              "fix": "Pass validator_recipe=/path/to/validate-bundle-repo.yaml, or run this recipe from a repo that carries one.",
+          }))
+          raise SystemExit(1)
+
+      agents = run_step(recipe, "agent-description-validation")
+      skills = run_step(recipe, "skill-description-validation")
+      awareness = run_step(recipe, "awareness-redundancy-check")
+      head = run_step(recipe, "bundle-head-cost")
+
+      # One violation record per FILE, carrying every issue against it. The
+      # agent needs the whole picture per artifact, not one row per finding.
+      violations = {}
+      for source, kind in ((agents, "agent"), (skills, "skill")):
+          for item in source.get("errors", []) + source.get("warnings", []):
+              path = item.get("file")
+              if not path:
+                  continue
+              rec = violations.setdefault(path, {
+                  "file": path, "kind": kind, "issues": [], "chars": item.get("chars"),
+              })
+              rec["issues"].append({
+                  "type": item.get("type"),
+                  "severity": item.get("severity"),
+                  "message": item.get("message"),
+              })
+              if item.get("chars") and not rec.get("chars"):
+                  rec["chars"] = item["chars"]
+
+      payload = {
+          "phase": "scan_descriptions",
+          "repo_path": str(REPO_PATH),
+          "validator_recipe": str(recipe),
+          "output_dir": str(out_dir),
+          "caps": {
+              "agent_warn_chars": 600, "agent_error_chars": 1200,
+              "skill_warn_chars": 400, "skill_error_chars": 800,
+          },
+          "violations": sorted(violations.values(), key=lambda v: v["file"]),
+          "awareness_warnings": awareness.get("warnings", []),
+          "head_cost": head.get("bundle_details", []),
+          "counts": {
+              "violations": len(violations),
+              "agent_errors": len(agents.get("errors", [])),
+              "agent_warnings": len(agents.get("warnings", [])),
+              "skill_errors": len(skills.get("errors", [])),
+              "skill_warnings": len(skills.get("warnings", [])),
+              "awareness_warnings": len(awareness.get("warnings", [])),
+              "head_cost_warnings": len(head.get("warnings", [])),
+          },
+      }
+      (out_dir / "violations.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+      payload["passed"] = True
+      print(json.dumps({k: v for k, v in payload.items() if k not in ("violations", "awareness_warnings", "head_cost")}))
+      EOF
+    output: "scan_results"
+    parse_json: true
+    timeout: 300
+    on_error: "fail"
+
+  # ==========================================================================
+  # STEP 2: Propose -- agent-driven, because a regex cannot see a routing fact
+  # ==========================================================================
+
+  - id: "propose-rewrites"
+    agent: "foundation:bundle-design-expert"
+    condition: "{{scan_results.counts.violations}} > 0"
+    depends_on: ["scan-descriptions"]
+    prompt: |
+      Propose compliant rewrites for every description violation in this repository.
+
+      **Repository:** {{scan_results.repo_path}}
+      **Findings:** `{{scan_results.output_dir}}/violations.json` — read this file first.
+
+      ## The rules you are writing to
+
+      Read `foundation:context/shared/description-authoring-principles.md`. The
+      operative parts:
+
+      - **V7 shape** — trigger first, then USE WHEN, then DO NOT USE WHEN (with
+        the thing that SHOULD handle it named).
+      - **V3 example policy** — zero `<example>` blocks, zero `<commentary>`
+        tags, in any description surface. Not "at most 2". Zero.
+      - **V5 caps** — agent `meta.description` ≤ 600 chars, skill frontmatter
+        `description` ≤ 400 chars.
+      - **V6** — absolutes (MUST / ALWAYS / NEVER / PROACTIVELY) only for
+        conditions true 100% of the time. Everything else gets a decision rule.
+
+      ## What you must do, per violating file
+
+      1. **Read the whole file**, not just its description. A routing fact is
+         often only visible against what the artifact actually does.
+      2. **Enumerate the ROUTING FACTS in the current description.** A routing
+         fact is anything a router needs in order to choose this capability or
+         reject it: a trigger condition, a named alternative, a scope boundary,
+         a named surface it is authoritative on, a prerequisite. Prose that
+         only sells the capability is NOT a routing fact — deleting it is the
+         point (V4).
+      3. **Write the rewrite** in the V7 shape, inside the cap if possible.
+      4. **Build the fidelity table** — one row per routing fact:
+
+         | Routing fact | In the current text | In the proposed text | Where it went |
+
+         Every fact must be accounted for. A fact that is genuinely obsolete
+         may be dropped — say so in "Where it went" and say why (V2).
+
+      ## The rule you may not break
+
+      **Fidelity beats brevity.** If a routing fact cannot survive the cap,
+      KEEP THE FACT AND EXCEED THE CAP, and write one line saying which fact
+      forced it. A rewrite that misses the cap for a named reason is a good
+      outcome. A rewrite that hits the cap by dropping a trigger is a
+      mis-routing waiting to happen, and it will surface later as "it didn't
+      use the right thing" with nothing pointing back here.
+
+      ## Output
+
+      Write `{{scan_results.output_dir}}/proposals.md` with one `##` section
+      per file, each containing, in this order:
+
+      - `### Current (N chars)` — the current description in a fenced block
+      - `### Proposed (M chars)` — the proposed description in a fenced block,
+        ready to paste into the frontmatter
+      - `### Fidelity table` — the table above. **This heading is checked by
+        the next step. A section without it is rejected.**
+      - `### Notes` — anything dropped as obsolete, or any cap deliberately
+        exceeded and the fact that forced it.
+
+      Then reply with a short summary: how many files, how many rewrites land
+      inside the cap, how many deliberately exceed it and why.
+    output: "proposal_summary"
+    timeout: 1800
+    on_error: "fail"
+
+  # ==========================================================================
+  # STEP 3: Verify -- the proposals are re-checked, and so are their tables
+  # ==========================================================================
+
+  - id: "verify-proposals"
+    type: "bash"
+    condition: "{{scan_results.counts.violations}} > 0"
+    depends_on: ["propose-rewrites"]
+    command: |
+      REFRESH_OUTPUT_DIR="{{scan_results.output_dir}}" "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
+      import json
+      import os
+      import re
+      from pathlib import Path
+
+      out_dir = Path(os.environ["REFRESH_OUTPUT_DIR"])
+      proposals = out_dir / "proposals.md"
+      scan = json.loads((out_dir / "violations.json").read_text(encoding="utf-8"))
+      caps = scan["caps"]
+
+      verdict = {
+          "phase": "verify_proposals",
+          "proposals_file": str(proposals),
+          "sections": [],
+          "errors": [],
+          "warnings": [],
+      }
+
+      if not proposals.is_file():
+          verdict["errors"].append({
+              "type": "proposals_missing",
+              "severity": "ERROR",
+              "message": f"{proposals} was not written -- there is nothing to review.",
+          })
+          verdict["passed"] = False
+          print(json.dumps(verdict))
+          raise SystemExit(0)
+
+      text = proposals.read_text(encoding="utf-8")
+      sections = re.split(r"^##\s+(?!#)", text, flags=re.MULTILINE)[1:]
+      expected = {v["file"] for v in scan["violations"]}
+      covered = set()
+
+      for section in sections:
+          title = section.splitlines()[0].strip()
+          name = title.strip("`")
+
+          # A `##` section that does not name a violating file is narrative,
+          # not a proposal -- a summary table, a preamble. Validating it as a
+          # proposal rejects the whole run for a heading. It is recorded, not
+          # graded. The hole this could open is already closed below: every
+          # violating file must still have a section of its own
+          # (violations_not_addressed), so a MISSPELLED heading still fails.
+          if name not in expected:
+              verdict.setdefault("extra_sections", []).append(name)
+              continue
+
+          covered.add(name)
+          entry = {"section": name, "issues": []}
+
+          # THE STRUCTURAL GATE. A shortening pass with no fidelity table is
+          # exactly the silent trigger-drop this recipe exists to prevent, so
+          # its absence is an ERROR and not a style note.
+          if not re.search(r"^###\s+Fidelity table", section, flags=re.MULTILINE):
+              verdict["errors"].append({
+                  "type": "fidelity_table_missing",
+                  "file": name,
+                  "severity": "ERROR",
+                  "message": f"{name}: proposal carries no '### Fidelity table' section -- rejected.",
+                  "fix": "Every rewrite must account for each routing fact in the current text.",
+              })
+              entry["issues"].append("fidelity_table_missing")
+          else:
+              rows = [
+                  ln for ln in section.splitlines()
+                  if ln.strip().startswith("|") and ln.count("|") >= 4
+              ]
+              # header + separator + at least one fact
+              if len(rows) < 3:
+                  verdict["errors"].append({
+                      "type": "fidelity_table_empty",
+                      "file": name,
+                      "severity": "ERROR",
+                      "message": f"{name}: the fidelity table has no rows -- no routing fact was accounted for.",
+                  })
+                  entry["issues"].append("fidelity_table_empty")
+              entry["fidelity_rows"] = max(0, len(rows) - 2)
+
+          proposed = re.search(
+              r"^###\s+Proposed[^\n]*\n+```[^\n]*\n(.*?)^```",
+              section,
+              flags=re.MULTILINE | re.DOTALL,
+          )
+          if not proposed:
+              verdict["errors"].append({
+                  "type": "proposed_text_missing",
+                  "file": name,
+                  "severity": "ERROR",
+                  "message": f"{name}: no '### Proposed' fenced block to check.",
+              })
+              entry["issues"].append("proposed_text_missing")
+              verdict["sections"].append(entry)
+              continue
+
+          body = proposed.group(1)
+          entry["proposed_chars"] = len(body.strip())
+
+          kind = next((v["kind"] for v in scan["violations"] if v["file"] == name), "agent")
+          cap = caps["agent_warn_chars"] if kind == "agent" else caps["skill_warn_chars"]
+          entry["cap"] = cap
+
+          if re.search(r"<example>|<commentary>", body, flags=re.IGNORECASE):
+              verdict["errors"].append({
+                  "type": "proposal_still_has_example",
+                  "file": name,
+                  "severity": "ERROR",
+                  "message": f"{name}: the PROPOSED text still carries an <example>/<commentary> block.",
+              })
+              entry["issues"].append("proposal_still_has_example")
+
+          if entry["proposed_chars"] > cap:
+              # Not an error. Fidelity beats brevity -- but it must be SAID.
+              verdict["warnings"].append({
+                  "type": "proposal_over_cap",
+                  "file": name,
+                  "severity": "WARNING",
+                  "chars": entry["proposed_chars"],
+                  "cap": cap,
+                  "message": (
+                      f"{name}: proposal is {entry['proposed_chars']} chars against a {cap} cap. "
+                      "Acceptable ONLY if the Notes section names the routing fact that forced it."
+                  ),
+              })
+              entry["issues"].append("proposal_over_cap")
+              if not re.search(r"^###\s+Notes", section, flags=re.MULTILINE):
+                  verdict["errors"].append({
+                      "type": "over_cap_without_reason",
+                      "file": name,
+                      "severity": "ERROR",
+                      "message": f"{name}: over the cap with no Notes section naming why.",
+                  })
+                  entry["issues"].append("over_cap_without_reason")
+
+          verdict["sections"].append(entry)
+
+      missing = sorted(expected - covered)
+      if missing:
+          verdict["errors"].append({
+              "type": "violations_not_addressed",
+              "severity": "ERROR",
+              "message": f"{len(missing)} violating file(s) have no proposal section: {', '.join(missing[:5])}",
+          })
+
+      verdict["summary"] = {
+          "violations_found": len(expected),
+          "sections_written": len(sections),
+          "errors": len(verdict["errors"]),
+          "warnings": len(verdict["warnings"]),
+      }
+      verdict["passed"] = len(verdict["errors"]) == 0
+      (out_dir / "verdict.json").write_text(json.dumps(verdict, indent=2), encoding="utf-8")
+      print(json.dumps(verdict))
+      EOF
+    output: "verify_results"
+    parse_json: true
+    timeout: 120
+    on_error: "continue"
+
+  # ==========================================================================
+  # STEP 4: Report
+  # ==========================================================================
+
+  - id: "report"
+    type: "bash"
+    depends_on: ["scan-descriptions"]
+    command: |
+      REFRESH_OUTPUT_DIR="{{scan_results.output_dir}}" "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
+      import json
+      import os
+      from pathlib import Path
+
+      out_dir = Path(os.environ["REFRESH_OUTPUT_DIR"])
+      scan = json.loads((out_dir / "violations.json").read_text(encoding="utf-8"))
+      verdict_path = out_dir / "verdict.json"
+      verdict = json.loads(verdict_path.read_text(encoding="utf-8")) if verdict_path.is_file() else None
+
+      lines = ["# Description refresh", ""]
+      lines.append(f"Repository: `{scan['repo_path']}`")
+      lines.append(f"Rules read from: `{scan['validator_recipe']}`")
+      lines.append("")
+      counts = scan["counts"]
+      lines.append("| Finding | Count |")
+      lines.append("|---|---|")
+      for key in (
+          "violations", "agent_errors", "agent_warnings", "skill_errors",
+          "skill_warnings", "awareness_warnings", "head_cost_warnings",
+      ):
+          lines.append(f"| {key.replace('_', ' ')} | {counts[key]} |")
+      lines.append("")
+
+      if counts["violations"] == 0:
+          lines.append("No description violations. Nothing to propose.")
+      elif verdict is None:
+          lines.append("Proposals were not verified -- `verdict.json` is absent.")
+      else:
+          s = verdict["summary"]
+          lines.append(
+              f"Proposals: {s['sections_written']} written for {s['violations_found']} "
+              f"violating files; {s['errors']} rejected, {s['warnings']} over the cap "
+              f"with a stated reason."
+          )
+          lines.append("")
+          if verdict["errors"]:
+              lines.append("## Rejected proposals")
+              lines.append("")
+              for e in verdict["errors"]:
+                  lines.append(f"- **{e['type']}** — {e['message']}")
+              lines.append("")
+          lines.append("Review `proposals.md` and apply the rewrites you accept. ")
+          lines.append("Nothing has been changed in the repository.")
+
+      lines.append("")
+      lines.append("## Head cost (chars added to every root prompt)")
+      lines.append("")
+      lines.append("| Bundle | head chars | context | agents | skills |")
+      lines.append("|---|---|---|---|---|")
+      for d in scan["head_cost"][:10]:
+          bound = " (lower bound)" if d.get("is_lower_bound") else ""
+          lines.append(
+              f"| `{d['file']}` | {d['head_chars']}{bound} | {d['context_chars']} | "
+              f"{d['agent_description_chars']} | {d['skill_description_chars']} |"
+          )
+
+      report = "\n".join(lines) + "\n"
+      (out_dir / "REPORT.md").write_text(report, encoding="utf-8")
+      print(report)
+      EOF
+    output: "refresh_report"
+    timeout: 120
+    on_error: "continue"

--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -194,8 +194,8 @@
 #   description-authoring-principles.md V3 bans them entirely, not just >2)
 # - Has explicit tools section (even if empty [])
 # - Description >= 100 characters
-# - Description token budget respected (provisional: WARN >300 tok,
-#   ERROR >600 tok -- see foundation:context/shared/
+# - Description length cap respected: WARN >600 chars, ERROR >1200
+#   (v1.8.0 -- see foundation:context/shared/
 #   description-authoring-principles.md V5)
 #
 # NOTE: presence of MUST/ALWAYS/REQUIRED/PROACTIVELY keywords is reported
@@ -1735,7 +1735,7 @@ steps:
 
       ## Metadata
       - **Validated**: [timestamp]
-      - **Recipe**: validate-agents v1.7.0
+      - **Recipe**: validate-agents v1.8.0
       - **Discovery scope**: repo-wide `agents/*.md`. State the
         `scan_patterns` and the `excluded_parts` from `discovery_results`
         verbatim.
@@ -1754,7 +1754,12 @@ steps:
         (including any `<example>`/`<commentary>` block in the
         description -- rejected entirely per V3, not merely capped),
         explicit tools section, description >= 100 chars, description
-        token budget (provisional WARN >300 / ERROR >600 tok).
+        length cap in CHARS (v1.8.0: WARN >600, ERROR >1200 -- the
+        superseded token tier put its ERROR above the longest
+        description in every aligned repo measured, so it could not
+        fire). Point an author over the cap at
+        `foundation:recipes/refresh-descriptions.yaml`, which proposes a
+        rewrite WITH a fidelity table rather than shortening by eye.
         MUST/ALWAYS/REQUIRED/PROACTIVELY keyword presence is reported as
         a metric, not a gate.
       - **Severity Guide**:

--- a/recipes/validate-agents.yaml
+++ b/recipes/validate-agents.yaml
@@ -1,8 +1,28 @@
 # validate-agents.yaml
-# Agent Definition Validator Recipe v1.4.0
+# Agent Definition Validator Recipe v1.8.0
 # Validates agent definitions in a bundle repository for quality, tool access, and structural requirements
 #
 # CHANGELOG:
+# v1.8.0 - THE LENGTH GATE COULD NOT FIRE ON AN ALIGNED REPO, AND BARELY FIRED
+#          ON AN UNALIGNED ONE.
+#          The gate was tokens: WARN >300, ERROR >600 -- 1,200 and 2,400 chars
+#          at the chars/4 estimator this repo uses. Measured 2026-09-07 across
+#          9 bundle repos: foundation's own agents (the one corpus with PR
+#          #341's policy applied) run n=24, mean 410, MAX 761 chars, so the
+#          ERROR line sat above every description in the repo it was supposed
+#          to govern. Now WARN >600 chars, ERROR >1,200 (2x the cap), as a
+#          structural ERROR in structural-validation and as the quality gate in
+#          quality-classification. Tokens remain a reported metric.
+#        - The two numbers are BYTE-IDENTICAL to validate-bundle-repo.yaml
+#          v3.15.0 Phase 2.8's AGENT_DESCRIPTION_WARN_CHARS/_ERROR_CHARS, and
+#          tests/test_description_alignment_checks.py fails the build if they
+#          diverge. Two validators that disagree about the cap are worse than
+#          one.
+#        - SCOPE NOTE: skill descriptions, awareness redundancy and bundle head
+#          cost are repo-wide concerns and live in validate-bundle-repo.yaml
+#          v3.15.0 (Phases 2.82 / 2.84 / 2.86). This recipe stays agent-scoped.
+#        - No threshold, severity, skip rule or exclusion set changed other
+#          than the description length gate named above.
 # v1.7.0 - Two defects in v1.6.0's widened discovery, both silent.
 #        - (1) CLASSIFICATION BY DIRECTORY NAME. v1.6.0 treated every
 #          `agents/*.md` as an agent, so `context/agents/*.md` -- four
@@ -237,7 +257,7 @@ description: |
   
   This recipe helps maintain agent quality across the Amplifier ecosystem by codifying
   the audit criteria discovered in manual reviews.
-version: "1.7.0"
+version: "1.8.0"
 author: "Amplifier Foundation Team"
 tags: ["agents", "validation", "quality", "audit", "tools", "descriptions"]
 
@@ -612,6 +632,16 @@ steps:
           "planning": "Renamed to 'reasoning'",
       }
 
+      # v1.8.0: description length caps, in CHARACTERS (description-authoring-
+      # principles.md V5). Measured 2026-09-07 across 9 bundle repos: the one
+      # corpus with the #341 policy applied (foundation, n=24, mean 410, max
+      # 761) has ZERO descriptions over 1,200 chars; unswept repos put 17 of 54
+      # there. Kept BYTE-IDENTICAL to validate-bundle-repo.yaml Phase 2.8's
+      # AGENT_DESCRIPTION_WARN_CHARS / _ERROR_CHARS -- two validators that
+      # disagree about the cap are worse than one.
+      DESCRIPTION_WARN_CHARS = 600
+      DESCRIPTION_ERROR_CHARS = 1200
+
       discovery = json.loads('''{{discovery_results}}''')
       
       def get_bundle_level_tools(repo_path: str) -> dict:
@@ -881,6 +911,39 @@ steps:
                   "remediation": "Expand description to explain WHAT the agent does and WHEN to delegate to it"
               })
 
+          # v1.8.0: the length CAP, in characters. WARN at the cap, ERROR at 2x.
+          # description-authoring-principles.md V5. Chars, not tokens: chars are
+          # the unit every head measurement in this program was taken in, they
+          # need no tokenizer, and a validator counts them identically on every
+          # platform. The superseded token tier (ERROR >600 tokens == 2,400
+          # chars) sat ABOVE the longest description in every already-aligned
+          # repo measured (foundation max 761), so it could not fire on the
+          # defect it existed to catch.
+          if result["description_length"] > DESCRIPTION_ERROR_CHARS:
+              result["errors"].append({
+                  "severity": "ERROR",
+                  "code": "DESCRIPTION_EXCESSIVE",
+                  "message": (
+                      f"Description is {result['description_length']} chars "
+                      f"(>{DESCRIPTION_ERROR_CHARS}, 2x the {DESCRIPTION_WARN_CHARS}-char cap)"
+                  ),
+                  "remediation": (
+                      f"Shorten to <={DESCRIPTION_WARN_CHARS} chars. For a proposed rewrite WITH a "
+                      "fidelity table (so a routing fact cannot be dropped silently), run "
+                      "recipes/refresh-descriptions.yaml. See description-authoring-principles.md V5/V7."
+                  )
+              })
+          elif result["description_length"] > DESCRIPTION_WARN_CHARS:
+              result["warnings"].append({
+                  "severity": "WARNING",
+                  "code": "DESCRIPTION_HIGH",
+                  "message": f"Description is {result['description_length']} chars (>{DESCRIPTION_WARN_CHARS} cap)",
+                  "remediation": (
+                      f"Trim toward <={DESCRIPTION_WARN_CHARS} chars. See "
+                      "description-authoring-principles.md V5/V7."
+                  )
+              })
+
           # Check for <commentary> tags -- v1.4.0: ERROR, not WARNING.
           # <commentary> only ever occurs inside an <example> block, and
           # example blocks are now rejected entirely (see below), so this
@@ -990,8 +1053,8 @@ steps:
       # 1. No structural errors (valid YAML, has meta.name, meta.description)
       # 2. Has explicit tools section (even if empty)
       # 3. Description >= 100 characters
-      # 4. Description token budget respected (provisional: WARN >300 tok,
-      #    ERROR >600 tok -- description-authoring-principles.md V5)
+      # 4. Description length cap respected, in CHARS (v1.8.0: WARN >600,
+      #    ERROR >1200 -- description-authoring-principles.md V5)
       #
       # has_strong_trigger / absolute_keyword_count are reported as METRICS
       # below, not gates. A measured eval campaign found these do not by
@@ -1006,9 +1069,11 @@ steps:
       # routes through has_errors -> "critical" below -- no separate
       # classify_agent branch needed for them.
 
-      # Provisional token thresholds (see description-authoring-principles.md V5)
-      DESCRIPTION_TOKEN_WARN = 300
-      DESCRIPTION_TOKEN_ERROR = 600
+      # v1.8.0: the gate is CHARACTERS (description-authoring-principles.md V5).
+      # Same two numbers as structural-validation above and as
+      # validate-bundle-repo.yaml Phase 2.8. Tokens remain a reported metric.
+      DESCRIPTION_WARN_CHARS = 600
+      DESCRIPTION_ERROR_CHARS = 1200
 
       def classify_agent(agent: dict) -> dict:
           """Classify a single agent's quality level."""
@@ -1037,12 +1102,12 @@ steps:
           elif description_length < 100:
               quality = "needs_work"
               reason = f"Description too short ({description_length} chars)"
-          elif description_tokens > DESCRIPTION_TOKEN_ERROR:
+          elif description_length > DESCRIPTION_ERROR_CHARS:
               quality = "needs_work"
-              reason = f"Description is {description_tokens} tokens (>{DESCRIPTION_TOKEN_ERROR} threshold -- must shorten)"
-          elif description_tokens > DESCRIPTION_TOKEN_WARN:
+              reason = f"Description is {description_length} chars (>{DESCRIPTION_ERROR_CHARS} threshold -- must shorten)"
+          elif description_length > DESCRIPTION_WARN_CHARS:
               quality = "polish"
-              reason = f"Description is {description_tokens} tokens (>{DESCRIPTION_TOKEN_WARN} threshold -- consider trimming)"
+              reason = f"Description is {description_length} chars (>{DESCRIPTION_WARN_CHARS} cap -- consider trimming)"
           elif has_model_role_errors:
               quality = "needs_work"
               reason = "Invalid or deprecated model_role values"

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -1,9 +1,77 @@
 # validate-bundle-repo.yaml
-# Repository-Wide Bundle Validator Recipe v3.14.0
+# Repository-Wide Bundle Validator Recipe v3.15.0
 # Validates an entire bundle repository against structural requirements, conventions,
 # and Amplifier bundle philosophy (context sink pattern, thin behaviors, tool placement)
 #
 # CHANGELOG:
+# v3.15.0 - THE DESCRIPTION RULES WERE A CONVENTION, AND A CONVENTION QUIETLY
+#          STOPS BEING TRUE.
+#          PR #341 set the no-<example> policy for description surfaces in
+#          context/shared/description-authoring-principles.md. It was applied
+#          inside amplifier-foundation and NOWHERE ELSE, because nothing at
+#          authoring or validation time said otherwise. A sweep a year later
+#          found 29 files across 6 repos still shipping example blocks in
+#          descriptions and fixed them BY HAND (android-tester 8/8 -> 0,
+#          browser-tester 6 -> 0, reality-check 10/10 -> 0, dot-graph 28/28 -> 0
+#          with its agent descriptions 14,615 -> 6,484 chars, context-
+#          intelligence 3 -> 0, plus two forks). This version moves the rules
+#          to where they execute.
+#        - (1) THE LENGTH GATE IS NOW CHARACTERS, AND IT CAN ACTUALLY FIRE.
+#          Phase 2.8 gated on tokens: WARN >300, ERROR >600, i.e. 1,200 and
+#          2,400 chars at chars/4. Measured across 9 bundle repos on
+#          2026-09-07, the ERROR line sat ABOVE THE LONGEST DESCRIPTION IN
+#          EVERY ALREADY-ALIGNED REPO (foundation: n=24, mean 410, max 761), so
+#          on an aligned repo it was unfireable and on an unaligned one it
+#          caught only the very worst. Now WARN >600 chars, ERROR >1,200 (2x).
+#          On the aligned corpus that is 6 warnings and ZERO errors; on the
+#          unswept corpus 17 of 54 agents cross the ERROR line. Tokens stay as
+#          a reported metric. validate-agents.yaml v1.8.0 carries the same two
+#          numbers, and a test fails the build if they diverge.
+#        - (2) NEW PHASE 2.82: SKILL DESCRIPTIONS. The <example>/<commentary>
+#          policy was written for every description surface and enforced on
+#          agents only, in one repo. Skill frontmatter `description` renders
+#          into the hooks-skills-visibility block on every request exactly as
+#          an agent description renders into the delegate catalog. Same example
+#          policy (ERROR), a tighter length cap (WARN >400, ERROR >800 chars --
+#          a session commonly sees 30+ skills where it has 6-24 agents), and
+#          v3.13.0's own lesson applied from the start: each way of FAILING to
+#          read a description gets its own status and its own ERROR, because
+#          collapsing them into "" makes a broken skill pass every check clean.
+#        - (3) NEW PHASE 2.84: AWARENESS REDUNDANCY. An always-on context file
+#          that only restates an agent/skill catalog entry is the same sentence
+#          bought twice -- the catalog line is paid anyway. Two measurable
+#          rules, both WARNING, both STATED IN THE STEP so a reader can audit a
+#          finding instead of trusting it: R1 term-overlap (>= 60% of a file's
+#          substantive sentences >= 60% covered by one description's key terms)
+#          and R2 pointer-only (the file invokes delegate()/load_skill() naming
+#          an in-repo entry, and >= 60% of its sentences are trigger-shaped by
+#          phrase or by sitting under a "When/How to Use" heading).
+#          CALIBRATED, not guessed: across every cached bundle repo on one host
+#          (36 context files), R1 fires 0 times (max coverage observed 0.333)
+#          and R2 fires 3 times -- each on a file that genuinely is when-to-use
+#          prose plus a pointer. `best_coverage` is reported for every file
+#          whether or not it fires, so the threshold can be re-argued against
+#          real numbers rather than re-guessed.
+#        - (4) NEW PHASE 2.86: BUNDLE HEAD COST -- the number a bundle author
+#          never sees. context chars + agent description chars + skill
+#          description chars, per bundle, WARNING at 4,000. THE THRESHOLD IS
+#          JUSTIFIED AGAINST THE MEASURED BUNDLES, not asserted: the two
+#          bundles explicitly engineered for head cost measure 2,483
+#          (bundles/anchors) and 1,760 (bundles/anchors-amp-dev); the nearest
+#          unengineered one measures 5,479, then 14,198 (foundation's own root
+#          bundle), 15,002, 26,368, 29,684 and 87,555. 4,000 is the smallest
+#          round number above every engineered bundle and below every
+#          unengineered one. WARNING, not ERROR, because foundation's own root
+#          bundle exceeds it -- that is a design conversation, not a build
+#          break. An include this repo cannot resolve is NOT charged a flat
+#          guess: the total is marked `is_lower_bound` and the unresolved refs
+#          are named (v3.14.0's lesson).
+#        - (5) FAIL-BEFORE, REPRODUCIBLE BY ANYONE. test-fixtures/misaligned-
+#          bundle/ violates all four at once, and
+#          tests/test_description_alignment_checks.py runs the recipe's own
+#          step bodies against it. Pointing ALIGNMENT_RECIPE_DIR at a checkout
+#          of the pre-change recipes makes the suite fail: 21 failed / 1 passed
+#          at origin/main 4384805, 22 passed on this branch.
 # v3.14.0 - THE CONTEXT-TOKEN ESTIMATOR UNDERSTATED BY 6.28x, AND LANDED
 #          EXACTLY ON ITS OWN ERROR BOUNDARY WHILE DOING IT.
 #          behavior-hygiene Rule 4 resolved a context.include only two ways:
@@ -490,7 +558,7 @@ description: |
   - All measurements use TOKENS (len/4), never line counts
   
   For single bundle validation, use validate-bundle.yaml instead.
-version: "3.14.0"
+version: "3.15.0"
 author: "Amplifier Foundation Team"
 tags: ["bundle", "validation", "quality", "conventions", "repository", "packaging", "hygiene", "context-sink"]
 
@@ -3746,6 +3814,15 @@ steps:
 
       EXCLUDED_DIRS = {"test-fixtures", "tests", "node_modules", ".git", ".venv"}
 
+      # --- The description length cap, in CHARACTERS (v3.15.0) ---------------
+      # foundation:context/shared/description-authoring-principles.md V5.
+      # WARN at the cap, ERROR at 2x. Measured, not chosen: across 9 bundle
+      # repos on 2026-09-07, the one corpus that had the #341 policy applied
+      # (foundation, n=24 agents, mean 410, max 761) has ZERO descriptions over
+      # 1,200 chars, while the unswept repos put 17 of 54 there.
+      AGENT_DESCRIPTION_WARN_CHARS = 600
+      AGENT_DESCRIPTION_ERROR_CHARS = 1200
+
       # --- What makes a file an agent (v3.13.0) ------------------------------
       # The block below is COPIED BYTE-FOR-BYTE from `validate-agents.yaml`'s
       # `agent-discovery` step (v1.7.0, lane 39z0). It is not a second
@@ -3980,40 +4057,56 @@ steps:
               # pass this branch exists to prevent.
               continue
 
-          token_count = len(description) // 4
+          # v3.15.0: the GATE is CHARACTERS. Tokens stay a reported metric.
+          #
+          # Chars are the unit every head measurement in this program was taken
+          # in, they need no tokenizer, and a validator counts them identically
+          # on every platform. The superseded token tier (WARN 300 / ERROR 600
+          # tokens == 1,200 / 2,400 chars at chars/4) put its ERROR line ABOVE
+          # the longest description in every already-aligned repo measured
+          # (foundation max 761 chars), so it could not fire on the defect it
+          # existed to catch.
+          char_count = len(description)
+          token_count = char_count // 4
+          detail["description_chars"] = char_count
           detail["description_tokens"] = token_count
 
-          if token_count > 600:
+          if char_count > AGENT_DESCRIPTION_ERROR_CHARS:
               results["errors"].append({
                   "type": "agent_description_excessive",
                   "file": rel_path,
+                  "chars": char_count,
                   "tokens": token_count,
                   "severity": "ERROR",
                   "message": (
-                      f"Agent description in {rel_path} is {token_count} tokens "
-                      f"(>600 threshold -- must shorten)."
+                      f"Agent description in {rel_path} is {char_count} chars "
+                      f"(>{AGENT_DESCRIPTION_ERROR_CHARS} threshold, 2x the "
+                      f"{AGENT_DESCRIPTION_WARN_CHARS}-char cap -- must shorten)."
                   ),
                   "fix": (
-                      "Shorten the description to <300 tokens. See "
-                      "foundation:context/shared/description-authoring-principles.md "
-                      "V5 (provisional tier)."
+                      f"Shorten the description to <={AGENT_DESCRIPTION_WARN_CHARS} chars. "
+                      "See foundation:context/shared/description-authoring-principles.md "
+                      "V5. For a proposed rewrite WITH a fidelity table, run "
+                      "recipes/refresh-descriptions.yaml."
                   )
               })
               detail["issues"].append("agent_description_excessive")
-          elif token_count > 300:
+          elif char_count > AGENT_DESCRIPTION_WARN_CHARS:
               results["warnings"].append({
                   "type": "agent_description_high",
                   "file": rel_path,
+                  "chars": char_count,
                   "tokens": token_count,
                   "severity": "WARNING",
                   "message": (
-                      f"Agent description in {rel_path} is {token_count} tokens "
-                      f"(>300 threshold -- consider trimming)."
+                      f"Agent description in {rel_path} is {char_count} chars "
+                      f"(>{AGENT_DESCRIPTION_WARN_CHARS} cap -- consider trimming)."
                   ),
                   "fix": (
-                      "Trim description toward <300 tokens. See "
-                      "foundation:context/shared/description-authoring-principles.md "
-                      "V5 (provisional tier)."
+                      f"Trim description toward <={AGENT_DESCRIPTION_WARN_CHARS} chars. "
+                      "See foundation:context/shared/description-authoring-principles.md "
+                      "V5, or run recipes/refresh-descriptions.yaml for a proposed "
+                      "rewrite with a fidelity table."
                   )
               })
               detail["issues"].append("agent_description_high")
@@ -4084,6 +4177,922 @@ steps:
       print(json.dumps(results))
       EOF
     output: "agent_description_validation_results"
+    parse_json: true
+    timeout: 120
+    on_error: "continue"
+    depends_on: ["repo-discovery"]
+
+  # ============================================================================
+  # PHASE 2.82: Skill Description Validation (v3.15.0)
+  #
+  # Phase 2.8 above checks AGENT descriptions. Skill descriptions were never
+  # checked by any recipe, in any repo -- and they are paid the same way: the
+  # `hooks-skills-visibility` block renders every visible skill's frontmatter
+  # `description` into the head on EVERY request. PR #341's no-<example> policy
+  # was written for both surfaces and enforced on neither outside foundation.
+  #
+  # Checks (foundation:context/shared/description-authoring-principles.md):
+  #   A  length, in CHARS:   WARNING >400 (skill_description_high)
+  #                          ERROR   >800 (skill_description_excessive, 2x)
+  #   B  <example> / <commentary>: ERROR, same policy as agents (V3)
+  #   C  the description could be READ AT ALL -- the v3.13.0 lesson, applied
+  #      here from the start: an unreadable file, absent frontmatter,
+  #      unparseable YAML, a non-mapping frontmatter or an absent/empty
+  #      `description` each get their OWN status and their own ERROR, because
+  #      collapsing them into "" makes a broken skill pass every check clean.
+  #
+  # Scope: <repo>/**/SKILL.md minus EXCLUDED_DIRS. A SKILL.md is a skill by
+  # definition of its filename (the Agent Skills spec), so unlike agents there
+  # is no classifier to share -- but non-skills are still named, never dropped.
+  # ============================================================================
+
+  - id: "skill-description-validation"
+    type: "bash"
+    command: |
+      VALIDATE_BUNDLE_REPO_PATH="{{repo_path}}" "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
+      import json
+      import os
+      import re
+      from pathlib import Path
+
+      try:
+          import yaml
+      except ImportError:
+          yaml = None
+
+      # Through the environment, never interpolated into Python source -- see
+      # Phase 2.8 for what a Windows path costs inside a string literal.
+      REPO_PATH = os.environ["VALIDATE_BUNDLE_REPO_PATH"]
+
+      EXCLUDED_DIRS = {"test-fixtures", "tests", "node_modules", ".git", ".venv"}
+
+      # description-authoring-principles.md V5. Skills are capped tighter than
+      # agents (400 vs 600) because the visible-skills block lists EVERY skill
+      # a session can see, and a session commonly sees 30+ where it has 6-24
+      # agents: measured 2026-09-07, the skills bundle ships n=31 skills
+      # (mean 413, max 928 chars) against foundation's n=24 agents.
+      SKILL_DESCRIPTION_WARN_CHARS = 400
+      SKILL_DESCRIPTION_ERROR_CHARS = 800
+
+      FRONTMATTER_RE = re.compile(r"\A---\s*\r?\n(.*?)\r?\n---\s*\r?\n", re.DOTALL)
+
+      DESCRIPTION_FIXES = {
+          "unreadable": "The file could not be read as UTF-8 text. Fix the encoding or the permissions.",
+          "no_frontmatter": "Add a `---` YAML frontmatter block declaring name and description (Agent Skills spec).",
+          "no_yaml_module": "PyYAML is not importable in the environment running this recipe, so the description could not be parsed. Install PyYAML; do not read this as a clean skill.",
+          "unparseable_frontmatter": "The frontmatter block is not valid YAML. Fix the YAML syntax.",
+          "frontmatter_not_a_mapping": "The frontmatter must be a YAML mapping with `name:` and `description:` keys.",
+          "no_description_key": "Add a `description:` key to the skill frontmatter -- without it the skill cannot be matched to a request.",
+          "description_not_a_string": "`description` must be a string.",
+          "description_empty": "`description` is present but empty. Write it (see foundation:context/shared/description-authoring-principles.md).",
+      }
+
+      FRONTMATTER_STATUSES = {
+          "unreadable",
+          "no_frontmatter",
+          "no_yaml_module",
+          "unparseable_frontmatter",
+          "frontmatter_not_a_mapping",
+      }
+
+      results = {
+          "phase": "skill_description_validation",
+          "skills_checked": 0,
+          "candidates_scanned": 0,
+          "errors": [],
+          "warnings": [],
+          "skill_details": [],
+          "thresholds": {
+              "warn_chars": SKILL_DESCRIPTION_WARN_CHARS,
+              "error_chars": SKILL_DESCRIPTION_ERROR_CHARS,
+          },
+      }
+
+      def extract_description(skill_file):
+          try:
+              content = skill_file.read_text(encoding="utf-8", errors="replace")
+          except Exception:
+              return "unreadable", ""
+          match = FRONTMATTER_RE.match(content)
+          if not match:
+              return "no_frontmatter", ""
+          if yaml is None:
+              return "no_yaml_module", ""
+          try:
+              fm = yaml.safe_load(match.group(1))
+          except Exception:
+              return "unparseable_frontmatter", ""
+          if not isinstance(fm, dict):
+              return "frontmatter_not_a_mapping", ""
+          if "description" not in fm:
+              return "no_description_key", ""
+          description = fm.get("description")
+          if not isinstance(description, str):
+              return "description_not_a_string", ""
+          if not description.strip():
+              return "description_empty", description
+          return "ok", description
+
+      path = Path(REPO_PATH).expanduser().resolve()
+
+      if not path.exists():
+          results["errors"].append({
+              "type": "skill_scan_path_error",
+              "file": None,
+              "severity": "ERROR",
+              "message": (
+                  f"Repository path does not exist: {REPO_PATH} -- no SKILL.md was "
+                  "scanned. This is a run-ending condition, not a finding that the "
+                  "repo's skills are clean."
+              ),
+              "fix": "Check the repo_path context variable passed to this recipe.",
+          })
+          results["passed"] = False
+          results["summary"] = {"skills_checked": 0, "candidates_scanned": 0, "errors": 1, "warnings": 0}
+          print(json.dumps(results))
+          raise SystemExit(0)
+
+      skill_files = []
+      for f in sorted(path.rglob("SKILL.md")):
+          if EXCLUDED_DIRS & set(f.relative_to(path).parts):
+              continue
+          skill_files.append(f)
+
+      for skill_file in skill_files:
+          rel_path = skill_file.relative_to(path).as_posix()
+          results["candidates_scanned"] += 1
+          results["skills_checked"] += 1
+          status, description = extract_description(skill_file)
+          detail = {"file": rel_path, "description_status": status, "issues": []}
+
+          if status != "ok":
+              error_type = (
+                  "skill_frontmatter_invalid"
+                  if status in FRONTMATTER_STATUSES
+                  else "skill_description_missing"
+              )
+              results["errors"].append({
+                  "type": error_type,
+                  "file": rel_path,
+                  "reason": status,
+                  "severity": "ERROR",
+                  "message": f"{rel_path}: skill description could not be read ({status}).",
+                  "fix": DESCRIPTION_FIXES[status],
+              })
+              detail["issues"].append(error_type)
+              detail["description_chars"] = None
+              results["skill_details"].append(detail)
+              # The checks below are meaningless against an empty string.
+              continue
+
+          char_count = len(description)
+          detail["description_chars"] = char_count
+          detail["description_tokens"] = char_count // 4
+
+          if char_count > SKILL_DESCRIPTION_ERROR_CHARS:
+              results["errors"].append({
+                  "type": "skill_description_excessive",
+                  "file": rel_path,
+                  "chars": char_count,
+                  "severity": "ERROR",
+                  "message": (
+                      f"Skill description in {rel_path} is {char_count} chars "
+                      f"(>{SKILL_DESCRIPTION_ERROR_CHARS} threshold, 2x the "
+                      f"{SKILL_DESCRIPTION_WARN_CHARS}-char cap -- must shorten)."
+                  ),
+                  "fix": (
+                      f"Shorten to <={SKILL_DESCRIPTION_WARN_CHARS} chars. See "
+                      "foundation:context/shared/description-authoring-principles.md V5, "
+                      "or run recipes/refresh-descriptions.yaml for a proposed rewrite "
+                      "with a fidelity table."
+                  ),
+              })
+              detail["issues"].append("skill_description_excessive")
+          elif char_count > SKILL_DESCRIPTION_WARN_CHARS:
+              results["warnings"].append({
+                  "type": "skill_description_high",
+                  "file": rel_path,
+                  "chars": char_count,
+                  "severity": "WARNING",
+                  "message": (
+                      f"Skill description in {rel_path} is {char_count} chars "
+                      f"(>{SKILL_DESCRIPTION_WARN_CHARS} cap -- consider trimming)."
+                  ),
+                  "fix": (
+                      f"Trim toward <={SKILL_DESCRIPTION_WARN_CHARS} chars. See "
+                      "foundation:context/shared/description-authoring-principles.md V5."
+                  ),
+              })
+              detail["issues"].append("skill_description_high")
+
+          commentary_count = description.lower().count("<commentary>")
+          detail["commentary_count"] = commentary_count
+          if commentary_count > 0:
+              results["errors"].append({
+                  "type": "commentary_present",
+                  "file": rel_path,
+                  "severity": "ERROR",
+                  "message": f"{rel_path}: skill description has {commentary_count} <commentary> tag(s) -- rejected entirely",
+                  "fix": "Delete <commentary> tags (and the <example> block containing them). See description-authoring-principles.md V3.",
+              })
+              detail["issues"].append("commentary_present")
+
+          example_count = len(re.findall(r"<example>", description, re.IGNORECASE))
+          detail["example_count"] = example_count
+          if example_count > 0:
+              results["errors"].append({
+                  "type": "example_block_present",
+                  "file": rel_path,
+                  "severity": "ERROR",
+                  "message": f"{rel_path}: skill description has {example_count} <example> block(s) -- example blocks are rejected entirely, not merely capped",
+                  "fix": "Delete all <example> blocks. State the trigger as a decision rule in the WHEN clause (V6). See description-authoring-principles.md V3.",
+              })
+              detail["issues"].append("example_block_present")
+
+          results["skill_details"].append(detail)
+
+      if results["candidates_scanned"] == 0:
+          results["skipped"] = True
+          results["skip_reason"] = "no SKILL.md files found in this repository"
+
+      results["passed"] = len(results["errors"]) == 0
+      results["summary"] = {
+          "skills_checked": results["skills_checked"],
+          "candidates_scanned": results["candidates_scanned"],
+          "errors": len(results["errors"]),
+          "warnings": len(results["warnings"]),
+      }
+
+      print(json.dumps(results))
+      EOF
+    output: "skill_description_validation_results"
+    parse_json: true
+    timeout: 120
+    on_error: "continue"
+    depends_on: ["repo-discovery"]
+
+  # ============================================================================
+  # PHASE 2.84: Awareness Redundancy (v3.15.0)
+  #
+  # An "awareness" file is a context.include that exists to tell the model a
+  # capability exists. It is ALWAYS-ON: every byte is paid on every request of
+  # every session that loads the bundle. The agent catalog and the visible-
+  # skills block already say a capability exists, in a line that is paid
+  # anyway -- so an awareness file that only restates a catalog entry is a
+  # SECOND copy of the same sentence, bought twice.
+  #
+  # THE RULE, STATED SO A READER CAN AUDIT IT (both sub-rules are WARNING; a
+  # judgment call about what a doc is FOR is not a build break):
+  #
+  #   Terms:      key term  = /[a-z][a-z0-9_-]{3,}/ over lowercased text,
+  #                           minus STOPWORDS (listed in full below).
+  #               sentence  = split on /[.!?]\s+|\n/, outside fenced code,
+  #                           excluding ATX headings and bare list bullets.
+  #               substantive sentence = a sentence with >= MIN_SENTENCE_TERMS
+  #                           (3) key terms. Shorter ones carry no measurable
+  #                           overlap signal in either direction.
+  #
+  #   R1 awareness_redundant_with_catalog
+  #       covered(sentence, entry) := |terms(sentence) & terms(entry.description)|
+  #                                   / |terms(sentence)|  >= SENTENCE_COVER (0.60)
+  #       coverage(entry)          := covered sentences / substantive sentences
+  #       FIRES when substantive >= MIN_FILE_SENTENCES (3)
+  #             and max over entries of coverage(entry) >= FILE_REDUNDANT (0.60)
+  #       Reports the winning entry by name and the coverage that won.
+  #
+  #   R2 awareness_is_pointer_only
+  #       FIRES when the file invokes `delegate(` or `load_skill(` naming an
+  #       agent/skill that exists IN THIS REPO, and >= TRIGGER_SHARE (0.60) of
+  #       its substantive sentences are trigger-shaped (TRIGGER_RE below) --
+  #       i.e. the file is "when to use X" plus a pointer to X, which is what
+  #       the catalog line already is.
+  #
+  # WHY 0.60 AND NOT 0.5 OR 0.8: calibrated against this repo's own context
+  # files, which are NOT awareness files and must not fire. Reported per file
+  # as `best_coverage` whether or not it fires, so the threshold can be
+  # re-argued against real numbers instead of re-guessed.
+  # ============================================================================
+
+  - id: "awareness-redundancy-check"
+    type: "bash"
+    command: |
+      VALIDATE_BUNDLE_REPO_PATH="{{repo_path}}" "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
+      import json
+      import os
+      import re
+      from pathlib import Path
+
+      try:
+          import yaml
+      except ImportError:
+          yaml = None
+
+      REPO_PATH = os.environ["VALIDATE_BUNDLE_REPO_PATH"]
+
+      EXCLUDED_DIRS = {"test-fixtures", "tests", "node_modules", ".git", ".venv"}
+
+      SENTENCE_COVER = 0.60
+      FILE_REDUNDANT = 0.60
+      TRIGGER_SHARE = 0.60
+      MIN_SENTENCE_TERMS = 3
+      MIN_FILE_SENTENCES = 3
+
+      STOPWORDS = {
+          "that", "this", "with", "from", "have", "will", "when", "what", "your",
+          "they", "them", "then", "than", "into", "each", "only", "more", "most",
+          "some", "such", "been", "were", "does", "done", "also", "here", "there",
+          "which", "while", "where", "would", "could", "should", "about", "after",
+          "before", "every", "other", "their", "these", "those", "using", "used",
+          "make", "makes", "made", "need", "needs", "want", "wants", "like",
+          "just", "over", "under", "same", "both", "must", "never", "always",
+          "instead", "rather", "because", "through", "across", "between",
+      }
+
+      # A sentence is CATALOG-SHAPED if it states a trigger, either by phrase
+      # or by POSITION -- sitting under a "When to Use" / "How to Use" heading.
+      # Position matters more than phrasing in practice: the awareness files
+      # this rule exists to find write their triggers as bullets ("User needs
+      # an isolated environment ...") that carry no trigger PHRASE at all.
+      TRIGGER_RE = re.compile(
+          r"\b(use when|when to use|use this|use it|use the|use for|triggers? on|"
+          r"use proactively|proactively when|delegate to|do not use|"
+          r"do not attempt|always delegate|use these|user (needs|wants|has|asks))\b"
+      )
+      WHEN_HEADING_RE = re.compile(
+          r"^\s*(when|how)\s+to\s+use|^\s*usage\b|^\s*triggers?\b|"
+          r"^\s*when\s+to\s+(delegate|reach)",
+          re.IGNORECASE,
+      )
+      POINTER_RE = re.compile(r"(delegate\s*\(|load_skill\s*\()")
+      FENCE_RE = re.compile(r"^\s*```")
+      HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s")
+      MENTION_RE = re.compile(r"@([A-Za-z0-9_.-]+):([^\s`\"')\]]+)")
+      FRONTMATTER_RE = re.compile(r"\A---\s*\r?\n(.*?)\r?\n---\s*\r?\n", re.DOTALL)
+      TERM_RE = re.compile(r"[a-z][a-z0-9_-]{3,}")
+
+      def terms(text):
+          return {t for t in TERM_RE.findall(text.lower()) if t not in STOPWORDS}
+
+      def substantive_sentences(text):
+          """(sentence, enclosing heading) outside fenced code.
+
+          Headings and bare bullets are not sentences; the heading each
+          sentence sits under is carried alongside it, because a trigger
+          stated as a bullet under "When to Use" is a trigger.
+          """
+          out = []
+          in_fence = False
+          heading = ""
+          for raw in text.splitlines():
+              if FENCE_RE.match(raw):
+                  in_fence = not in_fence
+                  continue
+              if in_fence:
+                  continue
+              if HEADING_RE.match(raw):
+                  heading = raw.lstrip("# ").strip()
+                  continue
+              line = raw.strip()
+              if not line:
+                  continue
+              line = re.sub(r"^[-*+]\s+|^\d+\.\s+|^\|", "", line)
+              for piece in re.split(r"(?<=[.!?])\s+", line):
+                  piece = piece.strip()
+                  if not piece:
+                      continue
+                  if len(terms(piece)) >= MIN_SENTENCE_TERMS:
+                      out.append((piece, heading))
+          return out
+
+      def read(p):
+          try:
+              return p.read_text(encoding="utf-8", errors="replace")
+          except Exception:
+              return ""
+
+      def frontmatter_and_body(content):
+          m = FRONTMATTER_RE.match(content)
+          if not m:
+              return content, ""
+          return m.group(1), content[m.end():]
+
+      def resolve(repo, base_dir, ref):
+          """Resolve a context reference inside THIS repo, or None.
+
+          Same shape as behavior-hygiene's resolver (v3.14.0): strip an optional
+          '@', and for a `<namespace>:<path>` ref also try the path part against
+          the repo root and the referring file's own directory.
+          """
+          ref = ref.strip().lstrip("@")
+          if ref.startswith(("http://", "https://", "git+")):
+              return None
+          candidates = []
+          if ":" in ref:
+              _, _, rest = ref.partition(":")
+              if rest and not rest.startswith("//"):
+                  candidates += [repo / rest, base_dir / rest]
+          candidates += [base_dir / ref, repo / ref]
+          for c in candidates:
+              try:
+                  if c.is_file():
+                      return c
+              except OSError:
+                  continue
+          return None
+
+      results = {
+          "phase": "awareness_redundancy",
+          "context_files_checked": 0,
+          "catalog_entries": 0,
+          "errors": [],
+          "warnings": [],
+          "file_details": [],
+          "rule": {
+              "sentence_cover": SENTENCE_COVER,
+              "file_redundant": FILE_REDUNDANT,
+              "trigger_share": TRIGGER_SHARE,
+              "min_sentence_terms": MIN_SENTENCE_TERMS,
+              "min_file_sentences": MIN_FILE_SENTENCES,
+          },
+      }
+
+      path = Path(REPO_PATH).expanduser().resolve()
+      if not path.exists() or yaml is None:
+          results["skipped"] = True
+          results["skip_reason"] = (
+              "repository path does not exist" if not path.exists() else "PyYAML not available"
+          )
+          results["passed"] = True
+          results["summary"] = {"context_files_checked": 0, "catalog_entries": 0, "errors": 0, "warnings": 0}
+          print(json.dumps(results))
+          raise SystemExit(0)
+
+      # --- The catalog: every agent + skill description this repo ships -------
+      catalog = []
+      agent_files = list(path.rglob("*/agents/*.md")) + list((path / "agents").glob("*.md"))
+      for f in sorted(set(agent_files)):
+          if EXCLUDED_DIRS & set(f.relative_to(path).parts):
+              continue
+          fm_text, _ = frontmatter_and_body(read(f))
+          try:
+              fm = yaml.safe_load(fm_text)
+          except Exception:
+              continue
+          if not isinstance(fm, dict) or not isinstance(fm.get("meta"), dict):
+              continue
+          d = fm["meta"].get("description")
+          name = fm["meta"].get("name") or f.stem
+          if isinstance(d, str) and d.strip():
+              catalog.append({"kind": "agent", "name": str(name), "file": f.relative_to(path).as_posix(), "terms": terms(d)})
+      for f in sorted(path.rglob("SKILL.md")):
+          if EXCLUDED_DIRS & set(f.relative_to(path).parts):
+              continue
+          fm_text, _ = frontmatter_and_body(read(f))
+          try:
+              fm = yaml.safe_load(fm_text)
+          except Exception:
+              continue
+          if not isinstance(fm, dict):
+              continue
+          d = fm.get("description")
+          name = fm.get("name") or f.parent.name
+          if isinstance(d, str) and d.strip():
+              catalog.append({"kind": "skill", "name": str(name), "file": f.relative_to(path).as_posix(), "terms": terms(d)})
+      results["catalog_entries"] = len(catalog)
+      catalog_names = {c["name"] for c in catalog}
+
+      # --- Every context file a bundle or behavior pulls into the head --------
+      bundle_files = []
+      for pattern in ("bundle.md", "bundles/*.yaml", "bundles/*.md", "bundles/*/bundle.md", "behaviors/*.yaml", "behaviors/*.md"):
+          bundle_files += list(path.glob(pattern))
+      seen_refs = {}
+      for bf in sorted(set(bundle_files)):
+          if EXCLUDED_DIRS & set(bf.relative_to(path).parts):
+              continue
+          content = read(bf)
+          fm_text, body = frontmatter_and_body(content)
+          if not body and bf.suffix in (".yaml", ".yml"):
+              fm_text, body = content, ""
+          refs = []
+          try:
+              data = yaml.safe_load(fm_text)
+          except Exception:
+              data = None
+          if isinstance(data, dict):
+              ctx = data.get("context")
+              if isinstance(ctx, dict):
+                  inc = ctx.get("include") or []
+                  if isinstance(inc, list):
+                      refs += [str(x) for x in inc if isinstance(x, str)]
+              elif isinstance(ctx, list):
+                  refs += [str(x) for x in ctx if isinstance(x, str)]
+          refs += [f"{ns}:{p}" for ns, p in MENTION_RE.findall(body)]
+          for ref in refs:
+              target = resolve(path, bf.parent, ref)
+              if target is None:
+                  continue
+              rel = target.relative_to(path).as_posix() if str(target).startswith(str(path)) else str(target)
+              seen_refs.setdefault(rel, []).append(bf.relative_to(path).as_posix())
+
+      for rel, referrers in sorted(seen_refs.items()):
+          target = path / rel
+          text = read(target)
+          _, body = frontmatter_and_body(text)
+          body = body or text
+          sentences = substantive_sentences(body)
+          results["context_files_checked"] += 1
+          detail = {
+              "file": rel,
+              "referenced_by": sorted(set(referrers)),
+              "substantive_sentences": len(sentences),
+              "chars": len(text),
+              "issues": [],
+          }
+
+          if len(sentences) < MIN_FILE_SENTENCES:
+              detail["best_coverage"] = None
+              detail["skip_reason"] = f"fewer than {MIN_FILE_SENTENCES} substantive sentences"
+              results["file_details"].append(detail)
+              continue
+
+          sentence_terms = [terms(s) for s, _h in sentences]
+          best = {"coverage": 0.0, "entry": None}
+          for entry in catalog:
+              covered = 0
+              for st in sentence_terms:
+                  if not st:
+                      continue
+                  if len(st & entry["terms"]) / len(st) >= SENTENCE_COVER:
+                      covered += 1
+              coverage = covered / len(sentence_terms)
+              if coverage > best["coverage"]:
+                  best = {"coverage": coverage, "entry": entry}
+          detail["best_coverage"] = round(best["coverage"], 3)
+          if best["entry"]:
+              detail["best_entry"] = f"{best['entry']['kind']}:{best['entry']['name']}"
+
+          if best["coverage"] >= FILE_REDUNDANT and best["entry"]:
+              entry = best["entry"]
+              results["warnings"].append({
+                  "type": "awareness_redundant_with_catalog",
+                  "file": rel,
+                  "entry": f"{entry['kind']}:{entry['name']}",
+                  "entry_file": entry["file"],
+                  "coverage": round(best["coverage"], 3),
+                  "severity": "WARNING",
+                  "message": (
+                      f"{rel} is redundant with catalog entry {entry['kind']}:{entry['name']} "
+                      f"({entry['file']}): {round(best['coverage'] * 100)}% of its "
+                      f"{len(sentences)} substantive sentences are already covered by that "
+                      f"description, at or above the {int(FILE_REDUNDANT * 100)}% rule. "
+                      f"Referenced by: {', '.join(sorted(set(referrers)))}."
+                  ),
+                  "fix": (
+                      "An always-on context file that restates a catalog entry is paid twice. "
+                      "Keep the catalog line and delete the awareness file, or cut the file "
+                      "down to the concept the catalog line CANNOT carry. See "
+                      "docs/BUNDLE_GUIDE.md 'Awareness: concept + trigger + pointer'."
+                  ),
+              })
+              detail["issues"].append("awareness_redundant_with_catalog")
+
+          pointed_at = [n for n in catalog_names if n and n in body]
+          if POINTER_RE.search(body) and pointed_at:
+              trigger_hits = sum(
+                  1
+                  for s, h in sentences
+                  if TRIGGER_RE.search(s.lower()) or WHEN_HEADING_RE.search(h)
+              )
+              share = trigger_hits / len(sentences)
+              detail["trigger_share"] = round(share, 3)
+              if share >= TRIGGER_SHARE:
+                  results["warnings"].append({
+                      "type": "awareness_is_pointer_only",
+                      "file": rel,
+                      "entry": sorted(pointed_at)[0],
+                      "trigger_share": round(share, 3),
+                      "severity": "WARNING",
+                      "message": (
+                          f"{rel} is when-to-use prose plus a delegate()/load_skill() pointer "
+                          f"({round(share * 100)}% of its {len(sentences)} substantive sentences "
+                          f"are trigger-shaped, at or above the {int(TRIGGER_SHARE * 100)}% rule), "
+                          f"naming {', '.join(sorted(pointed_at)[:3])}. The catalog entry already "
+                          "carries both, and is paid anyway."
+                      ),
+                      "fix": (
+                          "Move the trigger into the agent/skill description (where routing reads "
+                          "it) and delete the awareness file, unless it teaches a CONCEPT that has "
+                          "no catalog line of its own."
+                      ),
+                  })
+                  detail["issues"].append("awareness_is_pointer_only")
+
+          results["file_details"].append(detail)
+
+      if results["context_files_checked"] == 0:
+          results["skipped"] = True
+          results["skip_reason"] = "no in-repo context files are referenced by any bundle or behavior"
+
+      results["passed"] = len(results["errors"]) == 0
+      results["summary"] = {
+          "context_files_checked": results["context_files_checked"],
+          "catalog_entries": results["catalog_entries"],
+          "errors": len(results["errors"]),
+          "warnings": len(results["warnings"]),
+      }
+
+      print(json.dumps(results))
+      EOF
+    output: "awareness_redundancy_results"
+    parse_json: true
+    timeout: 120
+    on_error: "continue"
+    depends_on: ["repo-discovery"]
+
+  # ============================================================================
+  # PHASE 2.86: Bundle Head Cost (v3.15.0)
+  #
+  # THE NUMBER A BUNDLE AUTHOR NEVER SEES: how many characters this bundle adds
+  # to EVERY root prompt of EVERY session that loads it, whether or not a
+  # single one of its capabilities is used.
+  #
+  #   head_chars = context chars + agent description chars + skill description chars
+  #
+  # HOW EACH TERM IS COMPUTED (state it so a reader can audit the number):
+  #   context chars   Every `context.include` entry plus every `@ns:path`
+  #                   mention in the bundle body that RESOLVES INSIDE THIS
+  #                   REPO, summed by file size, plus the bundle body itself
+  #                   (for a polyglot bundle.md the body IS the root
+  #                   instruction). A reference this repo does not carry is
+  #                   NOT guessed at: it is listed in `unresolved_refs` and
+  #                   the total is marked `is_lower_bound`. A lower bound is a
+  #                   true statement; a flat guess folded into a number that
+  #                   reads as measured is the v3.14.0 defect.
+  #   agent chars     len(meta.description) for agents under this bundle's own
+  #                   `agents/` directory -- or the repo-root `agents/` for a
+  #                   repo-root bundle. Attribution by LOCATION, because an
+  #                   `agents.include` list can name agents from other repos
+  #                   that this scan cannot see.
+  #   skill chars     len(description) for every `skills/**/SKILL.md` in this
+  #                   repo, counted ONLY when this bundle file itself mounts
+  #                   `tool-skills` without `visibility.enabled: false`. A
+  #                   bundle that disables visibility does not pay this half;
+  #                   the amount is still reported, as
+  #                   `skill_description_chars_excluded`, because turning
+  #                   visibility off is a real lever and the reader should see
+  #                   what it bought.
+  #
+  # THRESHOLD: WARNING at 4,000 chars. JUSTIFIED, not asserted -- measured
+  # 2026-09-07 across the bundles on this host:
+  #     engineered for head cost:  anchors 2,483 | anchors-amp-dev 1,760
+  #     not engineered:            context-intelligence 7,464 | foundation root
+  #                                14,198 | superpowers 15,523 | dot-graph
+  #                                30,413 | converge 89,733
+  # 4,000 is the smallest round number above every bundle that was explicitly
+  # cost-engineered and below every bundle that was not -- a 1.6x margin over
+  # the largest engineered bundle and a 1.9x gap below the nearest unengineered
+  # one. WARNING and not ERROR because foundation's own root bundle exceeds it:
+  # that is a design conversation, not a build break.
+  # ============================================================================
+
+  - id: "bundle-head-cost"
+    type: "bash"
+    command: |
+      VALIDATE_BUNDLE_REPO_PATH="{{repo_path}}" "${AMPLIFIER_PYTHON:-python3}" << 'EOF'
+      import json
+      import os
+      import re
+      from pathlib import Path
+
+      try:
+          import yaml
+      except ImportError:
+          yaml = None
+
+      REPO_PATH = os.environ["VALIDATE_BUNDLE_REPO_PATH"]
+
+      EXCLUDED_DIRS = {"test-fixtures", "tests", "node_modules", ".git", ".venv"}
+      HEAD_COST_WARN_CHARS = 4000
+
+      FRONTMATTER_RE = re.compile(r"\A---\s*\r?\n(.*?)\r?\n---\s*\r?\n", re.DOTALL)
+      MENTION_RE = re.compile(r"@([A-Za-z0-9_.-]+):([^\s`\"')\]]+)")
+
+      results = {
+          "phase": "bundle_head_cost",
+          "bundles_measured": 0,
+          "errors": [],
+          "warnings": [],
+          "bundle_details": [],
+          "threshold_chars": HEAD_COST_WARN_CHARS,
+      }
+
+      def read(p):
+          try:
+              return p.read_text(encoding="utf-8", errors="replace")
+          except Exception:
+              return ""
+
+      def frontmatter_and_body(content):
+          m = FRONTMATTER_RE.match(content)
+          if not m:
+              return content, ""
+          return m.group(1), content[m.end():]
+
+      def resolve(repo, base_dir, ref):
+          ref = ref.strip().lstrip("@")
+          if ref.startswith(("http://", "https://", "git+")):
+              return None
+          candidates = []
+          if ":" in ref:
+              _, _, rest = ref.partition(":")
+              if rest and not rest.startswith("//"):
+                  candidates += [repo / rest, base_dir / rest]
+          candidates += [base_dir / ref, repo / ref]
+          for c in candidates:
+              try:
+                  if c.is_file():
+                      return c
+              except OSError:
+                  continue
+          return None
+
+      def agent_description(p):
+          fm_text, _ = frontmatter_and_body(read(p))
+          try:
+              fm = yaml.safe_load(fm_text)
+          except Exception:
+              return None
+          if not isinstance(fm, dict) or not isinstance(fm.get("meta"), dict):
+              return None
+          d = fm["meta"].get("description")
+          return d if isinstance(d, str) else None
+
+      def skill_description(p):
+          fm_text, _ = frontmatter_and_body(read(p))
+          try:
+              fm = yaml.safe_load(fm_text)
+          except Exception:
+              return None
+          if not isinstance(fm, dict):
+              return None
+          d = fm.get("description")
+          return d if isinstance(d, str) else None
+
+      def mounts_visible_skills(data):
+          """(mounts_tool_skills, visibility_enabled) for one bundle's own tools."""
+          if not isinstance(data, dict):
+              return False, False
+          tools = data.get("tools")
+          if not isinstance(tools, list):
+              return False, False
+          for tool in tools:
+              if not isinstance(tool, dict):
+                  continue
+              if tool.get("module") != "tool-skills":
+                  continue
+              config = tool.get("config") if isinstance(tool.get("config"), dict) else {}
+              visibility = config.get("visibility") if isinstance(config.get("visibility"), dict) else {}
+              enabled = visibility.get("enabled", True)
+              return True, bool(enabled)
+          return False, False
+
+      path = Path(REPO_PATH).expanduser().resolve()
+      if not path.exists() or yaml is None:
+          results["skipped"] = True
+          results["skip_reason"] = (
+              "repository path does not exist" if not path.exists() else "PyYAML not available"
+          )
+          results["passed"] = True
+          results["summary"] = {"bundles_measured": 0, "errors": 0, "warnings": 0}
+          print(json.dumps(results))
+          raise SystemExit(0)
+
+      skill_files = [
+          f for f in sorted(path.rglob("SKILL.md"))
+          if not (EXCLUDED_DIRS & set(f.relative_to(path).parts))
+      ]
+      repo_skill_chars = 0
+      repo_skill_count = 0
+      for f in skill_files:
+          d = skill_description(f)
+          if isinstance(d, str) and d.strip():
+              repo_skill_chars += len(d)
+              repo_skill_count += 1
+
+      bundle_files = []
+      for pattern in ("bundle.md", "bundles/*.yaml", "bundles/*.md", "bundles/*/bundle.md", "behaviors/*.yaml", "behaviors/*.md"):
+          bundle_files += list(path.glob(pattern))
+
+      for bf in sorted(set(bundle_files)):
+          if EXCLUDED_DIRS & set(bf.relative_to(path).parts):
+              continue
+          content = read(bf)
+          fm_text, body = frontmatter_and_body(content)
+          if not body and bf.suffix in (".yaml", ".yml"):
+              fm_text, body = content, ""
+          try:
+              data = yaml.safe_load(fm_text)
+          except Exception:
+              data = None
+
+          refs = []
+          if isinstance(data, dict):
+              ctx = data.get("context")
+              if isinstance(ctx, dict):
+                  inc = ctx.get("include") or []
+                  if isinstance(inc, list):
+                      refs += [str(x) for x in inc if isinstance(x, str)]
+              elif isinstance(ctx, list):
+                  refs += [str(x) for x in ctx if isinstance(x, str)]
+          refs += [f"{ns}:{p}" for ns, p in MENTION_RE.findall(body)]
+
+          context_chars = len(body.strip())
+          resolved_refs = []
+          unresolved_refs = []
+          for ref in refs:
+              target = resolve(path, bf.parent, ref)
+              if target is None:
+                  unresolved_refs.append(ref)
+                  continue
+              context_chars += len(read(target))
+              resolved_refs.append(ref)
+
+          bundle_dir = bf.parent
+          agents_dir = (path / "agents") if bundle_dir == path else (bundle_dir / "agents")
+          agent_chars = 0
+          agent_count = 0
+          if agents_dir.is_dir():
+              for f in sorted(agents_dir.glob("*.md")):
+                  d = agent_description(f)
+                  if isinstance(d, str) and d.strip():
+                      agent_chars += len(d)
+                      agent_count += 1
+
+          mounts_skills, visible = mounts_visible_skills(data)
+          skill_chars = repo_skill_chars if (mounts_skills and visible) else 0
+          excluded_skill_chars = repo_skill_chars if (mounts_skills and not visible) else 0
+
+          head_chars = context_chars + agent_chars + skill_chars
+          results["bundles_measured"] += 1
+          detail = {
+              "file": bf.relative_to(path).as_posix(),
+              "head_chars": head_chars,
+              "context_chars": context_chars,
+              "agent_description_chars": agent_chars,
+              "agents_counted": agent_count,
+              "skill_description_chars": skill_chars,
+              "skills_counted": repo_skill_count if skill_chars else 0,
+              "is_lower_bound": bool(unresolved_refs),
+          }
+          if unresolved_refs:
+              detail["unresolved_refs"] = unresolved_refs
+          if excluded_skill_chars:
+              detail["skill_description_chars_excluded"] = excluded_skill_chars
+              detail["skill_exclusion_reason"] = "this bundle mounts tool-skills with visibility.enabled: false"
+          results["bundle_details"].append(detail)
+
+          if head_chars > HEAD_COST_WARN_CHARS:
+              bound = " (lower bound -- some refs are not in this repo)" if unresolved_refs else ""
+              results["warnings"].append({
+                  "type": "bundle_head_cost_high",
+                  "file": detail["file"],
+                  "head_chars": head_chars,
+                  "context_chars": context_chars,
+                  "agent_description_chars": agent_chars,
+                  "skill_description_chars": skill_chars,
+                  "severity": "WARNING",
+                  "message": (
+                      f"{detail['file']} adds {head_chars} chars to every root prompt"
+                      f"{bound}: {context_chars} context + {agent_chars} agent descriptions "
+                      f"({agent_count}) + {skill_chars} skill descriptions "
+                      f"(>{HEAD_COST_WARN_CHARS} threshold)."
+                  ),
+                  "fix": (
+                      "Every byte here is paid on every request of every session that loads this "
+                      "bundle, used or not. Measured comparison: the two bundles engineered for "
+                      "head cost sit at 2,483 and 1,760 chars. Move always-on prose into an agent "
+                      "(paid only when delegated to) or a skill (paid only when loaded), shorten "
+                      "the descriptions (see description-authoring-principles.md V5), or split "
+                      "the bundle."
+                  ),
+              })
+
+      if results["bundles_measured"] == 0:
+          results["skipped"] = True
+          results["skip_reason"] = "no bundle or behavior files found in this repository"
+
+      results["bundle_details"].sort(key=lambda d: d["head_chars"], reverse=True)
+      results["passed"] = len(results["errors"]) == 0
+      results["summary"] = {
+          "bundles_measured": results["bundles_measured"],
+          "errors": len(results["errors"]),
+          "warnings": len(results["warnings"]),
+          "largest_head_chars": max((d["head_chars"] for d in results["bundle_details"]), default=0),
+      }
+
+      print(json.dumps(results))
+      EOF
+    output: "bundle_head_cost_results"
     parse_json: true
     timeout: 120
     on_error: "continue"
@@ -4501,6 +5510,30 @@ steps:
       except (json.JSONDecodeError, ValueError):
           agent_description_validation = {"passed": True, "skipped": True, "errors": [], "warnings": []}
 
+      # v3.15.0: Parse the three new description-alignment step outputs. Each
+      # falls back to a SKIPPED shape on an unparseable payload, matching every
+      # sibling above -- but note what that costs: a skipped step contributes
+      # nothing to the verdict, so a step that dies silently reads as clean.
+      # That is why each of these steps prints its own summary even when it
+      # finds nothing.
+      skill_description_raw = '''{{skill_description_validation_results}}'''
+      try:
+          skill_description_validation = json.loads(skill_description_raw)
+      except (json.JSONDecodeError, ValueError):
+          skill_description_validation = {"passed": True, "skipped": True, "errors": [], "warnings": []}
+
+      awareness_redundancy_raw = '''{{awareness_redundancy_results}}'''
+      try:
+          awareness_redundancy = json.loads(awareness_redundancy_raw)
+      except (json.JSONDecodeError, ValueError):
+          awareness_redundancy = {"passed": True, "skipped": True, "errors": [], "warnings": []}
+
+      bundle_head_cost_raw = '''{{bundle_head_cost_results}}'''
+      try:
+          bundle_head_cost = json.loads(bundle_head_cost_raw)
+      except (json.JSONDecodeError, ValueError):
+          bundle_head_cost = {"passed": True, "skipped": True, "errors": [], "warnings": [], "bundle_details": []}
+
       # v3.10.0: Parse README install-instructions convention check results
       readme_convention_raw = '''{{readme_install_convention_results}}'''
       try:
@@ -4630,6 +5663,9 @@ steps:
               "mode_validation_issues": [],  # v3.6.0
               "body_instruction_issues": [],  # v3.7.0
               "agent_description_issues": [],  # Phase 2.8
+              "skill_description_issues": [],  # v3.15.0 Phase 2.82
+              "awareness_redundancy_issues": [],  # v3.15.0 Phase 2.84
+              "head_cost_issues": [],  # v3.15.0 Phase 2.86
               "readme_convention_issues": [],  # v3.10.0
               "module_dep_issues": [],  # v3.11.0
               # v3.2.0: Environment status tracking
@@ -4879,6 +5915,55 @@ steps:
                       "fix": warning.get("fix", "")
                   })
 
+          # v3.15.0 Phase 2.82: skill description findings. Same tier as the
+          # agent half above -- an <example> block in a skill description is
+          # paid on every request exactly as one in an agent description is,
+          # and no recipe checked for it before this version.
+          if not skill_description_validation.get("skipped", False):
+              for error in skill_description_validation.get("errors", []):
+                  results["skill_description_issues"].append({
+                      "type": error.get("type"),
+                      "file": error.get("file"),
+                      "message": error.get("message"),
+                      "severity": "ERROR",
+                      "fix": error.get("fix", "")
+                  })
+              for warning in skill_description_validation.get("warnings", []):
+                  results["skill_description_issues"].append({
+                      "type": warning.get("type"),
+                      "file": warning.get("file"),
+                      "message": warning.get("message"),
+                      "severity": "WARNING",
+                      "fix": warning.get("fix", "")
+                  })
+
+          # v3.15.0 Phase 2.84: awareness redundancy. WARNING only -- whether a
+          # doc duplicates a catalog entry is a judgment the rule can only
+          # measure, not settle.
+          if not awareness_redundancy.get("skipped", False):
+              for warning in awareness_redundancy.get("warnings", []):
+                  results["awareness_redundancy_issues"].append({
+                      "type": warning.get("type"),
+                      "file": warning.get("file"),
+                      "entry": warning.get("entry"),
+                      "message": warning.get("message"),
+                      "severity": "WARNING",
+                      "fix": warning.get("fix", "")
+                  })
+
+          # v3.15.0 Phase 2.86: head cost. WARNING only -- foundation's own root
+          # bundle exceeds the threshold, and that is a design conversation.
+          if not bundle_head_cost.get("skipped", False):
+              for warning in bundle_head_cost.get("warnings", []):
+                  results["head_cost_issues"].append({
+                      "type": warning.get("type"),
+                      "file": warning.get("file"),
+                      "head_chars": warning.get("head_chars"),
+                      "message": warning.get("message"),
+                      "severity": "WARNING",
+                      "fix": warning.get("fix", "")
+                  })
+
           # v3.10.0: README install-instructions convention findings.
           # Severity is "needs_work" (not ERROR/WARNING) -- these are
           # structural/convention findings, same tier as orphan_agents /
@@ -4934,6 +6019,7 @@ steps:
           critical_count += len([i for i in results["experiment_issues"] if i.get("severity") == "ERROR"])
           critical_count += len([i for i in results["mode_validation_issues"] if i.get("severity") == "ERROR"])  # v3.6.0
           critical_count += len([i for i in results["agent_description_issues"] if i.get("severity") == "ERROR"])  # Phase 2.8
+          critical_count += len([i for i in results["skill_description_issues"] if i.get("severity") == "ERROR"])  # v3.15.0
           critical_count += len([i for i in results["module_dep_issues"] if i.get("severity") == "ERROR"])  # v3.11.0
           critical_count += len([i for i in results["behavior_reference_hygiene_issues"] if i.get("severity") == "ERROR"])  # v3.13.0
 
@@ -4956,6 +6042,9 @@ steps:
           warning_count += len([i for i in results["mode_validation_issues"] if i.get("severity") == "WARNING"])  # v3.6.0
           warning_count += len(results["body_instruction_issues"])  # v3.7.0: all are WARNING
           warning_count += len([i for i in results["agent_description_issues"] if i.get("severity") == "WARNING"])  # Phase 2.8
+          warning_count += len([i for i in results["skill_description_issues"] if i.get("severity") == "WARNING"])  # v3.15.0
+          warning_count += len(results["awareness_redundancy_issues"])  # v3.15.0: all are WARNING
+          warning_count += len(results["head_cost_issues"])  # v3.15.0: all are WARNING
           if recipe_quality == "polish":
               warning_count += 1
           
@@ -5005,6 +6094,11 @@ steps:
               "body_instruction_warnings": len(results["body_instruction_issues"]),  # v3.7.0
               "agent_description_errors": len([i for i in results["agent_description_issues"] if i.get("severity") == "ERROR"]),  # Phase 2.8
               "agent_description_warnings": len([i for i in results["agent_description_issues"] if i.get("severity") == "WARNING"]),  # Phase 2.8
+              "skill_description_errors": len([i for i in results["skill_description_issues"] if i.get("severity") == "ERROR"]),  # v3.15.0
+              "skill_description_warnings": len([i for i in results["skill_description_issues"] if i.get("severity") == "WARNING"]),  # v3.15.0
+              "awareness_redundancy_warnings": len(results["awareness_redundancy_issues"]),  # v3.15.0
+              "head_cost_warnings": len(results["head_cost_issues"]),  # v3.15.0
+              "largest_head_chars": bundle_head_cost.get("summary", {}).get("largest_head_chars", 0),  # v3.15.0
               "readme_convention_needs_work": len([i for i in results["readme_convention_issues"] if i.get("severity") == "needs_work"]),  # v3.10.0
               "module_dep_errors": len([i for i in results["module_dep_issues"] if i.get("severity") == "ERROR"])  # v3.11.0
           }
@@ -5711,6 +6805,15 @@ steps:
       **Agent Description Budget Validation (Phase 2.8):**
       ```json
       {{agent_description_validation_results}}
+
+      SKILL DESCRIPTION VALIDATION RESULTS (v3.15.0):
+      {{skill_description_validation_results}}
+
+      AWARENESS REDUNDANCY RESULTS (v3.15.0):
+      {{awareness_redundancy_results}}
+
+      BUNDLE HEAD COST RESULTS (v3.15.0):
+      {{bundle_head_cost_results}}
       ```
 
       **README Install-Instructions Convention Check (v3.10.0):**
@@ -5889,11 +6992,13 @@ steps:
       - For each ERROR of type agent_scan_path_error (v3.13.0):
         - [ERROR] the message verbatim. NOTHING was scanned; this is a
           run-ending condition, not evidence that the repo's agents are clean.
-      - For each ERROR of type agent_description_excessive (>600 tokens, provisional):
-        - [ERROR] "Agent description in <file> is N tokens -- must shorten to <300"
-        - Refer author to foundation:context/shared/description-authoring-principles.md V5
-      - For each WARNING of type agent_description_high (>300 tokens, provisional):
-        - [WARNING] "Agent description in <file> is N tokens -- consider trimming toward <300"
+      - For each ERROR of type agent_description_excessive (>1,200 chars, 2x the cap):
+        - [ERROR] "Agent description in <file> is N chars -- must shorten to <=600"
+        - Refer author to foundation:context/shared/description-authoring-principles.md V5,
+          and to `recipes/refresh-descriptions.yaml` for a proposed rewrite WITH a
+          fidelity table (the whole risk in shortening is dropping a routing fact)
+      - For each WARNING of type agent_description_high (>600 chars):
+        - [WARNING] "Agent description in <file> is N chars -- consider trimming toward <=600"
         - Same reference as above
       - For each ERROR of type commentary_present (v3.10.0 -- was WARNING):
         - [ERROR] "<file>: description has N <commentary> tag(s) -- rejected entirely (V3)"
@@ -5903,6 +7008,56 @@ steps:
       - If agent_description_validation_results.skipped == true: "Agent description validation: skipped (no agents/*.md files found)"
       - If body_instruction_check_results.skipped == true: "Body instruction check: skipped (no bundle.md or agents/*.md files found)"
       - commentary_present and example_block_present ARE blocking (ERROR); the token-budget findings above stay WARNING/ERROR per their own thresholds
+
+      ### Skill Description Validation (v3.15.0)
+      Use skill_description_validation_results to report:
+      - skills_checked: how many SKILL.md files were read.
+      - For each ERROR of type skill_frontmatter_invalid / skill_description_missing:
+        - [ERROR] the message verbatim, with its `reason`.
+      - For each ERROR of type skill_description_excessive (>800 chars, 2x the 400 cap):
+        - [ERROR] "Skill description in <file> is N chars -- must shorten to <=400"
+      - For each WARNING of type skill_description_high (>400 chars):
+        - [WARNING] "Skill description in <file> is N chars -- consider trimming"
+      - For each ERROR of type example_block_present / commentary_present:
+        - [ERROR] the message verbatim. This half of the #341 policy was
+          enforced by NO recipe before v3.15.0, in any repository -- a sweep
+          across 6 repos found 29 files still carrying example blocks.
+      - If no issues: "Skill description validation: all N skills within cap, no example/commentary blocks"
+      - If skipped == true: "Skill description validation: skipped (no SKILL.md files found)"
+
+      ### Awareness Redundancy (v3.15.0)
+      Use awareness_redundancy_results to report:
+      - context_files_checked and catalog_entries, both verbatim.
+      - STATE THE RULE, from `rule`, so the reader can audit the finding rather
+        than trust it: a sentence counts as covered when >= `sentence_cover` of
+        its key terms appear in a catalog description; a file is redundant when
+        >= `file_redundant` of its substantive sentences are covered; a file is
+        pointer-only when it invokes delegate()/load_skill() naming an in-repo
+        entry and >= `trigger_share` of its sentences are trigger-shaped.
+      - For each WARNING of type awareness_redundant_with_catalog:
+        - [WARNING] "<file> duplicates <entry> (<coverage> covered)" -- ALWAYS
+          name the entry. A redundancy finding that does not say what it is
+          redundant WITH is not actionable.
+      - For each WARNING of type awareness_is_pointer_only:
+        - [WARNING] the message verbatim, including the trigger share.
+      - If no issues: "Awareness redundancy: N context files checked against M
+        catalog entries, none redundant"
+
+      ### Bundle Head Cost (v3.15.0)
+      Use bundle_head_cost_results to report, ALWAYS -- this line prints whether
+      or not anything exceeded the threshold, because the number is the point:
+      - A table, largest first, from `bundle_details`:
+        | Bundle | head chars | context | agent descriptions | skill descriptions |
+      - The head-cost line for the repo: "Largest bundle head cost: N chars
+        (threshold <threshold_chars>)".
+      - Mark any row with `is_lower_bound` as a LOWER BOUND and name its
+        `unresolved_refs`. A reference this repo does not carry is never
+        guessed at.
+      - Where `skill_description_chars_excluded` is present, say so: that bundle
+        mounts tool-skills with visibility disabled and does not pay that half.
+      - For each WARNING of type bundle_head_cost_high:
+        - [WARNING] the message verbatim, then the comparison: the two bundles
+          engineered for head cost measure 2,483 and 1,760 chars.
 
       ### README Install-Instructions Convention Check (v3.10.0)
       Use readme_install_convention_results to report:

--- a/recipes/validate-bundle-repo.yaml
+++ b/recipes/validate-bundle-repo.yaml
@@ -4224,6 +4224,19 @@ steps:
       # Phase 2.8 for what a Windows path costs inside a string literal.
       REPO_PATH = os.environ["VALIDATE_BUNDLE_REPO_PATH"]
 
+      # The repo-wide exclusion set, IDENTICAL to every other EXCLUDED_DIRS in
+      # this recipe -- `tests/test_anchors_bundles_dry.py` fails the build if
+      # they diverge by one entry, and the only permitted difference from
+      # validate-agents' wider `EXCLUDED_PARTS` is the documented `docs`.
+      #
+      # CONSEQUENCE, MEASURED AND LEFT AS-IS: `docs/` IS scanned here. A
+      # SKILL.md committed under docs/ as documentation or lane evidence counts
+      # as a shipped skill and also lands in the head-cost total (observed
+      # live: skills_checked 3 -> 7, largest_head_chars 26,368 -> 28,279 when
+      # four evidence files were added under docs/lanes/). Reported rather than
+      # silently widened: narrowing this set is a change to a contract another
+      # lane established, and would hide a real agent or skill that genuinely
+      # lives under docs/. Name evidence files something other than SKILL.md.
       EXCLUDED_DIRS = {"test-fixtures", "tests", "node_modules", ".git", ".venv"}
 
       # description-authoring-principles.md V5. Skills are capped tighter than
@@ -4257,6 +4270,7 @@ steps:
 
       results = {
           "phase": "skill_description_validation",
+          "excluded_dirs": sorted(EXCLUDED_DIRS),
           "skills_checked": 0,
           "candidates_scanned": 0,
           "errors": [],
@@ -4602,6 +4616,7 @@ steps:
 
       results = {
           "phase": "awareness_redundancy",
+          "excluded_dirs": sorted(EXCLUDED_DIRS),
           "context_files_checked": 0,
           "catalog_entries": 0,
           "errors": [],
@@ -4879,6 +4894,7 @@ steps:
 
       results = {
           "phase": "bundle_head_cost",
+          "excluded_dirs": sorted(EXCLUDED_DIRS),
           "bundles_measured": 0,
           "errors": [],
           "warnings": [],

--- a/skills/creating-amplifier-modules/SKILL.md
+++ b/skills/creating-amplifier-modules/SKILL.md
@@ -94,7 +94,15 @@ class MyTool:
 
     @property
     def description(self) -> str:
-        return "Description of what this tool does and when to use it."
+        # A tool description IS a description surface: it is rendered into the
+        # tool block on EVERY request of every session that mounts the tool,
+        # used or not. Write it to
+        # foundation:context/shared/description-authoring-principles.md --
+        # trigger first, then USE WHEN, then DO NOT USE WHEN naming what
+        # should handle the rejected case; zero <example> blocks. One measured
+        # tool description ran 15,271 chars -- 56% of that session's entire
+        # tool-description budget -- and drove 7-8x over-delegation (V5).
+        return "What this tool does. USE WHEN <condition>. DO NOT USE WHEN <condition> -- use <alternative>."
 
     @property
     def input_schema(self) -> dict:
@@ -291,13 +299,17 @@ After creating a module, verify it will pass protocol compliance:
 - [ ] Does `mount()` call `await coordinator.mount("tools", tool, name=tool.name)`?
 - [ ] Does the tool class have a `name` property (string)?
 - [ ] Does the tool class have a `description` property (string)?
+- [ ] Does that description lead with the TRIGGER, carry a DO NOT USE WHEN
+      clause naming the alternative, and contain zero `<example>` blocks?
+      (foundation:context/shared/description-authoring-principles.md -- a tool
+      description is paid on every request whether or not the tool is called)
 - [ ] Does the tool class have an `input_schema` property (dict)?
 - [ ] Does the tool class have a callable `execute()` method?
 - [ ] Does `mount()` return a metadata dict (not `None`)?
 - [ ] Does `pyproject.toml` declare the `amplifier.modules` entry point?
 - [ ] Do tests verify `coordinator.mount()` was called (not that result is `None`)?
 
-All eight boxes must be checked before committing.
+All nine boxes must be checked before committing.
 
 ---
 

--- a/test-fixtures/misaligned-bundle/README.md
+++ b/test-fixtures/misaligned-bundle/README.md
@@ -1,0 +1,20 @@
+# misaligned-bundle — a fixture that violates all four description checks
+
+This is not a bundle anyone should install. It exists so the checks added in
+`validate-bundle-repo.yaml` v3.15.0 and `validate-agents.yaml` v1.8.0 have
+something that FAILS, and so the fail-before evidence is reproducible by
+anyone rather than quoted from a lane note.
+
+It violates, by construction:
+
+| # | Check | How this fixture violates it |
+|---|---|---|
+| 1 | Description length cap | `agents/fixture-agent.md` description is >1,200 chars (2x the 600 cap); `skills/fixture-skill/SKILL.md` is >800 (2x the 400 cap) |
+| 2 | `<example>` / `<commentary>` | Both the agent AND the skill description carry them — the skill half was unenforced everywhere before v3.15.0 |
+| 3 | Awareness redundancy | `context/fixture-awareness.md` restates the agent description (R1) and is when-to-use prose plus a `delegate()` pointer (R2) |
+| 4 | Bundle head cost | `bundle.md` pulls all of it into every root prompt, over the 4,000-char WARNING |
+
+`test-fixtures/` is in every scan's `EXCLUDED_DIRS`, so this directory does
+not contaminate foundation's own validation run. The tests point `repo_path`
+directly AT this directory, which makes it the repo root and the exclusion
+inapplicable.

--- a/test-fixtures/misaligned-bundle/agents/fixture-agent.md
+++ b/test-fixtures/misaligned-bundle/agents/fixture-agent.md
@@ -1,0 +1,40 @@
+---
+meta:
+  name: fixture-agent
+  description: |
+    A sophisticated and comprehensive fixture agent subsystem that provides
+    extensive capabilities for the analysis, inspection, examination, review
+    and comprehensive assessment of fixture artifacts across the entire
+    repository, including but not limited to markdown documents, YAML
+    manifests, JSON payloads and arbitrary text files of every description.
+    This agent MUST ALWAYS be used PROACTIVELY whenever any fixture artifact
+    is encountered anywhere in any repository, and you should NEVER attempt
+    to inspect a fixture artifact yourself under any circumstances.
+
+    <example>
+    Context: The user has a fixture artifact that needs inspection
+    user: 'Can you look at this fixture file for me?'
+    assistant: 'I will delegate to fixture-agent to inspect the fixture.'
+    <commentary>
+    Fixture inspection is exactly what fixture-agent exists for, so the
+    orchestrator delegates rather than reading the file itself.
+    </commentary>
+    </example>
+
+    <example>
+    Context: The user is confused about fixture artifacts
+    user: 'What even is a fixture?'
+    assistant: 'Let me bring in fixture-agent, which owns this domain.'
+    <commentary>
+    Even a definitional question routes here, because fixture-agent is
+    authoritative on everything fixture-shaped.
+    </commentary>
+    </example>
+model_role: general
+tools:
+  - read_file
+---
+
+# Fixture Agent
+
+Inspect the fixture artifact named by the caller and report what it contains.

--- a/test-fixtures/misaligned-bundle/bundle.md
+++ b/test-fixtures/misaligned-bundle/bundle.md
@@ -1,0 +1,21 @@
+---
+bundle:
+  name: misaligned
+  version: 0.0.1
+  description: A deliberately misaligned fixture bundle. Not for installation.
+
+tools:
+  - module: tool-skills
+    source: git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=modules/tool-skills
+    config:
+      skills:
+        - "./skills"
+
+agents:
+  include:
+    - misaligned:fixture-agent
+---
+
+@misaligned:context/fixture-awareness.md
+
+@misaligned:context/fixture-operating-rules.md

--- a/test-fixtures/misaligned-bundle/context/fixture-awareness.md
+++ b/test-fixtures/misaligned-bundle/context/fixture-awareness.md
@@ -1,0 +1,22 @@
+# Fixture Agent Awareness
+
+## When to Use
+
+- Use this fixture agent for the analysis, inspection and examination of fixture artifacts.
+- Use it for the comprehensive review and assessment of fixture artifacts across the repository.
+- Use this agent for markdown documents, YAML manifests, JSON payloads and arbitrary text files.
+- Always use fixture-agent proactively whenever any fixture artifact is encountered anywhere.
+
+## How to Use
+
+Never attempt to inspect a fixture artifact yourself under any circumstances:
+
+```
+delegate(agent="misaligned:fixture-agent", instruction="<what the user needs>")
+```
+
+For the extensive comprehensive theory of fixture artifact handling, load the skill:
+
+```
+load_skill(skill_name="fixture-skill")
+```

--- a/test-fixtures/misaligned-bundle/context/fixture-operating-rules.md
+++ b/test-fixtures/misaligned-bundle/context/fixture-operating-rules.md
@@ -1,0 +1,45 @@
+# Fixture Operating Rules
+
+These rules are always-on context: every byte below is paid on every request of
+every session that loads this bundle, whether or not a fixture is ever touched.
+That is the point of the fixture — it is what the head-cost check exists to
+measure, and it is deliberately the sort of prose that accretes in a real
+bundle without anybody noticing the bill.
+
+## Naming
+
+Fixture files are named for the defect they carry, never for the test that
+consumes them. A fixture named `test_case_3.md` tells a later reader nothing;
+a fixture named `overlong-description.md` tells them exactly what it is for and
+survives the test being renamed, split, or rewritten entirely.
+
+## Placement
+
+Fixtures live under `test-fixtures/`, which every scan in this repository
+excludes by name. A fixture that lives anywhere else will be picked up by a
+validator run against the repository root and will be reported as a real
+defect, which wastes exactly as much of a reader's attention as a real defect
+would.
+
+## Content
+
+A fixture violates one thing on purpose, or several things on purpose, and
+nothing by accident. An accidental second violation makes every assertion in
+the consuming test ambiguous: a count that moves might be the thing under test
+or might be the accident, and the test cannot tell you which. Keep the
+violations enumerated in the fixture's own README so a later reader can check
+the fixture against its stated intent rather than inferring it.
+
+## Lifecycle
+
+A fixture outlives the change that motivated it. When the check it exercises is
+removed, the fixture is deleted in the same commit — a fixture with no consumer
+is stale content that still costs a reader the time it takes to work out
+whether anything depends on it.
+
+## Review
+
+Every fixture is reviewed against the check it exercises, not against taste. A
+fixture that no longer fails the check it was written for is not a fixture; it
+is a passing file with a misleading name, and it will quietly hold a regression
+open for as long as it stays that way.

--- a/test-fixtures/misaligned-bundle/skills/fixture-skill/SKILL.md
+++ b/test-fixtures/misaligned-bundle/skills/fixture-skill/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: fixture-skill
+description: |
+  A comprehensive and extensive skill package covering the complete theory and
+  practice of fixture artifact handling, including the creation, validation,
+  inspection, review, refresh, alignment, migration, archival and eventual
+  deletion of fixture artifacts of every kind, in every repository layout that
+  this ecosystem supports or has ever supported at any point in its history,
+  together with the historical rationale for each of those layouts and the
+  migration path between them. Load this skill whenever fixtures are mentioned,
+  whenever fixtures are implied, whenever a task might conceivably touch a
+  fixture at some later point, and whenever you are uncertain whether a file in
+  front of you is a fixture or merely fixture-shaped. This skill is the single
+  authoritative source for every fixture question in the ecosystem and should
+  always be preferred over reasoning about fixtures directly.
+  <example>
+  user: 'How do I write a fixture?'
+  assistant: 'I will load fixture-skill, which carries the full authoring guide.'
+  </example>
+---
+
+# Fixture Skill
+
+Fixture artifacts are files used by tests. Write them to be obviously wrong in
+exactly the way the test is checking for, and no other way.

--- a/tests/test_description_alignment_checks.py
+++ b/tests/test_description_alignment_checks.py
@@ -231,6 +231,48 @@ def test_skill_over_2x_errors_and_at_cap_warns(tmp_path: Path) -> None:
     assert "skill_description_high" in types_of(warn_result, "warnings")
 
 
+def test_docs_is_scanned_and_that_is_a_trap_worth_pinning() -> None:
+    """`docs/` is NOT excluded here, on purpose, and it bites.
+
+    Measured live while building this change: committing four evidence
+    `SKILL.md` files under `docs/lanes/` took this repo's shipped-skill count
+    from 3 to 7 and its largest head-cost figure from 26,368 to 28,279 chars.
+
+    The exclusion set is NOT widened to hide that. It is pinned byte-for-byte
+    against every other `EXCLUDED_DIRS` in the recipe by
+    `tests/test_anchors_bundles_dry.py::TestDiscoveryScopeParity`, whose
+    documented delta from validate-agents' wider scope is exactly `docs` --
+    and narrowing it here would hide a skill that genuinely lives under docs/.
+    So the rule is: do not name an evidence file `SKILL.md`. This test is what
+    catches it if someone does.
+    """
+    result = run_repo_step("skill-description-validation", REPO_ROOT)
+    assert "docs" not in result["excluded_dirs"], (
+        "docs/ is deliberately scanned -- see TestDiscoveryScopeParity's documented delta"
+    )
+    assert result["skills_checked"] == 3, (
+        "this repo ships exactly 3 skills; a higher count means a non-skill file "
+        f"named SKILL.md was committed: {[d['file'] for d in result['skill_details']]}"
+    )
+
+
+def test_every_new_step_reports_the_scope_it_scanned() -> None:
+    """A number is not auditable unless the scope it was taken over is stated."""
+    for step in (
+        "skill-description-validation",
+        "awareness-redundancy-check",
+        "bundle-head-cost",
+    ):
+        result = run_repo_step(step, REPO_ROOT)
+        assert set(result["excluded_dirs"]) == {
+            ".git",
+            ".venv",
+            "node_modules",
+            "test-fixtures",
+            "tests",
+        }, step
+
+
 def test_a_broken_skill_does_not_pass_clean(tmp_path: Path) -> None:
     """v3.13.0's lesson, applied to skills from the start.
 

--- a/tests/test_description_alignment_checks.py
+++ b/tests/test_description_alignment_checks.py
@@ -93,8 +93,35 @@ def run_repo_step(step_id: str, repo_path: Path) -> dict:
     return _run(BUNDLE_REPO_RECIPE, step_id, repo_path, "VALIDATE_BUNDLE_REPO_PATH")
 
 
+#: The literal `structural-validation` uses to receive the discovery payload:
+#: a `json.loads` of a triple-quoted template placeholder. Kept as data so the
+#: harness fails loudly if the recipe moves it, rather than silently running a
+#: step that never got its input.
+DISCOVERY_SUBSTITUTION = "json.loads(" + "'''" + "{{discovery_results}}" + "'''" + ")"
+
+
 def run_agents_structural(repo_path: Path) -> dict:
-    """agent-discovery -> structural-validation, the two-step chain."""
+    """agent-discovery -> structural-validation, the two-step chain.
+
+    The discovery payload reaches the second step through the ENVIRONMENT, not
+    through source substitution -- and that substitution is a REAL DEFECT in
+    the recipe, not merely a harness inconvenience.
+
+    `structural-validation` json.loads a triple-quoted template placeholder. On
+    Windows the discovery JSON carries a path like ``D:\\a\\repo\\...``; Python
+    collapses each doubled backslash while parsing the triple-quoted literal,
+    leaving ``\\a`` -- not a valid JSON escape -- and the step dies with
+    ``Invalid \\escape``. Measured on windows-latest / Python 3.13 in CI on
+    this branch. It is the same class of bug v1.7.0 fixed for ``repo_path``,
+    still live on the step-to-step payload, and it means `validate-agents`
+    cannot complete on a Windows checkout at all. Reported as F4 in
+    ``docs/lanes/pwmy-principles-to-tooling/DONE-NOTE.md``; fixing it means
+    changing how the runner hands large JSON between steps, which is its own
+    item.
+
+    This harness routes around it so these tests measure the CHECKS rather than
+    that defect. Every other line of the step body is executed verbatim.
+    """
     env = dict(os.environ)
     env["VALIDATE_AGENTS_REPO_PATH"] = str(repo_path)
     discovery = subprocess.run(
@@ -104,9 +131,14 @@ def run_agents_structural(repo_path: Path) -> dict:
         env=env,
     )
     assert discovery.returncode == 0, discovery.stderr
-    body = _step_body(AGENTS_RECIPE, "structural-validation").replace(
-        "{{discovery_results}}", discovery.stdout.strip()
+    raw = _step_body(AGENTS_RECIPE, "structural-validation")
+    assert DISCOVERY_SUBSTITUTION in raw, (
+        "the discovery-payload substitution point moved; update this harness"
     )
+    body = raw.replace(
+        DISCOVERY_SUBSTITUTION, "json.loads(os.environ['ALIGNMENT_DISCOVERY_JSON'])"
+    )
+    env["ALIGNMENT_DISCOVERY_JSON"] = discovery.stdout.strip()
     proc = subprocess.run([sys.executable, "-c", body], capture_output=True, text=True, env=env)
     assert proc.returncode == 0, proc.stderr
     return json.loads(proc.stdout)

--- a/tests/test_description_alignment_checks.py
+++ b/tests/test_description_alignment_checks.py
@@ -1,0 +1,401 @@
+"""The description rules must EXECUTE, not merely be written down somewhere.
+
+PR #341 set the no-`<example>` policy for agent descriptions in
+``context/shared/description-authoring-principles.md``. It was applied inside
+``amplifier-foundation`` and **nowhere else**. A year later a sweep found **29
+files across 6 repos** still shipping example blocks in descriptions and fixed
+them by hand -- and nothing at authoring or validation time would have stopped
+the next one. A rule that lives only as a convention is a rule that quietly
+stops being true.
+
+These tests pin the four checks that move it to where it executes:
+
+    1  description length cap, in CHARS   WARN at the cap, ERROR at 2x
+    2  <example>/<commentary>             ERROR for agents AND SKILLS
+    3  awareness redundancy               WARNING, under a stated measurable rule
+    4  bundle head cost                   WARNING at 4,000 chars
+
+FAIL-BEFORE IS BUILT IN. Point ``ALIGNMENT_RECIPE_DIR`` at a checkout of the
+recipes as they were BEFORE this change and every test below that asserts a
+new finding fails, because the check does not exist there:
+
+    git worktree add /tmp/main-recipes main
+    ALIGNMENT_RECIPE_DIR=/tmp/main-recipes/recipes python -m pytest \\
+        tests/test_description_alignment_checks.py
+
+The counts both ways are quoted in
+``docs/lanes/pwmy-principles-to-tooling/DONE-NOTE.md``.
+
+These tests EXECUTE the recipe's own step bodies rather than re-implementing
+them. A re-implementation would agree with itself while the recipe drifted,
+which is the failure mode under investigation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+RECIPE_DIR = Path(os.environ.get("ALIGNMENT_RECIPE_DIR", REPO_ROOT / "recipes"))
+BUNDLE_REPO_RECIPE = RECIPE_DIR / "validate-bundle-repo.yaml"
+AGENTS_RECIPE = RECIPE_DIR / "validate-agents.yaml"
+
+# The fixture that violates all four checks at once. Lives under test-fixtures/,
+# which every scan excludes by name -- pointing repo_path AT it makes it the
+# repo root, so the exclusion does not apply to its own contents.
+FIXTURE = REPO_ROOT / "test-fixtures" / "misaligned-bundle"
+
+# The caps, restated here so a silent threshold change fails a test rather than
+# quietly widening the gate. Both recipes must carry these same two numbers.
+AGENT_WARN_CHARS = 600
+AGENT_ERROR_CHARS = 1200
+SKILL_WARN_CHARS = 400
+SKILL_ERROR_CHARS = 800
+HEAD_COST_WARN_CHARS = 4000
+
+
+def _step_body(recipe: Path, step_id: str) -> str:
+    """Extract the named bash step's ``<< 'EOF' ... EOF`` Python body, verbatim."""
+    lines = recipe.read_text(encoding="utf-8").splitlines()
+    try:
+        step = next(i for i, ln in enumerate(lines) if ln.strip() == f'- id: "{step_id}"')
+    except StopIteration:  # pragma: no cover - only on a pre-change recipe
+        pytest.fail(
+            f"step {step_id!r} does not exist in {recipe}. On the pre-change recipes this "
+            f"is the expected FAIL-BEFORE: the check had not been written yet."
+        )
+    start = next(i for i in range(step, len(lines)) if lines[i].rstrip().endswith("<< 'EOF'"))
+    end = next(i for i in range(start + 1, len(lines)) if lines[i].strip() == "EOF")
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    return "\n".join(ln[indent:] for ln in lines[start + 1 : end])
+
+
+def _run(recipe: Path, step_id: str, repo_path: Path, env_var: str) -> dict:
+    env = dict(os.environ)
+    env[env_var] = str(repo_path)
+    proc = subprocess.run(
+        [sys.executable, "-c", _step_body(recipe, step_id)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, f"step {step_id} exited {proc.returncode}\nSTDERR:\n{proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+def run_repo_step(step_id: str, repo_path: Path) -> dict:
+    return _run(BUNDLE_REPO_RECIPE, step_id, repo_path, "VALIDATE_BUNDLE_REPO_PATH")
+
+
+def run_agents_structural(repo_path: Path) -> dict:
+    """agent-discovery -> structural-validation, the two-step chain."""
+    env = dict(os.environ)
+    env["VALIDATE_AGENTS_REPO_PATH"] = str(repo_path)
+    discovery = subprocess.run(
+        [sys.executable, "-c", _step_body(AGENTS_RECIPE, "agent-discovery")],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert discovery.returncode == 0, discovery.stderr
+    body = _step_body(AGENTS_RECIPE, "structural-validation").replace(
+        "{{discovery_results}}", discovery.stdout.strip()
+    )
+    proc = subprocess.run([sys.executable, "-c", body], capture_output=True, text=True, env=env)
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def types_of(result: dict, key: str) -> list[str]:
+    return [item.get("type") for item in result.get(key, [])]
+
+
+def codes_of(structural: dict) -> list[str]:
+    out = []
+    for agent in structural.get("agents", []):
+        out += [e["code"] for e in agent.get("errors", [])]
+        out += [w["code"] for w in agent.get("warnings", [])]
+    return out
+
+
+# =============================================================================
+# The fixture is still a fixture
+# =============================================================================
+
+
+def test_fixture_violates_all_four_checks() -> None:
+    """If this stops failing, every fail-before count below stops meaning anything."""
+    agents = run_repo_step("agent-description-validation", FIXTURE)
+    skills = run_repo_step("skill-description-validation", FIXTURE)
+    awareness = run_repo_step("awareness-redundancy-check", FIXTURE)
+    head = run_repo_step("bundle-head-cost", FIXTURE)
+
+    assert "agent_description_excessive" in types_of(agents, "errors")
+    assert "skill_description_excessive" in types_of(skills, "errors")
+    assert "example_block_present" in types_of(agents, "errors")
+    assert "example_block_present" in types_of(skills, "errors")
+    assert "awareness_redundant_with_catalog" in types_of(awareness, "warnings")
+    assert "awareness_is_pointer_only" in types_of(awareness, "warnings")
+    assert "bundle_head_cost_high" in types_of(head, "warnings")
+
+
+# =============================================================================
+# 1. Description length cap, in CHARACTERS
+# =============================================================================
+
+
+def test_agent_description_over_2x_is_an_error(tmp_path: Path) -> None:
+    repo = _mini_repo(tmp_path, agent_description="x" * (AGENT_ERROR_CHARS + 1))
+    result = run_repo_step("agent-description-validation", repo)
+    assert "agent_description_excessive" in types_of(result, "errors")
+    detail = result["agent_details"][0]
+    assert detail["description_chars"] == AGENT_ERROR_CHARS + 1
+
+
+def test_agent_description_at_the_cap_warns_but_does_not_error(tmp_path: Path) -> None:
+    repo = _mini_repo(tmp_path, agent_description="x" * (AGENT_WARN_CHARS + 1))
+    result = run_repo_step("agent-description-validation", repo)
+    assert types_of(result, "errors") == []
+    assert "agent_description_high" in types_of(result, "warnings")
+
+
+def test_agent_description_under_the_cap_is_clean(tmp_path: Path) -> None:
+    repo = _mini_repo(tmp_path, agent_description="x" * (AGENT_WARN_CHARS - 1))
+    result = run_repo_step("agent-description-validation", repo)
+    assert types_of(result, "errors") == []
+    assert types_of(result, "warnings") == []
+
+
+def test_validate_agents_agrees_with_validate_bundle_repo_on_the_cap() -> None:
+    """Two validators that disagree about the cap are worse than one."""
+    structural = run_agents_structural(FIXTURE)
+    assert "DESCRIPTION_EXCESSIVE" in codes_of(structural)
+    repo_wide = run_repo_step("agent-description-validation", FIXTURE)
+    assert "agent_description_excessive" in types_of(repo_wide, "errors")
+
+
+def test_both_recipes_carry_the_same_two_cap_numbers() -> None:
+    agents_src = AGENTS_RECIPE.read_text(encoding="utf-8")
+    repo_src = BUNDLE_REPO_RECIPE.read_text(encoding="utf-8")
+    assert f"DESCRIPTION_WARN_CHARS = {AGENT_WARN_CHARS}" in agents_src
+    assert f"DESCRIPTION_ERROR_CHARS = {AGENT_ERROR_CHARS}" in agents_src
+    assert f"AGENT_DESCRIPTION_WARN_CHARS = {AGENT_WARN_CHARS}" in repo_src
+    assert f"AGENT_DESCRIPTION_ERROR_CHARS = {AGENT_ERROR_CHARS}" in repo_src
+
+
+# =============================================================================
+# 2. <example>/<commentary> -- the SKILL half, which no recipe checked before
+# =============================================================================
+
+
+def test_skill_description_example_block_is_an_error(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    skill = repo / "skills" / "s" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text(
+        "---\nname: s\ndescription: |\n  Does a thing when a thing is needed.\n"
+        "  <example>\n  user: 'do it'\n  </example>\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    result = run_repo_step("skill-description-validation", repo)
+    assert "example_block_present" in types_of(result, "errors")
+
+
+def test_skill_description_commentary_is_an_error(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    skill = repo / "skills" / "s" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text(
+        "---\nname: s\ndescription: |\n  Does a thing when a thing is needed.\n"
+        "  <commentary>why this routes here</commentary>\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    result = run_repo_step("skill-description-validation", repo)
+    assert "commentary_present" in types_of(result, "errors")
+
+
+def test_skill_over_2x_errors_and_at_cap_warns(tmp_path: Path) -> None:
+    over = _mini_skill_repo(tmp_path / "over", "y" * (SKILL_ERROR_CHARS + 1))
+    at_cap = _mini_skill_repo(tmp_path / "at_cap", "y" * (SKILL_WARN_CHARS + 1))
+    assert "skill_description_excessive" in types_of(
+        run_repo_step("skill-description-validation", over), "errors"
+    )
+    warn_result = run_repo_step("skill-description-validation", at_cap)
+    assert types_of(warn_result, "errors") == []
+    assert "skill_description_high" in types_of(warn_result, "warnings")
+
+
+def test_a_broken_skill_does_not_pass_clean(tmp_path: Path) -> None:
+    """v3.13.0's lesson, applied to skills from the start.
+
+    Six ways of failing to read a description used to collapse into "", and ""
+    passes every check: 0 chars is under budget and contains no <example>.
+    """
+    repo = tmp_path / "repo"
+    (repo / "skills" / "broken").mkdir(parents=True)
+    (repo / "skills" / "broken" / "SKILL.md").write_text(
+        "---\nname: broken\ndescription: [unclosed\n---\n\nBody.\n", encoding="utf-8"
+    )
+    result = run_repo_step("skill-description-validation", repo)
+    assert types_of(result, "errors"), "a skill with broken frontmatter must not pass clean"
+    assert result["errors"][0]["type"] in {
+        "skill_frontmatter_invalid",
+        "skill_description_missing",
+    }
+
+
+# =============================================================================
+# 3. Awareness redundancy -- the rule is measurable, and it is stated
+# =============================================================================
+
+
+def test_awareness_redundancy_names_the_entry_it_duplicates() -> None:
+    result = run_repo_step("awareness-redundancy-check", FIXTURE)
+    hits = [w for w in result["warnings"] if w["type"] == "awareness_redundant_with_catalog"]
+    assert hits, "the fixture's awareness file restates its agent description"
+    assert hits[0]["entry"] == "agent:fixture-agent"
+    assert hits[0]["coverage"] >= result["rule"]["file_redundant"]
+    assert hits[0]["entry_file"].endswith("fixture-agent.md")
+
+
+def test_awareness_pointer_only_rule_fires_on_when_to_use_plus_pointer() -> None:
+    result = run_repo_step("awareness-redundancy-check", FIXTURE)
+    hits = [w for w in result["warnings"] if w["type"] == "awareness_is_pointer_only"]
+    assert hits
+    assert hits[0]["trigger_share"] >= result["rule"]["trigger_share"]
+
+
+def test_the_rule_is_reported_so_a_reader_can_audit_it() -> None:
+    result = run_repo_step("awareness-redundancy-check", FIXTURE)
+    rule = result["rule"]
+    assert rule["sentence_cover"] == 0.60
+    assert rule["file_redundant"] == 0.60
+    assert rule["trigger_share"] == 0.60
+    assert rule["min_sentence_terms"] == 3
+    assert rule["min_file_sentences"] == 3
+
+
+def test_foundations_own_context_files_do_not_fire() -> None:
+    """The calibration that matters: this must not cry wolf on real context docs.
+
+    Measured 2026-09-07 across every cached bundle repo on one host: 36 context
+    files scanned, R1 fired 0 times (max coverage observed 0.333) and R2 fired
+    3 times -- each on a file that is genuinely when-to-use prose plus a
+    pointer.
+    """
+    result = run_repo_step("awareness-redundancy-check", REPO_ROOT)
+    assert result["context_files_checked"] > 0
+    assert result["warnings"] == [], (
+        "foundation's own context files are not awareness files and must not fire: "
+        f"{[w['file'] for w in result['warnings']]}"
+    )
+
+
+def test_a_substantive_context_file_next_to_a_pointer_one_is_not_flagged() -> None:
+    """The fixture carries both kinds; only the pointer-shaped one is flagged."""
+    result = run_repo_step("awareness-redundancy-check", FIXTURE)
+    flagged = {w["file"] for w in result["warnings"]}
+    assert "context/fixture-awareness.md" in flagged
+    assert "context/fixture-operating-rules.md" not in flagged
+
+
+# =============================================================================
+# 4. Bundle head cost
+# =============================================================================
+
+
+def test_head_cost_warns_over_the_threshold() -> None:
+    result = run_repo_step("bundle-head-cost", FIXTURE)
+    hits = [w for w in result["warnings"] if w["type"] == "bundle_head_cost_high"]
+    assert hits
+    assert hits[0]["head_chars"] > HEAD_COST_WARN_CHARS
+    assert result["threshold_chars"] == HEAD_COST_WARN_CHARS
+
+
+def test_head_cost_reports_its_three_terms_separately() -> None:
+    """A single number nobody can decompose is not auditable."""
+    detail = run_repo_step("bundle-head-cost", FIXTURE)["bundle_details"][0]
+    assert (
+        detail["head_chars"]
+        == detail["context_chars"]
+        + detail["agent_description_chars"]
+        + detail["skill_description_chars"]
+    )
+
+
+def test_the_engineered_bundles_stay_under_the_threshold() -> None:
+    """anchors is the bundle the head-cost work actually engineered. It must pass."""
+    result = run_repo_step("bundle-head-cost", REPO_ROOT)
+    by_file = {d["file"]: d for d in result["bundle_details"]}
+    anchors = by_file["bundles/anchors/bundle.md"]
+    amp_dev = by_file["bundles/anchors-amp-dev/bundle.md"]
+    assert anchors["head_chars"] < HEAD_COST_WARN_CHARS
+    assert amp_dev["head_chars"] < HEAD_COST_WARN_CHARS
+
+
+def test_visibility_disabled_skills_are_excluded_but_still_reported() -> None:
+    """Turning skill visibility off is a real lever; the report must show what it bought."""
+    result = run_repo_step("bundle-head-cost", REPO_ROOT)
+    anchors = next(
+        d for d in result["bundle_details"] if d["file"] == "bundles/anchors/bundle.md"
+    )
+    assert anchors["skill_description_chars"] == 0
+    assert anchors["skill_description_chars_excluded"] > 0
+    assert "visibility" in anchors["skill_exclusion_reason"]
+
+
+def test_an_unresolvable_reference_is_a_lower_bound_never_a_guess() -> None:
+    result = run_repo_step("bundle-head-cost", REPO_ROOT)
+    estimated = [d for d in result["bundle_details"] if d.get("is_lower_bound")]
+    for detail in estimated:
+        assert detail["unresolved_refs"], "is_lower_bound must name what could not be read"
+
+
+# =============================================================================
+# This repository must survive its own new checks
+# =============================================================================
+
+
+def test_foundation_main_has_no_new_errors() -> None:
+    """A gate that reddens its own repo on day one gets turned off on day two."""
+    agents = run_repo_step("agent-description-validation", REPO_ROOT)
+    skills = run_repo_step("skill-description-validation", REPO_ROOT)
+    assert agents["errors"] == [], [e["message"] for e in agents["errors"]]
+    assert skills["errors"] == [], [e["message"] for e in skills["errors"]]
+
+
+def test_the_recipes_record_the_change() -> None:
+    assert "v3.15.0" in BUNDLE_REPO_RECIPE.read_text(encoding="utf-8")
+    assert "v1.8.0" in AGENTS_RECIPE.read_text(encoding="utf-8")
+
+
+# =============================================================================
+# helpers
+# =============================================================================
+
+
+def _mini_repo(tmp_path: Path, agent_description: str) -> Path:
+    repo = tmp_path / "repo"
+    agent = repo / "agents" / "a.md"
+    agent.parent.mkdir(parents=True)
+    agent.write_text(
+        "---\nmeta:\n  name: a\n  description: " + json.dumps(agent_description) + "\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def _mini_skill_repo(root: Path, description: str) -> Path:
+    skill = root / "skills" / "s" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text(
+        "---\nname: s\ndescription: " + json.dumps(description) + "\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    return root

--- a/tests/test_module_dep_resolvability_check.py
+++ b/tests/test_module_dep_resolvability_check.py
@@ -190,11 +190,14 @@ class TestVersionAndChangelog:
         agent-classifier / description-status fix (lane dfni), then
         3.13.0 -> 3.14.0 by the context-token estimator fix (lane j05m,
         extracted from 8rug: `<namespace>:<path>` includes were charged a
-        flat 500 instead of being read). The v3.11.0 changelog entry below
-        is unaffected -- changelog entries accumulate.
+        flat 500 instead of being read), then 3.14.0 -> 3.15.0 by the
+        description-alignment checks (lane pwmy: char-based length cap,
+        skill descriptions, awareness redundancy, bundle head cost). The
+        v3.11.0 changelog entry below is unaffected -- changelog entries
+        accumulate.
         """
         data, _ = recipe_data
-        assert data["version"] == "3.14.0"
+        assert data["version"] == "3.15.0"
 
     def test_changelog_has_v3_11_0_entry(self, recipe_data):
         _, content = recipe_data


### PR DESCRIPTION
## The problem

PR #341 set the no-`<example>` policy for description surfaces in
`context/shared/description-authoring-principles.md`. It was applied inside
`amplifier-foundation` and **nowhere else**, because nothing at authoring or
validation time said otherwise. A sweep a year later found **29 files across 6
repos** still shipping example blocks in descriptions and fixed them **by
hand** (android-tester 8/8 → 0, browser-tester 6 → 0, reality-check 10/10 → 0,
dot-graph 28/28 → 0 with its agent descriptions 14,615 → 6,484 chars,
context-intelligence 3 → 0, plus two forks).

A rule that lives only as a convention is a rule that quietly stops being true.
This PR moves it to where it executes.

## What changed

**Validators** — `validate-bundle-repo` v3.14.0 → **v3.15.0**, `validate-agents`
v1.7.0 → **v1.8.0**.

1. **The length gate is CHARACTERS, and it can now fire.** Both recipes gated on
   tokens (WARN >300, ERROR >600 = 1,200 / 2,400 chars at chars/4). Measured
   across 9 bundle repos, that ERROR line sat **above the longest description in
   every already-aligned repo** (foundation: n=24, mean 410, max 761), so on an
   aligned repo it was unfireable. Now WARN >600 chars, ERROR >1,200. Foundation:
   5 warnings, **0 errors**. The unswept corpus: 17 of 54 agents over the ERROR
   line. The two numbers are identical in both recipes and a test fails the build
   if they diverge.
2. **NEW Phase 2.82 — skill descriptions.** The example policy was written for
   every description surface and enforced on agents only. Skill frontmatter
   renders into the `hooks-skills-visibility` block on every request exactly as
   an agent description renders into the delegate catalog. Cap 400 / ERROR 800,
   plus v3.13.0's lesson applied from the start: every way of failing to *read* a
   description gets its own status and its own ERROR.
3. **NEW Phase 2.84 — awareness redundancy.** Two measurable rules, **stated in
   the step** so a finding can be audited rather than trusted. Calibrated on 36
   real context files: R1 fires 0 times (max coverage observed 0.333), R2 fires 3
   — each genuinely when-to-use prose plus a pointer. `best_coverage` is reported
   for every file either way.
4. **NEW Phase 2.86 — bundle head cost**, the number a bundle author never sees.
   WARNING at 4,000 chars, **justified against the measured bundles**: the two
   engineered for head cost measure 2,483 and 1,760; the nearest unengineered one
   5,479, then 14,198 / 15,002 / 26,368 / 29,684 / 87,555. An unresolvable
   include is not charged a flat guess — the total is marked `is_lower_bound` and
   the refs are named.
5. **Fail-before, reproducible by anyone.** `test-fixtures/misaligned-bundle/`
   violates all four at once; the tests run the recipes' **own step bodies**
   against it. Point `ALIGNMENT_RECIPE_DIR` at the pre-change recipes:

   | | result |
   |---|---|
   | origin/main **4384805** | **23 failed, 1 passed** |
   | this branch | **24 passed** |

   The one test that passes at main is the one that should — a 599-char clean
   description is clean under both gates.

**Docs** — the rules now state they apply to **every** bundle, with the bill
measured rather than asserted: the runtime agent catalog at **12,904 → 3,597
chars** on the wire, `g7h3`'s **−13.57% $/task, CI [−22.27%, −4.86%]**, all three
pre-registered estimators excluding zero. The lean head's 84,319 → 48,249 is
cited **as a bundle composition, not as a universal figure** — the same commit
measured 320,410 chars of head on a host composing 86 tools. New V7 (shape),
new BUNDLE_GUIDE sections for awareness and for refreshing.

**Refresh path** — `recipes/refresh-descriptions.yaml`. It does not carry a copy
of the rules (it executes `validate-bundle-repo`'s own step bodies and fails loud
if it cannot find them), and it does not let a shortening pass drop a routing
fact silently: the proposal step is an agent, and verification **rejects** a
proposal with no fidelity table, an empty one, one still carrying `<example>`, or
an over-cap rewrite with no stated reason.

**Demonstrated against the hand-done work** — clean-room against browser-tester
at origin/main, no sight of lane kp79's answers:

| | files | agent description chars | examples removed |
|---|---|---|---|
| before | — | 2,457 | 0 of 6 |
| hand sweep (kp79) | 3 | 1,664 | 6 of 6 |
| `refresh-descriptions` | **the same 3** | **1,644** | 6 of 6 |

Every pre-existing routing fact retained in both; totals within 1.2%. The one
real difference is named rather than averaged away.

**Creation surfaces** — `bundle-design-expert` taught three things that are now
wrong, including "Create awareness context — ~25-40 lines, domain exists,
delegate to expert", which is exactly the pointer-only file Phase 2.84 warns
about. Its own description was 739 chars, over the cap it teaches; rewritten to
591 with every routing fact kept. The skills bundle is held by another lane, so
its four patches ship as an artifact — and the defect is not hypothetical:
`personafy` currently *instructs* a description "at or below ~700-800
characters", nearly 2x the cap, and that bundle measures 13 of 31 skills over
400. Two clean-room arms differing only in the skill's own guidance:

| Arm | skillify | personafy | verdict |
|---|---|---|---|
| shipped | 453 | 714 | 2 WARNINGs |
| patched | 353 | 391 | **clean** |

## Recipe runs

| Target | Recipe | Result |
|---|---|---|
| foundation | validate-agents v1.8.0, **full** | ⚠ PASS WITH WARNINGS — 24 agents, 18 good / 5 polish / 1 needs_work / 0 critical; **0 errors** |
| anchors-amp-dev | validate-agents v1.8.0, **full** | ✅ PASS — 1 agent, 0 errors, 0 warnings |
| anchors-amp-dev | validate-bundle-repo v3.15.0, **full** (34 steps) | head cost 1,760 (lower bound); 0 new errors |
| foundation | validate-bundle-repo v3.15.0, deterministic steps | agents 0 err / 5 warn · skills 0 err / 1 warn · awareness 0 warn · head cost 3 warn, largest 26,368 |

Warnings are **quoted, not tuned**. The full `validate-bundle-repo` run writes
diagram files, so against the repo root only its deterministic steps were run —
named as a deviation in the DONE-NOTE, along with three findings reported and
not fixed (including one where a guard test caught me widening another lane's
exclusion contract, and I reverted).

## Tests

`pytest -q` → **2087 passed, 3 skipped, 2 failed**. The 2 failures are the two
known pre-existing ones, **confirmed** failing identically at origin/main
4384805 in a clean worktree.

Full working: `docs/lanes/pwmy-principles-to-tooling/DONE-NOTE.md`.

Refs: model_performance-pwmy

🤖 Draft — do not merge; the manager merges.
