### PR TITLE
fix(git-ops): classify CI discovery outcomes

### DIFF
--- a/agents/git-ops.md
+++ b/agents/git-ops.md
@@ -195,6 +195,34 @@ that trailer belongs in **commit messages only** (where GitHub parses it for
 contributor attribution). In PR descriptions it is just displayed as text with
 no effect.
 
+## Post-Push / Post-PR CI Completion
+
+After every successful push, and after creating or updating a PR, finish by
+checking the CI associated with the pushed commit:
+
+1. Pin the report to the pushed SHA: `pushed_sha="$(git rev-parse HEAD)"`.
+   Never substitute the latest branch or PR SHA if it differs.
+2. Discover workflows and runs with `gh workflow list` and
+   `gh run list --commit "$pushed_sha" --limit 100`. Inspect the relevant
+   workflow triggers and PR checks to determine whether this ref is applicable.
+3. If a workflow or check is applicable, wait and refresh its runs for up to
+   the default 20-minute cap. Keep applicable queued or in-progress work
+   explicitly **Pending** while waiting; do not report it as successful.
+4. Report each run URL and each job's pass/fail outcome. For every failed job,
+   include a concise excerpt from `gh run view <run-id> --log-failed`. Every CI
+   report must name `$pushed_sha`.
+
+Use exactly one honest conclusion for each applicable surface:
+
+- **No CI** -- say `no CI on this repo`: it has no actionable CI workflow or check.
+- **Not triggered** -- CI exists, but no workflow applies to this event/ref;
+  do not wait for a run that cannot be created.
+- **Pending** -- an applicable run is queued or in progress within the cap.
+- **Timeout** -- applicable work remains pending when the 20-minute cap ends.
+- **Failure** -- any applicable run or job ends unsuccessfully.
+- **Policy-only checks** -- branch/PR policy exists without a runnable CI job
+  for this SHA; report the policy separately and never call it CI success.
+
 ## Final Response Contract
 
 Your final message must include:

--- a/agents/git-ops.md
+++ b/agents/git-ops.md
@@ -202,26 +202,30 @@ checking the CI associated with the pushed commit:
 
 1. Pin the report to the pushed SHA: `pushed_sha="$(git rev-parse HEAD)"`.
    Never substitute the latest branch or PR SHA if it differs.
-2. Discover workflows and runs with `gh workflow list` and
-   `gh run list --commit "$pushed_sha" --limit 100`. Inspect the relevant
-   workflow triggers and PR checks to determine whether this ref is applicable.
+2. Before classifying, complete successful workflow-trigger inspection,
+   commit check-run/status inspection, and PR checks when applicable, all for
+   `$pushed_sha`. Use `gh workflow list`, `gh run list --commit "$pushed_sha" --limit 100`,
+   commit check-runs/status APIs, and applicable `gh pr checks`; inspect workflow
+   triggers to determine whether this ref is applicable. Never substitute a newer head.
 3. If a workflow or check is applicable, wait and refresh its runs for up to
-   the default 20-minute cap. Keep applicable queued or in-progress work
-   explicitly **Pending** while waiting; do not report it as successful.
+   the default 20-minute cap. A matching workflow has no run yet is **Pending**:
+   poll within that bound. Keep queued or in-progress work explicitly **Pending**;
+   do not report it as successful.
 4. Report each run URL and each job's pass/fail outcome. For every failed job,
    include a concise excerpt from `gh run view <run-id> --log-failed`. Every CI
    report must name `$pushed_sha`.
 
 Use exactly one honest conclusion for each applicable surface:
 
-- **No CI** -- say `no CI on this repo`: it has no actionable CI workflow or check.
-- **Not triggered** -- CI exists, but no workflow applies to this event/ref;
+- **No CI** -- say `no CI on this repo` only after successful discovery finds no workflows or checks.
+- **Not triggered** -- workflows exist, but none applies to this event/ref;
   do not wait for a run that cannot be created.
 - **Pending** -- an applicable run is queued or in progress within the cap.
 - **Timeout** -- applicable work remains pending when the 20-minute cap ends.
 - **Failure** -- any applicable run or job ends unsuccessfully.
-- **Policy-only checks** -- branch/PR policy exists without a runnable CI job
-  for this SHA; report the policy separately and never call it CI success.
+- **Policy-only checks** -- only CLA/policy checks exist, without a runnable test
+  CI job for this SHA; report the policy separately and never call it CI success.
+- **Unable to verify** -- Discovery/API/auth errors are unable to verify, never **No CI** or green.
 
 ## Final Response Contract
 

