### PR TITLE
docs+test: close three gaps #373 left, and pin them -- the docs still taught what the validators now warn about

### DIFF
--- a/context/shared/description-authoring-principles.md
+++ b/context/shared/description-authoring-principles.md
@@ -31,6 +31,21 @@
 > head on a host composing 86 tools where the eval container composed 14. Cite
 > it as a composition, never as "the head is 48k".
 >
+> **And the bytes are dollars, measured end-to-end on the daily driver.**
+> `model_performance-g7h3` bought 98 paired end-to-end tasks to price a leaner
+> head rather than argue it: **−13.57% $/task, 95% CI [−22.27%, −4.86%]**,
+> with all three pre-registered estimators excluding zero. Head bytes are not
+> a tidiness metric. They are the per-request bill of every session that
+> composes the bundle, whether the capability is used or not.
+>
+> **Per bundle, at the granularity an author works in:** android-tester's
+> three agents rendered **6,258 → 1,911 bytes** of `delegate` catalog after
+> that sweep — a 69.5% cut on one bundle's always-on line item. (UTF-8 bytes
+> of each description as stored plus the catalog line's own framing;
+> re-measured 2026-09-07 from that repo's pre- and post-sweep commits
+> `443e393` and `863afa1`. Its whole-bundle head cost over the same pair is
+> in V5.)
+>
 > **This scope statement exists because the previous one was implicit and
 > quietly stopped being true.** PR #341 set the no-`<example>` policy below in
 > 2026-08; it was applied inside `amplifier-foundation` and **nowhere else**.
@@ -179,6 +194,16 @@ was not (1.37x below the nearest). It is a WARNING, not an ERROR, because
 foundation's own root bundle exceeds it — that is a design conversation, not
 a build break.
 
+**One corroboration the threshold did not get to choose.** android-tester was
+swept by hand (lane `kp79`) before this check existed. Running Phase 2.86 over
+its pre- and post-sweep commits afterwards gives **8,116 → 3,791 chars** — the
+hand pass crossed a line it had never seen, from the wrong side to the right
+one. Over the same pair, the four checks go from **9 agent ERRORs**
+(`agent_description_excessive`, `example_block_present`, `commentary_present`)
+and 1 head-cost WARNING to **zero of either**. The thresholds and an
+independent human judgement of "short enough" agree; reproduce with
+`docs/lanes/8050-principles-to-tooling/run_checks.py`.
+
 Note what the anchors row shows: `bundles/anchors` mounts `tool-skills` with
 `visibility.enabled: false`, so its 1,261 chars of skill descriptions are
 **not** in the head. The check reports that amount separately as
@@ -295,7 +320,9 @@ stability, quality-neutrality — real every-turn wire savings) but must not
 be sold as delegation-behavior fixes. The lever is mechanical spawn budgets,
 not description wording — separate work.
 
-The wave measured delegation counts and wire sizes, not V5's token-ceiling
-thresholds — **agent `meta.description` budgets in V5 remain provisional.**
-It supplies real distribution data (8,060 / 14,562 / 16,461 chars across
-arms) but WARN/ERROR calibration is still open.
+The wave measured delegation counts and wire sizes, **not** ceiling
+calibration, and it is not the source of V5's caps. It supplies real
+distribution data (8,060 / 14,562 / 16,461 chars across arms); the caps come
+from the 2026-09-07 nine-repo corpus tabulated in V5, which is what moved the
+agent budget from provisional to **enforced**. Read this section as history,
+not as an open question — V5's table is the answer to it.

--- a/docs/AGENT_AUTHORING.md
+++ b/docs/AGENT_AUTHORING.md
@@ -58,7 +58,7 @@ meta:
 
 See `context/shared/description-authoring-principles.md` for trigger
 phrasing (decision rules over bare absolutes), the example policy (no
-`<example>` blocks, no `<commentary>`), and the token budget.
+`<example>` blocks, no `<commentary>`), and the character budget.
 
 ### Real Example
 
@@ -427,7 +427,11 @@ meta:
 
 ### The Behavior + Agent Pattern
 
-Pair your expert agent with a behavior that injects a thin awareness pointer:
+**The default behavior has no `context.include` at all.** The agent's own
+`meta.description` is the discovery surface — it is already concatenated into
+the `delegate` catalog and paid on every request. A context file that says
+"this domain exists, delegate to `my-expert`" is a second copy of that same
+sentence, paid twice:
 
 ```yaml
 # behaviors/my-expert.yaml
@@ -437,16 +441,20 @@ bundle:
 
 agents:
   include:
-    - my-bundle:my-expert    # Heavy agent file
-
-context:
-  include:
-    - my-bundle:context/my-awareness.md  # Thin pointer (~30 lines)
+    - my-bundle:my-expert    # Heavy agent file; its meta.description IS the pointer
 ```
 
-The thin awareness file tells root sessions: "This domain exists. Delegate to `my-bundle:my-expert`."
-
 The agent file carries all the heavy @mentions that only load when the agent is actually spawned.
