### PR TITLE
fix(anchors): resolve workspace agents from session cwd

### DIFF
--- a/bundles/anchors/context/system.md
+++ b/bundles/anchors/context/system.md
@@ -14,3 +14,5 @@ Generated with Amplifier
 
 Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
 ```
+
+@AGENTS.md

--- a/docs/lanes/zc6t-lean-head-ship/DONE-NOTE.md
+++ b/docs/lanes/zc6t-lean-head-ship/DONE-NOTE.md
@@ -291,3 +291,13 @@ pin **per artifact**, never to a whole-head absolute · draft PR, ready on green
 Two children (`4qg2`, `va53`) additionally require their **no-op** target
 (`web_search`, `mode`) to be verified and **stated** — an unchanged file in a PR
 is noise, but a silently skipped one is a gap.
+
+## Addendum — 2026-09-08
+
+The current static census for `bundles/anchors/context/system.md` is 1,154
+chars, +12 over its recorded 1,142-char lean budget. The required `@AGENTS.md`
+rule auto-loads session-CWD `AGENTS.md`, so the budget is pinned at 1,154 rather
+than compressing unrelated prompt text. The owned-head total is now 3,392 chars
+against the unchanged 3,980-char stock: a current saving of 588 chars versus the
+original 600. Historical experimental results above are unchanged; no vendor
+cache metrics were rerun.

--- a/tests/test_instruction_mentions_lead_context.py
+++ b/tests/test_instruction_mentions_lead_context.py
@@ -102,6 +102,11 @@ def _write(path: Path, content: str) -> Path:
     return path
 
 
+_ANCHORS_SYSTEM = (
+    Path(__file__).parent.parent / "bundles" / "anchors" / "context" / "system.md"
+)
+
+
 @pytest.mark.asyncio
 async def test_public_factory_uses_prepared_bundle_and_target_session(
     tmp_path: Path,
@@ -299,3 +304,60 @@ async def test_mentions_resolved_payload_semantics_unchanged(tmp_path: Path) -> 
 
     # The instruction's mention now leads the resolutions list as well.
     assert payload["resolutions"][0]["mention"] == "@ns:context/system.md"
+
+
+@pytest.mark.asyncio
+async def test_anchors_system_loads_session_cwd_agents_not_bundle_or_process_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The actual anchors system mention resolves nested @AGENTS.md in session_cwd."""
+    anchors_root = _ANCHORS_SYSTEM.parent.parent
+    assert _ANCHORS_SYSTEM.read_text(encoding="utf-8").endswith("```\n\n@AGENTS.md\n")
+
+    session_cwd = tmp_path / "session-cwd"
+    cwd_agents = _write(
+        session_cwd / "AGENTS.md",
+        "SESSION CWD AGENTS\n@AGENTS.md",
+    )
+    bundle_root = tmp_path / "bundle-root"
+    _write(bundle_root / "AGENTS.md", "BUNDLE-LOCAL AGENTS DECOY")
+    process_cwd = tmp_path / "process-cwd"
+    _write(process_cwd / "AGENTS.md", "PROCESS CWD AGENTS DECOY")
+    monkeypatch.chdir(process_cwd)
+
+    bundle = Bundle(
+        name="host",
+        base_path=bundle_root,
+        source_base_paths={"anchors": anchors_root},
+        instruction="@anchors:context/system.md",
+    )
+    prompt = await _make_prepared(bundle)._create_system_prompt_factory(
+        bundle, _make_mock_session(), session_cwd=session_cwd
+    )()
+
+    assert str(cwd_agents.resolve()) in prompt
+    assert prompt.count("SESSION CWD AGENTS") == 1
+    assert "BUNDLE-LOCAL AGENTS DECOY" not in prompt
+    assert "PROCESS CWD AGENTS DECOY" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_anchors_system_missing_cwd_agents_is_nonfatal(tmp_path: Path) -> None:
+    """Absent optional cwd AGENTS.md leaves the anchors system prompt usable."""
+    bundle_root = tmp_path / "bundle-root"
+    _write(bundle_root / "AGENTS.md", "BUNDLE-LOCAL AGENTS DECOY")
+    session_cwd = tmp_path / "session-cwd"
+    session_cwd.mkdir()
+    bundle = Bundle(
+        name="host",
+        base_path=bundle_root,
+        source_base_paths={"anchors": _ANCHORS_SYSTEM.parent.parent},
+        instruction="@anchors:context/system.md",
+    )
+
+    prompt = await _make_prepared(bundle)._create_system_prompt_factory(
+        bundle, _make_mock_session(), session_cwd=session_cwd
+    )()
+
+    assert "You are Amplifier" in prompt
+    assert "BUNDLE-LOCAL AGENTS DECOY" not in prompt