--- a/bundles/anchors/agents/git-ops.md
+++ b/bundles/anchors/agents/git-ops.md
@@ -41,23 +41,27 @@ After every successful push, and after creating or updating a PR:
 
 1. Pin the report to the pushed SHA: `pushed_sha="$(git rev-parse HEAD)"`.
    Never substitute the latest branch or PR SHA if it differs.
-2. Discover workflows and runs with `gh workflow list` and
-   `gh run list --commit "$pushed_sha" --limit 100`. Inspect the relevant
-   workflow triggers and PR checks to determine whether this ref is applicable.
+2. Before classifying, complete successful workflow-trigger inspection,
+   commit check-run/status inspection, and PR checks when applicable, all for
+   `$pushed_sha`. Use `gh workflow list`, `gh run list --commit "$pushed_sha" --limit 100`,
+   commit check-runs/status APIs, and applicable `gh pr checks`; inspect workflow
+   triggers to determine whether this ref is applicable. Never substitute a newer head.
 3. If a workflow or check is applicable, wait and refresh its runs for up to
-   the default 20-minute cap. Keep applicable queued or in-progress work
-   explicitly **Pending** while waiting; do not report it as successful.
+   the default 20-minute cap. A matching workflow has no run yet is **Pending**:
+   poll within that bound. Keep queued or in-progress work explicitly **Pending**;
+   do not report it as successful.
 4. Report each run URL and each job's pass/fail outcome. For every failed job,
    include a concise excerpt from `gh run view <run-id> --log-failed`. Every CI
    report must name `$pushed_sha`.
 
 Use exactly one honest conclusion for each applicable surface:
 
-- **No CI** -- say `no CI on this repo`: it has no actionable CI workflow or check.
-- **Not triggered** -- CI exists, but no workflow applies to this event/ref;
+- **No CI** -- say `no CI on this repo` only after successful discovery finds no workflows or checks.
+- **Not triggered** -- workflows exist, but none applies to this event/ref;
   do not wait for a run that cannot be created.
 - **Pending** -- an applicable run is queued or in progress within the cap.
 - **Timeout** -- applicable work remains pending when the 20-minute cap ends.
 - **Failure** -- any applicable run or job ends unsuccessfully.
-- **Policy-only checks** -- branch/PR policy exists without a runnable CI job
-  for this SHA; report the policy separately and never call it CI success.
+- **Policy-only checks** -- only CLA/policy checks exist, without a runnable test
+  CI job for this SHA; report the policy separately and never call it CI success.
+- **Unable to verify** -- Discovery/API/auth errors are unable to verify, never **No CI** or green.

--- a/bundles/anchors/agents/git-ops.md
+++ b/bundles/anchors/agents/git-ops.md
@@ -34,3 +34,30 @@ Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.co
 ## PR Descriptions
 
 Include: what changed, why, how to verify, and any breaking changes.
+
+## Post-Push / Post-PR CI Completion
+
+After every successful push, and after creating or updating a PR:
+
+1. Pin the report to the pushed SHA: `pushed_sha="$(git rev-parse HEAD)"`.
+   Never substitute the latest branch or PR SHA if it differs.
+2. Discover workflows and runs with `gh workflow list` and
+   `gh run list --commit "$pushed_sha" --limit 100`. Inspect the relevant
+   workflow triggers and PR checks to determine whether this ref is applicable.
+3. If a workflow or check is applicable, wait and refresh its runs for up to
+   the default 20-minute cap. Keep applicable queued or in-progress work
+   explicitly **Pending** while waiting; do not report it as successful.
+4. Report each run URL and each job's pass/fail outcome. For every failed job,
+   include a concise excerpt from `gh run view <run-id> --log-failed`. Every CI
+   report must name `$pushed_sha`.
+
+Use exactly one honest conclusion for each applicable surface:
+
+- **No CI** -- say `no CI on this repo`: it has no actionable CI workflow or check.
+- **Not triggered** -- CI exists, but no workflow applies to this event/ref;
+  do not wait for a run that cannot be created.
+- **Pending** -- an applicable run is queued or in progress within the cap.
+- **Timeout** -- applicable work remains pending when the 20-minute cap ends.
+- **Failure** -- any applicable run or job ends unsuccessfully.
+- **Policy-only checks** -- branch/PR policy exists without a runnable CI job
+  for this SHA; report the policy separately and never call it CI success.