+
+Add a `context.include` only when you can name something it says that the
+catalog line cannot — a cross-cutting hazard, a routing table to *other*
+bundles, or a prerequisite the session needs before any of the capabilities
+work. `validate-bundle-repo.yaml` Phase 2.84 warns
+(`awareness_is_pointer_only`) on a file that is when-to-use prose plus a
+`delegate(`/`load_skill(` pointer, which is precisely the file this section
+used to recommend. The full test, the three legitimate content types, and the
+four rules are in
+[BUNDLE_GUIDE.md — Awareness: concept + trigger + pointer](BUNDLE_GUIDE.md#awareness-concept--trigger--pointer).
 
 ### Anti-Pattern: Heavy Context in Behaviors
 
@@ -457,16 +465,21 @@ context:
     - my-bundle:docs/FULL_GUIDE.md      # 500 lines in every session!
     - my-bundle:docs/REFERENCE.md       # More bloat
 
-# ✅ GOOD: Thin pointer in behavior, heavy docs in agent
+# ❌ ALSO BAD: a file whose whole content is "domain exists, delegate to X"
 context:
   include:
-    - my-bundle:context/awareness.md    # 30 lines: "domain exists, delegate"
+    - my-bundle:context/awareness.md    # duplicates the agent's own description
 
-# ✅ EVEN BETTER: No always-on context at all when an expert agent owns the domain
+# ✅ GOOD: no always-on context at all when an expert agent owns the domain
 agents:
   include:
     - my-bundle:my-expert    # Agent meta.description IS the discovery surface
 # (no context.include block needed — the agent catalog tells the LLM "this exists")
+
+# ✅ ALSO GOOD: always-on context that carries what no description can
+context:
+  include:
+    - my-bundle:context/hazards.md      # a hazard true of EVERY agent in the bundle
 ```
 
 ### Hard policy: behavior `context.include` token budget

--- a/docs/BUNDLE_GUIDE.md
+++ b/docs/BUNDLE_GUIDE.md
@@ -1310,12 +1310,16 @@ agents:
 
 ```yaml
 # behaviors/my-domain-with-awareness.yaml
-# Acceptable variant: a tiny breadcrumb if delegation isn't reliable enough
-# in the target audience of this behavior. Keep it under 500 tokens.
+# Variant: always-on context that carries what the catalog line CANNOT --
+# a cross-cutting hazard, a routing table to other bundles, a prerequisite.
+# NOT "this domain exists, delegate to my-domain-expert": that duplicates the
+# agent's own meta.description, and validate-bundle-repo.yaml Phase 2.84
+# warns on it (awareness_is_pointer_only). See "Awareness: concept + trigger
+# + pointer" above for the test this file has to pass.
 
 context:
   include:
-    - my-bundle:context/my-domain-awareness.md    # ~30 lines, "domain exists, delegate"
+    - my-bundle:context/my-domain-hazards.md    # true of EVERY agent in the bundle
 ```
 
 **Worked example (bad — anti-pattern):**

--- a/docs/lanes/8050-principles-to-tooling/DONE-NOTE.md
+++ b/docs/lanes/8050-principles-to-tooling/DONE-NOTE.md
@@ -1,0 +1,323 @@
+# DONE-NOTE — model_performance-8050
+
+**Encode the awareness/description principles into the authoring docs, creation
+skills, and validators.**
+
+Terminal outcome: **A — RESOLVED**, with a finding the goal did not anticipate:
+**this item is a duplicate of `model_performance-pwmy`, whose PR #373 merged to
+`origin/main` as `5f0f04b` at 12:27 PT on 2026-09-07 — before this lane's first
+tool call.** Both items quote the same owner directive verbatim, both were
+created 2026-09-07, and `pwmy`'s deliverable list is 8050's deliverable list.
+
+So this lane did not re-implement shipped work. It did three things instead:
+
+1. **Independently verified** every deliverable against the merged code —
+   re-running the fail-before/pass-after counts and both recipes' checks from a
+   clean base rather than quoting `pwmy`'s DONE-NOTE back at itself.
+2. **Closed the gaps that verification found** — three of them, all real, all
+   in `pwmy`'s own scope, one of them a creation surface still teaching the
+   defect the new validator warns about.
+3. **Filed the follow-up 8050 required and nobody had** — the skills-bundle
+   half of (c), which was sitting in an artifact directory with no queue item.
+
+Spend against the **$0** authority: **$0**. No API measurement, no DTU, no
+scratch session. Every number below came from executing recipe step bodies and
+`git archive` on local checkouts.
+
+---
+
+## 1. The supersession, established rather than assumed
+
+| | `model_performance-pwmy` | `model_performance-8050` |
+|---|---|---|
+| Owner directive | verbatim, 2026-09-07 | **the same text, verbatim** |
+| (a) docs | ✔ | ✔ |
+| (b) four validator checks + fail-before | ✔ | ✔ |
+| (c) creation skills + skills-bundle scope boundary | ✔ | ✔ |
+| (d) refresh entry point | ✔ | ✔ |
+| Landed | **PR #373, MERGED `5f0f04b`** | this PR |
+
+`git merge-base --is-ancestor 5f0f04b HEAD` → true.
+
+**This lane's worktree launched 22 commits behind.** It was cut from
+`origin/main` at `df8a266`; by first tool call `origin/main` was `cfd0e23`, and
+`5f0f04b` (PR #373) sat between them. Had this lane trusted its base and worked
+from `df8a266`, it would have re-written all four validator checks, all three
+docs and the refresh recipe from scratch and opened a competing PR. The first
+action taken here was `git fetch` + `git log HEAD..origin/main`, and it is the
+only reason that did not happen. **This is `model_performance-napw` (stale lane
+base → published false negative) recurring with a different blast radius**, and
+it is the single most transferable finding in this note: *fetch before you
+believe your own base.*
+
+---
+
+## 2. Independent verification of the merged work
+
+Nothing here is quoted from `pwmy`'s note. Each row was re-run in this worktree
+on 2026-09-07.
+
+### 2.1 Fail-before / pass-after, reproduced
+
+```
+git worktree add --detach /tmp/foundation-pre-8050 4384805
+ALIGNMENT_RECIPE_DIR=/tmp/foundation-pre-8050/recipes uv run pytest \
+    tests/test_description_alignment_checks.py -q
+```
+
+| Recipes under test | Result |
+|---|---|
+| `origin/main` **4384805** (pre-#373) | **23 failed, 1 passed** |
+| `HEAD` **cfd0e23** (post-#373) | **24 passed** |
+
+Matches `pwmy`'s published counts exactly. The single test that passes at
+4384805 is the one that should: a 599-char clean description is clean under
+both the old token gate and the new char gate.
+
+### 2.2 Both recipes' checks, re-run on foundation and anchors-amp-dev
+
+Executed via `docs/lanes/8050-principles-to-tooling/run_checks.py`, which
+imports the step-body extractor from `tests/test_description_alignment_checks.py`
+and therefore runs **the recipes' own bodies**, never a re-implementation.
+
+| Target | agents | skills | awareness | head cost | `validate-agents` structural |
+|---|---|---|---|---|---|
+| foundation `HEAD` | 24 checked, **0 err / 5 warn** (`agent_description_high`) | 3 checked, **0 err / 1 warn** | 7 files, **0 warn**, max coverage **0.111** | 19 bundles, **3 warn**, largest **26,368** | 24 agents, **0 err / 6 warn** |
+| `bundles/anchors-amp-dev` | 1 checked, **0 err / 0 warn** | 0 (no SKILL.md) | 1 file, **0 warn** | 1 bundle, **0 warn**, **1,760** | 1 agent, **0 err / 0 warn** |
+
+Every figure reproduces `pwmy` §5, including the 26,368 largest-head-cost
+number and the 6th `validate-agents` warning (`NO_TOOLS_SECTION` on the
+deliberate `examples/agents/file-responder.md` fixture, which four prior lanes
+have each reported and correctly left alone).
+
+Raw output: `evidence/checks-foundation-main.json`,
+`evidence/checks-anchors-amp-dev.json`.
+
+### 2.3 NEW — the checks agree with a hand sweep they never saw
+
+Neither `pwmy` nor 8050 asked for this, and it is the strongest evidence in
+either lane that the thresholds are calibrated rather than chosen.
+
+`amplifier-bundle-android-tester` was swept **by hand** (lane `kp79`) *before*
+Phase 2.82/2.84/2.86 existed. Exporting that repo at its pre- and post-sweep
+commits with `git archive` (read-only; that repo was not written to) and
+running all four checks over both:
+
+| | agents | skills | head cost | verdict |
+|---|---|---|---|---|
+| pre-sweep `443e393` | **9 ERRORs** — `agent_description_excessive`, `example_block_present`, `commentary_present` | 0 err / 1 warn | **8,116** chars, **1 WARNING** | fails |
+| post-sweep `863afa1` | **0 err / 0 warn** | **0 err / 0 warn** | **3,791** chars, **0 warnings** | clean |
+
+The hand pass crossed the 4,000-char head-cost line from the wrong side to the
+right one, on a threshold derived later from a *different* corpus (8 bundles,
+none of them this one). A machine rule and an independent human judgement of
+"short enough" landing on the same side is the calibration argument the
+threshold could not make for itself.
+
+Per-description, same pair, rendered `delegate`-catalog bytes (UTF-8 bytes of
+the description as stored, plus the catalog line's own `  - <bundle>:<name>: `
+framing and newline):
+
+| agent | pre | post |
+|---|---:|---:|
+| `android-debugger` | 2,122 | 598 |
+| `android-operator` | 2,271 | 594 |
+| `android-visual-tester` | 1,746 | 600 |
+| framing | 119 | 119 |
+| **total** | **6,258** | **1,911** |
+
+Both totals match the figures the item asserted, to the byte. That is now cited
+in `description-authoring-principles.md` with the method and the two commits, so
+the next reader can reproduce it instead of trusting it.
+
+Raw output: `evidence/checks-android-tester-{pre,post}-sweep-*.json`.
+
+---
+
+## 3. The three gaps verification found, and closed
+
+Each is a defect *inside* `pwmy`'s scope, found by checking its claims against
+the merged files rather than reading its summary.
+
+### G1 — two creation surfaces still teach the pattern Phase 2.84 warns about
+
+`pwmy` corrected `agents/bundle-design-expert.md`, whose build checklist said
+"Create awareness context — ~25-40 lines, domain exists, delegate to expert".
+**It left the same instruction in two documents:**
+
+* `docs/AGENT_AUTHORING.md` §"The Behavior + Agent Pattern" opened by telling
+  authors to pair the agent with a behavior injecting a *"thin awareness
+  pointer (~30 lines)"* that *"tells root sessions: This domain exists. Delegate
+  to `my-bundle:my-expert`"* — and then, 18 lines later, said "EVEN BETTER: no
+  always-on context at all". The wrong version was the headline; the right one
+  was a parenthetical.
+* `docs/BUNDLE_GUIDE.md` labelled the same file an **"Acceptable variant"** in a
+  worked example — in the same document whose new §"Awareness: concept +
+  trigger + pointer" says that file is exactly what
+  `awareness_is_pointer_only` warns on.
+
+This is worse than an unenforced convention. An author who followed the doc
+earned a WARNING the doc told them to earn — the same shape as `personafy`
+instructing a ~700–800-char cap against a 400-char enforced one, which `pwmy`
+itself identified as the reason creation surfaces matter.
+
+**Fixed.** The default behavior now ships *no* `context.include`; the agent's
+own `meta.description` is named as the discovery surface; a `context.include`
+is added only for something the catalog line cannot say, cross-referenced to
+BUNDLE_GUIDE's section rather than restated (V1). The phrase survives in both
+files only under a ❌ marker, and a test pins that.
+
+### G2 — the principles doc contradicted its own enforced table
+
+V5 marks the agent cap **Enforced** with a nine-repo corpus behind it. The
+closing "Settled" section still read *"agent `meta.description` budgets in V5
+remain provisional … WARN/ERROR calibration is still open"* — a second copy of
+the rule, disagreeing with the first, in the file whose own V1 says a rule
+stated twice "can drift from the first and force the model to arbitrate between
+two versions of your own instructions".
+
+**Fixed.** That paragraph now reads as history and points at V5 as the answer.
+
+### G3 — two measured citations the item required were absent
+
+The item named them explicitly; neither was in any of the three docs.
+
+* **`g7h3`'s −13.57% $/task, 95% CI [−22.27%, −4.86%]**, all three
+  pre-registered estimators excluding zero, from 98 paired end-to-end tasks on
+  the daily driver. `pwmy`'s DONE-NOTE §3 states this "is cited in the
+  head-cost WHY" of AGENT_AUTHORING; `grep -c 13.57` over all three docs
+  returned **0**. Without it the WHY was argued entirely in bytes, and bytes
+  are what people argue with.
+* **android-tester's 6,258 → 1,911 catalog bytes** — the per-bundle
+  granularity a bundle author actually works in. `pwmy` substituted dot-graph
+  and `zc6t` figures, which are repo- and composition-level.
+
+**Fixed**, both with their units and their provenance, and both verified here
+rather than copied (§2.3).
+
+---
+
+## 4. What is pinned so it cannot silently return
+
+`tests/test_description_docs_alignment.py` — 8 tests, deliberately narrow
+string pins on the *contradiction* rather than the prose around it, so the docs
+stay editable.
+
+| Recipes/docs under test | Result |
+|---|---|
+| `origin/main` **cfd0e23** | **7 failed, 1 passed** |
+| this branch | **8 passed** |
+
+The one that passes at `cfd0e23` is the one that should:
+`test_agent_authoring_points_at_the_canonical_awareness_section` — #373 already
+added that cross-reference; what it did not do was remove the contradicting
+guidance further down the same file.
+
+---
+
+## 5. Deliverables, per 8050
+
+| Deliverable | State |
+|---|---|
+| (a) Docs updated, citing the measured numbers | **DONE** — shipped by #373; **two required citations were missing and are added here** (§3 G3), plus a self-contradiction removed (§3 G2) |
+| (b) Four checks + fail-before tests, both recipes re-run on foundation AND anchors-amp-dev with results quoted | **DONE** — shipped by #373; **independently reproduced here**, §2.1–2.2, with one *added* real-repo demonstration §2.3 |
+| (c) Creation skills emit compliant descriptions by default | **DONE** — foundation-owned surfaces shipped by #373; **two that still emitted the defect are fixed here** (§3 G1). Skills-bundle half is out of this lane's single-repo checkout — see below |
+| (d) Refresh entry point, documented and demonstrated | **DONE** — `recipes/refresh-descriptions.yaml`, BUNDLE_GUIDE §"Refreshing descriptions", demonstrated clean-room against `kp79`'s hand sweep of browser-tester (#373) |
+| Refresh path demonstrated on a Stage-1 repo vs the kp79 lane's output | **DONE** — browser-tester (#373); this lane adds an independent **android-tester** cross-check of the *checks* against the same lane's hand output (§2.3) |
+| Out-of-scope work stated, not dropped | **DONE** — §6 |
+
+---
+
+## 6. Scope boundary, and the follow-up that was missing
+
+`skillify`, `personafy`, `councilify` and `skills-assist/authoring-guide.md`
+live in **`microsoft/amplifier-bundle-skills`**, which this lane's worktree does
+not cover and its goal forbids checking out. `pwmy` shipped drop-in patches for
+all four as an artifact
+(`docs/lanes/pwmy-principles-to-tooling/patches/skills-bundle-description-alignment.md`),
+because that repo was held by `smy5-patch-skills`.
+
+**A patch in an artifact directory with no queue item is a patch that does not
+get applied.** 8050 required a *linked follow-up* for exactly this case. The
+queue was checked on 2026-09-07 — 31 open items, none tracking it — so this
+lane filed:
+
+> **`model_performance-jlo6`** — *Apply the shipped skills-bundle
+> description-alignment patch (personafy / skillify / councilify /
+> skills-assist) — the creation skills still emit over-cap descriptions.*
+> Linked `follow-up-of` `pwmy` and `relates-to` `8050`. Carries the measured
+> defect (personafy instructs ~700–800 chars against a 400-char enforced cap;
+> that bundle measures 13 of 31 skills over the cap, 4 over the ERROR line) and
+> `pwmy`'s already-measured fail-before/pass-after (skillify 453→353,
+> personafy 714→391), so whoever picks it up does not re-derive any of it.
+
+Nothing else in 8050 is out of scope.
+
+---
+
+## 7. Findings reported, not fixed
+
+**F1 — a lane's worktree can launch behind `origin/main` far enough to hide a
+merged duplicate of its own item.** This lane launched 22 commits behind, and
+the commit that had already done its work sat in that gap. Distinct from
+`model_performance-napw` only in blast radius: napw published a false negative,
+this would have published a duplicate PR and a duplicate resolution. **A
+`git fetch && git log HEAD..origin/main` before the first substantive action
+should be in the goal template, not in each lane's judgement.**
+
+**F2 — two items were opened for one owner directive**, 8050 and `pwmy`, with
+byte-comparable descriptions. Both were claimable; both were claimed. The
+`discovered-from` / `relates-to` edges that would have shown this exist and were
+not used at creation time. Same family as `model_performance-40d8` (one item
+fanned to multiple lanes) inverted: multiple items for one job.
+
+**F3 — `pwmy`'s DONE-NOTE §3 over-claims one citation.** It states `g7h3`'s
+$/task figure "is cited in the head-cost WHY"; it was not in the merged file.
+Not a fabrication — the claim is about a doc edit that did not land — but it is
+the reason this note verified rather than quoted, and the reason §2 re-runs
+everything. Recorded so the next reader of that note knows which line to
+distrust; the rest of it verified exactly.
+
+**F4 — the `AWARENESS_INDEX.md` question is untouched here.**
+`context/shared/AWARENESS_INDEX.md` exists and was not part of either item's
+scope; whether it is itself subject to Phase 2.84's rules is a separate
+question nobody has asked.
+
+---
+
+## 8. Verification
+
+```
+uv run pytest -q        2110 passed, 4 skipped, 1 warning in 25.07s
+```
+
+**Zero failures.** Worth stating plainly, because `pwmy`'s note recorded
+`2087 passed, 3 skipped, 2 failed` and named both failures as pre-existing at
+`4384805`. Both now pass at `cfd0e23`; the three commits merged after #373
+(#375, #376, #377) close the gap. No test was skipped, xfailed or deselected to
+get here.
+
+Also green, and worth naming because it is the trap `pwmy` reported as F3:
+`TestDiscoveryScopeParity` and the shipped-skill-count pin. This lane commits
+one `.py` and four `.json` files under `docs/lanes/` and **no `SKILL.md`**, so
+the repo's shipped-skill count stays 3 and its head-cost figures do not move.
+
+**Census safety** (`GOAL.md`): no `amplifier` binary was run on this host at
+any point in this lane, with or without a scratch `AMPLIFIER_HOME`. The
+guard `grep -l /tmp/ ~/.local/share/uv/tools/amplifier/lib/python3.13/site-packages/*.pth`
+was checked before the completion marker.
+
+---
+
+## 9. What remains open
+
+1. **`model_performance-jlo6`** — apply the skills-bundle patch (§6).
+2. **Foundation's own 5 over-cap agent descriptions** (761/721/669/647/631) stay
+   WARNINGs. `pwmy` left them deliberately; re-sweeping them is a separate item
+   and `validate-agents`' report step already produced rewrites with fidelity
+   tables for all five.
+3. **F1's goal-template change** — fetch-before-you-trust-your-base.
+4. `pwmy`'s own open list (F1 `no_composable_surface` false positive, F2
+   anchors-amp-dev README include order, F4 `validate-agents` on Windows, F5
+   `publication/v1` step ordering, R1's never-fired threshold) is unchanged by
+   this lane and still stands.

--- a/docs/lanes/8050-principles-to-tooling/evidence/checks-anchors-amp-dev.json
+++ b/docs/lanes/8050-principles-to-tooling/evidence/checks-anchors-amp-dev.json
@@ -1,0 +1,35 @@
+{
+  "label": "anchors-amp-dev",
+  "repo_path": "/home/bkrabach/dev/hw-model-performance/lanes/8050-principles-to-tooling/amplifier-foundation/bundles/anchors-amp-dev",
+  "agents": {
+    "checked": 1,
+    "errors": 0,
+    "warnings": 0,
+    "error_types": [],
+    "warning_types": []
+  },
+  "skills": {
+    "checked": 0,
+    "errors": 0,
+    "warnings": 0,
+    "error_types": [],
+    "warning_types": []
+  },
+  "awareness": {
+    "files": 1,
+    "best_coverage_max": 0,
+    "warnings": 0,
+    "warning_types": []
+  },
+  "head_cost": {
+    "bundles": 1,
+    "warnings": 0,
+    "largest_head_chars": 1760,
+    "threshold_chars": 4000
+  },
+  "validate_agents_structural": {
+    "agents": 1,
+    "errors": 0,
+    "warnings": 0
+  }
+}

--- a/docs/lanes/8050-principles-to-tooling/evidence/checks-android-tester-post-sweep-863afa1.json
+++ b/docs/lanes/8050-principles-to-tooling/evidence/checks-android-tester-post-sweep-863afa1.json
@@ -1,0 +1,35 @@
+{
+  "label": "android-tester-post-sweep-863afa1",
+  "repo_path": "/tmp/at-post",
+  "agents": {
+    "checked": 3,
+    "errors": 0,
+    "warnings": 0,
+    "error_types": [],
+    "warning_types": []
+  },
+  "skills": {
+    "checked": 1,
+    "errors": 0,
+    "warnings": 0,
+    "error_types": [],
+    "warning_types": []
+  },
+  "awareness": {
+    "files": 1,
+    "best_coverage_max": 0.043,
+    "warnings": 0,
+    "warning_types": []
+  },
+  "head_cost": {
+    "bundles": 2,
+    "warnings": 0,
+    "largest_head_chars": 3791,
+    "threshold_chars": 4000
+  },
+  "validate_agents_structural": {
+    "agents": 3,
+    "errors": 0,
+    "warnings": 3
+  }
+}

--- a/docs/lanes/8050-principles-to-tooling/evidence/checks-android-tester-pre-sweep-443e393.json
+++ b/docs/lanes/8050-principles-to-tooling/evidence/checks-android-tester-pre-sweep-443e393.json
@@ -1,0 +1,41 @@
+{
+  "label": "android-tester-pre-sweep-443e393",
+  "repo_path": "/tmp/at-pre",
+  "agents": {
+    "checked": 3,
+    "errors": 9,
+    "warnings": 0,
+    "error_types": [
+      "agent_description_excessive",
+      "commentary_present",
+      "example_block_present"
+    ],
+    "warning_types": []
+  },
+  "skills": {
+    "checked": 1,
+    "errors": 0,
+    "warnings": 1,
+    "error_types": [],
+    "warning_types": [
+      "skill_description_high"
+    ]
+  },
+  "awareness": {
+    "files": 1,
+    "best_coverage_max": 0.087,
+    "warnings": 0,
+    "warning_types": []
+  },
+  "head_cost": {
+    "bundles": 2,
+    "warnings": 1,
+    "largest_head_chars": 8116,
+    "threshold_chars": 4000
+  },
+  "validate_agents_structural": {
+    "agents": 3,
+    "errors": 9,
+    "warnings": 3
+  }
+}

--- a/docs/lanes/8050-principles-to-tooling/evidence/checks-foundation-main.json
+++ b/docs/lanes/8050-principles-to-tooling/evidence/checks-foundation-main.json
@@ -1,0 +1,39 @@
+{
+  "label": "foundation-main",
+  "repo_path": "/home/bkrabach/dev/hw-model-performance/lanes/8050-principles-to-tooling/amplifier-foundation",
+  "agents": {
+    "checked": 24,
+    "errors": 0,
+    "warnings": 5,
+    "error_types": [],
+    "warning_types": [
+      "agent_description_high"
+    ]
+  },
+  "skills": {
+    "checked": 3,
+    "errors": 0,
+    "warnings": 1,
+    "error_types": [],
+    "warning_types": [
+      "skill_description_high"
+    ]
+  },
+  "awareness": {
+    "files": 7,
+    "best_coverage_max": 0.111,
+    "warnings": 0,
+    "warning_types": []
+  },
+  "head_cost": {
+    "bundles": 19,
+    "warnings": 3,
+    "largest_head_chars": 26368,
+    "threshold_chars": 4000
+  },
+  "validate_agents_structural": {
+    "agents": 24,
+    "errors": 0,
+    "warnings": 6
+  }
+}

--- a/docs/lanes/8050-principles-to-tooling/run_checks.py
+++ b/docs/lanes/8050-principles-to-tooling/run_checks.py
@@ -1,0 +1,83 @@
+"""Run the four description-alignment checks against an arbitrary repo path.
+
+Independent verification harness for model_performance-8050. It imports the
+step-body extractor from ``tests/test_description_alignment_checks.py`` so it
+executes the RECIPES' own bodies -- never a re-implementation, which is the
+failure mode the checks exist to catch.
+
+    python docs/lanes/8050-principles-to-tooling/run_checks.py <repo_path> [label]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tests.test_description_alignment_checks import (  # noqa: E402
+    run_agents_structural,
+    run_repo_step,
+)
+
+
+def summarise(repo: Path, label: str) -> dict:
+    agents = run_repo_step("agent-description-validation", repo)
+    skills = run_repo_step("skill-description-validation", repo)
+    awareness = run_repo_step("awareness-redundancy-check", repo)
+    head = run_repo_step("bundle-head-cost", repo)
+
+    def counts(r: dict) -> tuple[int, int]:
+        return len(r.get("errors", [])), len(r.get("warnings", []))
+
+    bundles = head.get("bundle_details", [])
+    largest = max((b.get("head_chars", 0) for b in bundles), default=0)
+
+    out = {
+        "label": label,
+        "repo_path": str(repo),
+        "agents": {
+            "checked": agents.get("agents_checked", len(agents.get("agent_details", []))),
+            "errors": counts(agents)[0],
+            "warnings": counts(agents)[1],
+            "error_types": sorted({e.get("type") for e in agents.get("errors", [])}),
+            "warning_types": sorted({w.get("type") for w in agents.get("warnings", [])}),
+        },
+        "skills": {
+            "checked": skills.get("skills_checked", len(skills.get("skill_details", []))),
+            "errors": counts(skills)[0],
+            "warnings": counts(skills)[1],
+            "error_types": sorted({e.get("type") for e in skills.get("errors", [])}),
+            "warning_types": sorted({w.get("type") for w in skills.get("warnings", [])}),
+        },
+        "awareness": {
+            "files": len(awareness.get("file_details", awareness.get("files", []))),
+            "best_coverage_max": max((f.get("best_coverage", 0) or 0 for f in awareness.get("file_details", [])), default=0),
+            "warnings": counts(awareness)[1],
+            "warning_types": sorted({w.get("type") for w in awareness.get("warnings", [])}),
+        },
+        "head_cost": {
+            "bundles": len(bundles),
+            "warnings": counts(head)[1],
+            "largest_head_chars": largest,
+            "threshold_chars": head.get("threshold_chars"),
+        },
+    }
+    try:
+        structural = run_agents_structural(repo)
+        out["validate_agents_structural"] = {
+            "agents": len(structural.get("agents", [])),
+            "errors": sum(len(a.get("errors", [])) for a in structural.get("agents", [])),
+            "warnings": sum(len(a.get("warnings", [])) for a in structural.get("agents", [])),
+        }
+    except Exception as exc:  # pragma: no cover - reported, never swallowed
+        out["validate_agents_structural"] = {"error": f"{type(exc).__name__}: {exc}"}
+    return out
+
+
+if __name__ == "__main__":
+    path = Path(sys.argv[1]).resolve()
+    label = sys.argv[2] if len(sys.argv) > 2 else path.name
+    print(json.dumps(summarise(path, label), indent=2))

--- a/tests/test_description_docs_alignment.py
+++ b/tests/test_description_docs_alignment.py
@@ -1,0 +1,159 @@
+"""The authoring docs must not teach what the validators now warn about.
+
+`validate-bundle-repo.yaml` Phase 2.84 (shipped in PR #373) warns
+`awareness_is_pointer_only` on a `context.include` file that is when-to-use
+prose plus a `delegate(`/`load_skill(` pointer. That PR corrected the rule in
+`agents/bundle-design-expert.md` and added BUNDLE_GUIDE's
+"Awareness: concept + trigger + pointer" section -- but left TWO older
+passages that still recommend building exactly that file:
+
+  * ``docs/AGENT_AUTHORING.md`` -- "The Behavior + Agent Pattern" opened by
+    telling authors to pair the agent with a behavior injecting a "thin
+    awareness pointer (~30 lines)" that "tells root sessions: this domain
+    exists, delegate to my-expert".
+  * ``docs/BUNDLE_GUIDE.md`` -- a worked example labelled the same file an
+    "Acceptable variant".
+
+A creation surface that emits the defect by default is the exact failure this
+whole item exists to close, and it is worse than an unenforced convention: the
+author who follows the doc gets a WARNING from the validator that the doc told
+them to earn. Same class as `personafy` instructing a ~700-800 char cap
+against a 400-char enforced one.
+
+These are string pins, and they are FAIL-BEFORE: every assertion below fails
+on ``origin/main`` at cfd0e23 and passes on this branch. They are deliberately
+narrow -- they pin the *contradiction*, not the prose around it, so the docs
+stay editable.
+
+Refs: model_performance-8050, model_performance-pwmy
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+AGENT_AUTHORING = REPO_ROOT / "docs" / "AGENT_AUTHORING.md"
+BUNDLE_GUIDE = REPO_ROOT / "docs" / "BUNDLE_GUIDE.md"
+PRINCIPLES = REPO_ROOT / "context" / "shared" / "description-authoring-principles.md"
+
+#: The section every doc that touches awareness files must point at rather
+#: than restate (description-authoring-principles.md V1).
+AWARENESS_SECTION_ANCHOR = "awareness-concept--trigger--pointer"
+
+
+def _text(path: Path) -> str:
+    assert path.exists(), f"{path} is missing; this test pins its content"
+    return path.read_text(encoding="utf-8")
+
+
+def _squash(text: str) -> str:
+    """Collapse whitespace so a reflow does not break a phrase pin."""
+    return re.sub(r"\s+", " ", text)
+
+
+# =============================================================================
+# 1. The pointer-only awareness file is not recommended anywhere
+# =============================================================================
+
+
+def test_agent_authoring_does_not_recommend_a_pointer_only_awareness_file() -> None:
+    """AGENT_AUTHORING must not tell authors to build the file 2.84 warns on."""
+    body = _squash(_text(AGENT_AUTHORING))
+    assert 'The thin awareness file tells root sessions: "This domain exists.' not in body, (
+        "AGENT_AUTHORING still recommends a pointer-only awareness file, which "
+        "validate-bundle-repo.yaml Phase 2.84 warns on as awareness_is_pointer_only"
+    )
+    assert "# Thin pointer (~30 lines)" not in body, (
+        "the Behavior + Agent Pattern example still ships a pointer-only context.include"
+    )
+
+
+def test_agent_authoring_points_at_the_canonical_awareness_section() -> None:
+    """It must cross-reference rather than restate the rule (V1)."""
+    assert AWARENESS_SECTION_ANCHOR in _text(AGENT_AUTHORING), (
+        "AGENT_AUTHORING must link BUNDLE_GUIDE's awareness section instead of "
+        "carrying its own second copy of the rule"
+    )
+
+
+def test_bundle_guide_does_not_call_a_pointer_only_file_an_acceptable_variant() -> None:
+    """One document must not answer the same question two different ways."""
+    body = _squash(_text(BUNDLE_GUIDE))
+    assert "Acceptable variant: a tiny breadcrumb" not in body, (
+        "BUNDLE_GUIDE's worked example still blesses the pointer-only awareness "
+        "file its own 'Awareness: concept + trigger + pointer' section warns about"
+    )
+    assert '# ~30 lines, "domain exists, delegate"' not in body
+
+
+@pytest.mark.parametrize("path", [AGENT_AUTHORING, BUNDLE_GUIDE])
+def test_the_phrase_survives_only_as_a_named_anti_pattern(path: Path) -> None:
+    """`domain exists, delegate` may still appear -- but only as the thing NOT to do.
+
+    Pinned rather than banned outright: naming the anti-pattern is how a reader
+    who already built one recognises it. What must not survive is the phrase
+    presented as guidance.
+    """
+    for line in _text(path).splitlines():
+        if "domain exists, delegate" not in line.lower():
+            continue
+        assert any(marker in line for marker in ("❌", "NOT ", "not ", "second copy")), (
+            f"{path.name}: {line.strip()!r} presents the pointer-only pattern as "
+            "guidance rather than as an anti-pattern"
+        )
+
+
+# =============================================================================
+# 2. The enforced caps are not simultaneously described as open
+# =============================================================================
+
+
+def test_the_principles_doc_does_not_call_the_enforced_agent_cap_provisional() -> None:
+    """V5 says Enforced; the closing section used to say the opposite.
+
+    Two versions of the same rule in one file is the defect V1 of that very
+    file describes -- "a second copy that can drift from the first and force
+    the model to arbitrate between two versions of your own instructions".
+    """
+    body = _squash(_text(PRINCIPLES))
+    assert "**Enforced**" in body, "V5's table must still mark the agent cap enforced"
+    assert "agent `meta.description` budgets in V5 remain provisional" not in body, (
+        "the closing section still contradicts V5's enforced table"
+    )
+    assert "WARN/ERROR calibration is still open" not in body
+
+
+# =============================================================================
+# 3. The WHY is paid for with measurements, not taste
+# =============================================================================
+
+
+def test_the_dollar_cost_of_head_bytes_is_cited() -> None:
+    """A rule justified only in bytes gets argued with; one priced in dollars does not.
+
+    `model_performance-g7h3` bought 98 paired end-to-end tasks on the daily
+    driver. The item that commissioned these docs named this citation
+    explicitly and it was missing.
+    """
+    body = _squash(_text(PRINCIPLES))
+    assert "−13.57% $/task" in body or "-13.57% $/task" in body
+    assert "[−22.27%, −4.86%]" in body or "[-22.27%, -4.86%]" in body
+
+
+def test_a_per_bundle_catalog_cost_is_cited_with_its_unit() -> None:
+    """Per-bundle is the granularity a bundle author actually works in.
+
+    6,258 -> 1,911 rendered `delegate` catalog bytes across android-tester's
+    three agents, re-measured from that repo's pre-/post-sweep commits. The
+    unit has to travel with the number: bytes of description as stored plus the
+    catalog line's own framing.
+    """
+    body = _squash(_text(PRINCIPLES))
+    assert "6,258 → 1,911 bytes" in body
+    assert "443e393" in body and "863afa1" in body, (
+        "the commits the figure was measured from must be named so it is reproducible"
+    )


### PR DESCRIPTION
## What this is

`model_performance-8050` is a **duplicate** of `model_performance-pwmy` — same
owner directive verbatim, same deliverable list, both opened 2026-09-07.
`pwmy`'s **PR #373 merged as `5f0f04b`** before this lane's first tool call.

So this branch does not re-implement it. It **verifies #373 independently**,
**closes three gaps that verification found**, and **pins them with tests**.

## The near miss, first

This lane's worktree was cut at `df8a266` — **22 commits behind `origin/main`,
with `5f0f04b` inside that gap.** Trusting its own base would have meant
rewriting four validator checks, three docs and a refresh recipe from scratch
and opening a competing PR against merged work. `git fetch && git log
HEAD..origin/main` as the first action is the only reason that did not happen.
Same family as `model_performance-napw`, different blast radius. **Recommend
this goes in the goal template.**

## Three gaps, all inside #373's own scope

**G1 — two creation surfaces still teach the pattern Phase 2.84 warns about.**
#373 fixed `bundle-design-expert`'s "create awareness context — domain exists,
delegate to expert" checklist item and left the identical instruction in two
documents:

* `docs/AGENT_AUTHORING.md` §"The Behavior + Agent Pattern" **opened** with a
  *"thin awareness pointer (~30 lines)"* that *"tells root sessions: This
  domain exists. Delegate to `my-bundle:my-expert`"* — then said "EVEN BETTER:
  no always-on context at all" 18 lines later. Wrong version as the headline,
  right one as a parenthetical.
* `docs/BUNDLE_GUIDE.md` called the same file an **"Acceptable variant"** — in
  the same document whose new §"Awareness: concept + trigger + pointer" says it
  is exactly what `awareness_is_pointer_only` fires on.

An author who followed the doc earned a WARNING the doc told them to earn.
Strictly worse than an unenforced convention, and the same shape as `personafy`
instructing a ~700–800 char cap against a 400-char enforced one — which #373
itself named as *why creation surfaces matter*.

**G2 — the principles doc contradicted its own enforced table.** V5 marks the
agent cap **Enforced** against a nine-repo corpus; the closing section still
read *"agent `meta.description` budgets in V5 remain provisional … WARN/ERROR
calibration is still open"*. A rule stated twice, disagreeing with itself, in
the file whose own V1 says that forces the model to arbitrate between two
versions of your own instructions.

**G3 — two required citations were absent.** `g7h3`'s **−13.57% $/task, 95% CI
[−22.27%, −4.86%]** — #373's DONE-NOTE says it "is cited in the head-cost WHY";
`grep -c 13.57` across all three docs returned **0**. Without it the WHY was
argued entirely in bytes, and bytes are what people argue with. And
android-tester's **6,258 → 1,911** rendered catalog bytes, the per-bundle
granularity an author actually works in.

## Independent verification — nothing quoted from the prior note

| | result |
|---|---|
| fail-before, `ALIGNMENT_RECIPE_DIR` → `4384805/recipes` | **23 failed, 1 passed** |
| pass-after, `HEAD` `cfd0e23` | **24 passed** |

| Target | agents | skills | awareness | head cost |
|---|---|---|---|---|
| foundation `HEAD` | 24 checked, **0 err / 5 warn** | 3, **0 / 1** | 7 files, **0 warn**, max coverage 0.111 | 19 bundles, **3 warn**, largest **26,368** |
| `bundles/anchors-amp-dev` | 1, **0 / 0** | — | 1 file, **0 warn** | **1,760**, 0 warn |

Every figure reproduces #373's published table.

## New: the checks agree with a hand sweep they never saw

Neither item asked for this, and it is the strongest calibration evidence in
either lane. `android-tester` was swept **by hand** (lane `kp79`) *before* Phase
2.82/2.84/2.86 existed:

| | agents | head cost |
|---|---|---|
| pre-sweep `443e393` | **9 ERRORs** (`agent_description_excessive`, `example_block_present`, `commentary_present`) | **8,116** → 1 WARNING |
| post-sweep `863afa1` | **0 err / 0 warn** | **3,791** → clean |

The hand pass crossed the 4,000-char line from the wrong side to the right one,
on a threshold derived later from a corpus that did not include it.

## Pinned

`tests/test_description_docs_alignment.py` — 8 narrow string pins on the
*contradiction*, not the prose around it.

| | result |
|---|---|
| `origin/main` `cfd0e23` | **7 failed, 1 passed** |
| this branch | **8 passed** |

The one that passes at main is the one that should: #373 *added* the
cross-reference; what it did not do was remove the contradicting guidance
further down the same file.

## Scope boundary + the follow-up that was missing

`skillify` / `personafy` / `councilify` / `skills-assist` live in
`amplifier-bundle-skills`, outside this lane's checkout. #373 shipped drop-in
patches as an artifact because that repo was held. **A patch in an artifact
directory with no queue item is a patch that does not get applied** — the queue
had 31 open items and none tracked it. Filed **`model_performance-jlo6`**,
linked `follow-up-of` `pwmy` / `relates-to` `8050`, carrying the measured defect
and the already-paid fail-before/pass-after.

## Verification

```
uv run pytest -q     2110 passed, 4 skipped     (0 failed)
```

**$0** of the $0 authority. No `amplifier` binary was run on this host at any
point; the census-safety `.pth` guard was checked clean.

Refs: `model_performance-8050`, `model_performance-pwmy`, `model_performance-g7h3`, `model_performance-kp79`, `model_performance-jlo6`
