### PR TITLE
session-naming: document that single-vendor naming is a configuration choice, not a code rule

### DIFF
--- a/modules/hooks-session-naming/README.md
+++ b/modules/hooks-session-naming/README.md
@@ -68,6 +68,20 @@ Resolution order:
 If the conversation is pinned to a provider that is no longer mounted, naming is
 **skipped** for that turn rather than run on some other provider.
 
+### Keeping naming on one vendor
+
+If a session must not emit even a small call on another vendor -- an evaluation
+cell pinned to anthropic, say -- the fix is configuration, not a code rule:
+
+- configure only the providers you want used in that session or cell (a role
+  candidate that resolves to a provider that is not mounted is refused), or
+- select a provider-specific or custom routing matrix (`amplifier routing use
+  anthropic`, or your own file under `~/.amplifier/routing/`) so `fast`
+  resolves inside the vendor.
+
+Either keeps naming cheap *and* single-vendor without a code path that silently
+overrides the user's matrix.
+
 ### History: the leak, and the rule that briefly over-corrected it
 
 Session naming used to resolve `model_role` through the routing matrix and, when

--- a/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
+++ b/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
@@ -764,6 +764,17 @@ class SessionNamingHook:
             # session's OWN provider, never dict order), a candidate that is
             # not mounted here is refused loudly, and a stale pin skips the
             # turn rather than answering on a provider the user never chose.
+            #
+            # IF YOU NEED NAMING TO STAY ON ONE VENDOR -- e.g. an evaluation
+            # cell pinned to anthropic that must not emit even a small openai
+            # call -- the fix is CONFIGURATION, not a rule here:
+            #   * configure only the providers you want used in that
+            #     session/cell (a candidate that is not mounted is refused), or
+            #   * select a provider-specific or custom routing matrix
+            #     (`amplifier routing use anthropic`, or your own file under
+            #     ~/.amplifier/routing/) so `fast` resolves inside the vendor.
+            # Either keeps naming cheap AND single-vendor without re-adding a
+            # code path that silently overrides the user's matrix.
             provider = None
             provider_name: str | None = None
             model_override: str | None = None


### PR DESCRIPTION
Follow-up to #375, comment-only.

After #375 a role candidate is honoured whenever it is mounted, whatever vendor answers the conversation. Anyone reading that site and thinking of an evaluation cell that must not emit even a small cross-vendor call now finds the answer next to the code:

- configure only the providers you want used in that session/cell (a candidate that is not mounted is refused), or
- select a provider-specific or custom routing matrix (`amplifier routing use anthropic`, or your own file under `~/.amplifier/routing/`) so `fast` resolves inside the vendor.

Either keeps naming cheap *and* single-vendor without re-adding a code path that silently overrides the user's matrix. Same guidance added to the README under "Keeping naming on one vendor".

38 module tests, ruff clean. No behaviour change.