--- a/tests/test_lean_head_guardrail.py
+++ b/tests/test_lean_head_guardrail.py
@@ -74,7 +74,8 @@ DELEGATE_MODULE_DIR = REPO_ROOT / "modules" / "tool-delegate"
 # above what shipped would let the head regrow up to it silently, which is the
 # whole failure mode.
 OWNED_HEAD_BUDGET_CHARS = {
-    "bundles/anchors/context/system.md": 1142,
+    # Required cwd-AGENTS auto-loading rule costs +12 chars.
+    "bundles/anchors/context/system.md": 1154,
     "bundles/anchors-amp-dev/context/amplifier-ecosystem.md": 1300,
     "delegate:preamble": 938,
 }
@@ -247,10 +248,11 @@ class TestGuardrailAHeadCensus:
         lean = sum(OWNED_HEAD_BUDGET_CHARS.values())
         stock = sum(OWNED_HEAD_STOCK_CHARS.values())
         assert lean < stock, f"lean {lean} is not below stock {stock}"
-        assert stock - lean == 600, (
-            f"The recorded saving moved: {stock - lean} chars, was 600. Update "
-            "both tables and the DONE-NOTE together, or the published census "
-            "and this repo disagree."
+        assert stock - lean == 588, (
+            f"The current saving moved: {stock - lean} chars, expected 588 "
+            "after the original measured 600-char saving absorbed the required "
+            "cwd-AGENTS rule. Update the budget and DONE-NOTE together, or the "
+            "current census and this repo disagree."
         )
 
 


### PR DESCRIPTION
## Summary

- Add the optional trailing `@AGENTS.md` reference to the anchors system context.
- Keep the production change limited to that reference; the generic resolver is unchanged.
- Add regression coverage using the actual anchors context for nested self-reference de-duplication, session-cwd resolution, process-cwd and bundle decoy exclusion, and a missing optional file.
- Add explicit prompt-budget accounting for the required cwd rule: +12 characters, a 1,154-character pinned budget, and a current 588-character saving.
- This PR replaces #383 with a narrower production diff and cwd-specific regression tests.

The Foundation bundle's cwd-only behavior is deliberately separate from the CLI's global/project `.amplifier` reference policy. The related CLI PR is https://github.com/microsoft/amplifier-app-cli/pull/332, but it is not a dependency of this change.

## Why

`@AGENTS.md` must resolve relative to the session working directory used to build the prompt, not the process working directory or the anchors bundle directory. The tests pin those boundaries while preserving self-reference de-duplication and optional-file behavior. The budget update records the required rule's measured cost rather than compressing unrelated prompt text.

## Verification

- Targeted guard: `uv run pytest tests/test_lean_head_guardrail.py -q --tb=short -rA` — **15 passed**.
- Focused anchors/regression suite: **65 passed**.
- CI-shaped dependency setup: `uv sync --extra grpc-adapter` — passed.
- Full suite: `uv run pytest tests/ -q --tb=short -rA` — **1,928 passed, 4 skipped**.
- `git diff --check` — passed.
- Added-lines leak scan — passed; no local host paths, credentials, or private identifiers in the new lines.

Prior combined DTU evidence, not rerun for this narrower PR: **23/23** provider-bound assertions using a deterministic provider and real CLI fresh/run --resume flows, covering minimal context/orchestrator, lifecycle hook, and partial-bundle behavior. No live vendor was tested; this evidence is not presented as live-provider validation.

## Scope

- Production: `bundles/anchors/context/system.md` — trailing `@AGENTS.md` mention only.
- Regression: `tests/test_instruction_mentions_lead_context.py` — cwd-specific coverage.
- Census accounting: `tests/test_lean_head_guardrail.py` and `docs/lanes/zc6t-lean-head-ship/DONE-NOTE.md` — required +12-character budget update and 588-character current saving.
- No generic resolver, CLI `.amplifier` policy, dependency, lockfile, or unrelated prompt prose changes.
- Historical experiment results in the DONE-NOTE are preserved; vendor cache metrics were not rerun.

## Breaking changes

None intended.

## Observations

None arose.