### PR TITLE
session-naming: honour the fast role across vendors — naming is an out-of-band chore, not a conversation turn

### DIFF
--- a/modules/hooks-session-naming/README.md
+++ b/modules/hooks-session-naming/README.md
@@ -42,20 +42,24 @@ hooks:
 matrix — the same mechanism used by the `delegate` tool and recipe agent steps.
 Session naming is a simple classification task; it does not need the priority model.
 
-**Naming never calls a provider this session did not select.** Every path below
-ends on either the session's own conversation provider or a *same-vendor* sibling
-of it. There is no arbitrary fallback.
+**Naming never BORROWS a provider; it may ROUTE to one you configured.** Every
+path below ends on either the routing matrix's candidate for the role -- if it is
+mounted in this session -- or the session's own conversation provider. There is no
+arbitrary fallback.
 
 Resolution order:
 
-1. **`model_role`** — Resolved against the `model_role_resolver` capability
-   (registered by whichever routing bundle is active — typically the
+1. **`model_role`** -- Resolved against the `model_role_resolver` capability
+   (registered by whichever routing bundle is active -- typically the
    matrix-based one shipped in `amplifier-bundle-routing-matrix`). Defaults to
-   `"fast"`. A resolved candidate is **accepted only if** it is mounted in this
-   session **and** its `get_info().id` matches the vendor of the session's own
-   provider. Anything else is refused with a WARNING (once per session).
+   `"fast"`. A resolved candidate is **accepted whenever it is mounted in this
+   session**, whatever vendor answers the conversation: naming is an
+   out-of-band chore, not a turn of the conversation, and `fast` is your own
+   statement of which cheap model to use for chores. A candidate that resolves
+   to a provider **not** mounted here is refused with a WARNING (once per
+   session) and naming falls back to path 2.
 
-2. **The session's own conversation provider** — the `conversation.provider_pin`
+2. **The session's own conversation provider** -- the `conversation.provider_pin`
    pin when one is set, otherwise the same priority ordering the streaming
    orchestrator uses to pick the conversation provider (`provider.priority`,
    then `provider.config["priority"]`, default 100, ties broken by mount order).
@@ -64,16 +68,24 @@ Resolution order:
 If the conversation is pinned to a provider that is no longer mounted, naming is
 **skipped** for that turn rather than run on some other provider.
 
-### Why the vendor check exists
+### History: the leak, and the rule that briefly over-corrected it
 
-Session naming used to resolve `model_role` through the routing matrix (whose
-default matrix is openai) and, when the resolved name matched no mount, fall
-through to `next(iter(providers.values()))` — an order-dependent, silent borrow
-of whichever provider instance happened to be first in the mount dict. In an
-Anthropic-pinned evaluation cell that emitted openai calls into the session's
-event stream (321 foreign responses across 12 capture roots; see
-`model_performance-egh`). Same-vendor siblings (`anthropic-sonnet` →
-`anthropic-haiku`) remain allowed: that is the intended cheap-model routing.
+Session naming used to resolve `model_role` through the routing matrix and, when
+the resolved name matched no mount, fall through to
+`next(iter(providers.values()))` -- an order-dependent, silent borrow of whichever
+provider instance happened to be first in the mount dict. In an Anthropic-pinned
+evaluation cell that emitted openai calls into the session's event stream (321
+foreign responses across 12 capture roots; see `model_performance-egh`). That
+fallback is gone: the fallback is the session's OWN provider, chosen the same
+way the orchestrator chooses it.
+
+The same fix (#348) also added a *same-vendor* rule for the role candidate. That
+rule was a stand-in for attribution, and the event stamping below now provides
+attribution directly -- scorers exclude naming's calls by marker, not by vendor.
+Kept as a rule, it made every naming call on a mixed-provider host run on the
+conversation's expensive model while `fast` resolved to a cheap one (measured
+2026-09-07: claude-opus-5 answering naming while `fast` -> gpt-5.6-luna), which is
+the exact cost the role exists to avoid. Removed 2026-09-07.
 
 ## Event Attribution
 

--- a/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
+++ b/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
@@ -557,39 +557,6 @@ class SessionNamingHook:
                 return float(value)
         return 100.0
 
