### PR TITLE
fix(anchors): load workspace AGENTS.md only

### DIFF
--- a/bundles/anchors/context/system.md
+++ b/bundles/anchors/context/system.md
@@ -14,3 +14,7 @@ Generated with Amplifier
 
 Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
 ```
+
+@~/.amplifier/AGENTS.md
+@.amplifier/AGENTS.md
+@AGENTS.md

--- a/bundles/anchors/context/system.md
+++ b/bundles/anchors/context/system.md
@@ -4,9 +4,9 @@ Principles governing every action: investigate before acting (understand fully b
 Rules:
 - Use `todo` to plan and track multi-step tasks; small steps; mark items complete as you finish them.
 - Format output as GitHub-flavored markdown; wrap structured content in code fences.
-- Reference code as `file_path:line_number`.
+- Reference code: `file_path:line_number`.
 - Assist with defensive security only; refuse malicious code requests.
-- Follow instructions in AGENTS.md files if present; update them when you change the system.
+- Follow AGENTS.md instructions if present; update them when changing the system.
 - Discover skills, modes, recipes via `load_skill(list=true)`, `mode(operation="list")`, `recipes(operation="list")`.
 - End every commit message with:
 ```
@@ -15,6 +15,4 @@ Generated with Amplifier
 Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
 ```
 
-@~/.amplifier/AGENTS.md
-@.amplifier/AGENTS.md
 @AGENTS.md

--- a/tests/test_instruction_mentions_lead_context.py
+++ b/tests/test_instruction_mentions_lead_context.py
@@ -319,14 +319,14 @@ async def test_mentions_resolved_payload_semantics_unchanged(tmp_path: Path) -> 
     assert payload["resolutions"][0]["mention"] == "@ns:context/system.md"
 
 
-# ── 5. anchors: the shipped root instruction discovers standard AGENTS files ─
+# ── 5. anchors: the shipped root instruction discovers workspace AGENTS ───────
 
 
 @pytest.mark.asyncio
-async def test_shipped_anchors_root_loads_standard_agents_and_workspace_scratch(
+async def test_shipped_anchors_root_loads_workspace_agents_and_scratch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The shipped anchors root resolves system.md's AGENTS chain at session CWD."""
+    """The shipped anchors root loads workspace AGENTS and its SCRATCH chain only."""
     home = tmp_path / "home"
     workspace = tmp_path / "workspace"
     global_agents = _write(
@@ -348,39 +348,42 @@ async def test_shipped_anchors_root_loads_standard_agents_and_workspace_scratch(
     )
     prompt = await factory()
 
-    # The actual root bundle instruction enters its namespaced system context,
-    # whose standard AGENTS mentions resolve from the supplied session CWD.
+    # The actual root bundle instruction enters its namespaced system context.
     assert prompt.startswith(f"{bundle.instruction}\n\n---\n\n")
     assert [block.body for block in _blocks(prompt)] == [
         (ANCHORS_DIR / "context" / "system.md").read_text(encoding="utf-8"),
-        global_agents.read_text(encoding="utf-8"),
-        local_agents.read_text(encoding="utf-8"),
         workspace_agents.read_text(encoding="utf-8"),
         scratch.read_text(encoding="utf-8"),
     ]
+    assert global_agents.read_text(encoding="utf-8") not in prompt
+    assert local_agents.read_text(encoding="utf-8") not in prompt
 
 
 @pytest.mark.asyncio
-async def test_shipped_anchors_root_skips_absent_optional_agents(
+async def test_shipped_anchors_root_permits_missing_workspace_agents(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Absent home and .amplifier AGENTS files do not prevent workspace discovery."""
-    home = tmp_path / "empty-home"
+    """A missing workspace AGENTS permits the root prompt without .amplifier fallback."""
+    home = tmp_path / "home"
     workspace = tmp_path / "workspace"
-    workspace_agents = _write(
-        workspace / "AGENTS.md", "WORKSPACE AGENTS SENTINEL\n@SCRATCH.md"
+    global_agents = _write(
+        home / ".amplifier" / "AGENTS.md", "GLOBAL AGENTS SENTINEL"
     )
-    scratch = _write(workspace / "SCRATCH.md", "WORKSPACE SCRATCH SENTINEL")
+    local_agents = _write(
+        workspace / ".amplifier" / "AGENTS.md", "LOCAL AGENTS SENTINEL"
+    )
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("USERPROFILE", str(home))
 
-    factory = _make_prepared(_shipped_anchors_bundle()).create_system_prompt_factory(
+    bundle = _shipped_anchors_bundle()
+    factory = _make_prepared(bundle).create_system_prompt_factory(
         _make_mock_session(), session_cwd=workspace
     )
     prompt = await factory()
 
+    assert prompt.startswith(f"{bundle.instruction}\n\n---\n\n")
     assert [block.body for block in _blocks(prompt)] == [
         (ANCHORS_DIR / "context" / "system.md").read_text(encoding="utf-8"),
-        workspace_agents.read_text(encoding="utf-8"),
-        scratch.read_text(encoding="utf-8"),
     ]
+    assert global_agents.read_text(encoding="utf-8") not in prompt
+    assert local_agents.read_text(encoding="utf-8") not in prompt

--- a/tests/test_instruction_mentions_lead_context.py
+++ b/tests/test_instruction_mentions_lead_context.py
@@ -41,11 +41,16 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from amplifier_foundation.bundle import Bundle
+from amplifier_foundation.io.frontmatter import parse_frontmatter
 
 _prep = importlib.import_module("amplifier_foundation.bundle._prepared")
 PreparedBundle: Any = _prep.PreparedBundle
 BundleModuleResolver: Any = _prep.BundleModuleResolver
 MENTIONS_RESOLVED: str = _prep._MENTIONS_RESOLVED_EVENT
+
+REPO_ROOT = Path(__file__).parent.parent
+ANCHORS_DIR = REPO_ROOT / "bundles" / "anchors"
+ANCHORS_BUNDLE = ANCHORS_DIR / "bundle.md"
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -94,6 +99,19 @@ def _make_mock_session() -> MagicMock:
     session = MagicMock()
     session.coordinator = coordinator
     return session
+
+
+def _shipped_anchors_bundle() -> Bundle:
+    """Load the shipped anchors root instruction without activating its modules."""
+    _frontmatter, instruction = parse_frontmatter(
+        ANCHORS_BUNDLE.read_text(encoding="utf-8")
+    )
+    return Bundle(
+        name="anchors",
+        instruction=instruction,
+        base_path=ANCHORS_DIR,
+        source_base_paths={"anchors": ANCHORS_DIR},
+    )
 
 
 def _write(path: Path, content: str) -> Path:
@@ -299,3 +317,70 @@ async def test_mentions_resolved_payload_semantics_unchanged(tmp_path: Path) -> 
 
     # The instruction's mention now leads the resolutions list as well.
     assert payload["resolutions"][0]["mention"] == "@ns:context/system.md"
+
+
+# ── 5. anchors: the shipped root instruction discovers standard AGENTS files ─
+
+
+@pytest.mark.asyncio
+async def test_shipped_anchors_root_loads_standard_agents_and_workspace_scratch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The shipped anchors root resolves system.md's AGENTS chain at session CWD."""
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    global_agents = _write(
+        home / ".amplifier" / "AGENTS.md", "GLOBAL AGENTS SENTINEL"
+    )
+    local_agents = _write(
+        workspace / ".amplifier" / "AGENTS.md", "LOCAL AGENTS SENTINEL"
+    )
+    workspace_agents = _write(
+        workspace / "AGENTS.md", "WORKSPACE AGENTS SENTINEL\n@SCRATCH.md"
+    )
+    scratch = _write(workspace / "SCRATCH.md", "WORKSPACE SCRATCH SENTINEL")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    bundle = _shipped_anchors_bundle()
+    factory = _make_prepared(bundle).create_system_prompt_factory(
+        _make_mock_session(), session_cwd=workspace
+    )
+    prompt = await factory()
+
+    # The actual root bundle instruction enters its namespaced system context,
+    # whose standard AGENTS mentions resolve from the supplied session CWD.
+    assert prompt.startswith(f"{bundle.instruction}\n\n---\n\n")
+    assert [block.body for block in _blocks(prompt)] == [
+        (ANCHORS_DIR / "context" / "system.md").read_text(encoding="utf-8"),
+        global_agents.read_text(encoding="utf-8"),
+        local_agents.read_text(encoding="utf-8"),
+        workspace_agents.read_text(encoding="utf-8"),
+        scratch.read_text(encoding="utf-8"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_shipped_anchors_root_skips_absent_optional_agents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Absent home and .amplifier AGENTS files do not prevent workspace discovery."""
+    home = tmp_path / "empty-home"
+    workspace = tmp_path / "workspace"
+    workspace_agents = _write(
+        workspace / "AGENTS.md", "WORKSPACE AGENTS SENTINEL\n@SCRATCH.md"
+    )
+    scratch = _write(workspace / "SCRATCH.md", "WORKSPACE SCRATCH SENTINEL")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    factory = _make_prepared(_shipped_anchors_bundle()).create_system_prompt_factory(
+        _make_mock_session(), session_cwd=workspace
+    )
+    prompt = await factory()
+
+    assert [block.body for block in _blocks(prompt)] == [
+        (ANCHORS_DIR / "context" / "system.md").read_text(encoding="utf-8"),
+        workspace_agents.read_text(encoding="utf-8"),
+        scratch.read_text(encoding="utf-8"),
+    ]


### PR DESCRIPTION
## Summary

- Make the anchors root instruction workspace-only: retain `@AGENTS.md` and remove home and local `.amplifier` `AGENTS.md` references.
- Keep transitive workspace `SCRATCH.md` loading when referenced by workspace `AGENTS.md`.
- Keep missing workspace `AGENTS.md` optional, without falling back to either `.amplifier` sentinel.
- Trim two equivalent prose lines in `system.md` while preserving the lean instruction budget (1,141/1,142 lines/bytes as previously measured); no guard behavior is weakened.

The CLI owns `.amplifier` path policy. This anchors-bundle change deliberately does not load those paths.

## Why

The anchors root should establish workspace context without independently reaching into home or local `.amplifier` instruction files. Workspace `AGENTS.md` remains the explicit contract, with its transitive workspace context preserved.

## Verification

Directly observed on Linux aarch64 with Python 3.12.3, uv 0.10.12, and pytest 9.0.3:

- Full suite: `uv run pytest tests/ -q --tb=short` — **1,925 passed, 4 skipped**.
- Focused regression file: `uv run pytest tests/test_instruction_mentions_lead_context.py -q` — **7 passed**.
- `git diff --check` passes.

## Breaking changes

None. The scope is intentionally limited to workspace `AGENTS.md`; `.amplifier` path handling remains owned by the CLI.

Relates to https://github.com/microsoft/amplifier-support/issues/474
