### PR TITLE
fix(bundle): expose target-owned system prompt factory

### DIFF
--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -507,6 +507,31 @@ class PreparedBundle:
 
         return factory
 
+    def create_system_prompt_factory(
+        self,
+        session: Any,
+        *,
+        session_cwd: Path | None = None,
+    ) -> "Callable[[], Awaitable[str]]":
+        """Create this prepared bundle's system-prompt factory for ``session``.
+
+        The returned factory is deliberately bound to the target session.  In
+        particular, mention-resolution events are emitted through that
+        session's coordinator, not through a session that happened to create
+        the factory.
+
+        Args:
+            session: Target session that owns factory event emission.
+            session_cwd: Working directory for local @-mentions.  Defaults to
+                the prepared bundle's base path.
+
+        Returns:
+            Async callable that returns this bundle's system prompt.
+        """
+        return self._create_system_prompt_factory(
+            self.bundle, session, session_cwd=session_cwd
+        )
+
     async def create_session(
         self,
         session_id: str | None = None,

--- a/tests/test_instruction_mentions_lead_context.py
+++ b/tests/test_instruction_mentions_lead_context.py
@@ -102,6 +102,32 @@ def _write(path: Path, content: str) -> Path:
     return path
 
 
+@pytest.mark.asyncio
+async def test_public_factory_uses_prepared_bundle_and_target_session(
+    tmp_path: Path,
+) -> None:
+    """The public API keeps mention content and events owned by its target."""
+    _write(tmp_path / "context" / "system.md", "TARGET SESSION BODY")
+    bundle = Bundle(
+        name="target-ns",
+        base_path=tmp_path,
+        instruction="@target-ns:context/system.md",
+    )
+    prepared = _make_prepared(bundle)
+    target_session = _make_mock_session()
+
+    factory = prepared.create_system_prompt_factory(
+        target_session, session_cwd=tmp_path
+    )
+    prompt = await factory()
+
+    assert "TARGET SESSION BODY" in prompt
+    target_session.coordinator.hooks.emit.assert_called_once()
+    event_name, payload = target_session.coordinator.hooks.emit.call_args.args
+    assert event_name == MENTIONS_RESOLVED
+    assert payload["resolutions"][0]["mention"] == "@target-ns:context/system.md"
+
+
 # ── 1. FAIL-BEFORE: the instruction's mention leads the context block ────────
 
 


### PR DESCRIPTION
## Why

Child-session callers need a supported foundation API for creating a system-prompt factory that remains owned by the target session. The existing behavior is available only through a private helper, which makes target ownership and working-directory binding difficult to use safely.

## Changes

- Add the additive `PreparedBundle.create_system_prompt_factory(...)` API.
- Bind prompt construction to the supplied target session and optional session working directory.
- Add regression coverage proving resolved mention content and `mentions:resolved` events use the target session's hooks.
- This changes exactly two project files (51 added lines) and does not change wire transport behavior.

## Tests

- Full suite: **1923 passed, 4 skipped** on Linux with Python 3.13.11.
- Diff checks passed.
- The repository CI matrix is not yet verified: Ubuntu and Windows across Python 3.11, 3.12, and 3.13.

## Limitations

- Live integration is **not verified**: request instrumentation did not reach the installed SDK HTTP client.
- This is an additive foundation API with no wire transport changes, so the integration-harness limitation is not a foundation blocker.