-    @staticmethod
-    def _vendor_of(provider: Any) -> str | None:
-        """Vendor identity of a provider via the kernel contract
-        ``get_info().id`` (e.g. ``"anthropic"``), lowercased.
-
-        Returns None when the vendor cannot be established — callers must
-        treat that as "cannot prove same vendor" and refuse, never as "no
-        conflict". Two mount names sharing an id (anthropic-sonnet /
-        anthropic-haiku) are the SAME vendor.
-        """
-        get_info = getattr(provider, "get_info", None)
-        if not callable(get_info):
-            return None
-        try:
-            info = get_info()
-        except Exception as e:  # pragma: no cover - defensive
-            logger.debug("get_info() failed while checking provider vendor: %s", e)
-            return None
-        vendor = getattr(info, "id", None)
-        if vendor is None and isinstance(info, dict):
-            vendor = info.get("id")
-        if isinstance(vendor, str) and vendor.strip():
-            return vendor.strip().lower()
-        return None
-
-    def _same_vendor(self, a: Any, b: Any) -> bool:
-        """True only when both vendors are known AND equal (fail closed)."""
-        if a is b:
-            return True
-        vendor_a = self._vendor_of(a)
-        vendor_b = self._vendor_of(b)
-        return bool(vendor_a and vendor_b and vendor_a == vendor_b)
-
     def _select_session_provider(
         self, providers: dict[str, Any]
     ) -> tuple[str | None, Any | None]:
@@ -783,7 +750,20 @@ class SessionNamingHook:
                 logger.debug("No session provider resolved for session naming")
                 return None
 
-            # Resolution order: model_role (same vendor only) > session provider
+            # Resolution order: model_role (any MOUNTED provider) > session provider
+            #
+            # Naming is an out-of-band chore, not a turn of the conversation.
+            # The routing matrix's `fast` role is exactly the user's statement
+            # of which cheap model to use for chores, so a candidate the
+            # resolver returns is honoured whenever it is mounted in this
+            # session -- whatever vendor answers the conversation. #348's
+            # same-vendor rule was a stand-in for attribution that the
+            # llm:* stamping below now provides directly (scorers exclude
+            # naming's own events by marker, not by vendor). What #348 keeps:
+            # no silent borrow of an arbitrary provider (the fallback is the
+            # session's OWN provider, never dict order), a candidate that is
+            # not mounted here is refused loudly, and a stale pin skips the
+            # turn rather than answering on a provider the user never chose.
             provider = None
             provider_name: str | None = None
             model_override: str | None = None
@@ -830,23 +810,17 @@ class SessionNamingHook:
                                 str(resolved_provider_name),
                                 "no provider with that name is mounted in this session",
                             )
-                        elif self._same_vendor(candidate, session_provider):
+                        else:
                             provider = candidate
                             provider_name = candidate_name
                             model_override = resolved[0].model
-                        else:
-                            refusal = (
-                                str(candidate_name),
-                                "it is a different provider vendor than the one"
-                                " answering this session",
-                            )
                     else:
                         role_had_no_candidates = True
 
             # Fall back to the session's OWN provider. Reached when model_role
             # is unset, no resolver capability is registered, the role resolved
-            # to no candidates, or the resolved candidate was refused as
-            # foreign — the last two are announced loudly below rather than
+            # to no candidates, or the resolved candidate is not mounted here
+            # — the last two are announced loudly below rather than
             # substituted silently.
             if provider is None:
                 provider = session_provider

