### PR TITLE
anchors: include the routing behavior so every agent's model_role actually routes

### DIFF
--- a/bundles/anchors/bundle.md
+++ b/bundles/anchors/bundle.md
@@ -18,6 +18,22 @@ includes:
   # Context Intelligence: session event capture + local-JSONL navigation
   - bundle: git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=behaviors/context-intelligence-logging.yaml
   - bundle: git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=behaviors/context-intelligence-navigation.yaml
+  # Model routing: the hook that makes every agent's `model_role` mean something.
+  #
+  # Every anchors agent declares a role (explorer: [general, fast]; architect:
+  # reasoning; ...). Without hooks-routing those declarations are dead config
+  # and every sub-agent silently inherits the parent's provider -- measured
+  # 2026-09-07: a session on anchors-amp-dev spawned explorer with
+  # `provider_preferences: null` and ran it on the parent's opus while
+  # `amplifier routing show` said "balanced ... active" for every role.
+  #
+  # amplifier-app-cli ALSO composes this behavior on every session (routing is
+  # app-level policy there, like skills/wayfinder). Including it here too is
+  # deliberate, not redundant: anchors does not need the CLI to work, and a
+  # host that mounts anchors without app-cli must still route. Compose dedupes
+  # by module id, so the two never produce a second hook. Cost: one ~750-byte
+  # context file (the model_role contract) and the role-definitions skill.
+  - bundle: git+https://github.com/microsoft/amplifier-bundle-routing-matrix@main#subdirectory=behaviors/routing.yaml
 
 session:
   raw: true


### PR DESCRIPTION
One include added to `bundles/anchors/bundle.md`.

## Why

Every anchors agent declares a `model_role` (`explorer: [general, fast]`, `architect: reasoning`, …). Without `hooks-routing` those declarations are **dead config** — nothing reads them, and every sub-agent silently inherits the parent session's provider.

Measured 2026-09-07 on a project pinned to `anchors-amp-dev`:

```
delegate:agent_spawned … "provider_preferences": null              ← hook never ran
llm:request … "model": "claude-opus-5", "provider": "anthropic"     ← explorer on the parent's model
```

while `amplifier routing show` said `★ openai / gpt-?.?-terra ← active` for every role — that command reads matrix files from the cache and never checks the mount plan (fixed separately in app-cli#321, and about to become moot).

**`anchors` is also amplifier-app-cli's default bundle** (`runtime/config.py:1415`), so this was every default user's state, not one workspace's.

## What it brings

Behavior file only (`behaviors/routing.yaml`), never the bundle's root `bundle.md` — same shape as every other include here:

- `hooks-routing` (`default_matrix: balanced`)
- one ~750-byte context file: the `model_role` contract agents are written against
- the `role-definitions` skill, on the `tool-skills` instance anchors already declares

## Relationship to app-cli

amplifier-app-cli is **also** composing this behavior on every session (routing is app-level policy there, alongside skills/wayfinder/modes — PR to follow). Including it here too is deliberate: anchors doesn't need the CLI to work, and a host that mounts anchors without app-cli must still route.

Compose dedupes hooks by module id. Verified: `anchors` alone, `anchors` + the CLI-composed behavior, and `foundation` (which already includes routing-matrix) + the behavior each mount **exactly one** `hooks-routing`.

## Tests

1872 passed, 4 skipped. The one failure — `tests/test_sources.py::TestFileSourceHandler::test_resolve_existing_file` — fails identically on unmodified `main`; unrelated to this YAML edit.