### PR TITLE
fix: allow 60 seconds for session naming

### DIFF
--- a/modules/hooks-session-naming/README.md
+++ b/modules/hooks-session-naming/README.md
@@ -129,7 +129,7 @@ shared provider instance is never mutated, so the foreground conversation's own
 events are unaffected. If a provider's events cannot be stamped, the naming call
 is **skipped** with a WARNING rather than emitted unattributably.
 
-Note: the provider call has a 10 s hard timeout. A timed-out call can leave a
+Note: the provider call has a 60 s hard timeout. A timed-out call can leave a
 stamped `llm:request` with no matching `llm:response` — the stamp is what makes
 that orphan identifiable rather than mysterious.
 
@@ -153,9 +153,9 @@ Session naming is designed to be entirely non-blocking. Here is how the async ma
 
 3. **`done_callback`**: `task.add_done_callback(self._pending_tasks.discard)` is registered on each task so it removes itself from the set upon completion, keeping the set lean.
 
-4. **`session:end` drain (15s timeout)**: The `on_session_end` handler iterates `_pending_tasks` and calls `asyncio.wait_for(asyncio.shield(task), timeout=15.0)` for each. This gives in-flight naming tasks up to 15 seconds to complete before session teardown. If a task times out or is cancelled, the error is logged at `DEBUG` level and teardown continues — naming is best-effort.
+4. **`session:end` drain (15s timeout)**: The `on_session_end` handler iterates `_pending_tasks` and calls `asyncio.wait_for(task, timeout=15.0)` for each. This gives in-flight naming tasks up to 15 seconds to complete before session teardown. On drain timeout the task is cancelled; the error is logged at `DEBUG` level and teardown continues — naming is best-effort.
 
-5. **Internal 10s provider timeout**: Inside `_generate_name`, the LLM provider call is wrapped in `asyncio.wait_for(self._call_provider(prompt), timeout=10.0)`. This caps stalled or slow providers and ensures the naming task itself finishes well within the `session:end` 15-second drain window.
+5. **Internal 60s provider timeout**: Inside `_generate_name`, both initial naming and description updates wrap the provider call with `asyncio.wait_for(..., timeout=NAMING_PROVIDER_TIMEOUT_SECONDS)`. The 60-second limit gives slower requests more time without blocking the conversation. The separate 15-second session-end drain is unchanged and can cancel an in-flight request earlier during teardown.
 
 ## How It Works
 

--- a/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
+++ b/modules/hooks-session-naming/amplifier_module_hooks_session_naming/__init__.py
@@ -19,6 +19,8 @@ from amplifier_core import HookResult
 
 logger = logging.getLogger(__name__)
 
+NAMING_PROVIDER_TIMEOUT_SECONDS = 60.0
+
 # Provenance stamped onto every event this module's own LLM call emits.
 # The provider writes llm:request / llm:response into the SESSION'S event
 # stream through the coordinator it was mounted with, and the kernel adds