--- a/modules/hooks-session-naming/tests/test_session_naming.py
+++ b/modules/hooks-session-naming/tests/test_session_naming.py
@@ -129,7 +129,9 @@ def _make_resolver(
     """
     resolver = MagicMock()
     resolver.name = name
-    resolver.resolve = AsyncMock(return_value=return_value if return_value is not None else [])
+    resolver.resolve = AsyncMock(
+        return_value=return_value if return_value is not None else []
+    )
     return resolver
 
 
@@ -355,7 +357,9 @@ class TestModelRoleResolution:
 
         resolver = _make_resolver(
             return_value=[
-                ProviderPreference(provider="anthropic", model="claude-haiku-4-5", config={}),
+                ProviderPreference(
+                    provider="anthropic", model="claude-haiku-4-5", config={}
+                ),
             ]
         )
         hook = _make_hook(
@@ -377,6 +381,7 @@ class TestModelRoleResolution:
         call_kwargs = anthropic_provider.complete.call_args
         request = call_kwargs[0][0]
         assert request.model == "claude-haiku-4-5"
+
     @pytest.mark.asyncio
     async def test_model_role_falls_back_when_no_resolver_capability(self) -> None:
         """No model_role_resolver capability → falls back to priority provider."""
@@ -395,6 +400,7 @@ class TestModelRoleResolution:
             "Must fall back to priority provider when model_role_resolver capability is absent"
         )
         resolver.resolve.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_no_model_role_uses_priority_provider(self) -> None:
         """Without model_role, existing behavior is preserved (priority provider)."""
@@ -568,23 +574,38 @@ class TestModelRoleResolution:
 
 
 class TestProviderPurity:
-    """A session pinned to provider X must never emit a naming call on Y.
+    """Naming never BORROWS a provider; it may ROUTE to one the user configured.
 
-    Measured leak this pins shut (model_performance-egh): the routing matrix
-    defaults to openai, so in an Anthropic-pinned session ``model_role="fast"``
-    resolved to an openai candidate, and the unmatched-candidate path fell
-    through to ``next(iter(providers.values()))`` — an order-dependent,
-    SILENT borrow of whichever provider instance happened to be first in the
-    mount dict. 321 foreign responses across 12 capture roots came from here.
+    The leak #348 pinned shut (model_performance-egh): the unmatched-candidate
+    path fell through to ``next(iter(providers.values()))`` -- an
+    order-dependent, SILENT borrow of whichever provider instance happened to
+    be first in the mount dict. 321 foreign responses across 12 capture roots
+    came from that line. It is gone; the fallback is the session's OWN provider.
+
+    What #348 also added -- a same-vendor rule for the ``model_role``
+    candidate -- was a stand-in for attribution. Naming is an out-of-band
+    chore, not a turn of the conversation, and the matrix's ``fast`` role is
+    the user's own statement of which cheap model to use for chores. Since
+    naming's llm:* events are now stamped (TestAttribution below) scorers
+    exclude them by MARKER, not by vendor, so the candidate is honoured
+    whenever it is MOUNTED here -- whatever vendor answers the conversation.
+    Measured 2026-09-07 on a live host: the rule made every naming call run on
+    claude-opus-5 while ``fast`` resolved to gpt-5.6-luna, the exact expensive
+    default the role exists to avoid.
+
+    Still refused, loudly: a candidate that is not mounted in this session,
+    and a stale pin (the turn is skipped rather than answered elsewhere).
     """
 
     @pytest.mark.asyncio
-    async def test_pinned_session_never_calls_foreign_vendor(self, caplog) -> None:
-        """Anthropic-pinned session + openai-resolving role → anthropic only.
+    async def test_role_candidate_is_used_across_vendors(self, caplog) -> None:
+        """Anthropic-pinned session + openai-resolving ``fast`` -> naming runs on openai.
 
-        The mount dict deliberately lists openai FIRST, so the old
-        ``next(iter(providers))`` fallback would have picked openai even
-        without the resolver ever matching.
+        The mount dict deliberately lists openai FIRST so the old
+        ``next(iter(providers))`` fallback and the correct routing land on the
+        same provider for different reasons; the assertions below tell them
+        apart: the ROUTED call carries the role's model override and warns
+        about nothing.
         """
         openai_provider = _make_vendor_provider("openai")
         anthropic_provider = _make_vendor_provider("anthropic")
@@ -595,7 +616,7 @@ class TestProviderPurity:
 
         resolver = _make_resolver(
             return_value=[
-                ProviderPreference(provider="openai", model="gpt-5-mini", config={}),
+                ProviderPreference(provider="openai", model="gpt-5.6-luna", config={}),
             ]
         )
         hook = _make_hook(
@@ -608,28 +629,20 @@ class TestProviderPurity:
         with caplog.at_level("WARNING"):
             result = await hook._call_provider("name this session", "session-pin")
 
-        assert not openai_provider.complete.called, (
-            "A session pinned to anthropic must NEVER emit a naming call on "
-            "openai — this is the cross-provider leak"
+        assert openai_provider.complete.called, (
+            "The matrix's `fast` candidate is mounted here; naming must use it "
+            "even though the conversation is answered by anthropic"
         )
-        assert anthropic_provider.complete.called, (
-            "Naming must run on the session's own pinned provider"
+        assert not anthropic_provider.complete.called, (
+            "The session's own (expensive) provider must not be used when the "
+            "cheap role candidate is available"
         )
         assert result is not None
-
-        request = anthropic_provider.complete.call_args[0][0]
-        assert request.model is None, (
-            "A refused foreign candidate must not leave its model override "
-            "behind on the session's own provider"
+        assert openai_provider.complete.call_args[0][0].model == "gpt-5.6-luna", (
+            "Routing, not borrowing: the role's model override must ride along"
         )
-
-        warnings = [r.getMessage() for r in caplog.records if r.levelno >= 30]
-        assert warnings, "Refusing a foreign provider must be loud, not silent"
-        assert any("openai" in m for m in warnings), (
-            "The warning must name the provider that was refused"
-        )
-        assert any("anthropic-sonnet" in m for m in warnings), (
-            "The warning must name the provider actually used"
+        assert not [r for r in caplog.records if r.levelno >= 30], (
+            "Honouring a mounted role candidate is the normal path -- no warning"
         )
 
     @pytest.mark.asyncio
@@ -664,12 +677,12 @@ class TestProviderPurity:
         assert haiku.complete.call_args[0][0].model == "claude-haiku-4-5"
 
     @pytest.mark.asyncio
-    async def test_unknown_vendor_candidate_is_refused(self, caplog) -> None:
-        """Fail closed: a candidate whose vendor cannot be established is refused.
+    async def test_vendor_identity_is_not_required(self) -> None:
+        """A mounted candidate whose ``get_info()`` is broken is still usable.
 
-        ``get_info()`` is the only contract for vendor identity. If it is
-        missing or unreadable, sameness cannot be PROVEN, and an unprovable
-        sameness is exactly how the leak got in.
+        Vendor identity was only ever needed for the same-vendor rule. With
+        that rule gone, "mounted in this session" is the whole criterion, and a
+        provider that cannot describe itself is not thereby foreign.
         """
         session_provider = _make_vendor_provider("anthropic")
         mystery = _make_mock_provider()
@@ -691,14 +704,10 @@ class TestProviderPurity:
             provider_pin="anthropic-sonnet",
         )
 
