### PR TITLE
feat(activator): add configurable install target seam

### DIFF
--- a/amplifier_foundation/modules/activator.py
+++ b/amplifier_foundation/modules/activator.py
@@ -67,6 +67,8 @@ class ModuleActivator:
         install_deps: bool = True,
         base_path: Path | None = None,
         strict: bool = False,
+        install_python: str | None = None,
+        install_constraints: Path | None = None,
     ) -> None:
         """Initialize module activator.
 
@@ -80,10 +82,18 @@ class ModuleActivator:
             strict: If True, activation failures in activate_all() raise
                     ModuleActivationError instead of being logged and skipped.
                     Mirrors BundleRegistry(strict=...) for include failures.
+            install_python: Python interpreter targeted by dependency installs.
+                Defaults to the current interpreter.
+            install_constraints: Optional uv constraints file passed to dependency
+                installs.
         """
         self.cache_dir = cache_dir or get_amplifier_home() / "cache"
         self.install_deps = install_deps
         self.strict = strict
+        self.install_python = (
+            install_python if install_python is not None else sys.executable
+        )
+        self.install_constraints = install_constraints
         self._resolver = SimpleSourceResolver(
             cache_dir=self.cache_dir, base_path=base_path
         )
@@ -497,7 +507,7 @@ class ModuleActivator:
                     "-e",
                     str(module_path),
                     "--python",
-                    sys.executable,
+                    self.install_python,
                     "--quiet",
                     # Ignore [tool.uv.sources] in the package's pyproject.toml.
                     # Modules use this section for dev convenience (pointing
@@ -507,6 +517,8 @@ class ModuleActivator:
                     # native toolchains (Rust, protobuf) that users don't have.
                     "--no-sources",
                 ]
+                if self.install_constraints is not None:
+                    cmd.extend(["--constraints", str(self.install_constraints)])
                 if overrides:
                     import tempfile
 
@@ -546,17 +558,20 @@ class ModuleActivator:
                     Path(overrides_file.name).unlink(missing_ok=True)
         elif requirements.exists():
             try:
+                cmd = [
+                    "uv",
+                    "pip",
+                    "install",
+                    "-r",
+                    str(requirements),
+                    "--python",
+                    self.install_python,
+                    "--quiet",
+                ]
+                if self.install_constraints is not None:
+                    cmd.extend(["--constraints", str(self.install_constraints)])
                 subprocess.run(
-                    [
-                        "uv",
-                        "pip",
-                        "install",
-                        "-r",
-                        str(requirements),
-                        "--python",
-                        sys.executable,
-                        "--quiet",
-                    ],
+                    cmd,
                     check=True,
                     capture_output=True,
                     text=True,

--- a/docs/lanes/zv3p-moduleactivator-install-target/DONE-NOTE.md
+++ b/docs/lanes/zv3p-moduleactivator-install-target/DONE-NOTE.md
@@ -1,0 +1,15 @@
+# ModuleActivator install-target seam
+
+`ModuleActivator` now accepts `install_python` and `install_constraints` from
+its caller. With neither argument, it retains the existing `sys.executable`
+target and emits no constraints option.
+
+This is foundation's additive half of the per-`AMPLIFIER_HOME` environment
+change. The two-homes DTU verification in xq95 remains blocked until the
+app-cli follow-up release passes its home-specific target and pinned
+constraints through when it constructs `ModuleActivator`. Running that
+verification now would measure only a partial installation path and could
+mislead.
+
+Landing stage: this change is shipped as a draft PR; merging is the manager's
+next stage.

--- a/tests/test_activator.py
+++ b/tests/test_activator.py
@@ -9,6 +9,7 @@ from their import name, or that ship no import package at all).
 
 from __future__ import annotations
 
+import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -20,6 +21,69 @@ from amplifier_foundation.modules.activator import (
     ModuleActivator,
     _distribution_installed,
 )
+
+
+class TestInstallTarget:
+    """Tests for routing module installs to the caller's selected environment."""
+
+    @pytest.mark.asyncio
+    async def test_default_install_target_is_current_interpreter(self) -> None:
+        """The default command remains byte-for-byte compatible with the legacy path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir)
+            (module_path / "pyproject.toml").write_text(
+                '[project]\nname = "default-target-pkg"\nversion = "1.0.0"\n'
+            )
+            activator = ModuleActivator(cache_dir=module_path / "cache")
+
+            with patch("subprocess.run") as mock_subprocess:
+                await activator._install_dependencies(module_path, force=True)
+
+            assert mock_subprocess.call_args.args[0] == [
+                "uv",
+                "pip",
+                "install",
+                "-e",
+                str(module_path),
+                "--python",
+                sys.executable,
+                "--quiet",
+                "--no-sources",
+            ]
+
+    @pytest.mark.asyncio
+    async def test_explicit_install_target_and_constraints_are_passed_to_uv(self) -> None:
+        """Callers can direct an editable install away from the current interpreter."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir)
+            (module_path / "pyproject.toml").write_text(
+                '[project]\nname = "explicit-target-pkg"\nversion = "1.0.0"\n'
+            )
+            target_python = "/isolated/home/env/bin/python"
+            constraints = module_path / "constraints.txt"
+            constraints.write_text("example-dependency==1.2.3\n")
+            activator = ModuleActivator(
+                cache_dir=module_path / "cache",
+                install_python=target_python,
+                install_constraints=constraints,
+            )
+
+            with patch("subprocess.run") as mock_subprocess:
+                await activator._install_dependencies(module_path, force=True)
+
+            assert mock_subprocess.call_args.args[0] == [
+                "uv",
+                "pip",
+                "install",
+                "-e",
+                str(module_path),
+                "--python",
+                target_python,
+                "--quiet",
+                "--no-sources",
+                "--constraints",
+                str(constraints),
+            ]
 
 
 class TestInstallDependenciesWheelGuard:


### PR DESCRIPTION
## What changed

Adds an additive foundation seam to `ModuleActivator` for callers that need to control dependency-install placement:

- `install_python: str | None = None` selects the interpreter passed to `uv pip install`.
- `install_constraints: Path | None = None` optionally passes a uv constraints file to both install paths.
- Callers that omit both new arguments retain the existing `sys.executable` target and no constraints option, so this is a no-behavior-change foundation release for existing callers.

This lets the later app-cli release pass its per-`AMPLIFIER_HOME` target and pinned constraints through without moving the home-environment policy into foundation.

## Why

`ModuleActivator` performs installs beyond app-cli's provider-module installs. The seam must land in foundation first so the later app-cli release can isolate the complete installation path. The constraints file is part of the seam so dependency resolution fails loudly on a pin mismatch instead of installing a newer version that the base environment could shadow.

## Verification

- Fail-before/pass-after targeted test evidence: pre-change targeted run had 1 failed / 1 passed because the new test's `install_python` keyword was unexpected; after the seam, the targeted run is 2 passed.
- `uv run pytest -q`: **1636 passed, 1 skipped**.
- `uv run ruff check amplifier_foundation/modules/activator.py tests/test_activator.py`: passed.
- `uv run pyright amplifier_foundation/modules/activator.py tests/test_activator.py`: **0 errors**.

## Deferred verification

The two-homes DTU verification named in xq95's acceptance criteria remains blocked until the later app-cli release passes `install_python` and `install_constraints` through when constructing `ModuleActivator`. It is intentionally not attempted here because it would measure a misleading partial result.

## Breaking changes

None. Existing callers that omit the new arguments retain the prior install command behavior.