--- a/tests/test_git_ops_ci_catalog.py
+++ b/tests/test_git_ops_ci_catalog.py
@@ -32,6 +32,15 @@ CI_COMPLETION_MARKERS = (
     "**Timeout**",
     "**Failure**",
     "**Policy-only checks**",
+    "successful workflow-trigger inspection",
+    "commit check-run/status inspection",
+    "PR checks when applicable",
+    "only after successful discovery finds no workflows or checks",
+    "matching workflow has no run yet",
+    "only CLA/policy checks",
+    "**Unable to verify**",
+    "Discovery/API/auth errors",
+    "never **No CI** or green",
 )
 
 CATALOGS = (

--- a/tests/test_git_ops_ci_catalog.py
+++ b/tests/test_git_ops_ci_catalog.py
@@ -1,0 +1,137 @@
+"""Git-ops CI completion instructions reach the intended public catalogs."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from amplifier_foundation.io.frontmatter import parse_frontmatter
+from amplifier_foundation.modules.activator import ModuleActivator
+from amplifier_foundation.registry import BundleRegistry
+from amplifier_module_tool_delegate import DelegateTool
+
+REPO_ROOT = Path(__file__).parent.parent
+CATALOG_ROOT = Path(os.environ.get("GIT_OPS_CATALOG_ROOT", REPO_ROOT)).resolve()
+
+CI_COMPLETION_MARKERS = (
+    "Post-Push / Post-PR CI Completion",
+    'pushed_sha="$(git rev-parse HEAD)"',
+    'gh workflow list',
+    'gh run list --commit "$pushed_sha" --limit 100',
+    "this ref is applicable",
+    "default 20-minute cap",
+    "pass/fail outcome",
+    "gh run view <run-id> --log-failed",
+    "**No CI**",
+    "no CI on this repo",
+    "**Not triggered**",
+    "**Pending**",
+    "**Timeout**",
+    "**Failure**",
+    "**Policy-only checks**",
+)
+
+CATALOGS = (
+    (
+        "foundation:git-ops",
+        ".",
+        Path("agents/git-ops.md"),
+        Path("bundles/anchors/agents/git-ops.md"),
+    ),
+    (
+        "anchors:git-ops",
+        "bundles/anchors",
+        Path("bundles/anchors/agents/git-ops.md"),
+        Path("agents/git-ops.md"),
+    ),
+)
+
+
+def _agent_source(path: Path) -> tuple[str, str]:
+    """Return the catalog description and body from one real agent file."""
+    frontmatter, body = parse_frontmatter(path.read_text(encoding="utf-8"))
+    return frontmatter["meta"]["description"], body.strip()
+
+
+async def _prepared_catalog(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, subdirectory: str
+):
+    """Load source content through BundleRegistry and prepare its mount plan.
+
+    Module activation is outside this structural check; stubbing it leaves the
+    production loading, source resolution, metadata loading, and prepare path
+    intact without downloading any module.
+    """
+    uri = CATALOG_ROOT.as_uri()
+    if subdirectory != ".":
+        uri = f"{uri}#subdirectory={subdirectory}"
+
+    registry = BundleRegistry(home=tmp_path / "home")
+    bundle = await registry._load_single(uri, auto_include=False)
+    bundle.load_agent_metadata()
+
+    monkeypatch.setattr(ModuleActivator, "activate_all", AsyncMock(return_value={}))
+    monkeypatch.setattr(ModuleActivator, "finalize", lambda self: None)
+    return await bundle.prepare(install_deps=False)
+
+
+def _delegate_description(mount_plan: dict) -> str:
+    """Render the actual DelegateTool catalog from a prepared mount plan."""
+    coordinator = MagicMock()
+    coordinator.session_id = "git-ops-catalog-test"
+    coordinator.config = mount_plan
+    coordinator.session_state = {}
+    coordinator._tool_dispatch_context = {}
+    coordinator.get_capability = lambda _name: None
+    coordinator.get = MagicMock(return_value=None)
+    return DelegateTool(
+        coordinator, {"features": {}, "settings": {"exclude_tools": []}}
+    ).description
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("catalog_name", "subdirectory", "source_relative", "other_source_relative"),
+    CATALOGS,
+    ids=("foundation", "anchors"),
+)
+async def test_prepared_catalog_uses_its_own_git_ops_body_and_ci_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    catalog_name: str,
+    subdirectory: str,
+    source_relative: Path,
+    other_source_relative: Path,
+) -> None:
+    """Each public catalog loads its own body, then DelegateTool renders it."""
+    expected_description, expected_body = _agent_source(CATALOG_ROOT / source_relative)
+    _other_description, other_body = _agent_source(CATALOG_ROOT / other_source_relative)
+
+    prepared = await _prepared_catalog(tmp_path, monkeypatch, subdirectory)
+    agent = prepared.mount_plan["agents"][catalog_name]
+
+    assert agent["instruction"] == expected_body
+    assert agent["instruction"] != other_body
+    assert other_body not in agent["instruction"]
+    missing_markers = [
+        marker for marker in CI_COMPLETION_MARKERS if marker not in agent["instruction"]
+    ]
+    assert not missing_markers, f"missing CI completion markers: {missing_markers}"
+
+    description = _delegate_description(prepared.mount_plan)
+    assert f"  - {catalog_name}: {expected_description}" in description
+
+
+@pytest.mark.asyncio
+async def test_anchors_prepared_catalog_excludes_foundation_git_ops(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Anchors' independently live catalog does not inherit Foundation's one."""
+    prepared = await _prepared_catalog(tmp_path, monkeypatch, "bundles/anchors")
+
+    assert "anchors:git-ops" in prepared.mount_plan["agents"]
+    assert "foundation:git-ops" not in prepared.mount_plan["agents"]
+    assert "  - foundation:git-ops:" not in _delegate_description(prepared.mount_plan)


### PR DESCRIPTION
## Summary

- Tighten the git-ops post-push/post-PR protocol so CI discovery is classified only after successful, exact-head inspection of workflow triggers, commit check-runs/statuses, and applicable PR checks.
- Add explicit classifications: successful workflow-trigger inspection; exact-SHA commit check-run/status inspection; applicable PR-check discovery; **No CI** only after successful empty discovery; **Not triggered**; **Pending** (including no run yet); **Timeout**; **Failure**; **CLA/policy-only**; and **Unable to verify** for discovery/API/auth errors.
- Keep both independently live public catalogs structurally guarded, including the anchor catalog's exclusion of the Foundation catalog entry.

## Why

The previous guidance could collapse incomplete discovery or missing runs into an incorrect No CI/green conclusion. This change makes the evidence boundary explicit and keeps conclusions tied to the pushed commit SHA.

## Verification

- `uv run pytest tests/test_git_ops_ci_catalog.py tests/test_agent_docs_hygiene.py tests/test_description_alignment_checks.py tests/test_validate_agents_model_role.py -q` — **54 passed**.
- `git diff --check` — passed with no output.
- Structural catalog tests load/render the agent instructions; live evidence below separately proves a real agent followed the contract.
- **WITH-CI live agent session** — private disposable repository; exact PR-head SHA `4e241e08212917d7806f8c455efd73b252910601`. Workflow discovery found active `disposable-ci` with `pull_request` trigger; exact-SHA run discovery found completed successful run `34246859985`; exact-SHA check discovery found `test: success` (plus GitGuardian Security Checks: success); `gh pr checks` returned both passing checks. The agent used the stated **20-minute / 1,200-second cap**, refreshed once, and the run was already terminal (`0` seconds elapsed). Job outcome: `test` — **success**. No failure logs were required.
- **NO-CI live agent session** — different private disposable repository; exact PR-head SHA `ca33db98a64b39e9318c2c154dca0319c746b70c`. Successful discovery found `0` workflows (`gh workflow list` and Actions workflows API), `0` exact-SHA runs, `0` exact-SHA check-runs, `0` legacy statuses, and an empty PR status-check rollup. `gh pr checks` reported “no checks reported” (the CLI's expected no-check result), not an API/auth/discovery failure. The agent's resulting classification was exactly: **`no CI on this repo`**.
- Both reports are pinned to their PR heads; raw commands and private URLs are retained privately rather than placed in this public PR body.

## Breaking changes

None expected. This updates agent guidance and its structural catalog guards; it does not change a runtime API.

## Scope note

PR #287 is intentionally untouched and requires a separate manager decision.

## CI reporting

The post-push/post-PR CI report will be pinned to the exact head SHA and will distinguish workflow-trigger, exact-SHA check-run/status, and applicable PR-check evidence. It will not describe structural tests or mocked fixtures as behavioral proof.

Generated with Amplifier