@@ -329,11 +331,13 @@ class SessionNamingHook:
             # Call the provider — hard timeout caps stalled providers
             try:
                 response = await asyncio.wait_for(
-                    self._call_provider(prompt, session_id), timeout=10.0
+                    self._call_provider(prompt, session_id),
+                    timeout=NAMING_PROVIDER_TIMEOUT_SECONDS,
                 )
             except asyncio.TimeoutError:
                 logger.warning(
-                    "Session naming provider call timed out (10 s) for session %s",
+                    "Session naming provider call timed out (%g s) for session %s",
+                    NAMING_PROVIDER_TIMEOUT_SECONDS,
                     session_id[:8],
                 )
                 await self.coordinator.hooks.emit(

--- a/modules/hooks-session-naming/tests/test_session_naming.py
+++ b/modules/hooks-session-naming/tests/test_session_naming.py
@@ -281,11 +281,41 @@ class TestSessionEndDrain:
 
 
 class TestProviderTimeout:
-    """_generate_name must handle a stalled provider call within 10 s."""
+    """Naming and description updates allow 60 s for the provider call."""
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("is_update", [False, True])
+    async def test_provider_call_uses_sixty_second_timeout(
+        self, tmp_path: Path, is_update: bool
+    ) -> None:
+        """Both naming paths use the longer deadline and persist the result."""
+        provider = _make_mock_provider()
+        hook = _make_hook(providers={"provider-1": provider})
+        hook._get_conversation_context = AsyncMock(
+            return_value="some conversation text"
+        )
+        if is_update:
+            hook._save_metadata(
+                tmp_path, {"name": "Existing Name", "description": "Before update"}
+            )
+
+        with patch("asyncio.wait_for", wraps=asyncio.wait_for) as wait_for:
+            await hook._generate_name(
+                "session-abc123", tmp_path, is_update=is_update
+            )
+
+        wait_for.assert_awaited_once()
+        assert wait_for.await_args.kwargs["timeout"] == 60.0
+        provider.complete.assert_awaited_once()
+        metadata = hook._load_metadata(tmp_path)
+        assert metadata["name"] == ("Existing Name" if is_update else "Test Session")
+        assert metadata["description"] == "A test."
+        assert metadata["description_updated_at"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("is_update", [False, True])
     async def test_generate_name_returns_on_provider_timeout(
-        self, tmp_path: Path
+        self, tmp_path: Path, is_update: bool, caplog: pytest.LogCaptureFixture
     ) -> None:
         """_generate_name catches asyncio.TimeoutError from stalled _call_provider."""
         hook = _make_hook()
@@ -294,19 +324,34 @@ class TestProviderTimeout:
         hook._get_conversation_context = AsyncMock(
             return_value="some conversation text"
         )
-        hook._load_metadata = MagicMock(return_value={})
+        metadata = {"turn_count": 5 if is_update else 1}
+        if is_update:
+            metadata.update(name="Existing Name", description="Existing description")
+        hook._save_metadata(tmp_path, metadata)
+        metadata_path = tmp_path / "metadata.json"
+        original_metadata = metadata_path.read_bytes()
+        timeouts = []
 
         # Replace wait_for with a version that closes the coroutine before
         # raising, so the GC never sees an unawaited coroutine (no RuntimeWarning)
         async def fake_wait_for(coro, timeout=None):  # noqa: RUF029
+            timeouts.append(timeout)
             coro.close()
             raise asyncio.TimeoutError
 
         with patch("asyncio.wait_for", new=fake_wait_for):
             # Must not raise — timeout must be caught inside _generate_name
-            await hook._generate_name("session-abc123", tmp_path, is_update=False)
+            await hook._generate_name(
+                "session-abc123", tmp_path, is_update=is_update
+            )
 
-        # If we reach here, the timeout was handled correctly — no exception propagated
+        assert timeouts == [60.0]
+        assert "Session naming provider call timed out (60 s)" in caplog.text
+        hook.coordinator.hooks.emit.assert_awaited_once_with(
+            "session-naming:timeout",
+            {"session_id": "session-abc123", "is_update": is_update},
+        )
+        assert metadata_path.read_bytes() == original_metadata
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Increase the session-naming provider deadline from 10 seconds to 60 seconds.
- Apply the shared timeout constant to both initial naming and description updates.
- Keep the 15-second session-end drain unchanged and document the existing behavior accurately.

## Verification
- `PYTHONPATH=.:modules/hooks-session-naming python -m pytest -q modules/hooks-session-naming/tests/` — 41 passed, run separately because the repository's CI `pytest tests/` configuration does not include the embedded module tests.
- Foundation suite on the same base: 2113 passed, 4 skipped (prior evidence).
- Delayed mock-provider smoke: real background completion at 10.21 seconds, metadata persisted; hook returned in 0.0001 seconds and emitted no provider-timeout warning.
- Timeout tests verify existing metadata bytes remain unchanged on timeout.
- Independent architect review: PASS.

No live API or DTU claims; all verification uses mocks/local tests.

## Scope
- Exactly three files under `modules/hooks-session-naming/`.
- Runtime: 60-second provider timeout constant and formatted warning only; no routing, prompts, retries, provider-limit, or shutdown changes.
- Tests cover initial/update success paths and timeout preservation.
- README documents the 60-second provider deadline and the unchanged 15-second drain.

## Breaking changes
None expected.