-        with caplog.at_level("WARNING"):
-            await hook._call_provider("name this session", "session-unknown")
+        await hook._call_provider("name this session", "session-unknown")
 
-        assert not mystery.complete.called, (
-            "An unprovable-vendor candidate must be refused, not borrowed"
-        )
-        assert session_provider.complete.called
-        assert [r for r in caplog.records if r.levelno >= 30]
+        assert mystery.complete.called
+        assert not session_provider.complete.called
 
     @pytest.mark.asyncio
     async def test_resolved_provider_not_mounted_is_refused(self, caplog) -> None:
@@ -770,17 +779,16 @@ class TestProviderPurity:
         assert any("anthropic-sonnet" in m for m in warnings)
 
     @pytest.mark.asyncio
-    async def test_cross_provider_refusal_warns_once_per_session(
-        self, caplog
-    ) -> None:
-        """The refusal warning fires once per session, then drops to DEBUG."""
-        providers = {
-            "openai-gpt-5": _make_vendor_provider("openai"),
-            "anthropic-sonnet": _make_vendor_provider("anthropic"),
-        }
+    async def test_not_mounted_refusal_warns_once_per_session(self, caplog) -> None:
+        """The refusal warning fires once per session, then drops to DEBUG.
+
+        The only refusal left is "resolved to a provider that is not mounted
+        here"; it must still be loud exactly once.
+        """
+        providers = {"anthropic-sonnet": _make_vendor_provider("anthropic")}
         resolver = _make_resolver(
             return_value=[
-                ProviderPreference(provider="openai", model="gpt-5-mini", config={}),
+                ProviderPreference(provider="openai", model="gpt-5.6-luna", config={}),
             ]
         )
         hook = _make_hook(
@@ -799,6 +807,9 @@ class TestProviderPurity:
             second_debug = [r for r in caplog.records if r.levelno == 10]
 
         assert first, "First refusal in a session must warn"
+        assert any("openai" in r.getMessage() for r in first), (
+            "The warning must name the provider that was refused"
+        )
         assert not second, "Second refusal in the SAME session must not re-warn"
         assert second_debug, "Repeat refusals must still be logged at DEBUG"
 
@@ -924,9 +935,7 @@ class TestNamingEventAttribution:
         assert hook._stamped_provider(provider) is hook._stamped_provider(provider)
 
     @pytest.mark.asyncio
-    async def test_unstampable_provider_skips_rather_than_leaks(
-        self, caplog
-    ) -> None:
+    async def test_unstampable_provider_skips_rather_than_leaks(self, caplog) -> None:
         """If events cannot be stamped, skip the call — loudly.
 
         An unattributable naming call is worse than a missing session name:
@@ -995,11 +1004,13 @@ class TestNoStreamingEvents:
     them as foreground output and renders the naming JSON to the terminal.
     """
 
-    _STREAM_EVENTS = frozenset({
-        "llm:stream_block_start",
-        "llm:stream_block_delta",
-        "llm:stream_block_end",
-    })
+    _STREAM_EVENTS = frozenset(
+        {
+            "llm:stream_block_start",
+            "llm:stream_block_delta",
+            "llm:stream_block_end",
+        }
+    )
 
     def _make_streaming_simulator(self, emitted: list) -> MagicMock:
         """Mock provider that conditionally emits stream events.
@@ -1015,8 +1026,7 @@ class TestNoStreamingEvents:
 
         async def _complete(request: ChatRequest) -> MagicMock:
             force_no_stream = (
-                request.metadata is not None
-                and request.metadata.get("stream") is False
+                request.metadata is not None and request.metadata.get("stream") is False
             )
             if not force_no_stream:
                 emitted.append("llm:stream_block_start")
@@ -1154,7 +1164,9 @@ class TestParseResponseTruncation:
                 '{"action": "set", "name": "My Session", "description": "trunc'
             )
         warnings = [r for r in caplog.records if r.levelno >= 30]  # WARNING+
-        assert not warnings, f"unexpected warning(s): {[r.getMessage() for r in warnings]}"
+        assert not warnings, (
+            f"unexpected warning(s): {[r.getMessage() for r in warnings]}"
+        )
 
     def test_markdown_wrapped_response_parses(self) -> None:
         hook = _make_hook()


### PR DESCRIPTION
Partially reverses #348's same-vendor rule, keeps everything else #348 fixed.

## What was happening

Measured 2026-09-07 on a live mixed-provider host (anthropic answering the conversation, `fast` → `openai/gpt-5.6-luna`):

```
model_role 'fast' resolved to provider 'openai-chatgpt', but it is a different
provider vendor than the one answering this session. REFUSING to borrow it:
session naming will run on 'opus' ...
```

So every session name and rename ran on **claude-opus-5** — the exact expensive default the `fast` role exists to avoid — on every host that mixes vendors.

## Why the rule existed, and why it's now the wrong tool

#348 fixed a real leak: the unmatched-candidate path fell through to `next(iter(providers.values()))`, an order-dependent **silent borrow** of whichever provider was first in the mount dict (321 foreign responses across 12 capture roots). #348 also **stamped naming's own `llm:*` events** so scorers can exclude them.

The same-vendor rule was a stand-in for that attribution. With the stamping in place, scorers exclude naming's calls by *marker*, not by vendor — so the rule only costs money now.

## The change

Naming is an out-of-band chore, not a turn of the conversation. The matrix's `fast` role is the user's own statement of which cheap model to use for chores. A candidate the resolver returns is honoured **whenever it is mounted in this session**, whatever vendor answers the conversation.

**Kept from #348, unchanged:**
- no silent borrow — the fallback is the session's **own** provider, chosen the way the orchestrator chooses it, never dict order
- a candidate not mounted here is refused loudly, once per session
- a stale pin skips the turn rather than answering elsewhere
- event attribution

**Removed:** the `_same_vendor` branch and the now-dead `_vendor_of` / `_same_vendor` helpers.

## One nuance worth a look from the model_performance side

An Anthropic-*pinned* evaluation cell will now emit small openai naming calls. They're stamped and excluded from scoring (that's what the #348 stamping guarantees), so measurement is unaffected — but there's a tiny openai spend inside an Anthropic cell. If that matters for cost accounting, the narrow follow-up is "respect the vendor rule only when `conversation.provider_pin` is set"; I didn't add it because the owner's directive was that naming is out-of-band, full stop.

## Tests (`TestProviderPurity`)

- `test_pinned_session_never_calls_foreign_vendor` → **`test_role_candidate_is_used_across_vendors`**: naming runs on the openai candidate with its model override, warns about nothing
- `test_unknown_vendor_candidate_is_refused` → **`test_vendor_identity_is_not_required`**: a mounted candidate with a broken `get_info()` is still usable
- `test_cross_provider_refusal_warns_once_per_session` → **`test_not_mounted_refusal_warns_once_per_session`**: exercises the one refusal left
- same-vendor sibling · not-mounted refusal · priority-not-dict-order · stale-pin: unchanged

38 module tests · foundation suite 1897 passed (the one pre-existing `test_sources` failure fails identically on `main`) · ruff clean.

README resolution order and history rewritten to match.