### PR TITLE
fix: preserve provider preferences during cold resume

### DIFF
--- a/amplifier_foundation/bundle/_prepared.py
+++ b/amplifier_foundation/bundle/_prepared.py
@@ -836,6 +836,17 @@ class PreparedBundle:
         # This is done before session creation so the mount plan has the right provider
         # We need to initialize a temporary session to resolve model patterns
         if provider_preferences:
+            # Preserve the complete caller-selected chain on the child config.
+            # A resumed child can then reapply its own routing intent before its
+            # parent coordinator (and therefore its live catalog) is mounted.
+            # Copy every level we expose: Bundle/agent definitions remain immutable.
+            child_mount_plan["provider_preferences"] = [
+                {
+                    **preference.to_dict(),
+                    "config": dict(preference.config),
+                }
+                for preference in provider_preferences
+            ]
             child_mount_plan = await apply_provider_preferences_with_resolution(
                 child_mount_plan,
                 provider_preferences,

--- a/amplifier_foundation/spawn_utils.py
+++ b/amplifier_foundation/spawn_utils.py
@@ -231,7 +231,11 @@ async def _list_models_cached(provider: Any, provider_name: str) -> Any:
             # cache read) still benefit from it completing in the background.
             return await asyncio.shield(task)
     except TimeoutError:
-        logger.warning(
+        # Resolution callers own user-facing diagnostics. A contended cache
+        # lookup is an implementation detail, and warning here would produce
+        # a misleading cascade even if the direct retry or later preference
+        # succeeds.
+        logger.debug(
             "Timed out after %.1fs waiting for an in-flight list_models() "
             "fetch from provider '%s'; falling through to a direct call",
             wait_timeout,
@@ -353,12 +357,20 @@ class ModelResolutionResult:
         pattern: Original pattern (None if input wasn't a pattern).
         available_models: All models available from the provider.
         matched_models: Models that matched the pattern.
+        status: Machine-readable outcome. One of ``resolved``,
+            ``provider_not_mounted``, ``catalog_unavailable``,
+            ``catalog_query_failed``, ``empty_catalog``, or
+            ``no_matching_model``.
+        provider: The runtime provider instance queried (or requested when it
+            was not mounted).
     """
 
     resolved_model: str | None
     pattern: str | None = None
     available_models: list[str] | None = None
     matched_models: list[str] | None = None
+    status: str = "resolved"
+    provider: str | None = None
 
 
 def is_glob_pattern(model_hint: str) -> bool:
@@ -377,94 +389,167 @@ async def resolve_model_pattern(
     model_hint: str,
     provider_name: str | None,
     coordinator: Any,
+    *,
+    diagnostics: list[ModelResolutionResult] | None = None,
+    fallback_default_model: str | None = None,
 ) -> ModelResolutionResult:
     """Resolve a model pattern to a concrete model name.
 
     Args:
         model_hint: Exact model name or glob pattern (e.g., "claude-haiku-*").
-        provider_name: Provider to query for available models (e.g., "anthropic").
-        coordinator: Amplifier coordinator for accessing providers.
+        provider_name: Runtime provider registry key to query (for example, a
+            selected instance ``id`` such as ``anthropic-sonnet``).
+        coordinator: Amplifier coordinator for accessing providers. May be
+            absent during a cold resume.
+        diagnostics: Optional ordered result sink. Suppresses the standalone
+            warning so a preference-chain caller can report once at the end.
+        fallback_default_model: Concrete selected-entry default allowed only
+            when the coordinator or provider registry is unavailable.
 
     Returns:
         ModelResolutionResult with resolved model and resolution metadata.
 
     Resolution strategy:
         1. If not a glob pattern, return as-is
-        2. Query provider for available models
+        2. Query the selected provider instance for available models
         3. Filter with fnmatch
         4. Sort descending (latest date/version wins)
         5. Return the best match, or a failure signal (resolved_model=None)
-           if the provider has no models, or none of them match the pattern.
+           if the provider is unavailable, its catalog cannot be queried, it
+           has no models, or none of them match the pattern.
            The raw, unresolved pattern string is never returned disguised as
            a successful resolution -- callers must check for None and treat
            it as "could not resolve", not substitute in the pattern itself.
     """
+    def finish(result: ModelResolutionResult) -> ModelResolutionResult:
+        """Record a result or emit this standalone call's one warning."""
+        if diagnostics is not None:
+            diagnostics.append(result)
+        elif result.status != "resolved":
+            logger.warning(
+                "Could not resolve model pattern for provider '%s': %s",
+                result.provider or "unspecified",
+                result.status,
+            )
+        return result
+
+    def matching_fallback_default() -> ModelResolutionResult | None:
+        """Resolve a matching persisted default without querying a catalog."""
+        if not (
+            isinstance(fallback_default_model, str)
+            and not is_glob_pattern(fallback_default_model)
+            and _model_hint_matches(fallback_default_model, model_hint)
+        ):
+            return None
+        return ModelResolutionResult(
+            resolved_model=fallback_default_model,
+            pattern=model_hint,
+            available_models=[fallback_default_model],
+            matched_models=[fallback_default_model],
+            provider=provider_name,
+        )
+
+    def catalog_unavailable() -> ModelResolutionResult:
+        """Describe a missing coordinator or provider registry."""
+        return ModelResolutionResult(
+            resolved_model=None,
+            pattern=model_hint,
+            available_models=None,
+            matched_models=None,
+            status="catalog_unavailable",
+            provider=provider_name,
+        )
+
     # Not a pattern - return as-is
     if not is_glob_pattern(model_hint):
         logger.debug("Model '%s' is not a pattern, using as-is", model_hint)
-        return ModelResolutionResult(
+        return finish(ModelResolutionResult(
             resolved_model=model_hint,
             pattern=None,
             available_models=None,
             matched_models=None,
-        )
+            provider=provider_name,
+        ))
 
     # Need provider to resolve pattern
     if not provider_name:
-        logger.warning(
-            "Model pattern '%s' specified but no provider - cannot resolve, using as-is",
-            model_hint,
-        )
-        return ModelResolutionResult(
-            resolved_model=model_hint,
+        return finish(ModelResolutionResult(
+            resolved_model=None,
             pattern=model_hint,
             available_models=None,
             matched_models=None,
-        )
+            status="provider_not_mounted",
+            provider=None,
+        ))
 
-    # Try to get available models from provider
-    available_models: list[str] = []
+    # Try to get available models from provider.
+    available_models: list[str]
+    if coordinator is None:
+        return finish(matching_fallback_default() or catalog_unavailable())
+    get_providers = getattr(coordinator, "get", None)
+    if not callable(get_providers):
+        return finish(matching_fallback_default() or catalog_unavailable())
     try:
-        providers = coordinator.get("providers")
-        if providers:
-            provider = _find_provider_instance(providers, provider_name, coordinator)
-            if provider and hasattr(provider, "list_models"):
-                models = await _list_models_cached(provider, provider_name)
-                # Handle both list of strings and list of model objects
-                available_models = [
-                    m if isinstance(m, str) else getattr(m, "id", str(m))
-                    for m in models
-                ]
-                logger.debug(
-                    "Provider '%s' has %d available models",
-                    provider_name,
-                    len(available_models),
-                )
-            else:
-                logger.debug(
-                    "Provider '%s' not found or does not support list_models()",
-                    provider_name,
-                )
-    except Exception as e:
-        logger.warning(
-            "Failed to query models from provider '%s': %s",
-            provider_name,
-            e,
-        )
+        providers = get_providers("providers")
+    except Exception:
+        return finish(ModelResolutionResult(
+            resolved_model=None,
+            pattern=model_hint,
+            available_models=None,
+            matched_models=None,
+            status="catalog_query_failed",
+            provider=provider_name,
+        ))
 
+    if not isinstance(providers, dict):
+        return finish(matching_fallback_default() or catalog_unavailable())
+
+    provider = _find_provider_instance(providers, provider_name, coordinator)
+    if provider is None:
+        return finish(ModelResolutionResult(
+            resolved_model=None,
+            pattern=model_hint,
+            available_models=None,
+            matched_models=None,
+            status="provider_not_mounted",
+            provider=provider_name,
+        ))
+    if not hasattr(provider, "list_models"):
+        return finish(ModelResolutionResult(
+            resolved_model=None,
+            pattern=model_hint,
+            available_models=None,
+            matched_models=None,
+            status="catalog_unavailable",
+            provider=provider_name,
+        ))
+
+    try:
+        models = await _list_models_cached(provider, provider_name)
+    except Exception:
+        return finish(ModelResolutionResult(
+            resolved_model=None,
+            pattern=model_hint,
+            available_models=None,
+            matched_models=None,
+            status="catalog_query_failed",
+            provider=provider_name,
+        ))
+
+    # Handle both list of strings and list of model objects.
+    available_models = [
+        m if isinstance(m, str) else getattr(m, "id", str(m))
+        for m in models
+    ]
     if not available_models:
-        logger.warning(
-            "No available models from provider '%s' for pattern '%s' - "
-            "cannot resolve (provider has no models)",
-            provider_name,
-            model_hint,
-        )
-        return ModelResolutionResult(
+        return finish(ModelResolutionResult(
             resolved_model=None,
             pattern=model_hint,
             available_models=[],
             matched_models=[],
-        )
+            status="empty_catalog",
+            provider=provider_name,
+        ))
 
     # Match pattern against available models: case-insensitive, OS-independent.
     # Raw fnmatch.filter() uses os.path.normcase, which is case-sensitive on
@@ -479,20 +564,14 @@ async def resolve_model_pattern(
     matched = [m for m in available_models if fnmatch.fnmatch(m.lower(), lowered_hint)]
 
     if not matched:
-        logger.warning(
-            "Pattern '%s' matched no models from provider '%s'. "
-            "Available: %s. Cannot resolve.",
-            model_hint,
-            provider_name,
-            ", ".join(available_models[:10])
-            + ("..." if len(available_models) > 10 else ""),
-        )
-        return ModelResolutionResult(
+        return finish(ModelResolutionResult(
             resolved_model=None,
             pattern=model_hint,
             available_models=available_models,
             matched_models=[],
-        )
+            status="no_matching_model",
+            provider=provider_name,
+        ))
 
     # Sort descending (latest date/version typically sorts last alphabetically,
     # so reverse sort puts newest first)
@@ -508,12 +587,13 @@ async def resolve_model_pattern(
         ", ".join(matched[:5]) + ("..." if len(matched) > 5 else ""),
     )
 
-    return ModelResolutionResult(
+    return finish(ModelResolutionResult(
         resolved_model=resolved,
         pattern=model_hint,
         available_models=available_models,
         matched_models=matched,
-    )
+        provider=provider_name,
+    ))
 
 
 def _get_provider_specs(coordinator: Any) -> list[dict[str, Any]]:
@@ -555,6 +635,15 @@ def _module_type_of(spec: dict[str, Any] | None) -> str | None:
     if not module:
         return None
     return module.replace("provider-", "")
+
+
+def _runtime_provider_name(spec: dict[str, Any]) -> str:
+    """Return the runtime registry key for a selected mount-plan entry."""
+    for key in ("instance_id", "id", "module"):
+        value = spec.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
 
 
 def _find_provider_instance(
@@ -1018,6 +1107,8 @@ async def apply_provider_preferences_with_resolution(
     mount_plan: dict[str, Any],
     preferences: list[ProviderPreference],
     coordinator: Any,
+    *,
+    diagnostics: list[ModelResolutionResult] | None = None,
 ) -> dict[str, Any]:
     """Apply provider preferences with model pattern resolution.
 
@@ -1028,6 +1119,9 @@ async def apply_provider_preferences_with_resolution(
         mount_plan: The mount plan to modify.
         preferences: Ordered list of ProviderPreference objects.
         coordinator: Amplifier coordinator for querying provider models.
+        diagnostics: Optional ordered sink for every attempted preference,
+            including the terminal successful attempt. Suppresses this
+            mechanism layer's warnings so the caller can present one message.
 
     Returns:
         New mount plan with the first matching provider promoted and
@@ -1046,9 +1140,7 @@ async def apply_provider_preferences_with_resolution(
         return mount_plan
 
     providers = mount_plan.get("providers", [])
-    if not providers:
-        logger.warning("Provider preferences specified but no providers in mount plan")
-        return mount_plan
+    attempt_results = diagnostics if diagnostics is not None else []
 
     # Find first matching preference whose model actually resolves, and
     # apply it. A preference whose provider is present but whose glob
@@ -1063,34 +1155,52 @@ async def apply_provider_preferences_with_resolution(
         # comment above _provider_priority), so the model glob below is
         # resolved against the very instance that will be promoted.
         target_idx = _resolve_provider_index(providers, pref.provider, pref.model)
-        if target_idx is not None:
-            # Resolve model pattern if it's a glob
-            resolved_model = pref.model
-            if is_glob_pattern(pref.model):
-                result = await resolve_model_pattern(
-                    pref.model, pref.provider, coordinator
-                )
-                if result.resolved_model is None:
-                    logger.warning(
-                        "Preference for provider '%s' failed to resolve model "
-                        "pattern '%s' - trying next preference",
-                        pref.provider,
-                        pref.model,
-                    )
-                    continue
-                resolved_model = result.resolved_model
+        if target_idx is None:
+            attempt_results.append(ModelResolutionResult(
+                resolved_model=None,
+                pattern=pref.model if is_glob_pattern(pref.model) else None,
+                status="provider_not_mounted",
+                provider=pref.provider,
+            ))
+            continue
 
-            return _apply_single_override(
-                mount_plan, providers, target_idx, resolved_model, pref.config
+        target = providers[target_idx]
+        runtime_provider = _runtime_provider_name(target)
+        # Resolve model pattern if it's a glob.  The runtime instance comes
+        # from the same model-aware selection that chose target_idx: never
+        # query a bare alias then apply the resulting model to another mount.
+        if is_glob_pattern(pref.model):
+            default_model = (target.get("config") or {}).get("default_model")
+            result = await resolve_model_pattern(
+                pref.model,
+                runtime_provider,
+                coordinator,
+                diagnostics=attempt_results,
+                fallback_default_model=default_model,
             )
+        else:
+            result = ModelResolutionResult(
+                resolved_model=pref.model,
+                provider=runtime_provider,
+            )
+            attempt_results.append(result)
+
+        if result.resolved_model is None:
+            continue
+
+        return _apply_single_override(
+            mount_plan, providers, target_idx, result.resolved_model, pref.config
+        )
 
     # No preferences matched -- either no preference's provider was present
     # in the mount plan, or every candidate's model pattern failed to
     # resolve. Either way, leave the mount plan unmodified rather than
     # writing an unresolved pattern string into it.
-    logger.warning(
-        "No preferred providers found in mount plan. Preferences: %s, Available: %s",
-        [p.provider for p in preferences],
-        list({p.get("module", "?") for p in providers}),
-    )
+    if diagnostics is None:
+        statuses = ", ".join(sorted({result.status for result in attempt_results}))
+        logger.warning(
+            "No provider preference could be applied (%s); keeping the existing "
+            "provider selection.",
+            statuses or "no providers in mount plan",
+        )
     return mount_plan

--- a/tests/test_spawn_contract.py
+++ b/tests/test_spawn_contract.py
@@ -15,6 +15,7 @@ import pytest
 from amplifier_core.hooks import HookRegistry
 
 from amplifier_foundation.bundle import Bundle, PreparedBundle
+from amplifier_foundation.spawn_utils import ProviderPreference
 
 # Resolve the example file relative to this test file
 _EXAMPLE_07 = (
@@ -228,6 +229,59 @@ class TestSpawnSelfDelegationDepth:
 
         assert result["output"] == "Done"
         assert result["session_id"] == "test-child-123"
+
+    @pytest.mark.asyncio
+    async def test_spawn_preserves_full_preference_chain_in_child_config(self):
+        """A cold-resumed child retains the caller's ordered routing intent."""
+        hooks = HookRegistry()
+        child_bundle = Bundle(
+            name="test-child",
+            version="0.0.1",
+            providers=[
+                {
+                    "id": "sonnet",
+                    "module": "provider-anthropic",
+                    "config": {"default_model": "claude-sonnet-4-5"},
+                }
+            ],
+        )
+        prepared = _make_prepared_bundle()
+        mock_session = _make_mock_session(hooks)
+        captured_config = {}
+        preferences = [
+            ProviderPreference(
+                provider="anthropic",
+                model="claude-haiku-*",
+                config={"reasoning_effort": "low"},
+            ),
+            ProviderPreference(provider="anthropic", model="claude-sonnet-*"),
+        ]
+
+        def capture_session_init(config, **kwargs):
+            captured_config.update(config)
+            return mock_session
+
+        with patch(
+            "amplifier_core.AmplifierSession",
+            side_effect=capture_session_init,
+        ):
+            await prepared.spawn(
+                child_bundle,
+                "Do something",
+                compose=False,
+                provider_preferences=preferences,
+            )
+
+        assert captured_config["provider_preferences"] == [
+            {
+                "provider": "anthropic",
+                "model": "claude-haiku-*",
+                "config": {"reasoning_effort": "low"},
+            },
+            {"provider": "anthropic", "model": "claude-sonnet-*", "config": {}},
+        ]
+        assert captured_config["provider_preferences"][0]["config"] is not preferences[0].config
+        assert child_bundle.providers[0]["config"]["default_model"] == "claude-sonnet-4-5"
 
     @pytest.mark.asyncio
     async def test_spawn_turn_count_defaults_to_1(self):

--- a/tests/test_spawn_utils.py
+++ b/tests/test_spawn_utils.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from amplifier_foundation.spawn_utils import ProviderPreference
+from amplifier_foundation.spawn_utils import ModelResolutionResult
 from amplifier_foundation.spawn_utils import _apply_single_override
 from amplifier_foundation.spawn_utils import _build_provider_lookup
 from amplifier_foundation.spawn_utils import _find_provider_index
@@ -52,6 +53,11 @@ class TestProviderPreference:
         """Test from_dict raises error when model is missing."""
         with pytest.raises(ValueError, match="requires 'model' key"):
             ProviderPreference.from_dict({"provider": "openai"})
+
+    def test_resolution_result_keeps_legacy_positional_arguments(self) -> None:
+        result = ModelResolutionResult("model", "pattern", ["model"], ["model"])
+        assert result.status == "resolved"
+        assert result.provider is None
 
 
 class TestIsGlobPattern:
@@ -216,15 +222,16 @@ class TestResolveModelPattern:
         assert result.pattern is None
 
     @pytest.mark.asyncio
-    async def test_pattern_without_provider_returns_as_is(self) -> None:
-        """Test that patterns without provider are returned as-is."""
+    async def test_pattern_without_provider_is_an_explicit_failure(self) -> None:
+        """A glob without a provider must never become a literal model name."""
         result = await resolve_model_pattern(
             "claude-haiku-*",
             None,
             MagicMock(),
         )
-        assert result.resolved_model == "claude-haiku-*"
+        assert result.resolved_model is None
         assert result.pattern == "claude-haiku-*"
+        assert result.status == "provider_not_mounted"
 
     @pytest.mark.asyncio
     async def test_pattern_resolves_to_latest(self) -> None:
@@ -706,6 +713,207 @@ class TestApplyProviderPreferencesWithResolution:
         # No unresolved glob pattern string should appear anywhere in the result.
         for p in result["providers"]:
             assert "default_model" not in p["config"]
+
+
+class TestResolutionDiagnosticsAndColdResume:
+    """No-network regressions for resolution status and warning ownership."""
+
+    @pytest.mark.asyncio
+    async def test_cold_resume_promotes_matching_persisted_default_quietly(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        plan = {
+            "providers": [
+                {
+                    "id": "sonnet",
+                    "module": "provider-anthropic",
+                    "config": {"priority": 4, "default_model": "Claude-Sonnet-4-5"},
+                }
+            ]
+        }
+        diagnostics = []
+
+        with caplog.at_level(logging.WARNING, logger="amplifier_foundation.spawn_utils"):
+            result = await apply_provider_preferences_with_resolution(
+                plan,
+                [ProviderPreference(provider="anthropic", model="claude-sonnet-*")],
+                coordinator=None,
+                diagnostics=diagnostics,
+            )
+
+        assert result["providers"][0]["config"]["default_model"] == "Claude-Sonnet-4-5"
+        assert [(item.status, item.provider, item.resolved_model) for item in diagnostics] == [
+            ("resolved", "sonnet", "Claude-Sonnet-4-5")
+        ]
+        assert not caplog.records
+
+    @pytest.mark.asyncio
+    async def test_cold_resume_nonmatching_default_is_catalog_unavailable(self) -> None:
+        plan = {
+            "providers": [
+                {
+                    "id": "sonnet",
+                    "module": "provider-anthropic",
+                    "config": {"default_model": "claude-sonnet-4-5"},
+                }
+            ]
+        }
+        diagnostics = []
+
+        result = await apply_provider_preferences_with_resolution(
+            plan,
+            [ProviderPreference(provider="anthropic", model="claude-haiku-*")],
+            coordinator=None,
+            diagnostics=diagnostics,
+        )
+
+        assert result is plan
+        assert diagnostics[0].status == "catalog_unavailable"
+        assert diagnostics[0].resolved_model is None
+
+    @pytest.mark.asyncio
+    async def test_query_failure_never_uses_persisted_default_as_a_fallback(self) -> None:
+        plan = {
+            "providers": [
+                {
+                    "id": "sonnet",
+                    "module": "provider-anthropic",
+                    "config": {"default_model": "claude-sonnet-4-5"},
+                }
+            ]
+        }
+        coordinator = MagicMock()
+        coordinator.get.side_effect = RuntimeError("network details must stay hidden")
+        diagnostics = []
+
+        result = await apply_provider_preferences_with_resolution(
+            plan,
+            [ProviderPreference(provider="anthropic", model="claude-sonnet-*")],
+            coordinator,
+            diagnostics=diagnostics,
+        )
+
+        assert result is plan
+        assert diagnostics[0].status == "catalog_query_failed"
+        assert diagnostics[0].resolved_model is None
+
+    @pytest.mark.asyncio
+    async def test_catalog_query_failure_empty_catalog_and_no_match_stay_distinct(self) -> None:
+        async def resolve(models: Any) -> str:
+            provider = MagicMock()
+            provider.list_models = AsyncMock(
+                side_effect=models if isinstance(models, Exception) else None,
+                return_value=None if isinstance(models, Exception) else models,
+            )
+            coordinator = MagicMock()
+            coordinator.get.return_value = {"provider-anthropic": provider}
+            return (
+                await resolve_model_pattern("claude-haiku-*", "anthropic", coordinator)
+            ).status
+
+        assert await resolve(RuntimeError("not for logs")) == "catalog_query_failed"
+        assert await resolve([]) == "empty_catalog"
+        assert await resolve(["claude-sonnet-4-5"]) == "no_matching_model"
+
+    @pytest.mark.asyncio
+    async def test_selected_instance_is_the_only_catalog_queried(self) -> None:
+        opus = MagicMock()
+        opus.list_models = AsyncMock(return_value=["claude-opus-4-5"])
+        sonnet = MagicMock()
+        sonnet.list_models = AsyncMock(return_value=["claude-sonnet-4-5"])
+        plan = {
+            "providers": [
+                {
+                    "id": "opus",
+                    "module": "provider-anthropic",
+                    "config": {"priority": 1, "default_model": "claude-opus-4-5"},
+                },
+                {
+                    "id": "sonnet",
+                    "module": "provider-anthropic",
+                    "config": {"priority": 9, "default_model": "claude-sonnet-4-5"},
+                },
+            ]
+        }
+        coordinator = MagicMock()
+        coordinator.get.return_value = {"opus": opus, "sonnet": sonnet}
+
+        result = await apply_provider_preferences_with_resolution(
+            plan,
+            [ProviderPreference(provider="anthropic", model="claude-sonnet-*")],
+            coordinator,
+        )
+
+        assert result["providers"][1]["config"]["default_model"] == "claude-sonnet-4-5"
+        opus.list_models.assert_not_awaited()
+        sonnet.list_models.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_include_failed_attempt_and_terminal_success_without_warnings(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        openai = MagicMock()
+        openai.list_models = AsyncMock(return_value=["gpt-4o-mini"])
+        coordinator = MagicMock()
+        coordinator.get.return_value = {"provider-openai": openai}
+        diagnostics = []
+
+        with caplog.at_level(logging.WARNING, logger="amplifier_foundation.spawn_utils"):
+            result = await apply_provider_preferences_with_resolution(
+                {"providers": [{"module": "provider-openai", "config": {}}]},
+                [
+                    ProviderPreference(provider="anthropic", model="claude-haiku-*"),
+                    ProviderPreference(provider="openai", model="gpt-4o-*"),
+                ],
+                coordinator,
+                diagnostics=diagnostics,
+            )
+
+        assert result["providers"][0]["config"]["default_model"] == "gpt-4o-mini"
+        assert [(item.status, item.provider) for item in diagnostics] == [
+            ("provider_not_mounted", "anthropic"),
+            ("resolved", "provider-openai"),
+        ]
+        assert not caplog.records
+
+    @pytest.mark.asyncio
+    async def test_later_success_without_diagnostics_is_silent(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        openai = MagicMock()
+        openai.list_models = AsyncMock(return_value=["gpt-4o-mini"])
+        coordinator = MagicMock()
+        coordinator.get.return_value = {"provider-openai": openai}
+
+        with caplog.at_level(logging.WARNING, logger="amplifier_foundation.spawn_utils"):
+            result = await apply_provider_preferences_with_resolution(
+                {"providers": [{"module": "provider-openai", "config": {}}]},
+                [
+                    ProviderPreference(provider="anthropic", model="claude-haiku-*"),
+                    ProviderPreference(provider="openai", model="gpt-4o-*"),
+                ],
+                coordinator,
+            )
+
+        assert result["providers"][0]["config"]["default_model"] == "gpt-4o-mini"
+        assert not caplog.records
+
+    @pytest.mark.asyncio
+    async def test_all_failures_without_diagnostics_emit_one_final_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="amplifier_foundation.spawn_utils"):
+            await apply_provider_preferences_with_resolution(
+                {"providers": [{"module": "provider-openai", "config": {}}]},
+                [
+                    ProviderPreference(provider="anthropic", model="claude-haiku-*"),
+                    ProviderPreference(provider="openai", model="gpt-4o-*"),
+                ],
+                coordinator=None,
+            )
+
+        assert len(caplog.records) == 1
+        assert "No provider preference could be applied" in caplog.records[0].message
 
 
 class TestProviderPreferenceConfig:
@@ -1756,7 +1964,7 @@ class TestModuleNamedPreferenceWithAsyncResolution:
             return_value=["claude-opus-5", "claude-sonnet-5", "claude-sonnet-4-5"]
         )
         coordinator = MagicMock()
-        coordinator.get = MagicMock(return_value={"anthropic": provider})
+        coordinator.get = MagicMock(return_value={"fable": provider})
 
         result = await apply_provider_preferences_with_resolution(
             _measured_host(),
@@ -1767,6 +1975,7 @@ class TestModuleNamedPreferenceWithAsyncResolution:
         promoted = _promoted(result)
         assert promoted["id"] == "fable"
         assert promoted["config"]["default_model"] == "claude-sonnet-4-5"
+        provider.list_models.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_async_path_preserves_protected_config_keys(self) -> None:


### PR DESCRIPTION
## What changed

- Return structured model-resolution outcomes instead of treating unavailable provider catalogs as exceptional diagnostics.
- Preserve a matching concrete persisted provider/model fallback during cold resume.
- Query the selected named provider instance's catalog rather than an unavailable generic registry.
- Carry the complete preference chain through `PreparedBundle.spawn`.
- Avoid the coordinator `None` failure path when provider preference resolution cannot complete.

## Why

Cold resume could emit misleading provider warnings and lose a valid persisted preference when a catalog was unavailable. This keeps resolution truthful and preserves the effective preference chain without changing the core API.

## Compatibility

Backward-compatible. No `amplifier-core` API change is required.

## Verification

- Targeted validation: 122 passed.
- Combined validation: 2,128 passed, 2 pre-existing baseline failures.
- Those results came from the combined DTU with a locally patched core and are **not** proof against released `amplifier-core`.
- Fresh released-core verification is pending in the manager's validation environment.
- No real API credentials were used; provider/network-dependent paths were not exercised.

## Review / merge gate

Please review the behavior and CI results. Do not merge until the fresh released-core validation completes successfully. The released-core gate is intentionally pending and is separate from the local evidence above.

## How to verify

Run the repository CI test suite and the released-core validation described above. The relevant repository tests cover cold-resume provider preference resolution and spawn preference propagation.

## Breaking changes

None.
